### PR TITLE
making CREATE MIRROR command block until SetupFlow workflow completes

### DIFF
--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -73,7 +73,6 @@ func WorkerMain(opts *WorkerOptions) error {
 	w := worker.New(c, shared.PeerFlowTaskQueue, worker.Options{
 		EnableSessionWorker: true,
 	})
-	w.RegisterWorkflow(peerflow.PeerFlowWorkflow)
 	w.RegisterWorkflow(peerflow.PeerFlowWorkflowWithConfig)
 	w.RegisterWorkflow(peerflow.SyncFlowWorkflow)
 	w.RegisterWorkflow(peerflow.SetupFlowWorkflow)

--- a/flow/e2e/peer_flow_test.go
+++ b/flow/e2e/peer_flow_test.go
@@ -272,7 +272,6 @@ func registerWorkflowsAndActivities(env *testsuite.TestWorkflowEnvironment) {
 	// set a 300 second timeout for the workflow to execute a few runs.
 	env.SetTestTimeout(300 * time.Second)
 
-	env.RegisterWorkflow(peerflow.PeerFlowWorkflow)
 	env.RegisterWorkflow(peerflow.PeerFlowWorkflowWithConfig)
 	env.RegisterWorkflow(peerflow.SyncFlowWorkflow)
 	env.RegisterWorkflow(peerflow.SetupFlowWorkflow)
@@ -672,7 +671,7 @@ func (s *E2EPeerFlowTestSuite) SetupPeerFlowStatusQuery(env *testsuite.TestWorkf
 			err = response.Get(&state)
 			s.NoError(err)
 
-			if state.SetupComplete {
+			if state.SetupComplete && state.SnapshotComplete {
 				fmt.Println("query indicates setup is complete")
 				break
 			}


### PR DESCRIPTION
This fixes two issues:

1) CREATE MIRROR [for CDC] was completely asynchronous earlier, which ended up masking issues with the SetupFlow step which could fail for multiple reasons.
2) DROP MIRROR would not work for failed mirrors like this, since Temporal was spinning on SetupFlow.