### PR TITLE
remove SendWALHeartbeat from the CDCPullConnector interface

### DIFF
--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -43,9 +43,6 @@ type CDCPullConnector interface {
 	// PullFlowCleanup drops both the Postgres publication and replication slot, as a part of DROP MIRROR
 	PullFlowCleanup(jobName string) error
 
-	// SendWALHeartbeat allows for activity to progress restart_lsn on postgres.
-	SendWALHeartbeat() error
-
 	// GetSlotInfo returns the WAL (or equivalent) info of a slot for the connector.
 	GetSlotInfo(slotName string) ([]*protos.SlotInfo, error)
 

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -880,22 +880,6 @@ func (c *PostgresConnector) SyncFlowCleanup(jobName string) error {
 	return nil
 }
 
-func (c *PostgresConnector) SendWALHeartbeat() error {
-	command := `
-	BEGIN;
-	DROP aggregate IF EXISTS PEERDB_EPHEMERAL_HEARTBEAT(float4);
-	CREATE AGGREGATE PEERDB_EPHEMERAL_HEARTBEAT(float4) (SFUNC = float4pl, STYPE = float4);
-	DROP aggregate PEERDB_EPHEMERAL_HEARTBEAT(float4);
-	END;
-	`
-	_, err := c.pool.Exec(c.ctx, command)
-	if err != nil {
-		return fmt.Errorf("error bumping wal position: %w", err)
-	}
-
-	return nil
-}
-
 // GetLastOffset returns the last synced offset for a job.
 func (c *PostgresConnector) GetOpenConnectionsForUser() (*protos.GetOpenConnectionsForUserResult, error) {
 	row := c.pool.


### PR DESCRIPTION
Since this is done on the activity level now for all Postgres peers