### PR TITLE
Remove use of deprecated github ci command set-output

### DIFF
--- a/.github/workflows/customer-docker.yml
+++ b/.github/workflows/customer-docker.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: depot/setup-action@v1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
@@ -34,12 +34,12 @@ jobs:
 
       - name: Set Short Commit Hash
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: extract branch name suffix for customer
         id: branch
         run: |
-          echo "::set-output name=branch::$(echo $GITHUB_REF | sed -e 's/.*customer-//')"
+          echo "branch=$(echo $GITHUB_REF | sed -e 's/.*customer-//')" >> $GITHUB_OUTPUT
 
       - name: Build (optionally publish) PeerDB Images
         uses: depot/bake-action@v1

--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: depot/setup-action@v1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Set Short Commit Hash
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build (optionally publish) PeerDB Images
         uses: depot/bake-action@v1

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -33,9 +33,10 @@ jobs:
       - name: checkout sources
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ">=1.21.0"
+          cache-dependency-path: flow/go.sum
 
       - name: install gotestsum
         run: |

--- a/.github/workflows/stable-docker.yml
+++ b/.github/workflows/stable-docker.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: depot/setup-action@v1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}


### PR DESCRIPTION
Also update Actions setup-go & login-action

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands