### PR TITLE
Minor Fixes for Nexus CI Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ./nexus
 
       - name: cargo test
-        run: cargo test
+        run: cargo test -- --test-threads=1
         working-directory: ./nexus
         env:
           RUST_BACKTRACE: 1

--- a/nexus/server/tests/assets/seed.sql
+++ b/nexus/server/tests/assets/seed.sql
@@ -13,7 +13,7 @@ SET default_tablespace = '';
 
 SET default_table_access_method = heap;
 
-CREATE SCHEMA test;
+CREATE SCHEMA IF NOT EXISTS test;
 
 DROP TABLE IF EXISTS test.test_table;
 

--- a/nexus/server/tests/server_test.rs
+++ b/nexus/server/tests/server_test.rs
@@ -191,7 +191,6 @@ fn server_test() {
 fn extended_query_protocol_no_params_catalog() {
     let server = PeerDBServer::new();
     let mut client = server.connect_dying();
-    create_peers::create_bq::create(&mut client);
     // run `select * from peers` as a prepared statement.
     let stmt = client
         .prepare("SELECT * FROM peers;")

--- a/nexus/server/tests/sql/postgres.sql
+++ b/nexus/server/tests/sql/postgres.sql
@@ -61,6 +61,8 @@ SELECT JSONB -> 'gender' FROM pg_test.test.test_table;
 
 SELECT INT8 FROM pg_test.test.test_table WHERE INT4=172;
 
+DROP TABLE pg_test.test.test_table;
+
 CREATE TABLE IF NOT EXISTS pg_test.test.temp_table(INT4 INT4, BOOL BOOL, INT8 INT8 PRIMARY KEY);
 INSERT INTO pg_test.test.temp_table VALUES(17, true, 26);
 SELECT * FROM pg_test.test.temp_table;


### PR DESCRIPTION
Nexus tests although now idempotent seem to require multiple re-runs on CI side to pass successfully. This PR aims to prevent the need for that.

- Removes an unnecessary line in one of the tests
- Runs Rust tests sequentially