### PR TITLE
Backticks for BQ Column Names in Multi-Insert Merge

### DIFF
--- a/flow/connectors/bigquery/qrep_sync_method.go
+++ b/flow/connectors/bigquery/qrep_sync_method.go
@@ -111,11 +111,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 	// col names for the destination table joined by comma
 	colNames := []string{}
 	for _, col := range dstTableMetadata.Schema {
-		if strings.ToLower(col.Name) == "from" {
-			colNames = append(colNames, "`from`")
-		} else {
-			colNames = append(colNames, col.Name)
-		}
+		colNames = append(colNames, fmt.Sprintf("`%s`", col.Name))
 	}
 	colNamesStr := strings.Join(colNames, ", ")
 


### PR DESCRIPTION
This fix is to allow having reserve keywords as column names in BigQuery