### PR TITLE
Connectivity Checks in CREATE PEER Flow

### DIFF
--- a/nexus/peer-bigquery/src/lib.rs
+++ b/nexus/peer-bigquery/src/lib.rs
@@ -18,6 +18,16 @@ mod ast;
 mod cursor;
 mod stream;
 
+pub async fn bq_connection_valid(bq_config: BigqueryConfig) -> anyhow::Result<bool> {
+    let project_id = bq_config.clone().project_id;
+    let bq_client = bq_client_from_config(bq_config).await?;
+    let _ = bq_client
+        .job()
+        .query(&project_id, QueryRequest::new("SELECT 1;"))
+        .await?;
+    Ok(true)
+}
+
 pub struct BigQueryQueryExecutor {
     peer_name: String,
     config: BigqueryConfig,
@@ -41,7 +51,7 @@ pub async fn bq_client_from_config(config: BigqueryConfig) -> anyhow::Result<Cli
     };
     let client = Client::from_service_account_key(sa_key, false)
         .await
-        .expect("unable to create GcpClient.");
+        .context("unable to create GcpClient.")?;
 
     Ok(client)
 }

--- a/nexus/peer-cursor/src/lib.rs
+++ b/nexus/peer-cursor/src/lib.rs
@@ -51,4 +51,6 @@ pub trait QueryExecutor: Send + Sync {
     async fn execute(&self, stmt: &Statement) -> PgWireResult<QueryOutput>;
 
     async fn describe(&self, stmt: &Statement) -> PgWireResult<Option<SchemaRef>>;
+
+    async fn is_connection_valid(&self) -> anyhow::Result<bool>;
 }

--- a/nexus/peer-postgres/src/lib.rs
+++ b/nexus/peer-postgres/src/lib.rs
@@ -13,15 +13,10 @@ use tokio_postgres::Client;
 mod ast;
 mod stream;
 
-pub async fn pg_connection_valid(pg_config: PostgresConfig) -> anyhow::Result<bool> {
-    let _ = PostgresQueryExecutor::new(None, &pg_config).await?;
-    Ok(true)
-}
-
 // PostgresQueryExecutor is a QueryExecutor that uses a Postgres database as its
 // backing store.
 pub struct PostgresQueryExecutor {
-    _config: PostgresConfig,
+    config: PostgresConfig,
     peername: Option<String>,
     client: Box<Client>,
 }
@@ -64,7 +59,7 @@ impl PostgresQueryExecutor {
             })?;
 
         Ok(Self {
-            _config: config.clone(),
+            config: config.clone(),
             peername,
             client: Box::new(client),
         })
@@ -177,5 +172,10 @@ impl QueryExecutor for PostgresQueryExecutor {
             }
             _ => Ok(None),
         }
+    }
+
+    async fn is_connection_valid(&self) -> anyhow::Result<bool> {
+        let _ = PostgresQueryExecutor::new(None, &self.config).await?;
+        Ok(true)
     }
 }

--- a/nexus/peer-postgres/src/lib.rs
+++ b/nexus/peer-postgres/src/lib.rs
@@ -13,6 +13,11 @@ use tokio_postgres::Client;
 mod ast;
 mod stream;
 
