### PR TITLE
Eventhub Normalize Fix

### DIFF
--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -310,7 +310,11 @@ func (c *EventHubConnector) SetupNormalizedTables(
 
 func (c *EventHubConnector) NormalizeRecords(req *model.NormalizeRecordsRequest) (*model.NormalizeResponse, error) {
 	log.Infof("normalization for event hub is a no-op")
-	return nil, nil
+	return &model.NormalizeResponse{
+		EndBatchID:   0,
+		StartBatchID: 0,
+		Done:         true,
+	}, nil
 }
 
 // cleanup

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -144,7 +144,7 @@ func (p *PostgresCDCSource) consumeStream(
 			if err != nil {
 				return nil, fmt.Errorf("SendStandbyStatusUpdate failed: %w", err)
 			}
-			log.Debugf("Sent Standby status message")
+			log.Infof("Sent Standby status message")
 			nextStandbyMessageDeadline = time.Now().Add(standbyMessageTimeout)
 		}
 


### PR DESCRIPTION
`res` (result of normalize flow) in the below call is nil in case of Eventhub so we make it a non-nil:
```Go
err = a.CatalogMirrorMonitor.UpdateEndTimeForCDCBatch(ctx, input.FlowConnectionConfigs.FlowJobName,
		res.EndBatchID)
```