### PR TITLE
Make alerter independent of slack

### DIFF
--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -132,9 +132,15 @@ func WorkerMain(opts *WorkerOptions) error {
 	w.RegisterWorkflow(peerflow.XminFlowWorkflow)
 	w.RegisterWorkflow(peerflow.DropFlowWorkflow)
 	w.RegisterWorkflow(peerflow.HeartbeatFlowWorkflow)
+
+	alerter, err := alerting.NewAlerter(conn)
+	if err != nil {
+		return fmt.Errorf("unable to create alerter: %w", err)
+	}
+
 	w.RegisterActivity(&activities.FlowableActivity{
 		CatalogPool: conn,
-		Alerter:     alerting.NewAlerter(conn),
+		Alerter:     alerter,
 	})
 
 	err = w.Run(worker.InterruptCh())

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -60,9 +60,15 @@ func RegisterWorkflowsAndActivities(env *testsuite.TestWorkflowEnvironment, t *t
 	env.RegisterWorkflow(peerflow.QRepFlowWorkflow)
 	env.RegisterWorkflow(peerflow.XminFlowWorkflow)
 	env.RegisterWorkflow(peerflow.QRepPartitionWorkflow)
+
+	alerter, err := alerting.NewAlerter(conn)
+	if err != nil {
+		t.Fatalf("unable to create alerter: %v", err)
+	}
+
 	env.RegisterActivity(&activities.FlowableActivity{
 		CatalogPool: conn,
-		Alerter:     alerting.NewAlerter(conn),
+		Alerter:     alerter,
 	})
 	env.RegisterActivity(&activities.SnapshotActivity{})
 }


### PR DESCRIPTION
This makes the alerter log to catalog whether slack based alerting is setup or not. Also fixes usage of Context in the alerting class.