### PR TITLE
Replica Identity Check

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -568,7 +568,10 @@ func (c *PostgresConnector) getTableSchemaForTable(
 
 	pkey, err := c.getPrimaryKeyColumn(schemaTable)
 	if err != nil {
-		return nil, fmt.Errorf("error getting primary key column for table %s: %w", schemaTable, err)
+		replicaIdentity, err := c.getReplicaIdentityForTable(schemaTable)
+		if err != nil || replicaIdentity != "f" {
+			return nil, fmt.Errorf("error getting primary key column for table %s: %w", schemaTable, err)
+		}
 	}
 
 	res := &protos.TableSchema{


### PR DESCRIPTION
When we check for primary keys during pull, we should also check for no-pkey but replica identity case for the table.