### PR TITLE
Refactor SnapshotFlow out of setup flow

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -17,57 +17,9 @@ type CheckConnectionResult struct {
 	NeedsSetupMetadataTables bool
 }
 
-// IFlowable is a collection of activities that deal with flowables.
-// Flowables are entities that can be used as a source or destination in a peer flow.
-type IFlowable interface {
-	// CheckConnection checks the connection to the flowable.
-	CheckConnection(ctx context.Context, config *protos.Peer) (CheckConnectionResult, error)
-	// SetupMetadataTables sets up the metadata tables for the flowable.
-	SetupMetadataTables(ctx context.Context, config *protos.Peer) error
-	// GetLastSyncedID returns the last synced ID for the flowable.
-	// This typically corresponds to the LastLSN for Postgres and similar for other databases.
-	GetLastSyncedID(ctx context.Context, config *protos.GetLastSyncedIDInput) (*protos.LastSyncState, error)
-	// EnsurePullability ensurses that the flowable is pullable, i.e, table exists and requisite
-	// slots and publications are set up.
-	EnsurePullability(ctx context.Context, config *protos.EnsurePullabilityInput) error
-	// CreateRawTable creates the raw table on the flowable.
-	CreateRawTable(
-		ctx context.Context,
-		config *protos.CreateRawTableInput,
-	) (*protos.CreateRawTableOutput, error)
-	// Normalization Setup Methods
-	// GetTableSchema returns the schema of a table.
-	GetTableSchema(ctx context.Context, config *protos.GetTableSchemaInput) (*protos.TableSchema, error)
-	// CreateNormalizedTable sets up the normalized table on the flowable.
-	CreateNormalizedTable(ctx context.Context,
-		config *protos.SetupNormalizedTableInput) (*protos.SetupNormalizedTableOutput, error)
-	// StartFlow starts the flow of events from the source to the destination flowable.
-	StartFlow(ctx context.Context, input *protos.StartFlowInput) error
-
-	////////// QRep Methods //////////
-
-	// SetupQRepMetadataTables sets up the QRep metadata tables for the flowable.
-	SetupQRepMetadataTables(ctx context.Context, config *protos.Peer) error
-
-	// GetQRepPartitions returns the partitions for a given QRepConfig.
-	GetQRepPartitions(ctx context.Context, config *protos.QRepConfig) ([]*protos.QRepPartition, error)
-
-	// ReplicateQRepPartition replicates a QRepPartition from the source to the destination.
-	ReplicateQRepPartition(ctx context.Context, partition *protos.QRepPartition) error
-
-	// ConsolidateQRepPartitions consolidates the QRepPartitions into the destination.
-	ConsolidateQRepPartitions(ctx context.Context, config *protos.QRepConfig) error
-
-	// CleanupQrepFlow cleans up the QRep flow.
-	CleanupQrepFlow(ctx context.Context, config *protos.QRepConfig) error
-
-	DropFlow(ctx context.Context, config *protos.DropFlowInput) error
-}
-
-// FlowableActivity is the activity implementation for IFlowable.
 type FlowableActivity struct{}
 
-// CheckConnection implements IFlowable.CheckConnection.
+// CheckConnection implements CheckConnection.
 func (a *FlowableActivity) CheckConnection(
 	ctx context.Context,
 	config *protos.Peer,
@@ -86,7 +38,7 @@ func (a *FlowableActivity) CheckConnection(
 	}, nil
 }
 
