### PR TITLE
Check for existing table in CDC 

### DIFF
--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -35,7 +35,7 @@ func (c *BigQueryConnector) SyncQRepRecords(
 	bqTable := c.client.Dataset(c.datasetID).Table(destTable)
 	tblMetadata, err := bqTable.Metadata(c.ctx)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get metadata of table %s: %w", destTable, err)
+		return 0, fmt.Errorf("destination table does not exist: failed to get metadata of table %s: %w", destTable, err)
 	}
 
 	done, err := c.isPartitionSynced(partition.PartitionId)

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -108,22 +108,31 @@ func (c *PostgresConnector) getPrimaryKeyColumn(schemaTable *SchemaTable) (strin
 	return pkCol, nil
 }
 
-func (c *PostgresConnector) tableExists(schemaTable *SchemaTable) (bool, error) {
-	var exists bool
-	err := c.pool.QueryRow(c.ctx,
-		`SELECT EXISTS (
-			SELECT FROM pg_tables
-			WHERE schemaname = $1
-			AND tablename = $2
-		)`,
+type pgTableColumn struct {
+	colName string
+	colType string
+}
+
+func (c *PostgresConnector) tableExists(schemaTable *SchemaTable) ([]pgTableColumn, error) {
+	rows, err := c.pool.Query(c.ctx,
+		`SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2`,
 		schemaTable.Schema,
 		schemaTable.Table,
-	).Scan(&exists)
+	)
 	if err != nil {
-		return false, fmt.Errorf("error checking if table exists: %w", err)
+		return nil, fmt.Errorf("error checking if table exists: %w", err)
+	}
+	var columns []pgTableColumn
+	for rows.Next() {
+		var colName, colType string
+		err = rows.Scan(&colName, &colType)
+		if err != nil {
+			return nil, fmt.Errorf("error while checking for existing table: %w", err)
+		}
+		columns = append(columns, pgTableColumn{colName, colType})
 	}
 
-	return exists, nil
+	return columns, nil
 }
 
 // checkSlotAndPublication checks if the replication slot and publication exist.

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -529,21 +529,28 @@ func (c *PostgresConnector) SetupNormalizedTable(
 	if err != nil {
 		return nil, fmt.Errorf("error while parsing table schema and name: %w", err)
 	}
-	existingTableColumns, err := c.tableExists(normalizedTableNameComponents)
+	destinationColumns, err := c.tableExists(normalizedTableNameComponents)
 	if err != nil {
 		return nil, fmt.Errorf("error occurred while checking if normalized table exists: %w", err)
 	}
-	if existingTableColumns != nil {
+	if destinationColumns != nil {
 		log.Infoln("found existing normalized table, checking if it matches the desired schema")
-		for _, column := range existingTableColumns {
+		if len(destinationColumns) != len(req.SourceTableSchema.Columns) {
+			return nil, fmt.Errorf("failed to setup normalized table: schemas on both sides differ")
+		}
+		for _, column := range destinationColumns {
 			existingName := strings.ToLower(column.colName)
 			sourceType, ok := req.SourceTableSchema.Columns[existingName]
 			if !ok {
-				return nil, fmt.Errorf("failed to setup normalized table due to non-matching column name: %v", existingName)
+				return nil, fmt.Errorf("failed to setup normalized table:"+
+					"non-matching column name: %v",
+					existingName)
 			}
 			sourceTypeConverted := strings.ToLower(qValueKindToPostgresType(sourceType))
 			if sourceTypeConverted != column.colType {
-				return nil, fmt.Errorf("failed to setup normalized table: mismatched column %v with destination type %v and source type %v", existingName, column.colType, sourceTypeConverted)
+				return nil, fmt.Errorf("failed to setup normalized table: mismatched column %v "+
+					"with destination type %v and source type %v",
+					existingName, column.colType, sourceTypeConverted)
 			}
 		}
 		return &protos.SetupNormalizedTableOutput{

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -335,12 +335,12 @@ func (c *PostgresConnector) SyncQRepRecords(
 		return 0, fmt.Errorf("failed to parse destination table identifier: %w", err)
 	}
 
-	exists, err := c.tableExists(dstTable)
+	sourceColumns, err := c.tableExists(dstTable)
 	if err != nil {
 		return 0, fmt.Errorf("failed to check if table exists: %w", err)
 	}
 
-	if !exists {
+	if len(sourceColumns) == 0 {
 		return 0, fmt.Errorf("table %s does not exist, used schema: %s", dstTable.Table, dstTable.Schema)
 	}
 

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -40,7 +40,7 @@ func (c *SnowflakeConnector) SyncQRepRecords(
 
 	tblSchema, err := c.getTableSchema(destTable)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get schema of table %s: %w", destTable, err)
+		return 0, fmt.Errorf("destination table does not exist: failed to get schema of table %s: %w", destTable, err)
 	}
 
 	done, err := c.isPartitionSynced(partition.PartitionId)

--- a/flow/connectors/snowflake/qvalue_convert.go
+++ b/flow/connectors/snowflake/qvalue_convert.go
@@ -8,13 +8,13 @@ import (
 
 var qValueKindToSnowflakeTypeMap = map[qvalue.QValueKind]string{
 	qvalue.QValueKindBoolean:     "BOOLEAN",
-	qvalue.QValueKindInt16:       "INTEGER",
-	qvalue.QValueKindInt32:       "INTEGER",
-	qvalue.QValueKindInt64:       "INTEGER",
+	qvalue.QValueKindInt16:       "NUMBER",
+	qvalue.QValueKindInt32:       "NUMBER",
+	qvalue.QValueKindInt64:       "NUMBER",
 	qvalue.QValueKindFloat32:     "FLOAT",
 	qvalue.QValueKindFloat64:     "FLOAT",
 	qvalue.QValueKindNumeric:     "NUMBER(38, 9)",
-	qvalue.QValueKindString:      "STRING",
+	qvalue.QValueKindString:      "TEXT",
 	qvalue.QValueKindJSON:        "STRING",
 	qvalue.QValueKindTimestamp:   "TIMESTAMP_NTZ",
 	qvalue.QValueKindTimestampTZ: "TIMESTAMP_TZ",

--- a/flow/connectors/snowflake/qvalue_convert.go
+++ b/flow/connectors/snowflake/qvalue_convert.go
@@ -8,13 +8,13 @@ import (
 
 var qValueKindToSnowflakeTypeMap = map[qvalue.QValueKind]string{
 	qvalue.QValueKindBoolean:     "BOOLEAN",
-	qvalue.QValueKindInt16:       "NUMBER",
-	qvalue.QValueKindInt32:       "NUMBER",
-	qvalue.QValueKindInt64:       "NUMBER",
+	qvalue.QValueKindInt16:       "INTEGER",
+	qvalue.QValueKindInt32:       "INTEGER",
+	qvalue.QValueKindInt64:       "INTEGER",
 	qvalue.QValueKindFloat32:     "FLOAT",
 	qvalue.QValueKindFloat64:     "FLOAT",
 	qvalue.QValueKindNumeric:     "NUMBER(38, 9)",
-	qvalue.QValueKindString:      "TEXT",
+	qvalue.QValueKindString:      "STRING",
 	qvalue.QValueKindJSON:        "STRING",
 	qvalue.QValueKindTimestamp:   "TIMESTAMP_NTZ",
 	qvalue.QValueKindTimestampTZ: "TIMESTAMP_TZ",


### PR DESCRIPTION
This PR introduces check for an existing destination table for CDC for Snowflake, Bigquery and Postgres as sinks. Every column and its data type is matched with that of the source table.

Fixes #256 