### PR TITLE
Ignore error for catalog monitor for EH

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -205,7 +205,7 @@ func (a *FlowableActivity) StartFlow(ctx context.Context, input *protos.StartFlo
 	}
 	if a.CatalogMirrorMonitor.IsActive() && len(records.Records) > 0 {
 		syncBatchID, err := dest.GetLastSyncBatchID(input.FlowConnectionConfigs.FlowJobName)
-		if err != nil {
+		if err != nil && conn.Destination.Type != protos.DBType_EVENTHUB {
 			return nil, err
 		}
 


### PR DESCRIPTION
CDC to Eventhub errors in SyncFlow with 'GetLastSyncBatchID not supported for Eventhub', because in `flowable.go`'s `StartFlow` this method is being called for catalog metrics.
Eventhub does not have this method implemented so we can just ignore the error in this section and have sync ID in the metrics start from 0:
```Go
	if a.CatalogMirrorMonitor.IsActive() && len(records.Records) > 0 {
		syncBatchID, err := dest.GetLastSyncBatchID(input.FlowConnectionConfigs.FlowJobName)
		if err != nil && conn.Destination.Type != protos.DBType_EVENTHUB {
			return nil, err
		}
		....
	}
```