### PR TITLE
be compatible with podman-compose

### DIFF
--- a/dev-peerdb.sh
+++ b/dev-peerdb.sh
@@ -1,12 +1,27 @@
-#!/bin/bash
-set -Eeuo pipefail
-
-if ! command -v docker &> /dev/null
+#!/bin/sh
+if test -z "$USE_PODMAN"
 then
-    echo "docker could not be found on PATH"
-    exit 1
+    if ! command -v docker &> /dev/null
+    then
+        if command -v podman-compose
+        then
+            echo "docker could not be found on PATH, using podman-compose"
+            USE_PODMAN=1
+        else
+            echo "docker could not be found on PATH"
+            exit 1
+        fi
+    fi
+fi
+
+if test -z "$USE_PODMAN"
+then
+    DOCKER="docker compose"
+    EXTRA_ARGS="--no-attach temporal --no-attach pyroscope --no-attach temporal-ui"
+else
+    DOCKER="podman-compose --podman-run-args=--replace"
+    EXTRA_ARGS=""
 fi
 
 export PEERDB_VERSION_SHA_SHORT=local-$(git rev-parse --short HEAD)
-docker compose -f docker-compose-dev.yml up --build \
- --no-attach temporal --no-attach pyroscope --no-attach temporal-ui
+exec $DOCKER -f docker-compose-dev.yml up --build $EXTRA_ARGS

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "postgres", "-U", "postgres"]
+      test: ["CMD", "pg_isready", "-d", "postgres", "-U", "postgres"]
       interval: 10s
       timeout: 30s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "postgres", "-U", "postgres"]
+      test: ["CMD", "pg_isready", "-d", "postgres", "-U", "postgres"]
       interval: 10s
       timeout: 30s
       retries: 5


### PR DESCRIPTION
podman complains if multiple arguments are passed to `CMD-SHELL`. Turns out we don't need it. podman doesn't support `--no-attach`. Otherwise everything works. Adjust `dev-peerdb.sh` to support podman-compose fallback or being invoked with `USE_PODMAN=1 ./dev-peerdb.sh`