### PR TITLE
Array and Null Timestamp Fixes

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -826,8 +826,9 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 	idx := 0
 	for colName, genericColType := range sourceSchema.Columns {
 		columns[idx] = &bigquery.FieldSchema{
-			Name: colName,
-			Type: qValueKindToBigQueryType(genericColType),
+			Name:     colName,
+			Type:     qValueKindToBigQueryType(genericColType),
+			Repeated: strings.Contains(genericColType, "array"),
 		}
 		idx++
 	}

--- a/flow/connectors/bigquery/qvalue_convert.go
+++ b/flow/connectors/bigquery/qvalue_convert.go
@@ -39,6 +39,13 @@ func qValueKindToBigQueryType(colType string) bigquery.FieldType {
 	// bytes
 	case qvalue.QValueKindBit, qvalue.QValueKindBytes:
 		return bigquery.BytesFieldType
+	// For Arrays we return the types of the individual elements,
+	// and wherever this function is called, the 'Repeated' attribute of
+	// FieldSchema must be set to true.
+	case qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64:
+		return bigquery.IntegerFieldType
+	case qvalue.QValueKindArrayFloat32, qvalue.QValueKindArrayFloat64:
+		return bigquery.FloatFieldType
 	// rest will be strings
 	default:
 		return bigquery.StringFieldType

--- a/nexus/peer-bigquery/src/stream.rs
+++ b/nexus/peer-bigquery/src/stream.rs
@@ -145,15 +145,17 @@ impl BqRecordStream {
                         result_set.get_string_by_name(field_name)?.map(Value::Text)
                     }
                     FieldType::Timestamp => {
-                        let timestamp = result_set
-                            .get_i64_by_name(field_name)?
-                            .ok_or(anyhow::Error::msg("Invalid timestamp"))?;
-                        let naive_datetime = NaiveDateTime::from_timestamp_opt(timestamp, 0)
-                            .ok_or(anyhow::Error::msg("Invalid timestamp"))?;
-                        Some(Value::Timestamp(DateTime::<Utc>::from_utc(
-                            naive_datetime,
-                            Utc,
-                        )))
+                        let timestamp = result_set.get_i64_by_name(field_name)?;
+                        if let Some(ts) = timestamp {
+                            let naive_datetime = NaiveDateTime::from_timestamp_opt(ts, 0)
+                                .ok_or(anyhow::Error::msg("Invalid naive datetime"))?;
+                            Some(Value::Timestamp(DateTime::<Utc>::from_utc(
+                                naive_datetime,
+                                Utc,
+                            )))
+                        } else {
+                            None
+                        }
                     }
                     FieldType::Record => todo!(),
                     FieldType::Struct => todo!(),


### PR DESCRIPTION
- Now supports array columns for BigQuery mirror
- Fixes an issue where tables with null timestamp values in BigQuery tables could not be queried 