### PR TITLE
Remove direct dependency on pkcs1/pkcs8

### DIFF
--- a/nexus/Cargo.lock
+++ b/nexus/Cargo.lock
@@ -1934,8 +1934,6 @@ dependencies = [
  "peer-cursor",
  "pgerror",
  "pgwire",
- "pkcs1",
- "pkcs8",
  "pt",
  "reqwest",
  "rsa",
@@ -2590,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "async-compression",
  "base64 0.21.5",
@@ -3317,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
@@ -3339,9 +3337,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]
@@ -4161,9 +4159,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.28"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]

--- a/nexus/peer-snowflake/Cargo.toml
+++ b/nexus/peer-snowflake/Cargo.toml
@@ -20,9 +20,7 @@ dashmap = "5.0"
 pgwire = "0.17"
 sha2 = "0.10"
 pt = { path = "../pt" }
-pkcs8 = { version = "0.10.2", features = ["std", "pem", "encryption"] }
-pkcs1 = "0.7.5"
-rsa = "0.9.2"
+rsa = { version = "0.9.2", features = ["pem", "pkcs5"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures = "0.3"

--- a/nexus/peer-snowflake/src/auth.rs
+++ b/nexus/peer-snowflake/src/auth.rs
@@ -6,9 +6,9 @@ use std::{
 use anyhow::Context;
 use base64::prelude::{Engine as _, BASE64_STANDARD};
 use jsonwebtoken::{encode as jwt_encode, Algorithm, EncodingKey, Header};
-use pkcs1::EncodeRsaPrivateKey;
-use pkcs8::{DecodePrivateKey, EncodePublicKey};
-use rsa::{RsaPrivateKey, RsaPublicKey};
+use rsa::RsaPrivateKey;
+use rsa::pkcs1::EncodeRsaPrivateKey;
+use rsa::pkcs8::{DecodePrivateKey, EncodePublicKey};
 use secrecy::{Secret, SecretString};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -91,7 +91,7 @@ impl SnowflakeAuth {
 
     #[tracing::instrument(name = "peer_sflake::gen_public_key_fp", skip_all)]
     fn gen_public_key_fp(private_key: &RsaPrivateKey) -> anyhow::Result<String> {
-        let public_key = EncodePublicKey::to_public_key_der(&RsaPublicKey::from(private_key))?;
+        let public_key = private_key.to_public_key().to_public_key_der()?;
         let res = format!(
             "SHA256:{}",
             BASE64_STANDARD.encode(Sha256::new_with_prefix(public_key.as_bytes()).finalize())
@@ -102,7 +102,7 @@ impl SnowflakeAuth {
     #[tracing::instrument(name = "peer_sflake::auth_refresh_jwt", skip_all)]
     fn refresh_jwt(&mut self) -> anyhow::Result<()> {
         let private_key_jwt: EncodingKey = EncodingKey::from_rsa_der(
-            EncodeRsaPrivateKey::to_pkcs1_der(&self.private_key)?.as_bytes(),
+            self.private_key.to_pkcs1_der()?.as_bytes(),
         );
         self.last_refreshed = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
         info!(


### PR DESCRIPTION
Made while attempting to remove pkcs1 to get around https://people.redhat.com/~hkario/marvin

Unfortunately this'll require changing keys. So I'll look to implement support for pkcs8 encoded keys too so pkcs1 can be avoided