### PR TITLE
Minor UI Fixes

### DIFF
--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -57,10 +57,10 @@ export const cdcSettings: MirrorSetting[] = [
     stateHandler: (value, setter) =>
       setter((curr: CDCConfig) => ({
         ...curr,
-        snapshotNumTablesInParallel: parseInt(value as string, 10) || 1,
+        snapshotNumTablesInParallel: parseInt(value as string, 10) || 4,
       })),
-    tips: 'Specify the number of tables to sync perform initial load for, in parallel. The default value is 1.',
-    default: '1',
+    tips: 'Specify the number of tables to sync perform initial load for, in parallel. The default value is 4.',
+    default: '4',
     type: 'number',
   },
   {

--- a/ui/app/mirrors/page.tsx
+++ b/ui/app/mirrors/page.tsx
@@ -78,7 +78,13 @@ export default async function Mirrors() {
               href={'/mirrors/create'}
               variant='normalSolid'
             >
-              <div style={{ display: 'flex', alignItems: 'center' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 <Icon name='add' /> <Label>New mirror</Label>
               </div>
             </Button>

--- a/ui/app/mirrors/page.tsx
+++ b/ui/app/mirrors/page.tsx
@@ -21,6 +21,7 @@ const stringifyConfig = (flowArray: any[]) => {
 
 export default async function Mirrors() {
   let mirrors = await prisma.flows.findMany({
+    distinct: 'name',
     include: {
       sourcePeer: true,
       destinationPeer: true,

--- a/ui/app/peers/page.tsx
+++ b/ui/app/peers/page.tsx
@@ -34,8 +34,17 @@ export default async function Peers() {
               href={'/peers/create'}
               variant='normalSolid'
             >
-              <div style={{ display: 'flex', alignItems: 'center' }}>
-                <Icon name='add' /> <Label>New peer</Label>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                <Icon name='add' />
+                <Label style={{ marginLeft: '0.5rem', fontSize: 15 }}>
+                  New peer
+                </Label>
               </div>
             </Button>
           }

--- a/ui/lib/Dialog/Dialog.tsx
+++ b/ui/lib/Dialog/Dialog.tsx
@@ -22,7 +22,12 @@ export function Dialog({
     <RadixDialog.Root {...rootProps}>
       <RadixDialog.Trigger asChild>{TriggerButton}</RadixDialog.Trigger>
       <RadixDialog.Portal>
-        <DialogContent size={size}>{children}</DialogContent>
+        <DialogContent
+          onPointerDownOutside={(e) => e.preventDefault()}
+          size={size}
+        >
+          {children}
+        </DialogContent>
       </RadixDialog.Portal>
     </RadixDialog.Root>
   );


### PR DESCRIPTION
- Sets whitespace to nowrap  for create peer/mirror buttons
- Prevents drop modals from disappearing when clicking outside
- For multi-mirror shows a single flow now
- Sets snapshot parallel tables default to 4