### PR TITLE
Disable CI linting sqlparser-rs

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -18,10 +18,16 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+
+      - name: disable clippy for sqlparser-rs
+        run: echo -e "\n#![allow(clippy)]" >> nexus/sqlparser-rs/src/lib.rs
+
 
       - name: clippy
         run: cargo clippy -- -D warnings

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -26,7 +26,7 @@ jobs:
           components: clippy
 
       - name: disable clippy for sqlparser-rs
-        run: echo -e "\n#![allow(clippy)]" >> nexus/sqlparser-rs/src/lib.rs
+        run: sed -i '1s/^/#![allow(clippy)]/' nexus/sqlparser-rs/src/lib.rs
 
 
       - name: clippy

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -28,7 +28,6 @@ jobs:
       - name: disable clippy for sqlparser-rs
         run: sed -i '1s/^/#![allow(clippy::all)]\n/' nexus/sqlparser-rs/src/lib.rs
 
-
       - name: clippy
         run: cargo clippy -- -D warnings
         working-directory: ./nexus

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -26,7 +26,7 @@ jobs:
           components: clippy
 
       - name: disable clippy for sqlparser-rs
-        run: sed -i '1s/^/#![allow(clippy)]/' nexus/sqlparser-rs/src/lib.rs
+        run: sed -i '1s/^/#![allow(clippy::all)]\n/' nexus/sqlparser-rs/src/lib.rs
 
 
       - name: clippy


### PR DESCRIPTION
sqlparser-rs linting belongs at the source: https://github.com/PeerDB-io/sqlparser-rs

That way new clippy rules flagging old code in sqlparser-rs don't cause lint fails for this repo