### PR TITLE
use short sha for dev builds

### DIFF
--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -28,6 +28,10 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
+      - name: Set Short Commit Hash
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
       - name: Build (optionally publish) PeerDB Dev Image
         uses: depot/build-push-action@v1
         with:
@@ -36,7 +40,7 @@ jobs:
           file: stacks/nexus.Dockerfile
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
-            ghcr.io/peerdb-io/peerdb-server:dev
+            ghcr.io/peerdb-io/peerdb-server:dev-${{ steps.vars.outputs.sha_short }}
 
       - name: Build (optionally publish) Flow API Dev Image
         uses: depot/build-push-action@v1
@@ -46,7 +50,7 @@ jobs:
           file: stacks/flow-api.Dockerfile
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
-            ghcr.io/peerdb-io/flow-api:dev
+            ghcr.io/peerdb-io/flow-api:dev-${{ steps.vars.outputs.sha_short }}
 
       - name: Build (optionally publish) Flow Worker Dev Image
         uses: depot/build-push-action@v1
@@ -56,4 +60,4 @@ jobs:
           file: stacks/flow-worker.Dockerfile
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
-            ghcr.io/peerdb-io/flow-worker:dev
+            ghcr.io/peerdb-io/flow-worker:dev-${{ steps.vars.outputs.sha_short }}


### PR DESCRIPTION
- prevents issues and confusion when testing deployments