### PR TITLE
peerdb-server: use Debian slim over Ubuntu

### DIFF
--- a/scripts/install-protobuf.sh
+++ b/scripts/install-protobuf.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 # install the protobuf compiler
 PROTOBUF_MAJOR_VERSION=3
 PROTOBUF_MINOR_VERSION=23.4
-PROTOBUF_VERSION=${PROTOBUF_MAJOR_VERSION}.${PROTOBUF_MINOR_VERSION}
+PROTOBUF_VERSION="$PROTOBUF_MAJOR_VERSION.$PROTOBUF_MINOR_VERSION"
 ARCH=$(uname -m)
 
 case "$ARCH" in
@@ -17,14 +17,14 @@ case "$ARCH" in
 esac
 echo $ARCH
 # setup the variables for the archive and download url
-PROTOBUF_ARCHIVE=protoc-${PROTOBUF_MINOR_VERSION}-linux-${ARCH}.zip
-PROTOBUF_URL=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_MINOR_VERSION}/${PROTOBUF_ARCHIVE}
+PROTOBUF_ARCHIVE="protoc-$PROTOBUF_MINOR_VERSION-linux-$ARCH.zip"
+PROTOBUF_URL="https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_MINOR_VERSION/$PROTOBUF_ARCHIVE"
 
 mkdir -p /tmp/protoc-install
 pushd /tmp/protoc-install
 
-wget ${PROTOBUF_URL} -O ${PROTOBUF_ARCHIVE}
-unzip ${PROTOBUF_ARCHIVE} -d protoc3
+curl -L "$PROTOBUF_URL" -O
+unzip "$PROTOBUF_ARCHIVE" -d protoc3
 
 mv protoc3/bin/* /usr/local/bin/
 mv protoc3/include/* /usr/local/include/

--- a/stacks/peerdb-server.Dockerfile
+++ b/stacks/peerdb-server.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM lukemathwalker/cargo-chef:latest-rust-1.70-bullseye as chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.70-slim-bookworm as chef
 WORKDIR /root
 
 FROM chef as planner
@@ -12,10 +12,10 @@ FROM chef as builder
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive \
   apt-get install --assume-yes --no-install-recommends \
-  build-essential libssl-dev pkg-config wget unzip
+  build-essential libssl-dev pkg-config curl unzip
 WORKDIR /root/nexus
 COPY scripts /root/scripts
-RUN /bin/bash -c /root/scripts/install-protobuf.sh
+RUN /root/scripts/install-protobuf.sh
 COPY --from=planner /root/nexus/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --recipe-path recipe.json
@@ -25,8 +25,8 @@ COPY protos protos
 WORKDIR /root/nexus
 RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo build --release --bin peerdb-server
 
-FROM ubuntu:22.04
-RUN apt-get update && apt-get install -y ca-certificates postgresql-client wget curl iputils-ping
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates postgresql-client curl iputils-ping
 RUN mkdir -p /var/log/peerdb
 WORKDIR /root
 COPY --from=builder /root/nexus/target/release/peerdb-server .


### PR DESCRIPTION
This makes it consistent with the other docker images

Also remove wget