### PR TITLE
SyncedAt Column for QRep

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -268,6 +268,13 @@ func (h *FlowRequestHandler) CreateQRepFlow(
 	} else {
 		workflowFn = peerflow.QRepFlowWorkflow
 	}
+
+	if req.QrepConfig.SyncedAtColName == "" {
+		cfg.SyncedAtColName = "_PEERDB_SYNCED_AT"
+	} else {
+		// make them all uppercase
+		cfg.SyncedAtColName = strings.ToUpper(req.QrepConfig.SyncedAtColName)
+	}
 	_, err := h.temporalClient.ExecuteWorkflow(ctx, workflowOptions, workflowFn, cfg, state)
 	if err != nil {
 		slog.Error("unable to start QRepFlow workflow",

--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -46,7 +46,7 @@ func (c *BigQueryConnector) SyncQRepRecords(
 		partition.PartitionId, destTable))
 
 	avroSync := &QRepAvroSyncMethod{connector: c, gcsBucket: config.StagingPath}
-	return avroSync.SyncQRepRecords(config.FlowJobName, destTable, partition, tblMetadata, stream)
+	return avroSync.SyncQRepRecords(config.FlowJobName, destTable, partition, tblMetadata, stream, config.SyncedAtColName)
 }
 
 func (c *BigQueryConnector) replayTableSchemaDeltasQRep(config *protos.QRepConfig, partition *protos.QRepPartition,

--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -46,7 +46,8 @@ func (c *BigQueryConnector) SyncQRepRecords(
 		partition.PartitionId, destTable))
 
 	avroSync := &QRepAvroSyncMethod{connector: c, gcsBucket: config.StagingPath}
-	return avroSync.SyncQRepRecords(config.FlowJobName, destTable, partition, tblMetadata, stream, config.SyncedAtColName)
+	return avroSync.SyncQRepRecords(config.FlowJobName, destTable, partition,
+		tblMetadata, stream, config.SyncedAtColName)
 }
 
 func (c *BigQueryConnector) replayTableSchemaDeltasQRep(config *protos.QRepConfig, partition *protos.QRepPartition,

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -48,7 +48,7 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 			flowJobName, dstTableName, syncBatchID),
 	)
 	// You will need to define your Avro schema as a string
-	avroSchema, err := DefineAvroSchema(dstTableName, dstTableMetadata)
+	avroSchema, err := DefineAvroSchema(dstTableName, dstTableMetadata, "")
 	if err != nil {
 		return 0, fmt.Errorf("failed to define Avro schema: %w", err)
 	}