+pub async fn pg_connection_valid(pg_config: PostgresConfig) -> anyhow::Result<bool> {
+    let _ = PostgresQueryExecutor::new(None, &pg_config).await?;
+    Ok(true)
+}
+
 // PostgresQueryExecutor is a QueryExecutor that uses a Postgres database as its
 // backing store.
 pub struct PostgresQueryExecutor {

--- a/nexus/peer-snowflake/src/lib.rs
+++ b/nexus/peer-snowflake/src/lib.rs
@@ -4,6 +4,8 @@ use cursor::SnowflakeCursorManager;
 use peer_cursor::{CursorModification, QueryExecutor, QueryOutput, SchemaRef};
 use pgerror::PgError;
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser;
 use std::cmp::min;
 use std::{collections::HashMap, time::Duration};
 use stream::SnowflakeDataType;
@@ -83,6 +85,14 @@ pub struct ResultSet {
 #[derive(Deserialize)]
 struct PartitionResult {
     data: Vec<Vec<Option<String>>>,
+}
+
+pub async fn sf_connection_valid(sf_config: SnowflakeConfig) -> anyhow::Result<bool> {
+    let sf_client = SnowflakeQueryExecutor::new(&sf_config).await?;
+    let sql = "SELECT 1;";
+    let test_stmt = parser::Parser::parse_sql(&GenericDialect {}, sql).unwrap();
+    let _ = sf_client.execute(&test_stmt[0]).await?;
+    Ok(true)
 }
 pub struct SnowflakeQueryExecutor {
     config: SnowflakeConfig,

--- a/nexus/peer-snowflake/src/lib.rs
+++ b/nexus/peer-snowflake/src/lib.rs
@@ -87,13 +87,6 @@ struct PartitionResult {
     data: Vec<Vec<Option<String>>>,
 }
 
-pub async fn sf_connection_valid(sf_config: SnowflakeConfig) -> anyhow::Result<bool> {
-    let sf_client = SnowflakeQueryExecutor::new(&sf_config).await?;
-    let sql = "SELECT 1;";
-    let test_stmt = parser::Parser::parse_sql(&GenericDialect {}, sql).unwrap();
-    let _ = sf_client.execute(&test_stmt[0]).await?;
-    Ok(true)
-}
 pub struct SnowflakeQueryExecutor {
     config: SnowflakeConfig,
     partition_number: usize,
@@ -443,5 +436,12 @@ impl QueryExecutor for SnowflakeQueryExecutor {
                 "only SELECT statements are supported in bigquery".to_owned(),
             )))),
         }
+    }
+
+    async fn is_connection_valid(&self) -> anyhow::Result<bool> {
+        let sql = "SELECT 1;";
+        let test_stmt = parser::Parser::parse_sql(&GenericDialect {}, sql).unwrap();
+        let _ = self.execute(&test_stmt[0]).await?;
+        Ok(true)
     }
 }

--- a/nexus/server/src/main.rs
+++ b/nexus/server/src/main.rs
@@ -8,14 +8,12 @@ use clap::Parser;
 use cursor::PeerCursors;
 use dashmap::DashMap;
 use flow_rs::FlowHandler;
-use peer_bigquery::{bq_connection_valid, BigQueryQueryExecutor};
+use peer_bigquery::BigQueryQueryExecutor;
 use peer_connections::{PeerConnectionTracker, PeerConnections};
 use peer_cursor::{
     util::{records_to_query_response, sendable_stream_to_query_response},
     QueryExecutor, QueryOutput, SchemaRef,
 };
