### PR TITLE
Removes extra quotes bug in Array<Text> query

### DIFF
--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -176,8 +176,7 @@ impl Catalog {
             .prepare_typed("SELECT id FROM peers WHERE name = $1", &[types::Type::TEXT])
             .await?;
 
-        self
-            .pg
+        self.pg
             .query_opt(&stmt, &[&peer_name])
             .await?
             .map(|row| row.get(0))

--- a/nexus/peer-bigquery/src/ast.rs
+++ b/nexus/peer-bigquery/src/ast.rs
@@ -238,7 +238,7 @@ impl BigqueryAst {
                         )));
                     }
                     sqlparser::ast::Value::SingleQuotedString(_) => {
-                        list.push(Expr::Value(sqlparser::ast::Value::SingleQuotedString(
+                        list.push(Expr::Value(sqlparser::ast::Value::UnQuotedString(
                             element.to_string(),
                         )));
                     }

--- a/nexus/server/tests/sql/bq.sql
+++ b/nexus/server/tests/sql/bq.sql
@@ -92,3 +92,5 @@ SELECT * FROM bq_test.events WHERE id = ANY(CAST(ARRAY[1] AS BIGINT[]));
 SELECT * FROM bq_test.events WHERE id = ANY(ARRAY[1]);
 
 SELECT * FROM bq_test.events WHERE id = ANY(CAST('{1}' AS BIGINT[]));
+SELECT * FROM bq_test.events WHERE os = ANY(ARRAY['mac']::text[]);
+SELECT * FROM bq_test.events WHERE os = ANY(CAST(ARRAY['mac'] as text[]));


### PR DESCRIPTION
Now uses `UnQuotedString` instead of `SingleQuotedString` in the Array to List conversion in BigQuery AST.
Fixes #70 