### PR TITLE
Remove sync mode fields from UI

### DIFF
--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -155,12 +155,21 @@ export const handleCreateCDC = async (
     setMsg({ ok: false, msg: flowNameErr });
     return;
   }
+
   const tableNameMapping = reformattedTableMapping(rows);
   const isValid = validateCDCFields(tableNameMapping, setMsg, config);
   if (!isValid) return;
 
   config['tableMappings'] = tableNameMapping as TableMapping[];
   config['flowJobName'] = flowJobName;
+
+  if (config.destination?.type == DBType.POSTGRES) {
+    config.cdcSyncMode = QRepSyncMode.QREP_SYNC_MODE_MULTI_INSERT;
+    config.snapshotSyncMode = QRepSyncMode.QREP_SYNC_MODE_MULTI_INSERT;
+  } else {
+    config.cdcSyncMode = QRepSyncMode.QREP_SYNC_MODE_STORAGE_AVRO;
+    config.snapshotSyncMode = QRepSyncMode.QREP_SYNC_MODE_STORAGE_AVRO;
+  }
   setLoading(true);
   const statusMessage: UCreateMirrorResponse = await fetch('/api/mirrors/cdc', {
     method: 'POST',
@@ -220,6 +229,13 @@ export const handleCreateQRep = async (
   if (!isValid) return;
   config.flowJobName = flowJobName;
   config.query = query;
+
+  if (config.destinationPeer?.type == DBType.POSTGRES) {
+    config.syncMode = QRepSyncMode.QREP_SYNC_MODE_MULTI_INSERT;
+  } else {
+    config.syncMode = QRepSyncMode.QREP_SYNC_MODE_STORAGE_AVRO;
+  }
+
   setLoading(true);
   const statusMessage: UCreateMirrorResponse = await fetch(
     '/api/mirrors/qrep',

--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -1,4 +1,3 @@
-import { QRepSyncMode } from '@/grpc_generated/flow';
 import { CDCConfig } from '../../../dto/MirrorsDTO';
 import { MirrorSetting } from './common';
 export const cdcSettings: MirrorSetting[] = [
@@ -64,37 +63,13 @@ export const cdcSettings: MirrorSetting[] = [
     type: 'number',
   },
   {
-    label: 'Snapshot Sync Mode',
-    stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        snapshotSyncMode:
-          (value as QRepSyncMode) || QRepSyncMode.QREP_SYNC_MODE_MULTI_INSERT,
-      })),
-    tips: 'Specify whether you want the sync mode for initial load to be via SQL or by staging AVRO files. The default mode is SQL.',
-    default: 'SQL',
-    type: 'select',
-  },
-  {
-    label: 'CDC Sync Mode',
-    stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        cdcSyncMode:
-          (value as QRepSyncMode) || QRepSyncMode.QREP_SYNC_MODE_MULTI_INSERT,
-      })),
-    tips: 'Specify whether you want the sync mode for CDC to be via SQL or by staging AVRO files. The default mode is SQL.',
-    default: 'SQL',
-    type: 'select',
-  },
-  {
     label: 'Snapshot Staging Path',
     stateHandler: (value, setter) =>
       setter((curr: CDCConfig) => ({
         ...curr,
         snapshotStagingPath: value as string | '',
       })),
-    tips: 'You can specify staging path if you have set the Snapshot sync mode as AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket URL.',
+    tips: 'You can specify staging path for Snapshot sync mode AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket URL. For BigQuery, this must be either empty or an existing GCS bucket name. In both cases, if empty, the local filesystem will be used.',
   },
   {
     label: 'CDC Staging Path',
@@ -103,7 +78,7 @@ export const cdcSettings: MirrorSetting[] = [
         ...curr,
         cdcStagingPath: (value as string) || '',
       })),
-    tips: 'You can specify staging path if you have set the CDC sync mode as AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket url',
+    tips: 'You can specify staging path for CDC sync mode AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket URL. For BigQuery, this must be either empty or an existing GCS bucket name. In both cases, if empty, the local filesystem will be used.',
   },
   {
     label: 'Soft Delete',

--- a/ui/app/mirrors/create/helpers/qrep.ts
+++ b/ui/app/mirrors/create/helpers/qrep.ts
@@ -1,6 +1,5 @@
 import {
   QRepConfig,
-  QRepSyncMode,
   QRepWriteMode,
   QRepWriteType,
 } from '@/grpc_generated/flow';
@@ -72,27 +71,13 @@ export const qrepSettings: MirrorSetting[] = [
     type: 'number',
   },
   {
-    label: 'Sync Mode',
-    stateHandler: (value, setter) =>
-      setter((curr: QRepConfig) => ({
-        ...curr,
-        syncMode:
-          (value as QRepSyncMode) || QRepSyncMode.QREP_SYNC_MODE_MULTI_INSERT,
-      })),
-    tips: 'Specify whether you want the sync mode to be via SQL or by staging AVRO files. The default mode is SQL.',
-    default: 'SQL',
-    type: 'select',
-  },
-
-  {
     label: 'Staging Path',
     stateHandler: (value, setter) =>
       setter((curr: QRepConfig) => ({
         ...curr,
         stagingPath: (value as string) || '',
       })),
-    tips: `You can specify staging path if you have set the sync mode as AVRO. For Snowflake as destination peer.
-    If this starts with gs:// then it will be written to GCS.
+    tips: `You can specify staging path for sync mode AVRO. For Snowflake as destination peer:
     If this starts with s3:// then it will be written to S3.
     If nothing is specified then it will be written to local disk.`,
   },

--- a/ui/components/InfoPopover.tsx
+++ b/ui/components/InfoPopover.tsx
@@ -17,9 +17,8 @@ export const InfoPopover = ({
 
       <Popover.Portal>
         <Popover.Content
-          style={{ position: 'absolute' }}
+          style={{ backgroundColor: '#fff' }}
           className='PopoverContent'
-          side='right'
           sideOffset={5}
         >
           <div
@@ -31,9 +30,11 @@ export const InfoPopover = ({
               minWidth: '15rem',
             }}
           >
-            <p className='Text' style={{ fontSize: 13 }}>
-              {tips}
-            </p>
+            {tips.split('.').map((sentence, index) => (
+              <p className='Text' style={{ fontSize: 13 }} key={index}>
+                {sentence.trim()}
+              </p>
+            ))}
 
             {link && (
               <a


### PR DESCRIPTION
- Since Sync Mode fields are now defaulted (see: https://github.com/PeerDB-io/peerdb/pull/707), those fields in the UI are now removed.
- Staging path fields appear depending on if the destination is AVRO type.

