### PR TITLE
Fix an issue where catalog queries would hang

### DIFF
--- a/nexus/server/src/main.rs
+++ b/nexus/server/src/main.rs
@@ -169,10 +169,12 @@ impl NexusBackend {
                 // get the query executor
                 let executor = match assoc {
                     QueryAssocation::Peer(peer) => {
+                        tracing::info!("handling peer query: {}", peer.name);
                         peer_holder = Some(peer.clone());
                         self.get_peer_executor(&peer).await
                     }
                     QueryAssocation::Catalog => {
+                        tracing::info!("handling catalog query");
                         let catalog = self.catalog.lock().await;
                         catalog.get_executor()
                     }


### PR DESCRIPTION
- This is because we query the schema while holding a pin on the client.

- work around this by first querying the schema which will be a short lived connection and then hold the pin on a potentially long lived query.