### PR TITLE
Use catalog as external store

### DIFF
--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -98,7 +98,7 @@ func (c *S3Connector) Close() error {
 	return nil
 }
 
-func ValidCheck(s3Client *s3.S3, bucketUrl string, metadataDB *metadataStore.PostgresMetadataStore) error {
+func ValidCheck(s3Client *s3.S3, bucketURL string, metadataDB *metadataStore.PostgresMetadataStore) error {
 	_, listErr := s3Client.ListBuckets(nil)
 	if listErr != nil {
 		return fmt.Errorf("failed to list buckets: %w", listErr)

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -98,7 +98,7 @@ func (c *S3Connector) Close() error {
 	return nil
 }
 
-func ValidCheck(s3Client *s3.S3, bucketURL string, metadataDB *metadataStore.PostgresMetadataStore) error {
+func ValidCheck(s3Client *s3.S3, bucketUrl string, metadataDB *metadataStore.PostgresMetadataStore) error {
 	_, listErr := s3Client.ListBuckets(nil)
 	if listErr != nil {
 		return fmt.Errorf("failed to list buckets: %w", listErr)

--- a/ui/app/peers/create/[peerType]/helpers/s3.ts
+++ b/ui/app/peers/create/[peerType]/helpers/s3.ts
@@ -41,8 +41,8 @@ export const s3Setting: PeerSetting[] = [
     tips: 'If set, the role ARN will be used to assume the role before accessing the bucket.',
     helpfulLink:
       'https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns',
-    optional: true
-  }
+    optional: true,
+  },
 ];
 
 export const blankS3Setting: S3Config = {

--- a/ui/app/peers/create/[peerType]/helpers/s3.ts
+++ b/ui/app/peers/create/[peerType]/helpers/s3.ts
@@ -45,6 +45,15 @@ export const s3Setting: PeerSetting[] = [
   },
 ];
 
+export const blankMetadata = {
+  host: '',
+  port: 5432,
+  user: 'postgres',
+  password: '',
+  database: 'postgres',
+  transactionSnapshot: '',
+};
+
 export const blankS3Setting: S3Config = {
   url: 's3://<bucket_name>/<prefix_name>',
   accessKeyId: undefined,
@@ -52,5 +61,7 @@ export const blankS3Setting: S3Config = {
   roleArn: undefined,
   region: undefined,
   endpoint: '',
-  metadataDb: undefined,
+  // For Storage peers created in UI
+  // we use catalog as the metadata DB
+  metadataDb: blankMetadata,
 };

--- a/ui/app/peers/create/[peerType]/helpers/s3.ts
+++ b/ui/app/peers/create/[peerType]/helpers/s3.ts
@@ -52,12 +52,5 @@ export const blankS3Setting: S3Config = {
   roleArn: undefined,
   region: undefined,
   endpoint: '',
-  metadataDb: {
-    host: '',
-    port: 5432,
-    user: 'postgres',
-    password: '',
-    database: 'postgres',
-    transactionSnapshot: '',
-  },
+  metadataDb: undefined,
 };

--- a/ui/app/peers/create/[peerType]/helpers/s3.ts
+++ b/ui/app/peers/create/[peerType]/helpers/s3.ts
@@ -41,8 +41,8 @@ export const s3Setting: PeerSetting[] = [
     tips: 'If set, the role ARN will be used to assume the role before accessing the bucket.',
     helpfulLink:
       'https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns',
-    optional: true,
-  },
+    optional: true
+  }
 ];
 
 export const blankS3Setting: S3Config = {

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -234,4 +234,5 @@ export const s3Schema = z.object({
       invalid_type_error: 'Endpoint must be a string',
     })
     .optional(),
+  metadataDb: pgSchema.optional(),
 });

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -234,5 +234,4 @@ export const s3Schema = z.object({
       invalid_type_error: 'Endpoint must be a string',
     })
     .optional(),
-  metadataDb: pgSchema,
 });

--- a/ui/components/S3Form.tsx
+++ b/ui/components/S3Form.tsx
@@ -1,11 +1,5 @@
 'use client';
