### PR TITLE
[cdc] Flush at the beginning of CDC until consumedXLogPos

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -182,6 +182,12 @@ func (p *PostgresCDCSource) consumeStream(
 	consumedXLogPos := pglogrepl.LSN(0)
 	if clientXLogPos > 0 {
 		consumedXLogPos = clientXLogPos - 1
+
+		err := pglogrepl.SendStandbyStatusUpdate(p.ctx, conn,
+			pglogrepl.StandbyStatusUpdate{WALWritePosition: consumedXLogPos})
+		if err != nil {
+			return fmt.Errorf("[initial-flush] SendStandbyStatusUpdate failed: %w", err)
+		}
 	}
 
 	var standByLastLogged time.Time


### PR DESCRIPTION
This was missed before, when `wal_sender_timeout` is set to a large value waiting for PKMs is a bad idea