### PR TITLE
Mirror Overview UI

### DIFF
--- a/ui/app/mirrors/create/schema.ts
+++ b/ui/app/mirrors/create/schema.ts
@@ -6,8 +6,9 @@ export const flowNameSchema = z
     required_error: 'Mirror name is required.',
   })
   .min(1, { message: 'Mirror name cannot be empty.' })
-  .regex(/^[\w]*$/, {
-    message: 'Mirror name must contain only letters, numbers and underscores',
+  .regex(/^[a-z0-9_]*$/, {
+    message:
+      'Mirror name must contain only lowercase letters, numbers and underscores',
   });
 
 export const tableMappingSchema = z

--- a/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
+++ b/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
@@ -21,7 +21,6 @@ function aggregateCountsByInterval(
       timeUnit = 'YYYY-MM';
       break;
     case 'day':
-    case 'week':
       timeUnit = 'YYYY-MM-DD';
       break;
     case '1min':
@@ -37,7 +36,7 @@ function aggregateCountsByInterval(
 
   // Iterate through the timestamps and populate the aggregatedCounts object
   for (let { timestamp, count } of timestamps) {
-    const date = roundUpToNearest15Minutes(timestamp);
+    const date = roundUpToNearestNMinutes(timestamp, 15);
     const formattedTimestamp = moment(date).format(timeUnit);
 
     if (!aggregatedCounts[formattedTimestamp]) {
@@ -53,7 +52,10 @@ function aggregateCountsByInterval(
   let currentTimestamp = new Date();
 
   if (interval === '15min') {
-    currentTimestamp = roundUpToNearest15Minutes(currentTimestamp);
+    currentTimestamp = roundUpToNearestNMinutes(currentTimestamp, 15);
+  }
+  if (interval === '5min') {
+    currentTimestamp = roundUpToNearestNMinutes(currentTimestamp, 5);
   }
 
   while (intervals.length < 30) {
@@ -78,13 +80,13 @@ function aggregateCountsByInterval(
   return resultArray;
 }
 
-function roundUpToNearest15Minutes(date: Date) {
+function roundUpToNearestNMinutes(date: Date, N: number) {
   const minutes = date.getMinutes();
-  const remainder = minutes % 15;
+  const remainder = minutes % N;
 
   if (remainder > 0) {
-    // Round up to the nearest 15 minutes
-    date.setMinutes(minutes + (15 - remainder));
+    // Round up to the nearest N minutes
+    date.setMinutes(minutes + (N - remainder));
   }
 
   // Reset seconds and milliseconds to zero to maintain the same time

--- a/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
+++ b/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
@@ -21,16 +21,12 @@ function aggregateCountsByInterval(
       timeUnit = 'YYYY-MM';
       break;
     case 'day':
+    case 'week':
       timeUnit = 'YYYY-MM-DD';
       break;
     case '1min':
-      timeUnit = 'YYYY-MM-DD HH:mm';
-      break;
     case '5min':
       timeUnit = 'YYYY-MM-DD HH:mm';
-      break;
-    case 'week':
-      timeUnit = 'YYYY-MM-DD';
       break;
     default:
       throw new Error('Invalid interval provided');

--- a/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
+++ b/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
@@ -23,6 +23,15 @@ function aggregateCountsByInterval(
     case 'day':
       timeUnit = 'YYYY-MM-DD';
       break;
+    case '1min':
+      timeUnit = 'YYYY-MM-DD HH:mm';
+      break;
+    case '5min':
+      timeUnit = 'YYYY-MM-DD HH:mm';
+      break;
+    case 'week':
+      timeUnit = 'YYYY-MM-DD';
+      break;
     default:
       throw new Error('Invalid interval provided');
   }

--- a/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
@@ -277,9 +277,7 @@ export function CDCMirror({
   createdAt,
   syncStatusChild,
 }: CDCMirrorStatusProps) {
-  const [selectedTab, setSelectedTab] = useState(
-    localStorage?.getItem('mirrortab') || 'tab1'
-  );
+  const [selectedTab, setSelectedTab] = useState('');
 
   let snapshot = <></>;
   if (cdc.snapshotStatus) {
@@ -291,10 +289,16 @@ export function CDCMirror({
     setSelectedTab(tabVal);
   };
 
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setSelectedTab(localStorage?.getItem('mirrortab') || 'tab1');
+    }
+  }, []);
+
   return (
     <Tabs.Root
       className='flex flex-col w-full'
-      defaultValue={selectedTab}
+      value={selectedTab}
       onValueChange={(val) => handleTab(val)}
       style={{ marginTop: '2rem' }}
     >

--- a/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
@@ -1,16 +1,24 @@
 'use client';
 
 import TimeLabel from '@/components/TimeComponent';
-import { QRepMirrorStatus, SnapshotStatus } from '@/grpc_generated/route';
+import {
+  CDCMirrorStatus,
+  QRepMirrorStatus,
+  SnapshotStatus,
+} from '@/grpc_generated/route';
 import { Button } from '@/lib/Button';
 import { Icon } from '@/lib/Icon';
 import { Label } from '@/lib/Label';
 import { ProgressBar } from '@/lib/ProgressBar';
 import { SearchField } from '@/lib/SearchField';
 import { Table, TableCell, TableRow } from '@/lib/Table';
+import * as Tabs from '@radix-ui/react-tabs';
 import moment, { Duration, Moment } from 'moment';
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import ReactSelect from 'react-select';
+import styled from 'styled-components';
+import CdcDetails from './cdcDetails';
 
 class TableCloneSummary {
   flowJobName: string;
@@ -87,17 +95,59 @@ function summarizeTableClone(clone: QRepMirrorStatus): TableCloneSummary {
 type SnapshotStatusProps = {
   status: SnapshotStatus;
 };
+
+const ROWS_PER_PAGE = 6;
 export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
-  const [searchQuery, setSearchQuery] = useState<string>('');
-  const snapshotRows = useMemo(
-    () =>
-      status.clones
-        .map(summarizeTableClone)
-        .filter((row: any) =>
-          row.tableName.toLowerCase().includes(searchQuery.toLowerCase())
-        ),
-    [status.clones, searchQuery]
+  const allRows = status.clones.map(summarizeTableClone);
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const totalPages = Math.ceil(allRows.length / ROWS_PER_PAGE);
+
+  const startRow = (currentPage - 1) * ROWS_PER_PAGE;
+  const endRow = startRow + ROWS_PER_PAGE;
+  const [displayedRows, setDisplayedRows] = useState(
+    allRows.slice(startRow, endRow)
   );
+  const handlePrevPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+      const newStartRow = (currentPage - 2) * ROWS_PER_PAGE;
+      const newEndRow = newStartRow + ROWS_PER_PAGE;
+      setDisplayedRows(allRows.slice(newStartRow, newEndRow));
+    }
+  };
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage(currentPage + 1);
+      const newStartRow = currentPage * ROWS_PER_PAGE;
+      const newEndRow = newStartRow + ROWS_PER_PAGE;
+      setDisplayedRows(allRows.slice(newStartRow, newEndRow));
+    }
+  };
+
+  const handleSort = (sortField: 'cloneStartTime' | 'avgTimePerPartition') => {
+    const sortedRows = [...displayedRows].sort((a, b) => {
+      const aValue = a[sortField];
+      const bValue = b[sortField];
+      if (aValue === null || bValue === null) {
+        return 0;
+      }
+
+      if (aValue < bValue) {
+        return -1;
+      } else if (aValue > bValue) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+    setDisplayedRows(sortedRows);
+  };
+
+  useEffect(() => {
+    handleSort('cloneStartTime');
+  }, []);
 
   return (
     <div style={{ marginTop: '2rem' }}>
@@ -106,18 +156,32 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
         toolbar={{
           left: (
             <>
-              <Button variant='normalBorderless'>
+              <Button variant='normalBorderless' onClick={handlePrevPage}>
                 <Icon name='chevron_left' />
               </Button>
-              <Button variant='normalBorderless'>
+              <Button variant='normalBorderless' onClick={handleNextPage}>
                 <Icon name='chevron_right' />
               </Button>
+              <Label>{`${currentPage} of ${totalPages}`}</Label>
               <Button
                 variant='normalBorderless'
                 onClick={() => window.location.reload()}
               >
                 <Icon name='refresh' />
               </Button>
+              <ReactSelect
+                options={[
+                  { value: 'cloneStartTime', label: 'Start Time' },
+                  { value: 'avgTimePerPartition', label: 'Time Per Partition' },
+                ]}
+                onChange={(val, _) =>
+                  handleSort(
+                    (val?.value as 'cloneStartTime' | 'avgTimePerPartition') ??
+                      'cloneStartTime'
+                  )
+                }
+                defaultValue={{ value: 'cloneStartTime', label: 'Start Time' }}
+              />
             </>
           ),
           right: (
@@ -139,7 +203,7 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
           </TableRow>
         }
       >
-        {snapshotRows.map((clone, index) => (
+        {displayedRows.map((clone, index) => (
           <TableRow key={index}>
             <TableCell>
               <Label>
@@ -179,3 +243,98 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
     </div>
   );
 };
+
+const Trigger = styled(
+  ({ isActive, ...props }: { isActive?: boolean } & Tabs.TabsTriggerProps) => (
+    <Tabs.Trigger {...props} />
+  )
+)<{ isActive?: boolean }>`
+  background-color: ${({ theme, isActive }) =>
+    isActive ? theme.colors.accent.surface.selected : 'white'};
+
+  font-weight: ${({ isActive }) => (isActive ? 'bold' : 'normal')};
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.accent.text.highContrast};
+  }
+`;
+
+type SyncStatusRow = {
+  batchId: number;
+  startTime: Date;
+  endTime: Date | null;
+  numRows: number;
+};
+
+type CDCMirrorStatusProps = {
+  cdc: CDCMirrorStatus;
+  rows: SyncStatusRow[];
+  createdAt?: Date;
+  syncStatusChild?: React.ReactNode;
+};
+export function CDCMirror({
+  cdc,
+  rows,
+  createdAt,
+  syncStatusChild,
+}: CDCMirrorStatusProps) {
+  const [selectedTab, setSelectedTab] = useState(
+    localStorage?.getItem('mirrortab') || 'tab1'
+  );
+
+  let snapshot = <></>;
+  if (cdc.snapshotStatus) {
+    snapshot = <SnapshotStatusTable status={cdc.snapshotStatus} />;
+  }
+
+  const handleTab = (tabVal: string) => {
+    localStorage.setItem('mirrortab', tabVal);
+    setSelectedTab(tabVal);
+  };
+
+  return (
+    <Tabs.Root
+      className='flex flex-col w-full'
+      defaultValue={selectedTab}
+      onValueChange={(val) => handleTab(val)}
+      style={{ marginTop: '2rem' }}
+    >
+      <Tabs.List className='flex border-b' aria-label='Details'>
+        <Trigger
+          isActive={selectedTab === 'tab1'}
+          className='flex-1 px-5 h-[45px] flex items-center justify-center text-sm focus:shadow-outline focus:outline-none'
+          value='tab1'
+        >
+          Overview
+        </Trigger>
+        <Trigger
+          isActive={selectedTab === 'tab2'}
+          className='flex-1 px-5 h-[45px] flex items-center justify-center text-sm focus:shadow-outline focus:outline-none'
+          value='tab2'
+        >
+          Sync Status
+        </Trigger>
+        <Trigger
+          isActive={selectedTab === 'tab3'}
+          className='flex-1 px-5 h-[45px] flex items-center justify-center text-sm focus:shadow-outline focus:outline-none'
+          value='tab3'
+        >
+          Initial Copy
+        </Trigger>
+      </Tabs.List>
+      <Tabs.Content className='p-5 rounded-b-md' value='tab1'>
+        <CdcDetails
+          syncs={rows}
+          createdAt={createdAt}
+          mirrorConfig={cdc.config}
+        />
+      </Tabs.Content>
+      <Tabs.Content className='p-5 rounded-b-md' value='tab2'>
+        {syncStatusChild}
+      </Tabs.Content>
+      <Tabs.Content className='p-5 rounded-b-md' value='tab3'>
+        {snapshot}
+      </Tabs.Content>
+    </Tabs.Root>
+  );
+}

--- a/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
@@ -96,7 +96,7 @@ type SnapshotStatusProps = {
   status: SnapshotStatus;
 };
 
-const ROWS_PER_PAGE = 6;
+const ROWS_PER_PAGE = 10;
 export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
   const allRows = status.clones.map(summarizeTableClone);
   const [sortField, setSortField] = useState<
@@ -107,9 +107,10 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
 
   const startRow = (currentPage - 1) * ROWS_PER_PAGE;
   const endRow = startRow + ROWS_PER_PAGE;
-  const [displayedRows, setDisplayedRows] = useState(
+  const [displayedRows, setDisplayedRows] = useState(() =>
     allRows.slice(startRow, endRow)
   );
+
   const handlePrevPage = () => {
     if (currentPage > 1) {
       setCurrentPage(currentPage - 1);
@@ -186,7 +187,6 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
                     (val?.value as 'cloneStartTime' | 'avgTimePerPartition') ??
                     'cloneStartTime';
                   setSortField(sortVal);
-                  handleSort(sortVal);
                 }}
                 value={{
                   value: sortField,

--- a/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
@@ -15,7 +15,7 @@ import { Table, TableCell, TableRow } from '@/lib/Table';
 import * as Tabs from '@radix-ui/react-tabs';
 import moment, { Duration, Moment } from 'moment';
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import ReactSelect from 'react-select';
 import styled from 'styled-components';
 import CdcDetails from './cdcDetails';
@@ -126,28 +126,32 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
     }
   };
 
-  const handleSort = (sortField: 'cloneStartTime' | 'avgTimePerPartition') => {
-    const sortedRows = [...displayedRows].sort((a, b) => {
-      const aValue = a[sortField];
-      const bValue = b[sortField];
-      if (aValue === null || bValue === null) {
-        return 0;
-      }
+  const handleSort = useCallback(
+    (sortField: 'cloneStartTime' | 'avgTimePerPartition') => {
+      setDisplayedRows((currRows) =>
+        [...currRows].sort((a, b) => {
+          const aValue = a[sortField];
+          const bValue = b[sortField];
+          if (aValue === null || bValue === null) {
+            return 0;
+          }
 
-      if (aValue < bValue) {
-        return -1;
-      } else if (aValue > bValue) {
-        return 1;
-      } else {
-        return 0;
-      }
-    });
-    setDisplayedRows(sortedRows);
-  };
+          if (aValue < bValue) {
+            return -1;
+          } else if (aValue > bValue) {
+            return 1;
+          } else {
+            return 0;
+          }
+        })
+      );
+    },
+    [setDisplayedRows]
+  );
 
   useEffect(() => {
     handleSort('cloneStartTime');
-  }, []);
+  }, [handleSort]);
 
   return (
     <div style={{ marginTop: '2rem' }}>
@@ -216,16 +220,11 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
               </Label>
             </TableCell>
             <TableCell>
-              <Label>
-                {
-                  <TimeLabel
-                    timeVal={
-                      clone.cloneStartTime?.format('YYYY-MM-DD HH:mm:ss') ||
-                      'N/A'
-                    }
-                  />
+              <TimeLabel
+                timeVal={
+                  clone.cloneStartTime?.format('YYYY-MM-DD HH:mm:ss') || 'N/A'
                 }
-              </Label>
+              />
             </TableCell>
             <TableCell>
               <ProgressBar progress={clone.getPartitionProgressPercentage()} />

--- a/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
@@ -99,7 +99,9 @@ type SnapshotStatusProps = {
 const ROWS_PER_PAGE = 6;
 export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
   const allRows = status.clones.map(summarizeTableClone);
-
+  const [sortField, setSortField] = useState<
+    'cloneStartTime' | 'avgTimePerPartition'
+  >('cloneStartTime');
   const [currentPage, setCurrentPage] = useState(1);
   const totalPages = Math.ceil(allRows.length / ROWS_PER_PAGE);
 
@@ -127,11 +129,11 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
   };
 
   const handleSort = useCallback(
-    (sortField: 'cloneStartTime' | 'avgTimePerPartition') => {
+    (sortOption: 'cloneStartTime' | 'avgTimePerPartition') => {
       setDisplayedRows((currRows) =>
         [...currRows].sort((a, b) => {
-          const aValue = a[sortField];
-          const bValue = b[sortField];
+          const aValue = a[sortOption];
+          const bValue = b[sortOption];
           if (aValue === null || bValue === null) {
             return 0;
           }
@@ -150,9 +152,13 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
   );
 
   useEffect(() => {
-    handleSort('cloneStartTime');
-  }, [handleSort]);
+    handleSort(sortField);
+  }, [handleSort, currentPage, sortField]);
 
+  const sortOptions = [
+    { value: 'cloneStartTime', label: 'Start Time' },
+    { value: 'avgTimePerPartition', label: 'Time Per Partition' },
+  ];
   return (
     <div style={{ marginTop: '2rem' }}>
       <Table
@@ -174,16 +180,19 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
                 <Icon name='refresh' />
               </Button>
               <ReactSelect
-                options={[
-                  { value: 'cloneStartTime', label: 'Start Time' },
-                  { value: 'avgTimePerPartition', label: 'Time Per Partition' },
-                ]}
-                onChange={(val, _) =>
-                  handleSort(
+                options={sortOptions}
+                onChange={(val, _) => {
+                  const sortVal =
                     (val?.value as 'cloneStartTime' | 'avgTimePerPartition') ??
-                      'cloneStartTime'
-                  )
-                }
+                    'cloneStartTime';
+                  setSortField(sortVal);
+                  handleSort(sortVal);
+                }}
+                value={{
+                  value: sortField,
+                  label: sortOptions.find((opt) => opt.value === sortField)
+                    ?.label,
+                }}
                 defaultValue={{ value: 'cloneStartTime', label: 'Start Time' }}
               />
             </>

--- a/ui/app/mirrors/edit/[mirrorId]/cdcDetails.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdcDetails.tsx
@@ -1,4 +1,5 @@
 'use client';
+import MirrorInfo from '@/components/MirrorInfo';
 import PeerButton from '@/components/PeerComponent';
 import TimeLabel from '@/components/TimeComponent';
 import { FlowConnectionConfigs } from '@/grpc_generated/flow';
@@ -7,7 +8,8 @@ import { Badge } from '@/lib/Badge';
 import { Icon } from '@/lib/Icon';
 import { Label } from '@/lib/Label';
 import moment from 'moment';
-import CdcGraph from './cdcGraph';
+import MirrorValues from './configValues';
+import TablePairs from './tablePairs';
 
 type SyncStatusRow = {
   batchId: number;
@@ -113,109 +115,19 @@ function CdcDetails({ syncs, createdAt, mirrorConfig }: props) {
               <Label variant='body'>{numberWithCommas(rowsSynced)}</Label>
             </div>
           </div>
-        </div>
-      </div>
 
-      <div className='mt-10'>
-        <CdcGraph syncs={syncs} />
-      </div>
-
-      <div
-        style={{ display: 'flex', flexDirection: 'column', marginTop: '1rem' }}
-      >
-        <div className='mt-5'>
-          <Label colorName='lowContrast'>Mirror Configuration</Label>
-          <div
-            style={{
-              width: 'fit-content',
-              display: 'flex',
-              rowGap: '0.5rem',
-              flexDirection: 'column',
-            }}
-          >
-            <div
-              className='bg-white rounded-lg p-1'
-              style={{ border: '1px solid #ddd' }}
-            >
-              <Label variant='subheadline' colorName='lowContrast'>
-                Pull Batch Size:
-              </Label>
-              <Label variant='body'>{mirrorConfig?.maxBatchSize}</Label>
-            </div>
-            <div
-              className='bg-white rounded-lg p-1'
-              style={{ border: '1px solid #ddd' }}
-            >
-              <Label variant='subheadline' colorName='lowContrast'>
-                Snapshot Rows Per Partition:
-              </Label>
-              <Label variant='body'>
-                {mirrorConfig?.snapshotNumRowsPerPartition}
-              </Label>
-            </div>
-            <div
-              className='bg-white rounded-lg p-1'
-              style={{ border: '1px solid #ddd' }}
-            >
-              <Label variant='subheadline' colorName='lowContrast'>
-                Snapshot Parallel Workers:
-              </Label>
-              <Label variant='body'>
-                {mirrorConfig?.snapshotMaxParallelWorkers}
-              </Label>
-            </div>
-            <div
-              className='bg-white rounded-lg p-1'
-              style={{ border: '1px solid #ddd' }}
-            >
-              <Label variant='subheadline' colorName='lowContrast'>
-                Snapshot Tables In Parallel:
-              </Label>
-              <Label variant='body'>
-                {mirrorConfig?.snapshotNumTablesInParallel}
-              </Label>
-            </div>
+          <div className='basis-1/4'>
+            <MirrorInfo configs={MirrorValues(mirrorConfig)} />
           </div>
         </div>
-        <table
-          style={{
-            marginTop: '1rem',
-            borderCollapse: 'collapse',
-            width: '100%',
-          }}
-        >
-          <thead>
-            <tr style={{ borderBottom: '1px solid #ddd' }}>
-              <th style={{ textAlign: 'left', padding: '0.5rem' }}>
-                Source Table
-              </th>
-              <th style={{ textAlign: 'left', padding: '0.5rem' }}>
-                Destination Table
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {tablesSynced?.map((table) => (
-              <tr
-                key={`${table.sourceTableIdentifier}.${table.destinationTableIdentifier}`}
-                style={{ borderBottom: '1px solid #ddd' }}
-              >
-                <td style={{ padding: '0.5rem' }}>
-                  {table.sourceTableIdentifier}
-                </td>
-                <td style={{ padding: '0.5rem' }}>
-                  {table.destinationTableIdentifier}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
       </div>
+
+      <TablePairs tables={tablesSynced} />
     </>
   );
 }
 
-function numberWithCommas(x: Number): string {
+export function numberWithCommas(x: any): string {
   return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 

--- a/ui/app/mirrors/edit/[mirrorId]/cdcDetails.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdcDetails.tsx
@@ -121,37 +121,91 @@ function CdcDetails({ syncs, createdAt, mirrorConfig }: props) {
       </div>
 
       <div
-        style={{ display: 'flex', flexDirection: 'column', marginTop: '2rem' }}
+        style={{ display: 'flex', flexDirection: 'column', marginTop: '1rem' }}
       >
-        <Label colorName='lowContrast'>Mirror Configuration</Label>
-        <Label variant='subheadline'>
-          Pull Batch Size: {mirrorConfig?.maxBatchSize}
-        </Label>
-        <Label variant='subheadline'>
-          Snapshot Rows Per Partition:{' '}
-          {mirrorConfig?.snapshotNumRowsPerPartition}
-        </Label>
-        <Label variant='subheadline'>
-          Snapshot Parallel Workers: {mirrorConfig?.snapshotMaxParallelWorkers}
-        </Label>
-        <Label variant='subheadline'>
-          Snapshot Tables In Parallel:{' '}
-          {mirrorConfig?.snapshotNumTablesInParallel}
-        </Label>
-        <table style={{ marginTop: '1rem' }}>
+        <div className='mt-5'>
+          <Label colorName='lowContrast'>Mirror Configuration</Label>
+          <div
+            style={{
+              width: 'fit-content',
+              display: 'flex',
+              rowGap: '0.5rem',
+              flexDirection: 'column',
+            }}
+          >
+            <div
+              className='bg-white rounded-lg p-1'
+              style={{ border: '1px solid #ddd' }}
+            >
+              <Label variant='subheadline' colorName='lowContrast'>
+                Pull Batch Size:
+              </Label>
+              <Label variant='body'>{mirrorConfig?.maxBatchSize}</Label>
+            </div>
+            <div
+              className='bg-white rounded-lg p-1'
+              style={{ border: '1px solid #ddd' }}
+            >
+              <Label variant='subheadline' colorName='lowContrast'>
+                Snapshot Rows Per Partition:
+              </Label>
+              <Label variant='body'>
+                {mirrorConfig?.snapshotNumRowsPerPartition}
+              </Label>
+            </div>
+            <div
+              className='bg-white rounded-lg p-1'
+              style={{ border: '1px solid #ddd' }}
+            >
+              <Label variant='subheadline' colorName='lowContrast'>
+                Snapshot Parallel Workers:
+              </Label>
+              <Label variant='body'>
+                {mirrorConfig?.snapshotMaxParallelWorkers}
+              </Label>
+            </div>
+            <div
+              className='bg-white rounded-lg p-1'
+              style={{ border: '1px solid #ddd' }}
+            >
+              <Label variant='subheadline' colorName='lowContrast'>
+                Snapshot Tables In Parallel:
+              </Label>
+              <Label variant='body'>
+                {mirrorConfig?.snapshotNumTablesInParallel}
+              </Label>
+            </div>
+          </div>
+        </div>
+        <table
+          style={{
+            marginTop: '1rem',
+            borderCollapse: 'collapse',
+            width: '100%',
+          }}
+        >
           <thead>
-            <tr>
-              <th style={{ textAlign: 'left' }}>Source Table</th>
-              <th style={{ textAlign: 'left' }}>Destination Table</th>
+            <tr style={{ borderBottom: '1px solid #ddd' }}>
+              <th style={{ textAlign: 'left', padding: '0.5rem' }}>
+                Source Table
+              </th>
+              <th style={{ textAlign: 'left', padding: '0.5rem' }}>
+                Destination Table
+              </th>
             </tr>
           </thead>
           <tbody>
             {tablesSynced?.map((table) => (
               <tr
                 key={`${table.sourceTableIdentifier}.${table.destinationTableIdentifier}`}
+                style={{ borderBottom: '1px solid #ddd' }}
               >
-                <td>{table.sourceTableIdentifier}</td>
-                <td>{table.destinationTableIdentifier}</td>
+                <td style={{ padding: '0.5rem' }}>
+                  {table.sourceTableIdentifier}
+                </td>
+                <td style={{ padding: '0.5rem' }}>
+                  {table.destinationTableIdentifier}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
@@ -55,7 +55,6 @@ function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
           placeholder='Select a timeframe'
           options={timeOptions}
           defaultValue={{ label: 'hour', value: 'hour' }}
-          defaultInputValue={'hour'}
           onChange={(val, _) => val && setAggregateType(val.value)}
         />
       </div>

--- a/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
@@ -1,7 +1,7 @@
 import { Label } from '@/lib/Label';
 import moment from 'moment';
 import { useEffect, useState } from 'react';
-
+import ReactSelect from 'react-select';
 type SyncStatusRow = {
   batchId: number;
   startTime: Date;
@@ -13,9 +13,12 @@ import aggregateCountsByInterval from './aggregatedCountsByInterval';
 
 const aggregateTypeMap: { [key: string]: string } = {
   '15min': ' 15 mins',
+  '5min': '5 mins',
+  '1min': '1 min',
   hour: 'Hour',
   day: 'Day',
   month: 'Month',
+  week: 'Week',
 };
 
 function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
@@ -35,21 +38,28 @@ function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
     setCounts(counts);
   }, [aggregateType, syncs]);
 
+  const timeOptions = [
+    { label: '1min', value: '1min' },
+    { label: '5min', value: '5min' },
+    { label: '15min', value: '15min' },
+    { label: 'hour', value: 'hour' },
+    { label: 'day', value: 'day' },
+    { label: 'week', value: 'week' },
+    { label: 'month', value: 'month' },
+  ];
   return (
     <div>
       <div className='float-right'>
-        {['15min', 'hour', 'day', 'month'].map((type) => {
-          return (
-            <FilterButton
-              key={type}
-              aggregateType={type}
-              selectedAggregateType={aggregateType}
-              setAggregateType={setAggregateType}
-            />
-          );
-        })}
+        <ReactSelect
+          id={aggregateType}
+          placeholder='Select a timeframe'
+          options={timeOptions}
+          defaultValue={{ label: 'hour', value: 'hour' }}
+          defaultInputValue={'hour'}
+          onChange={(val, _) => val && setAggregateType(val.value)}
+        />
       </div>
-      <div>
+      <div style={{ height: '3rem' }}>
         <Label variant='body'>Sync history</Label>
       </div>
       <div className='flex space-x-2 justify-left ml-2'>
@@ -65,30 +75,6 @@ function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
   );
 }
 
-type filterButtonProps = {
-  aggregateType: string;
-  selectedAggregateType: string;
-  setAggregateType: Function;
-};
-function FilterButton({
-  aggregateType,
-  selectedAggregateType,
-  setAggregateType,
-}: filterButtonProps): React.ReactNode {
-  return (
-    <button
-      className={
-        aggregateType === selectedAggregateType
-          ? 'bg-gray-200 px-1 mx-1 rounded-md'
-          : 'px-1 mx-1'
-      }
-      onClick={() => setAggregateType(aggregateType)}
-    >
-      {aggregateTypeMap[aggregateType]}
-    </button>
-  );
-}
-
 function formatGraphLabel(date: Date, aggregateType: String): string {
   switch (aggregateType) {
     case '15min':
@@ -99,6 +85,12 @@ function formatGraphLabel(date: Date, aggregateType: String): string {
       return moment(date).format('MMM Do');
     case 'month':
       return moment(date).format('MMM yy');
+    case 'week':
+      return moment(date).format('MMM Do');
+    case '5min':
+      return moment(date).format('MMM Do HH:mm');
+    case '1min':
+      return moment(date).format('MMM Do HH:mm');
     default:
       return 'Unknown aggregate type: ' + aggregateType;
   }

--- a/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
@@ -35,7 +35,6 @@ function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
     { label: '15min', value: '15min' },
     { label: 'hour', value: 'hour' },
     { label: 'day', value: 'day' },
-    { label: 'week', value: 'week' },
     { label: 'month', value: 'month' },
   ];
   return (
@@ -67,20 +66,15 @@ function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
 
 function formatGraphLabel(date: Date, aggregateType: String): string {
   switch (aggregateType) {
+    case '1min':
+    case '5min':
     case '15min':
-      return moment(date).format('MMM Do HH:mm');
     case 'hour':
       return moment(date).format('MMM Do HH:mm');
     case 'day':
       return moment(date).format('MMM Do');
     case 'month':
       return moment(date).format('MMM yy');
-    case 'week':
-      return moment(date).format('MMM Do');
-    case '5min':
-      return moment(date).format('MMM Do HH:mm');
-    case '1min':
-      return moment(date).format('MMM Do HH:mm');
     default:
       return 'Unknown aggregate type: ' + aggregateType;
   }

--- a/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { Label } from '@/lib/Label';
 import moment from 'moment';
 import { useEffect, useState } from 'react';
@@ -10,16 +11,6 @@ type SyncStatusRow = {
 };
 
 import aggregateCountsByInterval from './aggregatedCountsByInterval';
-
-const aggregateTypeMap: { [key: string]: string } = {
-  '15min': ' 15 mins',
-  '5min': '5 mins',
-  '1min': '1 min',
-  hour: 'Hour',
-  day: 'Day',
-  month: 'Month',
-  week: 'Week',
-};
 
 function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
   let [aggregateType, setAggregateType] = useState('hour');

--- a/ui/app/mirrors/edit/[mirrorId]/configValues.ts
+++ b/ui/app/mirrors/edit/[mirrorId]/configValues.ts
@@ -1,0 +1,57 @@
+import { FlowConnectionConfigs, QRepSyncMode } from '@/grpc_generated/flow';
+
+const syncModeToLabel = (mode: QRepSyncMode) => {
+  switch (mode) {
+    case QRepSyncMode.QREP_SYNC_MODE_STORAGE_AVRO:
+      return 'AVRO';
+    case QRepSyncMode.QREP_SYNC_MODE_MULTI_INSERT:
+      return 'Copy with Binary';
+    default:
+      return 'AVRO';
+  }
+};
+const MirrorValues = (mirrorConfig: FlowConnectionConfigs | undefined) => {
+  return [
+    {
+      value: `${mirrorConfig?.maxBatchSize} rows`,
+      label: 'Pull Batch Size',
+    },
+    {
+      value: `${mirrorConfig?.snapshotNumRowsPerPartition} rows`,
+      label: 'Snapshot Rows Per Partition',
+    },
+    {
+      value: `${mirrorConfig?.snapshotNumTablesInParallel} table(s)`,
+      label: 'Snapshot Tables In Parallel',
+    },
+    {
+      value: `${mirrorConfig?.snapshotMaxParallelWorkers} worker(s)`,
+      label: 'Snapshot Parallel Tables',
+    },
+    {
+      value: `${syncModeToLabel(mirrorConfig?.cdcSyncMode!)} mode`,
+      label: 'CDC Sync Mode',
+    },
+    {
+      value: `${syncModeToLabel(mirrorConfig?.snapshotSyncMode!)} mode`,
+      label: 'Snapshot Sync Mode',
+    },
+    {
+      value: `${
+        mirrorConfig?.cdcStagingPath?.length
+          ? mirrorConfig?.cdcStagingPath
+          : 'Local'
+      }`,
+      label: 'CDC Staging Path',
+    },
+    {
+      value: `${
+        mirrorConfig?.snapshotStagingPath?.length
+          ? mirrorConfig?.snapshotStagingPath
+          : 'Local'
+      }`,
+      label: 'Snapshot Staging Path',
+    },
+  ];
+};
+export default MirrorValues;

--- a/ui/app/mirrors/edit/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/page.tsx
@@ -33,13 +33,6 @@ export default async function EditMirror({
     return <div>No mirror status found!</div>;
   }
 
-  let syncStatusChild = <></>;
-  if (mirrorStatus.cdcStatus) {
-    syncStatusChild = <SyncStatus flowJobName={mirrorId} />;
-  } else {
-    redirect(`/mirrors/status/qrep/${mirrorId}`);
-  }
-
   let createdAt = await prisma.flows.findFirst({
     select: {
       created_at: true,
@@ -60,6 +53,16 @@ export default async function EditMirror({
       start_time: 'desc',
     },
   });
+
+  let syncStatusChild = <></>;
+  if (mirrorStatus.cdcStatus) {
+    let rowsSynced = syncs.reduce((acc, sync) => acc + sync.rows_in_batch, 0);
+    syncStatusChild = (
+      <SyncStatus rowsSynced={rowsSynced} flowJobName={mirrorId} />
+    );
+  } else {
+    redirect(`/mirrors/status/qrep/${mirrorId}`);
+  }
 
   const rows = syncs.map((sync) => ({
     batchId: sync.id,

--- a/ui/app/mirrors/edit/[mirrorId]/syncStatus.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/syncStatus.tsx
@@ -1,11 +1,20 @@
 import prisma from '@/app/utils/prisma';
+import { Label } from '@/lib/Label';
+import CdcGraph from './cdcGraph';
 import { SyncStatusTable } from './syncStatusTable';
 
+function numberWithCommas(x: Number): string {
+  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
 type SyncStatusProps = {
   flowJobName: string | undefined;
+  rowsSynced: Number;
 };
 
-export default async function SyncStatus({ flowJobName }: SyncStatusProps) {
+export default async function SyncStatus({
+  flowJobName,
+  rowsSynced,
+}: SyncStatusProps) {
   if (!flowJobName) {
     return <div>Flow job name not provided!</div>;
   }
@@ -31,6 +40,20 @@ export default async function SyncStatus({ flowJobName }: SyncStatusProps) {
 
   return (
     <div>
+      <div className='flex items-center'>
+        <div>
+          <Label as='label' style={{ fontSize: 16 }}>
+            Rows synced:
+          </Label>
+        </div>
+        <div className='ml-4'>
+          <Label style={{ fontSize: 16 }}>{numberWithCommas(rowsSynced)}</Label>
+        </div>
+      </div>
+
+      <div className='my-10'>
+        <CdcGraph syncs={rows} />
+      </div>
       <SyncStatusTable rows={rows} />
     </div>
   );

--- a/ui/app/mirrors/edit/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/syncStatusTable.tsx
@@ -63,13 +63,10 @@ export const SyncStatusTable = ({ rows }: SyncStatusTableProps) => {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const startRow = (currentPage - 1) * ROWS_PER_PAGE;
   const endRow = startRow + ROWS_PER_PAGE;
-  const displayedRows = useMemo(() => {
-    const allRows = rows.slice(startRow, endRow);
-    const shownRows = allRows.filter(
-      (row: any) => row.batchId == parseInt(searchQuery, 10)
-    );
-    return shownRows.length > 0 ? shownRows : allRows;
-  }, [searchQuery, endRow, startRow, rows]);
+  const allRows = rows.slice(startRow, endRow);
+  const [displayedRows, setDisplayedRows] = useState(() =>
+    rows.slice(startRow, endRow)
+  );
   const handlePrevPage = () => {
     if (currentPage > 1) {
       setCurrentPage(currentPage - 1);

--- a/ui/app/mirrors/edit/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/syncStatusTable.tsx
@@ -8,7 +8,7 @@ import { ProgressCircle } from '@/lib/ProgressCircle';
 import { SearchField } from '@/lib/SearchField';
 import { Table, TableCell, TableRow } from '@/lib/Table';
 import moment from 'moment';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import ReactSelect from 'react-select';
 type SyncStatusRow = {
   batchId: number;
@@ -85,28 +85,32 @@ export const SyncStatusTable = ({ rows }: SyncStatusTableProps) => {
     }
   };
 
-  const handleSort = (sortField: 'startTime' | 'endTime' | 'numRows') => {
-    const sortedRows = [...displayedRows].sort((a, b) => {
-      const aValue = a[sortField];
-      const bValue = b[sortField];
-      if (aValue === null || bValue === null) {
-        return 0;
-      }
+  const handleSort = useCallback(
+    (sortField: 'startTime' | 'endTime' | 'numRows') => {
+      setDisplayedRows((currRows) =>
+        [...currRows].sort((a, b) => {
+          const aValue = a[sortField];
+          const bValue = b[sortField];
+          if (aValue === null || bValue === null) {
+            return 0;
+          }
 
-      if (aValue < bValue) {
-        return -1;
-      } else if (aValue > bValue) {
-        return 1;
-      } else {
-        return 0;
-      }
-    });
-    setDisplayedRows(sortedRows);
-  };
+          if (aValue < bValue) {
+            return -1;
+          } else if (aValue > bValue) {
+            return 1;
+          } else {
+            return 0;
+          }
+        })
+      );
+    },
+    [setDisplayedRows]
+  );
 
   useEffect(() => {
     handleSort('startTime');
-  }, []);
+  }, [handleSort]);
 
   return (
     <Table

--- a/ui/app/mirrors/edit/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/syncStatusTable.tsx
@@ -48,7 +48,7 @@ function TimeWithDurationOrRunning({
   }
 }
 
-const ROWS_PER_PAGE = 6;
+const ROWS_PER_PAGE = 10;
 const sortOptions = [
   { value: 'startTime', label: 'Start Time' },
   { value: 'endTime', label: 'End Time' },
@@ -146,7 +146,6 @@ export const SyncStatusTable = ({ rows }: SyncStatusTableProps) => {
                   (val?.value as 'startTime' | 'endTime' | 'numRows') ??
                   'startTime';
                 setSortField(sortVal);
-                handleSort(sortVal);
               }}
               defaultValue={{ value: 'startTime', label: 'Start Time' }}
             />

--- a/ui/app/mirrors/edit/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/syncStatusTable.tsx
@@ -56,6 +56,9 @@ const sortOptions = [
 ];
 export const SyncStatusTable = ({ rows }: SyncStatusTableProps) => {
   const [currentPage, setCurrentPage] = useState(1);
+  const [sortField, setSortField] = useState<
+    'startTime' | 'endTime' | 'numRows'
+  >('startTime');
   const totalPages = Math.ceil(rows.length / ROWS_PER_PAGE);
   const [searchQuery, setSearchQuery] = useState<string>('');
   const startRow = (currentPage - 1) * ROWS_PER_PAGE;
@@ -86,11 +89,11 @@ export const SyncStatusTable = ({ rows }: SyncStatusTableProps) => {
   };
 
   const handleSort = useCallback(
-    (sortField: 'startTime' | 'endTime' | 'numRows') => {
+    (sortOption: 'startTime' | 'endTime' | 'numRows') => {
       setDisplayedRows((currRows) =>
         [...currRows].sort((a, b) => {
-          const aValue = a[sortField];
-          const bValue = b[sortField];
+          const aValue = a[sortOption];
+          const bValue = b[sortOption];
           if (aValue === null || bValue === null) {
             return 0;
           }
@@ -109,8 +112,8 @@ export const SyncStatusTable = ({ rows }: SyncStatusTableProps) => {
   );
 
   useEffect(() => {
-    handleSort('startTime');
-  }, [handleSort]);
+    handleSort(sortField);
+  }, [handleSort, currentPage, sortField]);
 
   return (
     <Table
@@ -133,12 +136,18 @@ export const SyncStatusTable = ({ rows }: SyncStatusTableProps) => {
             </Button>
             <ReactSelect
               options={sortOptions}
-              onChange={(val, _) =>
-                handleSort(
+              value={{
+                value: sortField,
+                label: sortOptions.find((opt) => opt.value === sortField)
+                  ?.label,
+              }}
+              onChange={(val, _) => {
+                const sortVal =
                   (val?.value as 'startTime' | 'endTime' | 'numRows') ??
-                    'startTime'
-                )
-              }
+                  'startTime';
+                setSortField(sortVal);
+                handleSort(sortVal);
+              }}
               defaultValue={{ value: 'startTime', label: 'Start Time' }}
             />
           </>

--- a/ui/app/mirrors/edit/[mirrorId]/tablePairs.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/tablePairs.tsx
@@ -1,27 +1,28 @@
 'use client';
-import SearchBar from '@/components/Search';
 import { TableMapping } from '@/grpc_generated/flow';
-import { useState } from 'react';
+import { SearchField } from '@/lib/SearchField';
+import { useMemo, useState } from 'react';
 
 const TablePairs = ({ tables }: { tables?: TableMapping[] }) => {
-  const [shownTables, setShownTables] = useState<TableMapping[] | undefined>(
-    tables
-  );
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const shownTables = useMemo(() => {
+    const shownTables = tables?.filter((table: TableMapping) => {
+      return (
+        table.sourceTableIdentifier.includes(searchQuery) ||
+        table.destinationTableIdentifier.includes(searchQuery)
+      );
+    });
+    return shownTables?.length ? shownTables : tables;
+  }, [tables, searchQuery]);
   if (tables)
     return (
       <>
         <div style={{ width: '20%', marginTop: '2rem' }}>
-          <SearchBar
-            allItems={tables}
-            setItems={setShownTables}
-            filterFunction={(query: string) =>
-              tables.filter((table: TableMapping) => {
-                return (
-                  table.sourceTableIdentifier.includes(query) ||
-                  table.destinationTableIdentifier.includes(query)
-                );
-              })
-            }
+          <SearchField
+            placeholder='Search by table name'
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setSearchQuery(e.target.value);
+            }}
           />
         </div>
         <table

--- a/ui/app/mirrors/edit/[mirrorId]/tablePairs.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/tablePairs.tsx
@@ -6,12 +6,11 @@ import { useMemo, useState } from 'react';
 const TablePairs = ({ tables }: { tables?: TableMapping[] }) => {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const shownTables = useMemo(() => {
-    const shownTables = tables?.filter((table: TableMapping) => {
-      return (
+    const shownTables = tables?.filter(
+      (table: TableMapping) =>
         table.sourceTableIdentifier.includes(searchQuery) ||
         table.destinationTableIdentifier.includes(searchQuery)
-      );
-    });
+    );
     return shownTables?.length ? shownTables : tables;
   }, [tables, searchQuery]);
   if (tables)

--- a/ui/app/mirrors/edit/[mirrorId]/tablePairs.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/tablePairs.tsx
@@ -1,0 +1,83 @@
+'use client';
+import SearchBar from '@/components/Search';
+import { TableMapping } from '@/grpc_generated/flow';
+import { useState } from 'react';
+
+const TablePairs = ({ tables }: { tables?: TableMapping[] }) => {
+  const [shownTables, setShownTables] = useState<TableMapping[] | undefined>(
+    tables
+  );
+  if (tables)
+    return (
+      <>
+        <div style={{ width: '20%', marginTop: '2rem' }}>
+          <SearchBar
+            allItems={tables}
+            setItems={setShownTables}
+            filterFunction={(query: string) =>
+              tables.filter((table: TableMapping) => {
+                return (
+                  table.sourceTableIdentifier.includes(query) ||
+                  table.destinationTableIdentifier.includes(query)
+                );
+              })
+            }
+          />
+        </div>
+        <table
+          style={{
+            marginTop: '1rem',
+            borderCollapse: 'collapse',
+            width: '100%',
+            border: '1px solid #ddd',
+            fontSize: 15,
+          }}
+        >
+          <thead>
+            <tr
+              style={{
+                borderBottom: '1px solid #ddd',
+                backgroundColor: '#f9f9f9',
+              }}
+            >
+              <th
+                style={{
+                  textAlign: 'left',
+                  padding: '0.5rem',
+                  fontWeight: 'bold',
+                }}
+              >
+                Source Table
+              </th>
+              <th
+                style={{
+                  textAlign: 'left',
+                  padding: '0.5rem',
+                  fontWeight: 'bold',
+                }}
+              >
+                Destination Table
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {shownTables?.map((table) => (
+              <tr
+                key={`${table.sourceTableIdentifier}.${table.destinationTableIdentifier}`}
+                style={{ borderBottom: '1px solid #ddd' }}
+              >
+                <td style={{ padding: '0.5rem' }}>
+                  {table.sourceTableIdentifier}
+                </td>
+                <td style={{ padding: '0.5rem' }}>
+                  {table.destinationTableIdentifier}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </>
+    );
+};
+
+export default TablePairs;

--- a/ui/app/peers/[peerName]/datatables.tsx
+++ b/ui/app/peers/[peerName]/datatables.tsx
@@ -69,7 +69,7 @@ export const SlotTable = ({ data }: { data: SlotInfo[] }) => {
                 </TableCell>
                 <TableCell>
                   <Label as='label' style={{ fontSize: 14 }}>
-                    {lagInMb}
+                    {lagInMb < 0 ? 0 : lagInMb}
                   </Label>
                 </TableCell>
               </TableRow>

--- a/ui/app/peers/create/[peerType]/handlers.ts
+++ b/ui/app/peers/create/[peerType]/handlers.ts
@@ -4,19 +4,21 @@ import {
   UValidatePeerResponse,
 } from '@/app/dto/PeersDTO';
 import { Dispatch, SetStateAction } from 'react';
-import { bqSchema, pgSchema, sfSchema } from './schema';
+import { bqSchema, peerNameSchema, pgSchema, sfSchema } from './schema';
 
-// Frontend form validation
 const validateFields = (
   type: string,
   config: PeerConfig,
   setMessage: Dispatch<SetStateAction<{ ok: boolean; msg: string }>>,
   name?: string
 ): boolean => {
-  if (!name) {
-    setMessage({ ok: false, msg: 'Peer name is required' });
+  const peerNameValid = peerNameSchema.safeParse(name);
+  if (!peerNameValid.success) {
+    const peerNameErr = peerNameValid.error.issues[0].message;
+    setMessage({ ok: false, msg: peerNameErr });
     return false;
   }
+
   let validationErr: string | undefined;
   switch (type) {
     case 'POSTGRES':

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -1,5 +1,16 @@
 import * as z from 'zod';
 
+export const peerNameSchema = z
+  .string({
+    invalid_type_error: 'Peer name is invalid.',
+    required_error: 'Peer name is required.',
+  })
+  .min(1, { message: 'Peer name cannot be empty.' })
+  .regex(/^[a-z0-9_]*$/, {
+    message:
+      'Peer name must contain only lowercase letters, numbers and underscores',
+  });
+
 export const pgSchema = z.object({
   host: z
     .string({

--- a/ui/components/DropDialog.tsx
+++ b/ui/components/DropDialog.tsx
@@ -79,7 +79,7 @@ export const DropDialog = ({
 
   return (
     <Dialog
-      modal={true}
+      noInteract={true}
       size='large'
       triggerButton={
         <Button variant='drop' style={{ color: 'black' }}>

--- a/ui/components/MirrorInfo.tsx
+++ b/ui/components/MirrorInfo.tsx
@@ -1,0 +1,65 @@
+'use client';
+import { Button } from '@/lib/Button';
+import { Dialog, DialogClose } from '@/lib/Dialog';
+import { Icon } from '@/lib/Icon';
+import { Label } from '@/lib/Label';
+
+interface InfoPopoverProps {
+  configs: {
+    label: string;
+    value?: string | number;
+  }[];
+}
+
+const MirrorInfo = ({ configs }: InfoPopoverProps) => {
+  return (
+    <Dialog
+      noInteract={false}
+      size='large'
+      triggerButton={
+        <Button style={{ backgroundColor: 'white', border: '1px solid gray' }}>
+          <Label variant='body'>View More</Label>
+        </Button>
+      }
+    >
+      <div
+        style={{ display: 'flex', flexDirection: 'column', padding: '1rem' }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginBottom: '0.5rem',
+          }}
+        >
+          <Label variant='headline'>Configuration</Label>
+          <DialogClose>
+            <button className='IconButton' aria-label='Close'>
+              <Icon name='close' />
+            </button>
+          </DialogClose>
+        </div>
+        <table>
+          <tbody>
+            {configs.map((config, index) => (
+              <tr key={index}>
+                <td>
+                  <Label as='label' style={{ fontSize: 15 }}>
+                    {config.label}
+                  </Label>
+                </td>
+                <td>
+                  <Label as='label' style={{ fontSize: 15 }}>
+                    {config.value}
+                  </Label>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Dialog>
+  );
+};
+
+export default MirrorInfo;

--- a/ui/lib/Dialog/Dialog.tsx
+++ b/ui/lib/Dialog/Dialog.tsx
@@ -7,6 +7,7 @@ import { DialogContent, DialogContentProps } from './DialogContent';
 
 type DialogProps = RadixDialog.DialogProps & {
   triggerButton: RenderObject;
+  noInteract: boolean;
 } & PropsWithChildren &
   DialogContentProps;
 
@@ -14,6 +15,7 @@ export function Dialog({
   triggerButton,
   size,
   children,
+  noInteract,
   ...rootProps
 }: DialogProps) {
   const TriggerButton = isDefined(triggerButton) && triggerButton;
@@ -23,8 +25,17 @@ export function Dialog({
       <RadixDialog.Trigger asChild>{TriggerButton}</RadixDialog.Trigger>
       <RadixDialog.Portal>
         <DialogContent
-          onPointerDownOutside={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => {
+            if (noInteract) e.preventDefault();
+          }}
           size={size}
+          style={{
+            position: 'fixed',
+            left: '50%',
+            top: '50%',
+            transform: 'translate(-0%, -50%)',
+            boxShadow: '0px 2px 3px rgba(0,0,0,0.2)',
+          }}
         >
           {children}
         </DialogContent>

--- a/ui/lib/Dialog/DialogContent.styles.ts
+++ b/ui/lib/Dialog/DialogContent.styles.ts
@@ -26,6 +26,9 @@ const sizes = {
     width: ${({ theme }) => theme.size.xxLarge};
     ${css(({ theme }) => theme.dropShadow.xxLarge)};
   `,
+  auto: css`
+    width: fit-content;
+  `,
 };
 
 export type DialogSize = keyof typeof sizes;


### PR DESCRIPTION
Fixes #654 
Fixes #660 
Fixes #656 

- Restores tab UI for specific mirror page (`/edit/[mirrorId]`)
- Adds mirror configuration details and list of source tables to destination tables in overview tab (with search bar)
- Adds sort functionality for CDC tab and Initial load tab. In CDC you can sort by `Start Time`, `End Time` and `Rows Synced`. In Initial Load you can sort by `Start Time` and `Time per partition`.
- Timeframe options in CDC Graph now in a dropdown.
- Moves Sync History graph to Sync tab.
- Displays further mirror config via a `View More` button click which pops up a modal with the info.
- Centers the drop modal (same component as configuration modal in specific mirror page).

<img width="1724" alt="Screenshot 2023-11-16 at 1 59 44 AM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/db11bc6e-2f3a-4fed-832d-fba9c74cd171">

<img width="1724" alt="Screenshot 2023-11-16 at 2 00 30 AM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/4cc8f648-bcec-4e61-b7ba-db2a7ca30daa">
