### PR TITLE
peerdb-server: receive sigint & exit

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -173,6 +173,7 @@ services:
 
   peerdb:
     container_name: peerdb-server
+    stop_signal: SIGINT
     build:
       context: .
       dockerfile: stacks/peerdb-server.Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,7 @@ services:
 
   peerdb:
     container_name: peerdb-server
+    stop_signal: SIGINT
     image: ghcr.io/peerdb-io/peerdb-server:latest-dev
     environment:
       <<: *catalog-config


### PR DESCRIPTION
Does not gracefully shutdown all sockets. To do that we'd need to store the sockets from listen to a map & shutdown. But all the programs we're interfacing with should be handling connection being dropped suddenly

Fixes #682