### PR TITLE
Runs SendWalHeartbeat in parallel

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -671,19 +671,25 @@ func (a *FlowableActivity) SendWALHeartbeat(ctx context.Context, config *protos.
 		return fmt.Errorf("failed to get destination connector: %w", err)
 	}
 	defer connectors.CloseConnector(srcConn)
-
-	ticker := time.NewTicker(10 * time.Second)
+	log.WithFields(log.Fields{"flowName": config.FlowJobName}).Info("sending walheartbeat every 10 minutes")
+	ticker := time.NewTicker(10 * time.Minute)
 	for {
 		select {
 		case <-ctx.Done():
-			log.Info("context is done, exiting wal heartbeat send loop")
+			log.WithFields(
+				log.Fields{
+					"flowName": config.FlowJobName,
+				}).Info("context is done, exiting wal heartbeat send loop")
 			return nil
 		case <-ticker.C:
 			err = srcConn.SendWALHeartbeat()
 			if err != nil {
 				return fmt.Errorf("failed to send WAL heartbeat: %w", err)
 			}
-			log.Info("sent wal heartbeat")
+			log.WithFields(
+				log.Fields{
+					"flowName": config.FlowJobName,
+				}).Info("sent wal heartbeat")
 		}
 	}
 }

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -414,7 +414,7 @@ func CDCFlowWorkflowWithConfig(
 	}
 
 	// cancel the SendWalHeartbeat activity
-	cancelHeartbeat()
+	defer cancelHeartbeat()
 
 	state.TruncateProgress()
 	return nil, workflow.NewContinueAsNewError(ctx, CDCFlowWorkflowWithConfig, cfg, limits, state)

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -267,10 +267,9 @@ func CDCFlowWorkflowWithConfig(
 
 	heartbeatCancelCtx, cancelHeartbeat := workflow.WithCancel(ctx)
 	walHeartbeatCtx := workflow.WithActivityOptions(heartbeatCancelCtx, workflow.ActivityOptions{
-		StartToCloseTimeout: 5 * time.Minute,
+		StartToCloseTimeout: 7 * 24 * time.Hour,
 	})
 	workflow.ExecuteActivity(walHeartbeatCtx, flowable.SendWALHeartbeat, cfg)
-	//walHeartbeatFuture.Get(ctx, nil)
 
 	syncFlowOptions := &protos.SyncFlowOptions{
 		BatchSize: int32(limits.MaxBatchSize),

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -100,18 +100,6 @@ func (s *CDCFlowWorkflowState) TruncateProgress() {
 	}
 }
 
-func (s *CDCFlowWorkflowState) SendWALHeartbeat(ctx workflow.Context, cfg *protos.FlowConnectionConfigs) error {
-	walHeartbeatCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 5 * time.Minute,
-	})
-
-	if err := workflow.ExecuteActivity(walHeartbeatCtx, flowable.SendWALHeartbeat, cfg).Get(ctx, nil); err != nil {
-		return fmt.Errorf("failed to send WAL heartbeat: %w", err)
-	}
-
-	return nil
-}
-
 // CDCFlowWorkflowExecution represents the state for execution of a peer flow.
 type CDCFlowWorkflowExecution struct {
 	flowExecutionID string
@@ -277,6 +265,13 @@ func CDCFlowWorkflowWithConfig(
 		state.Progress = append(state.Progress, "executed setup flow and snapshot flow")
 	}
 
+	heartbeatCancelCtx, cancelHeartbeat := workflow.WithCancel(ctx)
+	walHeartbeatCtx := workflow.WithActivityOptions(heartbeatCancelCtx, workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+	})
+	workflow.ExecuteActivity(walHeartbeatCtx, flowable.SendWALHeartbeat, cfg)
+	//walHeartbeatFuture.Get(ctx, nil)
+
 	syncFlowOptions := &protos.SyncFlowOptions{
 		BatchSize: int32(limits.MaxBatchSize),
 	}
@@ -419,10 +414,8 @@ func CDCFlowWorkflowWithConfig(
 		selector.Select(ctx)
 	}
 
-	// send WAL heartbeat
-	if err := state.SendWALHeartbeat(ctx, cfg); err != nil {
-		return state, err
-	}
+	// cancel the SendWalHeartbeat activity
+	cancelHeartbeat()
 
 	state.TruncateProgress()
 	return nil, workflow.NewContinueAsNewError(ctx, CDCFlowWorkflowWithConfig, cfg, limits, state)


### PR DESCRIPTION
SendWalHeartbeat now runs every 10 seconds in parallel during the PeerFlow phase of CDC (after setup and snapshot)
cancelActivity is called where previously the .Get() on the activity was called in `cdc_flow.go`