### PR TITLE
Add signals to postgres replication for keep-alive

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -106,7 +106,7 @@ func (a *FlowableActivity) SetupReplication(
 	}
 
 	pgConn := conn.(*connpostgres.PostgresConnector)
-	err = pgConn.SetupReplication(config)
+	err = pgConn.SetupReplication(nil, config)
 	if err != nil {
 		return fmt.Errorf("failed to setup replication: %w", err)
 	}

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -199,6 +199,9 @@ func (c *PostgresConnector) createSlotAndPublication(
 		if err != nil {
 			return fmt.Errorf("[slot] error acquiring connection: %w", err)
 		}
+
+		defer conn.Release()
+
 		log.Infof("Creating replication slot '%s'", slot)
 
 		opts := pglogrepl.CreateReplicationSlotOptions{

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
 	log "github.com/sirupsen/logrus"
 )
@@ -41,7 +42,7 @@ const (
 	mergeStatementSQL = `WITH src_rank AS (
 		SELECT _peerdb_data,_peerdb_record_type,_peerdb_unchanged_toast_columns,
 		RANK() OVER (PARTITION BY %s ORDER BY _peerdb_timestamp DESC) AS rank
-		FROM %s.%s WHERE _peerdb_batch_id>$1 AND _peerdb_batch_id<=$2 AND _peerdb_destination_table_name=$3 
+		FROM %s.%s WHERE _peerdb_batch_id>$1 AND _peerdb_batch_id<=$2 AND _peerdb_destination_table_name=$3
 	)
 	MERGE INTO %s dst
 	USING (SELECT %s,_peerdb_record_type,_peerdb_unchanged_toast_columns FROM src_rank WHERE rank=1) src
@@ -164,6 +165,7 @@ func (c *PostgresConnector) checkSlotAndPublication(slot string, publication str
 
 // createSlotAndPublication creates the replication slot and publication.
 func (c *PostgresConnector) createSlotAndPublication(
+	signal *SlotSignal,
 	s *SlotCheckResult,
 	slot string,
 	publication string,
@@ -187,18 +189,33 @@ func (c *PostgresConnector) createSlotAndPublication(
 		stmt := fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", publication, tableNameString)
 		_, err := c.pool.Exec(c.ctx, stmt)
 		if err != nil {
-			return fmt.Errorf("error creating publication: %w", err)
+			return fmt.Errorf("error creating publication '%s': %w", stmt, err)
 		}
 	}
 
 	// create slot only after we succeeded in creating publication.
 	if !s.SlotExists {
-		// Create the logical replication slot
-		_, err := c.pool.Exec(c.ctx,
-			"SELECT * FROM pg_create_logical_replication_slot($1, 'pgoutput')",
-			slot)
+		conn, err := c.replPool.Acquire(c.ctx)
 		if err != nil {
-			return fmt.Errorf("error creating replication slot: %w", err)
+			return fmt.Errorf("[slot] error acquiring connection: %w", err)
+		}
+		log.Infof("Creating replication slot '%s'", slot)
+
+		opts := pglogrepl.CreateReplicationSlotOptions{
+			Temporary: false,
+			Mode:      pglogrepl.LogicalReplication,
+		}
+		res, err := pglogrepl.CreateReplicationSlot(c.ctx, conn.Conn().PgConn(), slot, "pgoutput", opts)
+		if err != nil {
+			return fmt.Errorf("[slot] error creating replication slot: %w", err)
+		}
+
+		log.Infof("Created replication slot '%s'", slot)
+		if signal != nil {
+			signal.SlotCreated <- res
+
+			log.Infof("Waiting for clone to complete")
+			<-signal.CloneComplete
 		}
 	}
 

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -59,6 +59,7 @@ func NewPostgresConnector(ctx context.Context, pgConfig *protos.PostgresConfig) 
 
 	connConfig.ConnConfig.RuntimeParams["replication"] = "database"
 	connConfig.ConnConfig.RuntimeParams["bytea_output"] = "hex"
+	connConfig.MaxConns = 1
 
 	replPool, err := pgxpool.NewWithConfig(ctx, connConfig)
 	if err != nil {
@@ -191,9 +192,6 @@ func (c *PostgresConnector) PullRecords(req *model.PullRecordsRequest) (*model.R
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cdc source: %w", err)
 	}
-
-	// NOTE that the connection pool is shared by PostgresConnector and PostgresCDCSource [passed by pointer]
-	defer cdc.Close()
 
 	return cdc.PullRecords(req)
 }

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -80,6 +80,11 @@ func (c *PostgresConnector) Close() error {
 	if c.pool != nil {
 		c.pool.Close()
 	}
+
+	if c.replPool != nil {
+		c.replPool.Close()
+	}
+
 	return nil
 }
 

--- a/flow/connectors/postgres/postgres_cdc_test.go
+++ b/flow/connectors/postgres/postgres_cdc_test.go
@@ -344,7 +344,7 @@ func (suite *PostgresCDCTestSuite) TestErrorForTableNotExist() {
 	tableNameMapping := map[string]string{
 		nonExistentFlowSrcTableName: nonExistentFlowDstTableName,
 	}
-	err = suite.connector.SetupReplication(&protos.SetupReplicationInput{
+	err = suite.connector.SetupReplication(nil, &protos.SetupReplicationInput{
 		FlowJobName:          nonExistentFlowName,
 		TableNameMapping:     tableNameMapping,
 		PeerConnectionConfig: nil, // not used by the connector itself.
@@ -403,7 +403,7 @@ func (suite *PostgresCDCTestSuite) TestErrorForTableNotExist() {
 	relIDTableNameMapping = map[uint32]string{
 		tableRelID: nonExistentFlowSrcTableName,
 	}
-	err = suite.connector.SetupReplication(&protos.SetupReplicationInput{
+	err = suite.connector.SetupReplication(nil, &protos.SetupReplicationInput{
 		FlowJobName:          nonExistentFlowName,
 		TableNameMapping:     tableNameMapping,
 		PeerConnectionConfig: nil, // not used by the connector itself.
@@ -449,7 +449,7 @@ func (suite *PostgresCDCTestSuite) TestSimpleHappyFlow() {
 	tableNameMapping := map[string]string{
 		simpleHappyFlowSrcTableName: simpleHappyFlowDstTableName,
 	}
-	err = suite.connector.SetupReplication(&protos.SetupReplicationInput{
+	err = suite.connector.SetupReplication(nil, &protos.SetupReplicationInput{
 		FlowJobName:          simpleHappyFlowName,
 		TableNameMapping:     tableNameMapping,
 		PeerConnectionConfig: nil, // not used by the connector itself.
@@ -558,7 +558,7 @@ func (suite *PostgresCDCTestSuite) TestAllTypesHappyFlow() {
 	tableNameMapping := map[string]string{
 		allTypesHappyFlowSrcTableName: allTypesHappyFlowDstTableName,
 	}
-	err = suite.connector.SetupReplication(&protos.SetupReplicationInput{
+	err = suite.connector.SetupReplication(nil, &protos.SetupReplicationInput{
 		FlowJobName:          allTypesHappyFlowName,
 		TableNameMapping:     tableNameMapping,
 		PeerConnectionConfig: nil, // not used by the connector itself.
@@ -669,7 +669,7 @@ func (suite *PostgresCDCTestSuite) TestToastHappyFlow() {
 	tableNameMapping := map[string]string{
 		toastHappyFlowSrcTableName: toastHappyFlowDstTableName,
 	}
-	err = suite.connector.SetupReplication(&protos.SetupReplicationInput{
+	err = suite.connector.SetupReplication(nil, &protos.SetupReplicationInput{
 		FlowJobName:          toastHappyFlowName,
 		TableNameMapping:     tableNameMapping,
 		PeerConnectionConfig: nil, // not used by the connector itself.

--- a/flow/connectors/postgres/postgres_repl_test.go
+++ b/flow/connectors/postgres/postgres_repl_test.go
@@ -1,0 +1,136 @@
+package connpostgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/jackc/pgx/v5"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type PostgresReplicationSnapshotTestSuite struct {
+	suite.Suite
+	connector *PostgresConnector
+}
+
+func (suite *PostgresReplicationSnapshotTestSuite) SetupSuite() {
+	var err error
+	suite.connector, err = NewPostgresConnector(context.Background(), &protos.PostgresConfig{
+		Host:     "localhost",
+		Port:     7132,
+		User:     "postgres",
+		Password: "postgres",
+		Database: "postgres",
+	})
+	require.NoError(suite.T(), err)
+
+	setupTx, err := suite.connector.pool.Begin(context.Background())
+	require.NoError(suite.T(), err)
+	defer func() {
+		err := setupTx.Rollback(context.Background())
+		if err != pgx.ErrTxClosed {
+			require.NoError(suite.T(), err)
+		}
+	}()
+
+	_, err = setupTx.Exec(context.Background(), "DROP SCHEMA IF EXISTS pgpeer_repl_test CASCADE")
+	require.NoError(suite.T(), err)
+
+	_, err = setupTx.Exec(context.Background(), "CREATE SCHEMA pgpeer_repl_test")
+	require.NoError(suite.T(), err)
+
+	// setup 3 tables in pgpeer_repl_test schema
+	// test_1, test_2, test_3, all have 5 columns all text, c1, c2, c3, c4, c5
+	tables := []string{"test_1", "test_2", "test_3"}
+	for _, table := range tables {
+		_, err = setupTx.Exec(context.Background(),
+			fmt.Sprintf("CREATE TABLE pgpeer_repl_test.%s (c1 text, c2 text, c3 text, c4 text, c5 text)", table))
+		require.NoError(suite.T(), err)
+	}
+
+	err = setupTx.Commit(context.Background())
+	require.NoError(suite.T(), err)
+}
+
+func (suite *PostgresReplicationSnapshotTestSuite) TearDownSuite() {
+	teardownTx, err := suite.connector.pool.Begin(context.Background())
+	require.NoError(suite.T(), err)
+	defer func() {
+		err := teardownTx.Rollback(context.Background())
+		if err != pgx.ErrTxClosed {
+			require.NoError(suite.T(), err)
+		}
+	}()
+
+	_, err = teardownTx.Exec(context.Background(), "DROP SCHEMA IF EXISTS pgpeer_test CASCADE")
+	require.NoError(suite.T(), err)
+
+	// Fetch all the publications
+	rows, err := teardownTx.Query(context.Background(),
+		"SELECT pubname FROM pg_publication WHERE pubname LIKE 'peerflow_pub%'")
+	require.NoError(suite.T(), err)
+
+	// Iterate over the publications and drop them
+	for rows.Next() {
+		var pubname string
+		err := rows.Scan(&pubname)
+		require.NoError(suite.T(), err)
+
+		// Drop the publication in a new transaction
+		_, err = suite.connector.pool.Exec(context.Background(), fmt.Sprintf("DROP PUBLICATION %s", pubname))
+		require.NoError(suite.T(), err)
+	}
+
+	_, err = teardownTx.Exec(context.Background(),
+		"SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots")
+	require.NoError(suite.T(), err)
+
+	err = teardownTx.Commit(context.Background())
+	require.NoError(suite.T(), err)
+
+	suite.True(suite.connector.ConnectionActive())
+
+	err = suite.connector.Close()
+	require.NoError(suite.T(), err)
+
+	suite.False(suite.connector.ConnectionActive())
+}
+
+func (suite *PostgresReplicationSnapshotTestSuite) TestSimpleSlotCreation() {
+	tables := map[string]string{
+		"pgpeer_repl_test.test_1": "test_1_dst",
+	}
+
+	flowJobName := "test_simple_slot_creation"
+	setupReplicationInput := &protos.SetupReplicationInput{
+		FlowJobName:      flowJobName,
+		TableNameMapping: tables,
+	}
+
+	signal := NewSlotSignal()
+
+	// Moved to a go routine
+	go func() {
+		err := suite.connector.SetupReplication(signal, setupReplicationInput)
+		require.NoError(suite.T(), err)
+	}()
+
+	log.Infof("waiting for slot creation to complete for %s", flowJobName)
+	slotInfo := <-signal.SlotCreated
+	log.Infof("slot creation complete for %s: %v", flowJobName, slotInfo)
+
+	log.Infof("signaling clone complete for %s after waiting for 2 seconds", flowJobName)
+	time.Sleep(2 * time.Second)
+	signal.CloneComplete <- true
+
+	log.Infof("successfully setup replication for %s", flowJobName)
+}
+
+func TestPostgresReplTestSuite(t *testing.T) {
+	suite.Run(t, new(PostgresReplicationSnapshotTestSuite))
+}

--- a/flow/connectors/postgres/slot_signal.go
+++ b/flow/connectors/postgres/slot_signal.go
@@ -1,0 +1,19 @@
+package connpostgres
+
+import "github.com/jackc/pglogrepl"
+
+// This struct contains two signals.
+// 1. SlotCreated - this can be waited on to ensure that the slot has been created.
+// 2. CloneComplete - which can be waited on to ensure that the clone has completed.
+type SlotSignal struct {
+	SlotCreated   chan pglogrepl.CreateReplicationSlotResult
+	CloneComplete chan bool
+}
+
+// NewSlotSignal returns a new SlotSignal.
+func NewSlotSignal() *SlotSignal {
+	return &SlotSignal{
+		SlotCreated:   make(chan pglogrepl.CreateReplicationSlotResult, 1),
+		CloneComplete: make(chan bool, 1),
+	}
+}


### PR DESCRIPTION
1. This will ensure that we have a valid snapshot while the initial clone happens.
2. Add tests to check simple slot creation