### PR TITLE
API Peer Validation for SQL Server

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -362,6 +362,13 @@ func (h *FlowRequestHandler) CreatePeer(
 		}
 		sfConfig := sfConfigObject.SnowflakeConfig
 		encodedConfig, encodingErr = proto.Marshal(sfConfig)
+	case protos.DBType_SQLSERVER:
+		sqlServerConfigObject, ok := config.(*protos.Peer_SqlserverConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		sqlServerConfig := sqlServerConfigObject.SqlserverConfig
+		encodedConfig, encodingErr = proto.Marshal(sqlServerConfig)
 
 	default:
 		return wrongConfigResponse, nil

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -219,12 +219,17 @@ func GetConnector(ctx context.Context, peer *protos.Peer) (Connector, error) {
 			return nil, fmt.Errorf("missing snowflake config for %s peer %s", peer.Type.String(), peer.Name)
 		}
 		return connsnowflake.NewSnowflakeConnector(ctx, sfConfig)
+
+	case protos.DBType_SQLSERVER:
+		sqlServerConfig := peer.GetSqlserverConfig()
+		if sqlServerConfig == nil {
+			return nil, fmt.Errorf("missing sqlserver config for %s peer %s", peer.Type.String(), peer.Name)
+		}
+		return connsqlserver.NewSQLServerConnector(ctx, sqlServerConfig)
 	// case protos.DBType_S3:
 	// 	return conns3.NewS3Connector(ctx, config.GetS3Config())
 	// case protos.DBType_EVENTHUB:
 	// 	return connsqlserver.NewSQLServerConnector(ctx, config.GetSqlserverConfig())
-	// case protos.DBType_SQLSERVER:
-	// 	return conneventhub.NewEventHubConnector(ctx, config.GetEventhubConfig())
 	default:
 		return nil, fmt.Errorf("unsupported peer type %s", peer.Type.String())
 	}

--- a/nexus/server/src/main.rs
+++ b/nexus/server/src/main.rs
@@ -206,7 +206,7 @@ impl NexusBackend {
 
     async fn validate_peer<'a>(&self, peer_type: i32, peer: &Peer) -> anyhow::Result<()> {
         if peer_type != 6 {
-            let peer_executor = self.get_peer_executor(&peer).await.map_err(|err| {
+            let peer_executor = self.get_peer_executor(peer).await.map_err(|err| {
                 PgWireError::ApiError(Box::new(PgError::Internal {
                     err_msg: format!("unable to get peer executor: {:?}", err),
                 }))
@@ -239,14 +239,14 @@ impl NexusBackend {
                     }))
                 })?;
             if let PeerValidationResult::Invalid(validation_err) = validity {
-                return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
+                Err(PgWireError::UserError(Box::new(ErrorInfo::new(
                     "ERROR".to_owned(),
                     "internal_error".to_owned(),
                     format!("[peer]: invalid configuration: {}", validation_err),
                 )))
-                .into());
+                .into())
             } else {
-                return Ok(());
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
For now, uses the `ValidatePeer` gRPC endpoint for SQL Server on the Rust side. Tested for all relevant peers - SQL Server, PG, SF and BQ.
Partially completes #484 