### PR TITLE
changed WAL update logic

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -201,6 +201,9 @@ func (p *PostgresCDCSource) consumeStream(
 			log.Debugf("Primary Keepalive Message => ServerWALEnd: %s ServerTime: %s ReplyRequested: %t",
 				pkm.ServerWALEnd, pkm.ServerTime, pkm.ReplyRequested)
 
+			if pkm.ServerWALEnd > clientXLogPos {
+				clientXLogPos = pkm.ServerWALEnd
+			}
 			if pkm.ReplyRequested {
 				nextStandbyMessageDeadline = time.Time{}
 			}

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -143,7 +143,7 @@ func (p *PostgresCDCSource) consumeStream(
 	for {
 		if time.Now().After(nextStandbyMessageDeadline) ||
 			earlyReturn ||
-			(records.Records != nil && (len(records.Records) == int(req.MaxBatchSize))) {
+			(len(records.Records) == int(req.MaxBatchSize)) {
 			// update the WALWritePosition to be clientXLogPos - 1
 			// as the clientXLogPos is the last checkpoint id + 1
 			// and we want to send the last checkpoint id as the last
@@ -163,7 +163,7 @@ func (p *PostgresCDCSource) consumeStream(
 			log.Infof("Sent Standby status message. %s", numRowsProcessedMessage)
 			nextStandbyMessageDeadline = time.Now().Add(standbyMessageTimeout)
 
-			if earlyReturn || (records.Records != nil && (len(records.Records) == int(req.MaxBatchSize))) {
+			if earlyReturn || (len(records.Records) == int(req.MaxBatchSize)) {
 				return result, nil
 			}
 		}


### PR DESCRIPTION
This PR is debugging an issue where schema change propagation (#368) don't apply properly when there are parallel transactions happening during an ALTER TABLE statement. 

Borrowing from https://github.com/jackc/pglogrepl/pull/59

This PR changes the handling of clientXLogPos to match the one from Postgres' own `pg_recvlogical`:

- keepalive messages should bump the position too, as they're only sent (from what I can tell) after any xlogdata message;
- both the WALStart and the ServerWALEnd in logical xlogdata messages represent the position that should be reported back, and adding the length of the post-decoding data to it is meaningless;
- relation messages have a position of zero, and in general we should match the pg_recvlogical behavior of only increasing the local position.
