### PR TITLE
Refactor replica identity type and primary key column retrieval in Postgres

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/lib/pq/oid"
 	"golang.org/x/exp/maps"
 )
 
@@ -77,6 +78,15 @@ const (
 	deleteJobMetadataSQL = "DELETE FROM %s.%s WHERE MIRROR_JOB_NAME=$1"
 )
 
+type ReplicaIdentityType string
+
+const (
+	ReplicaIdentityDefault ReplicaIdentityType = "d"
+	ReplicaIdentityFull                        = "f"
+	ReplicaIdentityIndex                       = "i"
+	ReplicaIdentityNothing                     = "n"
+)
+
 // getRelIDForTable returns the relation ID for a table.
 func (c *PostgresConnector) getRelIDForTable(schemaTable *utils.SchemaTable) (uint32, error) {
 	var relID pgtype.Uint32
@@ -92,10 +102,10 @@ func (c *PostgresConnector) getRelIDForTable(schemaTable *utils.SchemaTable) (ui
 }
 
 // getReplicaIdentity returns the replica identity for a table.
-func (c *PostgresConnector) isTableFullReplica(schemaTable *utils.SchemaTable) (bool, error) {
+func (c *PostgresConnector) getReplicaIdentityType(schemaTable *utils.SchemaTable) (ReplicaIdentityType, error) {
 	relID, relIDErr := c.getRelIDForTable(schemaTable)
 	if relIDErr != nil {
-		return false, fmt.Errorf("failed to get relation id for table %s: %w", schemaTable, relIDErr)
+		return ReplicaIdentityDefault, fmt.Errorf("failed to get relation id for table %s: %w", schemaTable, relIDErr)
 	}
 
 	var replicaIdentity rune
@@ -103,43 +113,88 @@ func (c *PostgresConnector) isTableFullReplica(schemaTable *utils.SchemaTable) (
 		`SELECT relreplident FROM pg_class WHERE oid = $1;`,
 		relID).Scan(&replicaIdentity)
 	if err != nil {
-		return false, fmt.Errorf("error getting replica identity for table %s: %w", schemaTable, err)
+		return ReplicaIdentityDefault, fmt.Errorf("error getting replica identity for table %s: %w", schemaTable, err)
 	}
-	return string(replicaIdentity) == "f", nil
+
+	var replicaIdentityMap = map[rune]ReplicaIdentityType{
+		'd': ReplicaIdentityDefault,
+		'f': ReplicaIdentityFull,
+		'i': ReplicaIdentityIndex,
+		'n': ReplicaIdentityNothing,
+	}
+
+	replicaType, ok := replicaIdentityMap[replicaIdentity]
+	if !ok {
+		return ReplicaIdentityDefault, fmt.Errorf("unknown replica identity type %c for table %s", replicaIdentity, schemaTable)
+	}
+
+	return replicaType, nil
 }
 
-// getPrimaryKeyColumns for table returns the primary key column for a given table
-// errors if there is no primary key column or if there is more than one primary key column.
-func (c *PostgresConnector) getPrimaryKeyColumns(schemaTable *utils.SchemaTable) ([]string, error) {
+// getPrimaryKeyColumns returns the primary key columns for a given table.
+// Errors if there is no primary key column or if there is more than one primary key column.
+func (c *PostgresConnector) getPrimaryKeyColumns(
+	replicaIdentity ReplicaIdentityType,
+	schemaTable *utils.SchemaTable,
+) ([]string, error) {
 	relID, err := c.getRelIDForTable(schemaTable)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get relation id for table %s: %w", schemaTable, err)
 	}
 
-	// Get the primary key column name
-	var pkCol pgtype.Text
-	pkCols := make([]string, 0)
+	if replicaIdentity == ReplicaIdentityIndex {
+		return c.getReplicaIdentityIndexColumns(relID, schemaTable)
+	}
+
+	// Find the primary key index OID
+	var pkIndexOID oid.Oid
+	err = c.pool.QueryRow(c.ctx,
+		`SELECT indexrelid FROM pg_index WHERE indrelid = $1 AND indisprimary`,
+		relID).Scan(&pkIndexOID)
+	if err != nil {
+		return nil, fmt.Errorf("error finding primary key index for table %s: %w", schemaTable, err)
+	}
+
+	return c.getColumnNamesForIndex(pkIndexOID)
+}
+
+// getReplicaIdentityIndexColumns returns the columns used in the replica identity index.
+func (c *PostgresConnector) getReplicaIdentityIndexColumns(relID uint32, schemaTable *utils.SchemaTable) ([]string, error) {
+	var indexRelID oid.Oid
+	// Fetch the OID of the index used as the replica identity
+	err := c.pool.QueryRow(c.ctx,
+		`SELECT indexrelid FROM pg_index
+         WHERE indrelid = $1 AND indisreplident = true`,
+		relID).Scan(&indexRelID)
+	if err != nil {
+		return nil, fmt.Errorf("error finding replica identity index for table %s: %w", schemaTable, err)
+	}
+
+	return c.getColumnNamesForIndex(indexRelID)
+}
+
+// getColumnNamesForIndex returns the column names for a given index.
+func (c *PostgresConnector) getColumnNamesForIndex(indexOID oid.Oid) ([]string, error) {
+	var col pgtype.Text
+	cols := make([]string, 0)
 	rows, err := c.pool.Query(c.ctx,
 		`SELECT a.attname FROM pg_index i
 		 JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-		 WHERE i.indrelid = $1 AND i.indisprimary ORDER BY a.attname ASC`,
-		relID)
+		 WHERE i.indexrelid = $1 ORDER BY a.attname ASC`,
+		indexOID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting primary key column for table %s: %w", schemaTable, err)
+		return nil, fmt.Errorf("error getting columns for index %v: %w", indexOID, err)
 	}
 	defer rows.Close()
-	for {
-		if !rows.Next() {
-			break
-		}
-		err = rows.Scan(&pkCol)
-		if err != nil {
-			return nil, fmt.Errorf("error scanning primary key column for table %s: %w", schemaTable, err)
-		}
-		pkCols = append(pkCols, pkCol.String)
-	}
 
-	return pkCols, nil
+	for rows.Next() {
+		err = rows.Scan(&col)
+		if err != nil {
+			return nil, fmt.Errorf("error scanning column for index %v: %w", indexOID, err)
+		}
+		cols = append(cols, col.String)
+	}
+	return cols, nil
 }
 
 func (c *PostgresConnector) tableExists(schemaTable *utils.SchemaTable) (bool, error) {

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -78,13 +78,13 @@ const (
 	deleteJobMetadataSQL = "DELETE FROM %s.%s WHERE MIRROR_JOB_NAME=$1"
 )
 
-type ReplicaIdentityType string
+type ReplicaIdentityType rune
 
 const (
-	ReplicaIdentityDefault ReplicaIdentityType = "d"
-	ReplicaIdentityFull                        = "f"
-	ReplicaIdentityIndex                       = "i"
-	ReplicaIdentityNothing                     = "n"
+	ReplicaIdentityDefault ReplicaIdentityType = 'd'
+	ReplicaIdentityFull                        = 'f'
+	ReplicaIdentityIndex                       = 'i'
+	ReplicaIdentityNothing                     = 'n'
 )
 
 // getRelIDForTable returns the relation ID for a table.
@@ -116,19 +116,7 @@ func (c *PostgresConnector) getReplicaIdentityType(schemaTable *utils.SchemaTabl
 		return ReplicaIdentityDefault, fmt.Errorf("error getting replica identity for table %s: %w", schemaTable, err)
 	}
 
-	var replicaIdentityMap = map[rune]ReplicaIdentityType{
-		'd': ReplicaIdentityDefault,
-		'f': ReplicaIdentityFull,
-		'i': ReplicaIdentityIndex,
-		'n': ReplicaIdentityNothing,
-	}
-
-	replicaType, ok := replicaIdentityMap[replicaIdentity]
-	if !ok {
-		return ReplicaIdentityDefault, fmt.Errorf("unknown replica identity type %c for table %s", replicaIdentity, schemaTable)
-	}
-
-	return replicaType, nil
+	return ReplicaIdentityType(replicaIdentity), nil
 }
 
 // getPrimaryKeyColumns returns the primary key columns for a given table.


### PR DESCRIPTION
This is to support `USING INDEX` replica identity types in Postgres. Treating the index columns as primary key columns for now as it is the fastest way for us to support replica identity index.