-import { PeerConfig } from '@/app/dto/PeersDTO';
-import { postgresSetting } from '@/app/peers/create/[peerType]/helpers/pg';
-import {
-  blankS3Setting,
-  s3Setting,
-} from '@/app/peers/create/[peerType]/helpers/s3';
-import { PostgresConfig } from '@/grpc_generated/peers';
+import { s3Setting } from '@/app/peers/create/[peerType]/helpers/s3';
 import { Label } from '@/lib/Label';
 import { RowWithRadiobutton, RowWithTextField } from '@/lib/Layout';
 import { RadioButton, RadioButtonGroup } from '@/lib/RadioButtonGroup';
@@ -19,9 +13,6 @@ interface S3Props {
   setter: PeerSetter;
 }
 const S3ConfigForm = ({ setter }: S3Props) => {
-  const [metadataDB, setMetadataDB] = useState<PeerConfig>(
-    blankS3Setting.metadataDb!
-  );
   const [storageType, setStorageType] = useState<'S3' | 'GCS'>('S3');
   const displayCondition = (label: string) => {
     return !(
@@ -31,23 +22,15 @@ const S3ConfigForm = ({ setter }: S3Props) => {
   };
   useEffect(() => {
     const endpoint = storageType === 'S3' ? '' : 'storage.googleapis.com';
+    const region = storageType === 'S3' ? '' : 'auto';
     setter((prev) => {
       return {
         ...prev,
-        metadataDb: metadataDB as PostgresConfig,
         endpoint,
+        region,
       };
     });
-
-    if (storageType === 'GCS') {
-      setter((prev) => {
-        return {
-          ...prev,
-          region: 'auto',
-        };
-      });
-    }
-  }, [metadataDB, storageType, setter]);
+  }, [storageType, setter]);
 
   return (
     <div>
@@ -130,75 +113,6 @@ const S3ConfigForm = ({ setter }: S3Props) => {
             />
           );
       })}
-
-      <Label
-        as='label'
-        style={{ marginTop: '1rem' }}
-        variant='subheadline'
-        colorName='lowContrast'
-      >
-        Metadata Database
-      </Label>
-      <Label>
-        For S3/GCS storage peers, PeerDB uses an external PostgreSQL database to
-        store metadata (last sync state) for mirrors.
-        <br></br>
-        More information on creation of storage peers in PeerDB{' '}
-        <a
-          style={{ color: 'teal' }}
-          href='https://docs.peerdb.io/sql/commands/create-peer#storage-peers-s3-and-gcs'
-        >
-          here.
-        </a>
-      </Label>
-      {postgresSetting.map(
-        (pgSetting, index) =>
-          pgSetting.label !== 'Transaction Snapshot' && (
-            <RowWithTextField
-              key={index}
-              label={
-                <Label>
-                  {pgSetting.label}{' '}
-                  <Tooltip
-                    style={{ width: '100%' }}
-                    content={'This is a required field.'}
-                  >
-                    <Label colorName='lowContrast' colorSet='destructive'>
-                      *
-                    </Label>
-                  </Tooltip>
-                </Label>
-              }
-              action={
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                  }}
-                >
-                  <TextField
-                    variant='simple'
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      pgSetting.stateHandler(e.target.value, setMetadataDB)
-                    }
-                    defaultValue={
-                      (metadataDB as PostgresConfig)[
-                        pgSetting.label.toLowerCase() as keyof PostgresConfig
-                      ] || ''
-                    }
-                  />
-                  {pgSetting.tips && (
-                    <InfoPopover
-                      tips={pgSetting.tips}
-                      link={pgSetting.helpfulLink}
-                    />
-                  )}
-                </div>
-              }
-            />
-          )
-      )}
     </div>
   );
 };

--- a/ui/components/S3Form.tsx
+++ b/ui/components/S3Form.tsx
@@ -1,8 +1,15 @@
 'use client';
-import { s3Setting } from '@/app/peers/create/[peerType]/helpers/s3';
+import { PeerConfig } from '@/app/dto/PeersDTO';
+import { postgresSetting } from '@/app/peers/create/[peerType]/helpers/pg';
+import {
+  blankS3Setting,
+  s3Setting,
+} from '@/app/peers/create/[peerType]/helpers/s3';
+import { PostgresConfig } from '@/grpc_generated/peers';
 import { Label } from '@/lib/Label';
 import { RowWithRadiobutton, RowWithTextField } from '@/lib/Layout';
 import { RadioButton, RadioButtonGroup } from '@/lib/RadioButtonGroup';