-// SetupMetadataTables implements IFlowable.SetupMetadataTables.
+// SetupMetadataTables implements SetupMetadataTables.
 func (a *FlowableActivity) SetupMetadataTables(ctx context.Context, config *protos.Peer) error {
 	conn, err := connectors.GetConnector(ctx, config)
 	defer connectors.CloseConnector(conn)
@@ -102,7 +54,7 @@ func (a *FlowableActivity) SetupMetadataTables(ctx context.Context, config *prot
 	return nil
 }
 
-// GetLastSyncedID implements IFlowable.GetLastSyncedID.
+// GetLastSyncedID implements GetLastSyncedID.
 func (a *FlowableActivity) GetLastSyncedID(
 	ctx context.Context,
 	config *protos.GetLastSyncedIDInput,
@@ -117,7 +69,7 @@ func (a *FlowableActivity) GetLastSyncedID(
 	return conn.GetLastOffset(config.FlowJobName)
 }
 
-// EnsurePullability implements IFlowable.EnsurePullability.
+// EnsurePullability implements EnsurePullability.
 func (a *FlowableActivity) EnsurePullability(
 	ctx context.Context,
 	config *protos.EnsurePullabilityInput,
@@ -199,7 +151,7 @@ func (a *FlowableActivity) CreateNormalizedTable(
 	return conn.SetupNormalizedTable(config)
 }
 
-// StartFlow implements IFlowable.StartFlow.
+// StartFlow implements StartFlow.
 func (a *FlowableActivity) StartFlow(ctx context.Context, input *protos.StartFlowInput) (*model.SyncResponse, error) {
 	conn := input.FlowConnectionConfigs
 

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -54,6 +54,7 @@ func WorkerMain(opts *WorkerOptions) error {
 	w.RegisterWorkflow(peerflow.PeerFlowWorkflowWithConfig)
 	w.RegisterWorkflow(peerflow.SyncFlowWorkflow)
 	w.RegisterWorkflow(peerflow.SetupFlowWorkflow)
+	w.RegisterWorkflow(peerflow.SnapshotFlowWorkflow)
 	w.RegisterWorkflow(peerflow.NormalizeFlowWorkflow)
 	w.RegisterWorkflow(peerflow.QRepFlowWorkflow)
 	w.RegisterWorkflow(peerflow.QRepPartitionWorkflow)

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -862,12 +862,6 @@ func (c *BigQueryConnector) EnsurePullability(*protos.EnsurePullabilityInput) (*
 	panic("not implemented")
 }
 
-// SetupReplication sets up replication for the source connector.
-func (c *BigQueryConnector) SetupReplication(req *protos.SetupReplicationInput) error {
-	log.Errorf("panicking at call to SetupReplication for Snowflake flow connector")
-	panic("SetupReplication is not implemented for the Snowflake flow connector")
-}
-
 func (c *BigQueryConnector) PullFlowCleanup(jobName string) error {
 	panic("not implemented")
 }

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -30,9 +30,6 @@ type Connector interface {
 	// EnsurePullability ensures that the connector is pullable.
 	EnsurePullability(req *protos.EnsurePullabilityInput) (*protos.EnsurePullabilityOutput, error)
 
-	// SetupReplication sets up replication for the source connector
-	SetupReplication(req *protos.SetupReplicationInput) error
-
 	// InitializeTableSchema initializes the table schema of all the destination tables for the connector.
 	InitializeTableSchema(req map[string]*protos.TableSchema) error
 

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -94,10 +94,6 @@ func (c *EventHubConnector) EnsurePullability(
 	panic("ensure pullability not implemented for event hub")
 }
 
-func (c *EventHubConnector) SetupReplication(req *protos.SetupReplicationInput) error {
-	panic("setup replication not implemented for event hub")
-}
-
 func (c *EventHubConnector) InitializeTableSchema(req map[string]*protos.TableSchema) error {
 	c.tableSchemas = req
 	return nil

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -100,11 +100,6 @@ func (c *S3Connector) EnsurePullability(req *protos.EnsurePullabilityInput,
 	panic("EnsurePullability is not implemented for the S3 flow connector")
 }
 
-func (c *S3Connector) SetupReplication(req *protos.SetupReplicationInput) error {
-	log.Errorf("panicking at call to SetupReplication for S3 flow connector")
-	panic("SetupReplication is not implemented for the S3 flow connector")
-}
-
 func (c *S3Connector) PullFlowCleanup(jobName string) error {
 	log.Errorf("panicking at call to PullFlowCleanup for S3 flow connector")
 	panic("PullFlowCleanup is not implemented for the S3 flow connector")

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -611,12 +611,6 @@ func (c *SnowflakeConnector) EnsurePullability(req *protos.EnsurePullabilityInpu
 	panic("EnsurePullability is not implemented for the Snowflake flow connector")
 }
 
-// SetupReplication sets up replication for the source connector.
-func (c *SnowflakeConnector) SetupReplication(req *protos.SetupReplicationInput) error {
-	log.Errorf("panicking at call to SetupReplication for Snowflake flow connector")
-	panic("SetupReplication is not implemented for the Snowflake flow connector")
-}
-
 func (c *SnowflakeConnector) PullFlowCleanup(jobName string) error {
 	log.Errorf("panicking at call to PullFlowCleanup for Snowflake flow connector")
 	panic("PullFlowCleanup is not implemented for the Snowflake flow connector")

--- a/flow/connectors/sqlserver/sqlserver.go
+++ b/flow/connectors/sqlserver/sqlserver.go
@@ -124,11 +124,6 @@ func (c *SQLServerConnector) EnsurePullability(req *protos.EnsurePullabilityInpu
 	panic("EnsurePullability is not implemented for the SQLServer flow connector")
 }
 
-func (c *SQLServerConnector) SetupReplication(req *protos.SetupReplicationInput) error {
-	log.Errorf("panicking at call to SetupReplication for SQLServer flow connector")
-	panic("SetupReplication is not implemented for the SQLServer flow connector")
-}
-
 func (c *SQLServerConnector) PullFlowCleanup(jobName string) error {
 	log.Errorf("panicking at call to PullFlowCleanup for SQLServer flow connector")
 	panic("PullFlowCleanup is not implemented for the SQLServer flow connector")

--- a/flow/e2e/peer_flow_test.go
+++ b/flow/e2e/peer_flow_test.go
@@ -276,6 +276,7 @@ func registerWorkflowsAndActivities(env *testsuite.TestWorkflowEnvironment) {
 	env.RegisterWorkflow(peerflow.PeerFlowWorkflowWithConfig)
 	env.RegisterWorkflow(peerflow.SyncFlowWorkflow)
 	env.RegisterWorkflow(peerflow.SetupFlowWorkflow)
+	env.RegisterWorkflow(peerflow.SnapshotFlowWorkflow)
 	env.RegisterWorkflow(peerflow.NormalizeFlowWorkflow)
 	env.RegisterWorkflow(peerflow.QRepFlowWorkflow)
 	env.RegisterWorkflow(peerflow.QRepPartitionWorkflow)

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -1,0 +1,52 @@
+package peerflow
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/workflow"
+)
+
+type SnapshotFlowExecution struct {
+	config *protos.FlowConnectionConfigs
+	logger log.Logger
+}
+
+// ensurePullability ensures that the source peer is pullable.
+func (s *SnapshotFlowExecution) setupReplication(
+	ctx workflow.Context,
+) error {
+	flowName := s.config.FlowJobName
+	s.logger.Info("setting up replication on source for peer flow - ", flowName)
+
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+	})
+
+	setupReplicationInput := &protos.SetupReplicationInput{
+		PeerConnectionConfig: s.config.Source,
+		FlowJobName:          flowName,
+		TableNameMapping:     s.config.TableNameMapping,
+	}
+	setupReplicationFuture := workflow.ExecuteActivity(ctx, flowable.SetupReplication, setupReplicationInput)
+	if err := setupReplicationFuture.Get(ctx, nil); err != nil {
+		return fmt.Errorf("failed to setup replication on source peer: %w", err)
+	}
+
+	return nil
+}
+
+func SnapshotFlowWorkflow(ctx workflow.Context, config *protos.FlowConnectionConfigs) error {
+	se := &SnapshotFlowExecution{
+		config: config,
+		logger: workflow.GetLogger(ctx),
+	}
+
+	if err := se.setupReplication(ctx); err != nil {
+		return fmt.Errorf("failed to setup replication: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- This now happens after setup flow, this is a precursor to snapshot cloning.
- Only postgres connector will support it for the foreseeable future so remove the method from the core interface.