### PR TITLE
Replication should now work from PG 16 Standbys

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -209,7 +209,8 @@ func (c *PostgresConnector) GetSlotInfo(slotName string) ([]*protos.SlotInfo, er
 	}
 	rows, err := c.pool.Query(c.ctx, "SELECT slot_name, redo_lsn::Text,restart_lsn::text,wal_status,"+
 		"confirmed_flush_lsn::text,active,"+
-		"round((pg_current_wal_lsn() - confirmed_flush_lsn) / 1024 / 1024) AS MB_Behind"+
+		"round((CASE WHEN pg_is_in_recovery() THEN pg_last_wal_receive_lsn() ELSE pg_current_wal_lsn() END"+
+		" - confirmed_flush_lsn) / 1024 / 1024) AS MB_Behind"+
 		" FROM pg_control_checkpoint(), pg_replication_slots"+specificSlotClause+";")
 	if err != nil {
 		return nil, err
@@ -730,31 +731,12 @@ func (c *PostgresConnector) generateUpdateStatement(allCols []string,
 }
 
 func (c *PostgresConnector) getCurrentLSN() (pglogrepl.LSN, error) {
-	isReplica, err := c.isReplica()
-	if err != nil {
-		return 0, fmt.Errorf("error while checking if replica: %w", err)
-	}
-	var query string
-	if isReplica {
-		query = "SELECT pg_last_wal_replay_lsn();"
-	} else {
-		query = "SELECT pg_current_wal_lsn();"
-	}
-	row := c.pool.QueryRow(c.ctx, query)
+	row := c.pool.QueryRow(c.ctx,
+		"SELECT CASE WHEN pg_is_in_recovery() THEN pg_last_wal_receive_lsn() ELSE pg_current_wal_lsn() END")
 	var result pgtype.Text
-	err = row.Scan(&result)
+	err := row.Scan(&result)
 	if err != nil {
 		return 0, fmt.Errorf("error while running query: %w", err)
 	}
 	return pglogrepl.ParseLSN(result.String)
-}
-
-func (c *PostgresConnector) isReplica() (bool, error) {
-	row := c.pool.QueryRow(c.ctx, "SELECT pg_is_in_recovery();")
-	var isReplica pgtype.Bool
-	err := row.Scan(&isReplica)
-	if err != nil {
-		return false, fmt.Errorf("error while running query: %w", err)
-	}
-	return isReplica.Bool, nil
 }


### PR DESCRIPTION
I tried PeerDB on Read Replicas in PG 16:
1. Initial Load worked as expected
2. SyncFlows were erroring out:
```
ERROR:  recovery is in progress
HINT:  WAL control functions cannot be executed during recovery.
```
The reason was `pg_current_wal_lsn()` cannot be run on a standby. I changed that function to `pg_last_wal_replay_lsn()` if Replica.