+import { Switch } from '@/lib/Switch';
 import { TextField } from '@/lib/TextField';
 import { Tooltip } from '@/lib/Tooltip';
 import { useEffect, useState } from 'react';
@@ -13,6 +20,10 @@ interface S3Props {
   setter: PeerSetter;
 }
 const S3ConfigForm = ({ setter }: S3Props) => {
+  const [showMetadata, setShowMetadata] = useState<boolean>(false);
+  const [metadataDB, setMetadataDB] = useState<PeerConfig>(
+    blankS3Setting.metadataDb!
+  );
   const [storageType, setStorageType] = useState<'S3' | 'GCS'>('S3');
   const displayCondition = (label: string) => {
     return !(
@@ -22,15 +33,23 @@ const S3ConfigForm = ({ setter }: S3Props) => {
   };
   useEffect(() => {
     const endpoint = storageType === 'S3' ? '' : 'storage.googleapis.com';
-    const region = storageType === 'S3' ? '' : 'auto';
     setter((prev) => {
       return {
         ...prev,
+        metadataDb: showMetadata ? (metadataDB as PostgresConfig) : undefined,
         endpoint,
-        region,
       };
     });
-  }, [storageType, setter]);
+
+    if (storageType === 'GCS') {
+      setter((prev) => {
+        return {
+          ...prev,
+          region: 'auto',
+        };
+      });
+    }
+  }, [metadataDB, storageType, setter, showMetadata]);
 
   return (
     <div>
@@ -113,6 +132,78 @@ const S3ConfigForm = ({ setter }: S3Props) => {
             />
           );
       })}
+
+      <Label
+        as='label'
+        style={{ marginTop: '1rem' }}
+        variant='subheadline'
+        colorName='lowContrast'
+      >
+        Metadata Database
+      </Label>
+      <Label>
+        For S3/GCS storage peers, PeerDB uses an external PostgreSQL database to
+        store metadata (last sync state) for mirrors.
+        <br></br>
+        By default, PeerDB will use its internal Catalog as the metadata
+        database.
+        <br></br>
+        <br></br>
+        You can also choose to use your own PostgreSQL database:
+      </Label>
+      <div style={{ width: '50%', display: 'flex', alignItems: 'center' }}>
+        <Label variant='subheadline'>Use my own metadata detabase</Label>
+        <Switch onCheckedChange={(state) => setShowMetadata(state)} />
+      </div>
+      {showMetadata &&
+        postgresSetting.map(
+          (pgSetting, index) =>
+            pgSetting.label !== 'Transaction Snapshot' && (
+              <RowWithTextField
+                key={index}
+                label={
+                  <Label>
+                    {pgSetting.label}{' '}
+                    <Tooltip
+                      style={{ width: '100%' }}
+                      content={'This is a required field.'}
+                    >
+                      <Label colorName='lowContrast' colorSet='destructive'>
+                        *
+                      </Label>
+                    </Tooltip>
+                  </Label>
+                }
+                action={
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <TextField
+                      variant='simple'
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        pgSetting.stateHandler(e.target.value, setMetadataDB)
+                      }
+                      defaultValue={
+                        (metadataDB as PostgresConfig)[
+                          pgSetting.label.toLowerCase() as keyof PostgresConfig
+                        ] || ''
+                      }
+                    />
+                    {pgSetting.tips && (
+                      <InfoPopover
+                        tips={pgSetting.tips}
+                        link={pgSetting.helpfulLink}
+                      />
+                    )}
+                  </div>
+                }
+              />
+            )
+        )}
     </div>
   );
 };


### PR DESCRIPTION
If metadataDB is set to empty string/undefined, we now use catalog as the metadata postgres instance for S3/GCS and Eventhub CDC

<img width="1479" alt="Screenshot 2023-11-17 at 11 14 29 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/4bed58cd-e472-48e7-8671-79481bcb7957">
