### PR TITLE
nexus: more cloning reduction

### DIFF
--- a/nexus/peer-snowflake/src/auth.rs
+++ b/nexus/peer-snowflake/src/auth.rs
@@ -36,21 +36,20 @@ pub struct SnowflakeAuth {
 }
 
 impl SnowflakeAuth {
-    // When initializing, private_key must not be copied, to improve security of credentials.
     #[tracing::instrument(name = "peer_sflake::init_client_auth", skip_all)]
     pub fn new(
         account_id: String,
         username: String,
-        private_key: String,
-        password: Option<String>,
+        private_key: &str,
+        password: Option<&str>,
         refresh_threshold: u64,
         expiry_threshold: u64,
     ) -> anyhow::Result<Self> {
         let pkey = match password {
-            Some(pw) => DecodePrivateKey::from_pkcs8_encrypted_pem(&private_key, pw)
+            Some(pw) => DecodePrivateKey::from_pkcs8_encrypted_pem(private_key, pw)
                 .context("Invalid private key or decryption failed")?,
             None => {
-                DecodePrivateKey::from_pkcs8_pem(&private_key).context("Invalid private key")?
+                DecodePrivateKey::from_pkcs8_pem(private_key).context("Invalid private key")?
             }
         };
         let mut snowflake_auth: SnowflakeAuth = SnowflakeAuth {

--- a/nexus/peer-snowflake/src/lib.rs
+++ b/nexus/peer-snowflake/src/lib.rs
@@ -142,8 +142,8 @@ impl SnowflakeQueryExecutor {
             auth: SnowflakeAuth::new(
                 config.account_id.clone(),
                 config.username.clone(),
-                config.private_key.clone(),
-                config.password.clone(),
+                &config.private_key,
+                config.password.as_deref(),
                 DEFAULT_REFRESH_THRESHOLD,
                 DEFAULT_EXPIRY_THRESHOLD,
             )?,


### PR DESCRIPTION
BigQueryQueryExecutor clones most of config into client, only needing 2 strings out of it afterwards

SnowflakeAuth says private_key must not be copied while the caller was calling clone to pass String

While going over String parameters to functions, noticed get_peer_of_mirror/handle_mirror_existence not needing ownership