### PR TITLE
minor bug fixes

### DIFF
--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -142,8 +142,8 @@ func CopyStageToDestination(
 
 	appendMode := true
 	if config.WriteMode != nil {
-		wirteType := config.WriteMode.WriteType
-		if wirteType == protos.QRepWriteType_QREP_WRITE_MODE_UPSERT {
+		writeType := config.WriteMode.WriteType
+		if writeType == protos.QRepWriteType_QREP_WRITE_MODE_UPSERT {
 			appendMode = false
 		}
 	}

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -210,11 +210,11 @@ func (c *SnowflakeConnector) GetLastOffset(jobName string) (*protos.LastSyncStat
 		return nil, fmt.Errorf("error querying Snowflake peer for last syncedID: %w", err)
 	}
 
-	var result int64
 	if !rows.Next() {
 		log.Warnf("No row found for job %s, returning nil", jobName)
 		return nil, nil
 	}
+	var result int64
 	err = rows.Scan(&result)
 	if err != nil {
 		return nil, fmt.Errorf("error while reading result row: %w", err)
@@ -841,8 +841,8 @@ func (c *SnowflakeConnector) updateNormalizeMetadata(flowJobName string, normali
 	return nil
 }
 
-func (c *SnowflakeConnector) createPeerDBInternalSchema(createsSchemaTx *sql.Tx) error {
-	_, err := createsSchemaTx.ExecContext(c.ctx, fmt.Sprintf(createPeerDBInternalSchemaSQL, peerDBInternalSchema))
+func (c *SnowflakeConnector) createPeerDBInternalSchema(createSchemaTx *sql.Tx) error {
+	_, err := createSchemaTx.ExecContext(c.ctx, fmt.Sprintf(createPeerDBInternalSchemaSQL, peerDBInternalSchema))
 	if err != nil {
 		return fmt.Errorf("error while creating internal schema for PeerDB: %w", err)
 	}


### PR DESCRIPTION
1) [CDC] rejects source tables which have composite primary keys, since they aren't supported yet.
2) [QRep] supporting tables with int32 and int16 primary keys properly now, along with handling edge case of source table not having any rows so MIN() and MAX() return nil instead of a a number/timestamp.
3) minor variable name nits