-use peer_postgres::pg_connection_valid;
-use peer_snowflake::sf_connection_valid;
 use peerdb_parser::{NexusParsedStatement, NexusQueryParser, NexusStatement};
 use pgerror::PgError;
 use pgwire::{
@@ -160,20 +158,13 @@ impl NexusBackend {
                     peer,
                     if_not_exists: _,
                 } => {
-                    // Checking if you can connect to the peer with the config
-                    match peer.clone().config {
-                        Some(Config::BigqueryConfig(bq_config)) => {
-                            bq_connection_valid(bq_config).await
-                        }
-                        Some(Config::SnowflakeConfig(sf_config)) => {
-                            sf_connection_valid(sf_config).await
-                        }
-                        Some(Config::PostgresConfig(pg_config)) => {
-                            pg_connection_valid(pg_config).await
-                        }
-                        _ => panic!("Peer config not supported"),
-                    }
-                    .map_err(|e| {
+                    let peer_executor = self.get_peer_executor(&peer).await.map_err(|err| {
+                        PgWireError::ApiError(Box::new(PgError::Internal {
+                            err_msg: format!("unable to get peer executor: {:?}", err),
+                        }))
+                    })?;
+                    peer_executor.is_connection_valid().await.map_err(|e| {
+                        self.executors.remove(&peer.name); // Otherwise it will keep returning the earlier configured executor
                         PgWireError::UserError(Box::new(ErrorInfo::new(
                             "ERROR".to_owned(),
                             "internal_error".to_owned(),
@@ -241,7 +232,7 @@ impl NexusBackend {
                             }))
                         })?;
                     // make a request to the flow service to start the job.
-                    let workflow_id = self
+                    let _workflow_id = self
                         .flow_handler
                         .start_qrep_flow_job(&qrep_flow_job)
                         .await
@@ -319,7 +310,11 @@ impl NexusBackend {
                     QueryAssocation::Peer(peer) => {
                         tracing::info!("handling peer[{}] query: {}", peer.name, stmt);
                         peer_holder = Some(peer.clone());
-                        self.get_peer_executor(&peer).await
+                        self.get_peer_executor(&peer).await.map_err(|err| {
+                            PgWireError::ApiError(Box::new(PgError::Internal {
+                                err_msg: format!("unable to get peer executor: {:?}", err),
+                            }))
+                        })?
                     }
                     QueryAssocation::Catalog => {
                         tracing::info!("handling catalog query: {}", stmt);
@@ -349,7 +344,11 @@ impl NexusBackend {
                             let catalog = self.catalog.lock().await;
                             catalog.get_executor()
                         }
-                        Some(peer) => self.get_peer_executor(peer).await,
+                        Some(peer) => self.get_peer_executor(peer).await.map_err(|err| {
+                            PgWireError::ApiError(Box::new(PgError::Internal {
+                                err_msg: format!("unable to get peer executor: {:?}", err),
+                            }))
+                        })?,
                     }
                 };
 
@@ -360,32 +359,25 @@ impl NexusBackend {
         }
     }
 
-    async fn get_peer_executor(&self, peer: &Peer) -> Arc<Box<dyn QueryExecutor>> {
+    async fn get_peer_executor(&self, peer: &Peer) -> anyhow::Result<Arc<Box<dyn QueryExecutor>>> {
         if let Some(executor) = self.executors.get(&peer.name) {
-            return Arc::clone(executor.value());
+            return Ok(Arc::clone(executor.value()));
         }
 
         let executor = match &peer.config {
             Some(Config::BigqueryConfig(ref c)) => {
                 let peer_name = peer.name.clone();
                 let executor =
-                    BigQueryQueryExecutor::new(peer_name, c, self.peer_connections.clone())
-                        .await
-                        .unwrap();
+                    BigQueryQueryExecutor::new(peer_name, c, self.peer_connections.clone()).await?;
                 Arc::new(Box::new(executor) as Box<dyn QueryExecutor>)
             }
             Some(Config::PostgresConfig(ref c)) => {
                 let peername = Some(peer.name.clone());
-                let executor = peer_postgres::PostgresQueryExecutor::new(peername, c)
-                    .await
-                    .unwrap();
+                let executor = peer_postgres::PostgresQueryExecutor::new(peername, c).await?;
                 Arc::new(Box::new(executor) as Box<dyn QueryExecutor>)
             }
             Some(Config::SnowflakeConfig(ref c)) => {
-                let peername = Some(peer.name.clone());
-                let executor = peer_snowflake::SnowflakeQueryExecutor::new(c)
-                    .await
-                    .unwrap();
+                let executor = peer_snowflake::SnowflakeQueryExecutor::new(c).await?;
                 Arc::new(Box::new(executor) as Box<dyn QueryExecutor>)
             }
             _ => {
@@ -395,7 +387,7 @@ impl NexusBackend {
 
         self.executors
             .insert(peer.name.clone(), Arc::clone(&executor));
-        executor
+        Ok(executor)
     }
 }
 
@@ -522,7 +514,15 @@ impl ExtendedQueryHandler for NexusBackend {
                         // if the peer is of type bigquery, let us route the query to bq.
                         match &peer.config {
                             Some(Config::BigqueryConfig(_)) => {
-                                let executor = self.get_peer_executor(peer).await;
+                                let executor =
+                                    self.get_peer_executor(peer).await.map_err(|err| {
+                                        PgWireError::ApiError(Box::new(PgError::Internal {
+                                            err_msg: format!(
+                                                "unable to get peer executor: {:?}",
+                                                err
+                                            ),
+                                        }))
+                                    })?;
                                 executor.describe(stmt).await?
                             }
                             _ => {


### PR DESCRIPTION
CREATE PEER flow now checks if the user-provided configuration can successfully connect to the peer.

Note that these sql files are CREATE PEER commands of the three peers.
```shell
amogh=> \i bq.sql
psql:bq.sql:37: ERROR:  [peer]: invalid configuration: unable to create GcpClient.
amogh=> \i sf.sql
psql:sf.sql:62: ERROR:  [peer]: invalid configuration: Internal error: error decoding response body: expected value at line 1 column 1
amogh=> \i pg.sql
psql:pg.sql:8: ERROR:  [peer]: invalid configuration: error encountered while connecting to postgres Error { kind: Connect, cause: Some(Custom { kind: Uncategorized, error: "failed to lookup address information: Name or service not known" }) }
```