### PR TITLE
UI: No index as key

### DIFF
--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -182,10 +182,10 @@ const SchemaBox = ({
                     row.schema === schema &&
                     row.source.toLowerCase().includes(tableQuery.toLowerCase())
                 )
-                .map((row, index) => {
+                .map((row) => {
                   const columns = getTableColumns(row.source);
                   return (
-                    <div key={index} style={tableBoxStyle}>
+                    <div key={row.source} style={tableBoxStyle}>
                       <div
                         style={{
                           display: 'flex',
@@ -222,6 +222,7 @@ const SchemaBox = ({
                             style={{
                               fontSize: 12,
                               marginTop: '0.5rem',
+                              cursor: 'pointer'
                             }}
                             variant='simple'
                             placeholder={'Enter target table'}
@@ -242,13 +243,13 @@ const SchemaBox = ({
                             Columns
                           </Label>
                           {columns ? (
-                            columns.map((column, index) => {
+                            columns.map((column) => {
                               const columnName = column.split(':')[0];
                               const columnType = column.split(':')[1];
                               const isPkey = column.split(':')[2] === 'true';
                               return (
                                 <RowWithCheckbox
-                                  key={index}
+                                  key={column}
                                   label={
                                     <Label
                                       as='label'
@@ -257,7 +258,7 @@ const SchemaBox = ({
                                         display: 'flex',
                                       }}
                                     >
-                                      {columnName}{' '}
+                                      {columnName}
                                       <p
                                         style={{
                                           marginLeft: '0.5rem',

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -222,7 +222,7 @@ const SchemaBox = ({
                             style={{
                               fontSize: 12,
                               marginTop: '0.5rem',
-                              cursor: 'pointer'
+                              cursor: 'pointer',
                             }}
                             variant='simple'
                             placeholder={'Enter target table'}

--- a/ui/app/mirrors/create/cdc/tablemapping.tsx
+++ b/ui/app/mirrors/create/cdc/tablemapping.tsx
@@ -61,9 +61,9 @@ const TableMapping = ({
             ?.filter((schema) => {
               return schema.toLowerCase().includes(schemaQuery.toLowerCase());
             })
-            .map((schema, index) => (
+            .map((schema) => (
               <SchemaBox
-                key={index}
+                key={schema}
                 schema={schema}
                 sourcePeer={sourcePeerName}
                 rows={rows}


### PR DESCRIPTION
For list of components whose ordering or cardinality can change, using the array index as the key attribute isn't ideal. This PR uses a unique component-based key instead such as row.id or row.name in those cases
