### PR TITLE
Remove 'name' key from docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ git clone --recursive git@github.com:PeerDB-io/peerdb.git
 cd peerdb
 
 # Run docker containers: peerdb-server, postgres as catalog, temporal
+expose COMPOSE_PROJECT_NAME=peerdb-stack
 docker compose up
 
 # connect to peerdb and query away

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
 version: '3.9'
 
-name: 'peerdb-stack'
-
 services:
   temporalite:
     image: slamdev/temporalite:0.3.0


### PR DESCRIPTION
Docker has done some confusing things with the Compose file format. They've introduced a [Compose specification](https://docs.docker.com/compose/compose-file/#name-top-level-element) which has some incompatibilities with the existing tooling, and then labeled the [existing](https://docs.docker.com/compose/compose-file/compose-file-v3/) [versions](https://docs.docker.com/compose/compose-file/compose-file-v2/) that are well-supported by all reasonably-current versions of the Compose tool as "legacy". The top-level `name:` key is new in the "specification" version, but not present in the "legacy" versions.