### PR TITLE
Send the events as soon as we have hit the batch size limit

### DIFF
--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -145,7 +145,7 @@ func (c *EventHubConnector) processBatch(
 			return 0, err
 		}
 
-		err = batchPerTopic.AddEvent(ctx, topicName, json)
+		err = batchPerTopic.AddEvent(ctx, topicName, json, false)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"flowName": flowJobName,

--- a/flow/connectors/eventhub/hub_batches.go
+++ b/flow/connectors/eventhub/hub_batches.go
@@ -53,7 +53,7 @@ func (h *HubBatches) AddEvent(
 		if retryForBatchSizeExceed {
 			// if we are already retrying, then we should just return the error
 			// as we have already tried to send the event to the batch.
-			return err
+			return fmt.Errorf("[retry-failed] event too large to add to batch: %v", err)
 		}
 
 		// if the event is too large, send the current batch and

--- a/flow/connectors/eventhub/hub_batches.go
+++ b/flow/connectors/eventhub/hub_batches.go
@@ -135,9 +135,14 @@ func (h *HubBatches) flushAllBatches(
 		})
 	})
 
-	log.Infof("[sendEventBatch] successfully sent %d events in total to event hub",
+	log.Infof("[flush] successfully sent %d events in total to event hub",
 		numEventsPushed)
-	return g.Wait()
+	err := g.Wait()
+
+	// clear the batches after flushing them.
+	h.Clear()
+
+	return err
 }
 
 // Clear removes all batches from the HubBatches

--- a/flow/connectors/eventhub/hub_batches.go
+++ b/flow/connectors/eventhub/hub_batches.go
@@ -135,9 +135,9 @@ func (h *HubBatches) flushAllBatches(
 		})
 	})
 
+	err := g.Wait()
 	log.Infof("[flush] successfully sent %d events in total to event hub",
 		numEventsPushed)
-	err := g.Wait()
 
 	// clear the batches after flushing them.
 	h.Clear()


### PR DESCRIPTION
This is for performance, we want to keep `START_REPLICATION` connection alive for as long as we can. This was observed to reduce the latency overall significantly.