@@ -107,6 +107,7 @@ func (s *QRepAvroSyncMethod) SyncQRepRecords(
 	partition *protos.QRepPartition,
 	dstTableMetadata *bigquery.TableMetadata,
 	stream *model.QRecordStream,
+	syncedAtCol string,
 ) (int, error) {
 	startTime := time.Now()
 	flowLog := slog.Group("sync_metadata",
@@ -115,7 +116,7 @@ func (s *QRepAvroSyncMethod) SyncQRepRecords(
 		slog.String("destinationTable", dstTableName),
 	)
 	// You will need to define your Avro schema as a string
-	avroSchema, err := DefineAvroSchema(dstTableName, dstTableMetadata)
+	avroSchema, err := DefineAvroSchema(dstTableName, dstTableMetadata, syncedAtCol)
 	if err != nil {
 		return 0, fmt.Errorf("failed to define Avro schema: %w", err)
 	}
@@ -137,9 +138,13 @@ func (s *QRepAvroSyncMethod) SyncQRepRecords(
 	// Start a transaction
 	stmts := []string{"BEGIN TRANSACTION;"}
 
+	selector := "*"
+	if syncedAtCol != "" { // PeerDB column
+		selector = "*, CURRENT_TIMESTAMP"
+	}
 	// Insert the records from the staging table into the destination table
-	insertStmt := fmt.Sprintf("INSERT INTO `%s.%s` SELECT * FROM `%s.%s`;",
-		datasetID, dstTableName, datasetID, stagingTable)
+	insertStmt := fmt.Sprintf("INSERT INTO `%s.%s` SELECT %s FROM `%s.%s`;",
+		datasetID, dstTableName, selector, datasetID, stagingTable)
 
 	stmts = append(stmts, insertStmt)
 
@@ -181,11 +186,15 @@ type AvroSchema struct {
 
 func DefineAvroSchema(dstTableName string,
 	dstTableMetadata *bigquery.TableMetadata,
+	syncedAtCol string,
 ) (*model.QRecordAvroSchemaDefinition, error) {
 	avroFields := []AvroField{}
 	nullableFields := make(map[string]struct{})
 
 	for _, bqField := range dstTableMetadata.Schema {
+		if bqField.Name == syncedAtCol {
+			continue
+		}
 		avroType, err := GetAvroType(bqField)
 		if err != nil {
 			return nil, err

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -471,7 +471,8 @@ func (c *PostgresConnector) SyncQRepRecords(
 
 	stagingTableSync := &QRepStagingTableSync{connector: c}
 	return stagingTableSync.SyncQRepRecords(
-		config.FlowJobName, dstTable, partition, stream, config.WriteMode)
+		config.FlowJobName, dstTable, partition, stream,
+		config.WriteMode, config.SyncedAtColName)
 }
 
 // SetupQRepMetadataTables function for postgres connector

--- a/flow/connectors/postgres/qrep_sync_method.go
+++ b/flow/connectors/postgres/qrep_sync_method.go
@@ -35,6 +35,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 	partition *protos.QRepPartition,
 	stream *model.QRecordStream,
 	writeMode *protos.QRepWriteMode,
+	syncedAtCol string,
 ) (int, error) {
 	syncLog := slog.Group("sync-qrep-log",
 		slog.String(string(shared.FlowNameKey), flowJobName),
@@ -81,6 +82,19 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 		if err != nil {
 			return -1, fmt.Errorf("failed to copy records into destination table: %v", err)
 		}
+
+		if syncedAtCol != "" {
+			updateSyncedAtStmt := fmt.Sprintf(
+				`UPDATE %s SET "%s" = CURRENT_TIMESTAMP WHERE "%s" IS NULL;`,
+				pgx.Identifier{dstTableName.Schema, dstTableName.Table}.Sanitize(),
+				syncedAtCol,
+				syncedAtCol,
+			)
+			_, err = tx.Exec(context.Background(), updateSyncedAtStmt)
+			if err != nil {
+				return -1, fmt.Errorf("failed to update synced_at column: %v", err)
+			}
+		}
 	} else {
 		// Step 2.1: Create a temp staging table
 		stagingTableName := fmt.Sprintf("_peerdb_staging_%s", shared.RandomString(8))
@@ -88,7 +102,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 		dstTableIdentifier := pgx.Identifier{dstTableName.Schema, dstTableName.Table}
 
 		createStagingTableStmt := fmt.Sprintf(
-			"CREATE UNLOGGED TABLE %s (LIKE %s);",
+			"CREATE UNLOGGED TABLE %s (LIKE %s INCLUDING INDEXES);",
 			stagingTableIdentifier.Sanitize(),
 			dstTableIdentifier.Sanitize(),
 		)
@@ -128,16 +142,19 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 			}
 			selectStrArray = append(selectStrArray, fmt.Sprintf(`"%s"`, col))
 		}
-
+		setClauseArray = append(setClauseArray,
+			fmt.Sprintf(`"%s" = CURRENT_TIMESTAMP`, syncedAtCol))
 		setClause := strings.Join(setClauseArray, ",")
-		selectStr := strings.Join(selectStrArray, ",")
+		selectStrColsSQL := strings.Join(append(selectStrArray,
+			fmt.Sprintf(`"%s"`, syncedAtCol)), ",")
+		selectStrValuesSQL := strings.Join(append(selectStrArray, `CURRENT_TIMESTAMP`), ",")
 
 		// Step 2.3: Perform the upsert operation, ON CONFLICT UPDATE
 		upsertStmt := fmt.Sprintf(
 			"INSERT INTO %s (%s) SELECT %s FROM %s ON CONFLICT (%s) DO UPDATE SET %s;",
 			dstTableIdentifier.Sanitize(),
-			selectStr,
-			selectStr,
+			selectStrColsSQL,
+			selectStrValuesSQL,
 			stagingTableIdentifier.Sanitize(),
 			strings.Join(writeMode.UpsertKeyColumns, ", "),
 			setClause,

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -249,7 +249,7 @@ func (c *SnowflakeConnector) createExternalStage(stageName string, config *proto
 }
 
 func (c *SnowflakeConnector) ConsolidateQRepPartitions(config *protos.QRepConfig) error {
-	c.logger.Error("Consolidating partitions")
+	c.logger.Info("Consolidating partitions")
 
 	destTable := config.DestinationTableIdentifier
 	stageName := c.getStageNameForJob(config.FlowJobName)
@@ -272,7 +272,7 @@ func (c *SnowflakeConnector) ConsolidateQRepPartitions(config *protos.QRepConfig
 
 // CleanupQRepFlow function for snowflake connector
 func (c *SnowflakeConnector) CleanupQRepFlow(config *protos.QRepConfig) error {
-	c.logger.Error("Cleaning up flow job")
+	c.logger.Info("Cleaning up flow job")
 	return c.dropStage(config.StagingPath, config.FlowJobName)
 }
 

--- a/flow/e2e/bigquery/qrep_flow_bq_test.go
+++ b/flow/e2e/bigquery/qrep_flow_bq_test.go
@@ -81,7 +81,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Complete_QRep_Flow_Avro() {
 	env.AssertExpectations(s.t)
 }
 
-func (s PeerFlowE2ETestSuiteBQ) Test_Columns_QRep_BQ() {
+func (s PeerFlowE2ETestSuiteBQ) Test_PeerDB_Columns_QRep_BQ() {
 	env := e2e.NewTemporalTestWorkflowEnvironment()
 	e2e.RegisterWorkflowsAndActivities(env, s.t)
 

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -153,10 +153,7 @@ func (s *PeerFlowE2ETestSuitePG) checkSyncedAt(dstSchemaQualified string) error 
 		}
 	}
 
-	if rows.Err() != nil {
-		return rows.Err()
-	}
-	return nil
+	return rows.Err()
 }
 
 func (s *PeerFlowE2ETestSuitePG) Test_Complete_QRep_Flow_Multi_Insert_PG() {

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -10,6 +10,7 @@ import (
 	connpostgres "github.com/PeerDB-io/peer-flow/connectors/postgres"
 	"github.com/PeerDB-io/peer-flow/e2e"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/suite"
@@ -67,7 +68,7 @@ func (s *PeerFlowE2ETestSuitePG) TearDownSuite() {
 }
 
 func (s *PeerFlowE2ETestSuitePG) setupSourceTable(tableName string, rowCount int) {
-	err := e2e.CreateSourceTableQRep(s.pool, postgresSuffix, tableName)
+	err := e2e.CreateTableForQRep(s.pool, postgresSuffix, tableName)
 	s.NoError(err)
 	err = e2e.PopulateSourceTable(s.pool, postgresSuffix, tableName, rowCount)
 	s.NoError(err)
@@ -134,6 +135,30 @@ func (s *PeerFlowE2ETestSuitePG) compareQuery(srcSchemaQualified, dstSchemaQuali
 	return nil
 }
 
+func (s *PeerFlowE2ETestSuitePG) checkSyncedAt(dstSchemaQualified string) error {
+	query := fmt.Sprintf(`SELECT "_PEERDB_SYNCED_AT" FROM %s`, dstSchemaQualified)
+
+	rows, _ := s.pool.Query(context.Background(), query)
+
+	defer rows.Close()
+	for rows.Next() {
+		var syncedAt pgtype.Timestamp
+		err := rows.Scan(&syncedAt)
+		if err != nil {
+			return err
+		}
+
+		if !syncedAt.Valid {
+			return fmt.Errorf("synced_at is not valid")
+		}
+	}
+
+	if rows.Err() != nil {
+		return rows.Err()
+	}
+	return nil
+}
+
 func (s *PeerFlowE2ETestSuitePG) Test_Complete_QRep_Flow_Multi_Insert_PG() {
 	env := s.NewTestWorkflowEnvironment()
 	e2e.RegisterWorkflowsAndActivities(env, s.T())
@@ -146,8 +171,8 @@ func (s *PeerFlowE2ETestSuitePG) Test_Complete_QRep_Flow_Multi_Insert_PG() {
 
 	//nolint:gosec
 	dstTable := "test_qrep_flow_avro_pg_2"
-	// the name is misleading, but this is the destination table
-	err := e2e.CreateSourceTableQRep(s.pool, postgresSuffix, dstTable)
+
+	err := e2e.CreateTableForQRep(s.pool, postgresSuffix, dstTable)
 	s.NoError(err)
 
 	srcSchemaQualified := fmt.Sprintf("%s_%s.%s", "e2e_test", postgresSuffix, srcTable)
@@ -165,6 +190,8 @@ func (s *PeerFlowE2ETestSuitePG) Test_Complete_QRep_Flow_Multi_Insert_PG() {
 		query,
 		postgresPeer,
 		"",
+		true,
+		"",
 	)
 	s.NoError(err)
 
@@ -177,6 +204,55 @@ func (s *PeerFlowE2ETestSuitePG) Test_Complete_QRep_Flow_Multi_Insert_PG() {
 	s.NoError(err)
 
 	err = s.comparePGTables(srcSchemaQualified, dstSchemaQualified, "*")
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	env.AssertExpectations(s.T())
+}
+
+func (s *PeerFlowE2ETestSuitePG) Test_Setup_Destination_And_PeerDB_Columns_QRep_PG() {
+	env := s.NewTestWorkflowEnvironment()
+	e2e.RegisterWorkflowsAndActivities(env, s.T())
+
+	numRows := 10
+
+	//nolint:gosec
+	srcTable := "test_qrep_columns_pg_1"
+	s.setupSourceTable(srcTable, numRows)
+
+	//nolint:gosec
+	dstTable := "test_qrep_columns_pg_2"
+
+	srcSchemaQualified := fmt.Sprintf("%s_%s.%s", "e2e_test", postgresSuffix, srcTable)
+	dstSchemaQualified := fmt.Sprintf("%s_%s.%s", "e2e_test", postgresSuffix, dstTable)
+
+	query := fmt.Sprintf("SELECT * FROM e2e_test_%s.%s WHERE updated_at BETWEEN {{.start}} AND {{.end}}",
+		postgresSuffix, srcTable)
+
+	postgresPeer := e2e.GeneratePostgresPeer(e2e.PostgresPort)
+
+	qrepConfig, err := e2e.CreateQRepWorkflowConfig(
+		"test_qrep_columns_pg",
+		srcSchemaQualified,
+		dstSchemaQualified,
+		query,
+		postgresPeer,
+		"",
+		true,
+		"_PEERDB_SYNCED_AT",
+	)
+	s.NoError(err)
+
+	e2e.RunQrepFlowWorkflow(env, qrepConfig)
+
+	// Verify workflow completes without error
+	s.True(env.IsWorkflowCompleted())
+
+	err = env.GetWorkflowError()
+	s.NoError(err)
+
+	err = s.checkSyncedAt(dstSchemaQualified)
 	if err != nil {
 		s.FailNow(err.Error())
 	}

--- a/flow/e2e/s3/qrep_flow_s3_test.go
+++ b/flow/e2e/s3/qrep_flow_s3_test.go
@@ -30,7 +30,7 @@ func TestPeerFlowE2ETestSuiteS3(t *testing.T) {
 }
 
 func (s *PeerFlowE2ETestSuiteS3) setupSourceTable(tableName string, rowCount int) {
-	err := e2e.CreateSourceTableQRep(s.pool, s3Suffix, tableName)
+	err := e2e.CreateTableForQRep(s.pool, s3Suffix, tableName)
 	s.NoError(err)
 	err = e2e.PopulateSourceTable(s.pool, s3Suffix, tableName, rowCount)
 	s.NoError(err)
@@ -106,6 +106,8 @@ func (s *PeerFlowE2ETestSuiteS3) Test_Complete_QRep_Flow_S3() {
 		query,
 		s.s3Helper.GetPeer(),
 		"stage",
+		false,
+		"",
 	)
 	s.NoError(err)
 	qrepConfig.StagingPath = s.s3Helper.s3Config.Url
@@ -152,6 +154,8 @@ func (s *PeerFlowE2ETestSuiteS3) Test_Complete_QRep_Flow_S3_CTID() {
 		query,
 		s.s3Helper.GetPeer(),
 		"stage",
+		false,
+		"",
 	)
 	s.NoError(err)
 	qrepConfig.StagingPath = s.s3Helper.s3Config.Url

--- a/flow/e2e/snowflake/qrep_flow_sf_test.go
+++ b/flow/e2e/snowflake/qrep_flow_sf_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s PeerFlowE2ETestSuiteSF) setupSourceTable(tableName string, numRows int) {
-	err := e2e.CreateSourceTableQRep(s.pool, s.pgSuffix, tableName)
+	err := e2e.CreateTableForQRep(s.pool, s.pgSuffix, tableName)
 	require.NoError(s.t, err)
 	err = e2e.PopulateSourceTable(s.pool, s.pgSuffix, tableName, numRows)
 	require.NoError(s.t, err)
@@ -77,6 +77,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF() {
 		query,
 		s.sfHelper.Peer,
 		"",
+		false,
+		"",
 	)
 	require.NoError(s.t, err)
 
@@ -115,6 +117,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_Upsert_Simple() 
 		dstSchemaQualified,
 		query,
 		s.sfHelper.Peer,
+		"",
+		false,
 		"",
 	)
 	qrepConfig.WriteMode = &protos.QRepWriteMode{
@@ -159,6 +163,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_S3() {
 		query,
 		s.sfHelper.Peer,
 		"",
+		false,
+		"",
 	)
 	require.NoError(s.t, err)
 	qrepConfig.StagingPath = fmt.Sprintf("s3://peerdb-test-bucket/avro/%s", uuid.New())
@@ -198,6 +204,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_Upsert_XMIN() {
 		dstSchemaQualified,
 		query,
 		s.sfHelper.Peer,
+		"",
+		false,
 		"",
 	)
 	qrepConfig.WriteMode = &protos.QRepWriteMode{
@@ -246,6 +254,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_S3_Integration()
 		query,
 
 		sfPeer,
+		"",
+		false,
 		"",
 	)
 	require.NoError(s.t, err)

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -123,7 +123,7 @@ func NormalizeFlowCountQuery(env *testsuite.TestWorkflowEnvironment,
 	}
 }
 
-func CreateSourceTableQRep(pool *pgxpool.Pool, suffix string, tableName string) error {
+func CreateTableForQRep(pool *pgxpool.Pool, suffix string, tableName string) error {
 	tblFields := []string{
 		"id UUID NOT NULL PRIMARY KEY",
 		"card_id UUID",
@@ -287,6 +287,8 @@ func CreateQRepWorkflowConfig(
 	query string,
 	dest *protos.Peer,
 	stagingPath string,
+	setupDst bool,
+	syncedAtCol string,
 ) (*protos.QRepConfig, error) {
 	connectionGen := QRepFlowConnectionGenerationConfig{
 		FlowJobName:                flowJobName,
@@ -304,6 +306,8 @@ func CreateQRepWorkflowConfig(
 		return nil, err
 	}
 	qrepConfig.InitialCopyOnly = true
+	qrepConfig.SyncedAtColName = syncedAtCol
+	qrepConfig.SetupWatermarkTableOnDestination = setupDst
 
 	return qrepConfig, nil
 }

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -125,6 +125,7 @@ func (q *QRepFlowExecution) SetupWatermarkTableOnDestination(ctx workflow.Contex
 			TableNameSchemaMapping: map[string]*protos.TableSchema{
 				q.config.DestinationTableIdentifier: tblSchemaOutput.TableNameSchemaMapping[q.config.WatermarkTable],
 			},
+			SyncedAtColName: q.config.SyncedAtColName,
 		}
 
 		future = workflow.ExecuteActivity(ctx, flowable.CreateNormalizedTable, setupConfig)

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -176,6 +176,7 @@ func (s *SnapshotFlowExecution) cloneTable(
 		NumRowsPerPartition:        numRowsPerPartition,
 		MaxParallelWorkers:         numWorkers,
 		StagingPath:                s.config.SnapshotStagingPath,
+		SyncedAtColName:            s.config.SyncedAtColName,
 		WriteMode: &protos.QRepWriteMode{
 			WriteType: protos.QRepWriteType_QREP_WRITE_MODE_APPEND,
 		},


### PR DESCRIPTION
Implements `_PEERDB_SYNCED_AT` for Query Replication mirrors for PG -> [PG, BQ, SF]
