### PR TITLE
More reliable mirror name search attribute script

### DIFF
--- a/scripts/mirror-name-search.sh
+++ b/scripts/mirror-name-search.sh
@@ -1,7 +1,9 @@
+sleep 5
+
 # Check if MirrorName attribute exists
 if ! temporal operator search-attribute list | grep -w MirrorName >/dev/null 2>&1; then
     # If not, create MirrorName attribute
-    temporal operator search-attribute create --name MirrorName --type Text
+    temporal operator search-attribute create --name MirrorName --type Text --namespace default
 fi
 
-tini -- sleep infinity
+tini -s -- sleep infinity


### PR DESCRIPTION
Noticed that temporal was not ready yet and so temporal-admin-tools could not list attributes
Now sleeping for 5 seconds. Tested it and now the above issue wasn't reproducible by me
Also adding `-s` to tini command as suggested by warnings