### PR TITLE
UI: Better mirror fetching

### DIFF
--- a/ui/app/api/mirrors/route.ts
+++ b/ui/app/api/mirrors/route.ts
@@ -3,15 +3,6 @@ import prisma from '@/app/utils/prisma';
 
 export const dynamic = 'force-dynamic';
 
-const stringifyConfig = (flowArray: any[]) => {
-  flowArray.forEach((flow) => {
-    if (flow.config_proto) {
-      flow.config_proto = new TextDecoder().decode(flow.config_proto);
-    }
-  });
-  return flowArray;
-};
-
 export async function GET(request: Request) {
   const mirrors = await prisma.flows.findMany({
     distinct: 'name',
@@ -21,7 +12,8 @@ export async function GET(request: Request) {
     },
   });
 
-  const flows = mirrors?.map((mirror) => {
+  // using any as type because of the way prisma returns data
+  const flows = mirrors?.map((mirror: any) => {
     let newMirror: any = {
       ...mirror,
       sourcePeer: getTruePeer(mirror.sourcePeer),
@@ -29,5 +21,5 @@ export async function GET(request: Request) {
     };
     return newMirror;
   });
-  return new Response(JSON.stringify(stringifyConfig(flows)));
+  return new Response(JSON.stringify(flows));
 }

--- a/ui/app/mirrors/page.tsx
+++ b/ui/app/mirrors/page.tsx
@@ -31,7 +31,7 @@ export default function Mirrors() {
 
   let qrepFlows = flows?.filter((flow) => {
     if (flow.config_proto && flow.query_string) {
-      let config = QRepConfig.decode(flow.config_proto);
+      let config = QRepConfig.decode(flow.config_proto.data);
       const watermarkCol = config.watermarkColumn.toLowerCase();
       return watermarkCol !== 'xmin' && watermarkCol !== 'ctid';
     }
@@ -40,7 +40,7 @@ export default function Mirrors() {
 
   let xminFlows = flows?.filter((flow) => {
     if (flow.config_proto && flow.query_string) {
-      let config = QRepConfig.decode(flow.config_proto);
+      let config = QRepConfig.decode(flow.config_proto.data);
       return config.watermarkColumn.toLowerCase() === 'xmin';
     }
     return false;


### PR DESCRIPTION
The mirror fetch API was sending data in the wrong format, causing the mirrors page to crash when qrep mirrors exist. This PR restores functionality of the mirrors page