### PR TITLE
remove code for int,timestamp partitioning using min,max values

### DIFF
--- a/flow/connectors/postgres/qrep_partition_test.go
+++ b/flow/connectors/postgres/qrep_partition_test.go
@@ -22,25 +22,6 @@ type testCase struct {
 	wantErr               bool
 }
 
-func newTestCase(schema string, name string, duration uint32, wantErr bool) *testCase {
-	schemaQualifiedTable := fmt.Sprintf("%s.test", schema)
-	query := fmt.Sprintf(
-		`SELECT * FROM %s WHERE "from" >= {{.start}} AND "from" < {{.end}}`,
-		schemaQualifiedTable)
-	return &testCase{
-		name: name,
-		config: &protos.QRepConfig{
-			FlowJobName:          "test_flow_job",
-			BatchDurationSeconds: duration,
-			Query:                query,
-			WatermarkTable:       schemaQualifiedTable,
-			WatermarkColumn:      "from",
-		},
-		want:    []*protos.QRepPartition{},
-		wantErr: wantErr,
-	}
-}
-
 func newTestCaseForNumRows(schema string, name string, rows uint32, expectedNum int) *testCase {
 	schemaQualifiedTable := fmt.Sprintf("%s.test", schema)
 	query := fmt.Sprintf(
@@ -155,47 +136,6 @@ func TestGetQRepPartitions(t *testing.T) {
 
 	// Define the test cases
 	testCases := []*testCase{
-		newTestCase(
-			schemaName,
-			"ensure all days are in 1 partition",
-			secondsInADay*100,
-			false,
-		).appendPartition(
-			time.Date(2010, time.January, 1, 10, 0, 0, 0, time.UTC),
-			time.Date(2010, time.January, 30, 10, 0, 0, 1000, time.UTC),
-		),
-		newTestCase(
-			schemaName,
-			"ensure all days are in 30 partitions",
-			secondsInADay,
-			false,
-		).appendPartitions(
-			time.Date(2010, time.January, 1, 10, 0, 0, 0, time.UTC),
-			time.Date(2010, time.January, 30, 10, 0, 0, 0, time.UTC),
-			29,
-		).appendPartition(
-			time.Date(2010, time.January, 30, 10, 0, 0, 0, time.UTC),
-			time.Date(2010, time.January, 30, 10, 0, 0, 1000, time.UTC),
-		),
-		newTestCase(
-			schemaName,
-			"ensure all days are in 60 partitions",
-			secondsInADay/2,
-			false,
-		).appendPartitions(
-			time.Date(2010, time.January, 1, 10, 0, 0, 0, time.UTC),
-			time.Date(2010, time.January, 30, 10, 0, 0, 0, time.UTC),
-			58,
-		).appendPartition(
-			time.Date(2010, time.January, 30, 10, 0, 0, 0, time.UTC),
-			time.Date(2010, time.January, 30, 10, 0, 0, 1000, time.UTC),
-		),
-		newTestCase(
-			schemaName,
-			"test for error condition with batch size 0",
-			0,
-			true,
-		),
 		newTestCaseForNumRows(
 			schemaName,
 			"ensure all rows are in 1 partition if num_rows_per_partition is size of table",

--- a/flow/e2e/congen.go
+++ b/flow/e2e/congen.go
@@ -199,6 +199,7 @@ func (c *QRepFlowConnectionGenerationConfig) GenerateQRepConfig(
 	ret.WriteMode = &protos.QRepWriteMode{
 		WriteType: protos.QRepWriteType_QREP_WRITE_MODE_APPEND,
 	}
+	ret.NumRowsPerPartition = 1000
 
 	return ret, nil
 }

--- a/flow/e2e/snowflake/qrep_flow_sf_test.go
+++ b/flow/e2e/snowflake/qrep_flow_sf_test.go
@@ -108,7 +108,7 @@ func (s *PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_Upsert_Simple()
 
 	dstSchemaQualified := fmt.Sprintf("%s.%s", s.sfHelper.testSchemaName, tblName)
 
-	query := fmt.Sprintf("SELECT * FROM e2e_test_%s.%s WHERE updated_at >= {{.start}} AND updated_at < {{.end}}",
+	query := fmt.Sprintf("SELECT * FROM e2e_test_%s.%s WHERE updated_at BETWEEN {{.start}} AND {{.end}}",
 		snowflakeSuffix, tblName)
 
 	qrepConfig, err := e2e.CreateQRepWorkflowConfig(
@@ -153,7 +153,7 @@ func (s *PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_S3() {
 
 	dstSchemaQualified := fmt.Sprintf("%s.%s", s.sfHelper.testSchemaName, tblName)
 
-	query := fmt.Sprintf("SELECT * FROM e2e_test_%s.%s WHERE updated_at >= {{.start}} AND updated_at < {{.end}}",
+	query := fmt.Sprintf("SELECT * FROM e2e_test_%s.%s WHERE updated_at BETWEEN {{.start}} AND {{.end}}",
 		snowflakeSuffix, tblName)
 
 	qrepConfig, err := e2e.CreateQRepWorkflowConfig(
@@ -173,7 +173,6 @@ func (s *PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_S3() {
 	// Verify workflow completes without error
 	s.True(env.IsWorkflowCompleted())
 
-	// assert that error contains "invalid connection configs"
 	err = env.GetWorkflowError()
 	s.NoError(err)
 
@@ -218,7 +217,6 @@ func (s *PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_Upsert_XMIN() {
 	// Verify workflow completes without error
 	s.True(env.IsWorkflowCompleted())
 
-	// assert that error contains "invalid connection configs"
 	err = env.GetWorkflowError()
 	s.NoError(err)
 
@@ -240,7 +238,7 @@ func (s *PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_S3_Integration(
 
 	dstSchemaQualified := fmt.Sprintf("%s.%s", s.sfHelper.testSchemaName, tblName)
 
-	query := fmt.Sprintf("SELECT * FROM e2e_test_%s.%s WHERE updated_at >= {{.start}} AND updated_at < {{.end}}",
+	query := fmt.Sprintf("SELECT * FROM e2e_test_%s.%s WHERE updated_at BETWEEN {{.start}} AND {{.end}}",
 		snowflakeSuffix, tblName)
 
 	sfPeer := s.sfHelper.Peer
@@ -263,7 +261,6 @@ func (s *PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_S3_Integration(
 	// Verify workflow completes without error
 	s.True(env.IsWorkflowCompleted())
 
-	// assert that error contains "invalid connection configs"
 	err = env.GetWorkflowError()
 	s.NoError(err)
 

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -262,14 +262,6 @@ func QRepFlowWorkflow(
 		waitBetweenBatches = time.Duration(config.WaitBetweenBatchesSeconds) * time.Second
 	}
 
-	if config.BatchDurationSeconds == 0 {
-		config.BatchDurationSeconds = 60
-	}
-
-	if config.BatchSizeInt == 0 {
-		config.BatchSizeInt = 10000
-	}
-
 	// register a signal handler to terminate the workflow
 	terminateWorkflow := false
 	signalChan := workflow.GetSignalChannel(ctx, shared.CDCFlowSignalName)

--- a/nexus/analyzer/src/qrep.rs
+++ b/nexus/analyzer/src/qrep.rs
@@ -191,7 +191,7 @@ pub fn process_options(
 
     // all options processed have been removed from the map
     // so any leftover keys are options that shouldn't be here
-    if raw_opts.len() > 0 {
+    if !raw_opts.is_empty() {
         anyhow::bail!("Unknown options for QRep mirrors: {:#?}", raw_opts.into_keys().collect::<Vec<&str>>());
     }
 

--- a/nexus/flow-rs/src/grpc.rs
+++ b/nexus/flow-rs/src/grpc.rs
@@ -264,16 +264,6 @@ impl FlowGrpcClient {
                             cfg.wait_between_batches_seconds = n as u32;
                         }
                     }
-                    "batch_size_int" => {
-                        if let Some(n) = n.as_i64() {
-                            cfg.batch_size_int = n as u32;
-                        }
-                    }
-                    "batch_duration_timestamp" => {
-                        if let Some(n) = n.as_i64() {
-                            cfg.batch_duration_seconds = n as u32;
-                        }
-                    }
                     "num_rows_per_partition" => {
                         if let Some(n) = n.as_i64() {
                             cfg.num_rows_per_partition = n as u32;

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -251,7 +251,9 @@ message QRepConfig {
   bool initial_copy_only = 8;
   QRepSyncMode sync_mode = 9;
 
+  // DEPRECATED: eliminate when breaking changes are allowed.
   uint32 batch_size_int = 10;
+  // DEPRECATED: eliminate when breaking changes are allowed.
   uint32 batch_duration_seconds = 11;
 
   uint32 max_parallel_workers = 12;


### PR DESCRIPTION
Only mechanism for partitioning will be `num_rows_per_partition` which is now a mandatory option. Unrecognized options in QRep mirror commands will now cause an error from the SQL interface layer.