### PR TITLE
added capability for BQ CDC across datasets

### DIFF
--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -35,7 +35,7 @@ func NewQRepAvroSyncMethod(connector *BigQueryConnector, gcsBucket string,
 }
 
 func (s *QRepAvroSyncMethod) SyncRecords(
-	dstTableName string,
+	rawTableName string,
 	flowJobName string,
 	lastCP int64,
 	dstTableMetadata *bigquery.TableMetadata,
@@ -45,16 +45,20 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 	activity.RecordHeartbeat(s.connector.ctx, time.Minute,
 		fmt.Sprintf("Flow job %s: Obtaining Avro schema"+
 			" for destination table %s and sync batch ID %d",
-			flowJobName, dstTableName, syncBatchID),
+			flowJobName, rawTableName, syncBatchID),
 	)
 	// You will need to define your Avro schema as a string
-	avroSchema, err := DefineAvroSchema(dstTableName, dstTableMetadata, "", "")
+	avroSchema, err := DefineAvroSchema(rawTableName, dstTableMetadata, "", "")
 	if err != nil {
 		return 0, fmt.Errorf("failed to define Avro schema: %w", err)
 	}
 
-	stagingTable := fmt.Sprintf("%s_%s_staging", dstTableName, fmt.Sprint(syncBatchID))
-	numRecords, err := s.writeToStage(fmt.Sprint(syncBatchID), dstTableName, avroSchema, stagingTable, stream)
+	stagingTable := fmt.Sprintf("%s_%s_staging", rawTableName, fmt.Sprint(syncBatchID))
+	numRecords, err := s.writeToStage(fmt.Sprint(syncBatchID), rawTableName, avroSchema,
+		&datasetTable{
+			dataset: s.connector.datasetID,
+			table:   stagingTable,
+		}, stream)
 	if err != nil {
 		return -1, fmt.Errorf("failed to push to avro stage: %v", err)
 	}
@@ -62,7 +66,7 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 	bqClient := s.connector.client
 	datasetID := s.connector.datasetID
 	insertStmt := fmt.Sprintf("INSERT INTO `%s.%s` SELECT * FROM `%s.%s`;",
-		datasetID, dstTableName, datasetID, stagingTable)
+		datasetID, rawTableName, datasetID, stagingTable)
 	updateMetadataStmt, err := s.connector.getUpdateMetadataStmt(flowJobName, lastCP, syncBatchID)
 	if err != nil {
 		return -1, fmt.Errorf("failed to update metadata: %v", err)
@@ -71,7 +75,7 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 	activity.RecordHeartbeat(s.connector.ctx, time.Minute,
 		fmt.Sprintf("Flow job %s: performing insert and update transaction"+
 			" for destination table %s and sync batch ID %d",
-			flowJobName, dstTableName, syncBatchID),
+			flowJobName, rawTableName, syncBatchID),
 	)
 
 	stmts := []string{
@@ -91,12 +95,12 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 		slog.Error("failed to delete staging table "+stagingTable,
 			slog.Any("error", err),
 			slog.String("syncBatchID", fmt.Sprint(syncBatchID)),
-			slog.String("destinationTable", dstTableName))
+			slog.String("destinationTable", rawTableName))
 	}
 
-	slog.Info(fmt.Sprintf("loaded stage into %s.%s", datasetID, dstTableName),
+	slog.Info(fmt.Sprintf("loaded stage into %s.%s", datasetID, rawTableName),
 		slog.String(string(shared.FlowNameKey), flowJobName),
-		slog.String("dstTableName", dstTableName))
+		slog.String("dstTableName", rawTableName))
 
 	return numRecords, nil
 }
@@ -124,8 +128,14 @@ func (s *QRepAvroSyncMethod) SyncQRepRecords(
 	slog.Info("Obtained Avro schema for destination table", flowLog)
 	slog.Info(fmt.Sprintf("Avro schema: %v\n", avroSchema), flowLog)
 	// create a staging table name with partitionID replace hyphens with underscores
-	stagingTable := fmt.Sprintf("%s_%s_staging", dstTableName, strings.ReplaceAll(partition.PartitionId, "-", "_"))
-	numRecords, err := s.writeToStage(partition.PartitionId, flowJobName, avroSchema, stagingTable, stream)
+	dstDatasetTable, _ := s.connector.convertToDatasetTable(dstTableName)
+	stagingDatasetTable := &datasetTable{
+		dataset: dstDatasetTable.dataset,
+		table: fmt.Sprintf("%s_%s_staging", dstDatasetTable.table,
+			strings.ReplaceAll(partition.PartitionId, "-", "_")),
+	}
+	numRecords, err := s.writeToStage(partition.PartitionId, flowJobName, avroSchema,
+		stagingDatasetTable, stream)
 	if err != nil {
 		return -1, fmt.Errorf("failed to push to avro stage: %v", err)
 	}
@@ -135,7 +145,6 @@ func (s *QRepAvroSyncMethod) SyncQRepRecords(
 		flowJobName, dstTableName, partition.PartitionId),
 	)
 	bqClient := s.connector.client
-	datasetID := s.connector.datasetID
 
 	selector := "*"
 	if softDeleteCol != "" { // PeerDB column
@@ -145,8 +154,8 @@ func (s *QRepAvroSyncMethod) SyncQRepRecords(
 		selector += ", CURRENT_TIMESTAMP"
 	}
 	// Insert the records from the staging table into the destination table
-	insertStmt := fmt.Sprintf("INSERT INTO `%s.%s` SELECT %s FROM `%s.%s`;",
-		datasetID, dstTableName, selector, datasetID, stagingTable)
+	insertStmt := fmt.Sprintf("INSERT INTO `%s` SELECT %s FROM `%s`;",
+		dstDatasetTable.string(), selector, stagingDatasetTable.string())
 
 	insertMetadataStmt, err := s.connector.createMetadataInsertStatement(partition, flowJobName, startTime)
 	if err != nil {
@@ -166,14 +175,15 @@ func (s *QRepAvroSyncMethod) SyncQRepRecords(
 	}
 
 	// drop the staging table
-	if err := bqClient.Dataset(datasetID).Table(stagingTable).Delete(s.connector.ctx); err != nil {
+	if err := bqClient.Dataset(stagingDatasetTable.dataset).
+		Table(stagingDatasetTable.table).Delete(s.connector.ctx); err != nil {
 		// just log the error this isn't fatal.
-		slog.Error("failed to delete staging table "+stagingTable,
+		slog.Error("failed to delete staging table "+stagingDatasetTable.string(),
 			slog.Any("error", err),
 			flowLog)
 	}
 
-	slog.Info(fmt.Sprintf("loaded stage into %s.%s", datasetID, dstTableName), flowLog)
+	slog.Info(fmt.Sprintf("loaded stage into %s", dstDatasetTable.string()), flowLog)
 	return numRecords, nil
 }
 
@@ -323,7 +333,7 @@ func (s *QRepAvroSyncMethod) writeToStage(
 	syncID string,
 	objectFolder string,
 	avroSchema *model.QRecordAvroSchemaDefinition,
-	stagingTable string,
+	stagingTable *datasetTable,
 	stream *model.QRecordStream,
 ) (int, error) {
 	shutdown := utils.HeartbeatRoutine(s.connector.ctx, time.Minute,
@@ -379,7 +389,6 @@ func (s *QRepAvroSyncMethod) writeToStage(
 	slog.Info(fmt.Sprintf("wrote %d records", avroFile.NumRecords), idLog)
 
 	bqClient := s.connector.client
-	datasetID := s.connector.datasetID
 	var avroRef bigquery.LoadSource
 	if s.gcsBucket != "" {
 		gcsRef := bigquery.NewGCSReference(fmt.Sprintf("gs://%s/%s", s.gcsBucket, avroFile.FilePath))
@@ -396,7 +405,7 @@ func (s *QRepAvroSyncMethod) writeToStage(
 		avroRef = localRef
 	}
 
-	loader := bqClient.Dataset(datasetID).Table(stagingTable).LoaderFrom(avroRef)
+	loader := bqClient.Dataset(stagingTable.dataset).Table(stagingTable.table).LoaderFrom(avroRef)
 	loader.UseAvroLogicalTypes = true
 	loader.WriteDisposition = bigquery.WriteTruncate
 	job, err := loader.Run(s.connector.ctx)
@@ -412,7 +421,7 @@ func (s *QRepAvroSyncMethod) writeToStage(
 	if err := status.Err(); err != nil {
 		return 0, fmt.Errorf("failed to load Avro file into BigQuery table: %w", err)
 	}
-	slog.Info(fmt.Sprintf("Pushed into %s/%s", avroFile.FilePath, syncID))
+	slog.Info(fmt.Sprintf("Pushed into %s", avroFile.FilePath))
 
 	err = s.connector.waitForTableReady(stagingTable)
 	if err != nil {

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -164,7 +164,7 @@ func (c *EventHubConnector) processBatch(
 				return 0, err
 			}
 
-			topicName, err := NewScopedEventhub(record.GetTableName())
+			topicName, err := NewScopedEventhub(record.GetDestinationTableName())
 			if err != nil {
 				c.logger.Error("failed to get topic name", slog.Any("error", err))
 				return 0, err

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -365,7 +365,7 @@ func (p *PostgresCDCSource) consumeStream(
 			}
 
 			if rec != nil {
-				tableName := rec.GetTableName()
+				tableName := rec.GetDestinationTableName()
 				switch r := rec.(type) {
 				case *model.UpdateRecord:
 					// tableName here is destination tableName.
@@ -843,7 +843,7 @@ func (p *PostgresCDCSource) processRelationMessage(
 func (p *PostgresCDCSource) recToTablePKey(req *model.PullRecordsRequest,
 	rec model.Record,
 ) (*model.TableWithPkey, error) {
-	tableName := rec.GetTableName()
+	tableName := rec.GetDestinationTableName()
 	pkeyColsMerged := make([]byte, 0)
 
 	for _, pkeyCol := range req.TableNameSchemaMapping[tableName].PrimaryKeyColumns {

--- a/flow/e2e/bigquery/bigquery_helper.go
+++ b/flow/e2e/bigquery/bigquery_helper.go
@@ -94,12 +94,11 @@ func generateBQPeer(bigQueryConfig *protos.BigqueryConfig) *protos.Peer {
 }
 
 // datasetExists checks if the dataset exists.
-func (b *BigQueryTestHelper) datasetExists() (bool, error) {
-	dataset := b.client.Dataset(b.Config.DatasetId)
+func (b *BigQueryTestHelper) datasetExists(datasetName string) (bool, error) {
+	dataset := b.client.Dataset(datasetName)
 	meta, err := dataset.Metadata(context.Background())
 	if err != nil {
 		// if err message contains `notFound` then dataset does not exist.
-		// first we cast the error to a bigquery.Error
 		if strings.Contains(err.Error(), "notFound") {
 			fmt.Printf("dataset %s does not exist\n", b.Config.DatasetId)
 			return false, nil
@@ -117,12 +116,12 @@ func (b *BigQueryTestHelper) datasetExists() (bool, error) {
 
 // RecreateDataset recreates the dataset, i.e, deletes it if exists and creates it again.
 func (b *BigQueryTestHelper) RecreateDataset() error {
-	exists, err := b.datasetExists()
+	exists, err := b.datasetExists(b.datasetName)
 	if err != nil {
 		return fmt.Errorf("failed to check if dataset %s exists: %w", b.Config.DatasetId, err)
 	}
 
-	dataset := b.client.Dataset(b.Config.DatasetId)
+	dataset := b.client.Dataset(b.datasetName)
 	if exists {
 		err := dataset.DeleteWithContents(context.Background())
 		if err != nil {
@@ -135,13 +134,13 @@ func (b *BigQueryTestHelper) RecreateDataset() error {
 		return fmt.Errorf("failed to create dataset: %w", err)
 	}
 
-	fmt.Printf("created dataset %s successfully\n", b.Config.DatasetId)
+	fmt.Printf("created dataset %s successfully\n", b.datasetName)
 	return nil
 }
 
 // DropDataset drops the dataset.
-func (b *BigQueryTestHelper) DropDataset() error {
-	exists, err := b.datasetExists()
+func (b *BigQueryTestHelper) DropDataset(datasetName string) error {
+	exists, err := b.datasetExists(datasetName)
 	if err != nil {
 		return fmt.Errorf("failed to check if dataset %s exists: %w", b.Config.DatasetId, err)
 	}
@@ -150,7 +149,7 @@ func (b *BigQueryTestHelper) DropDataset() error {
 		return nil
 	}
 
-	dataset := b.client.Dataset(b.Config.DatasetId)
+	dataset := b.client.Dataset(datasetName)
 	err = dataset.DeleteWithContents(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to delete dataset: %w", err)
@@ -171,7 +170,11 @@ func (b *BigQueryTestHelper) RunCommand(command string) error {
 
 // countRows(tableName) returns the number of rows in the given table.
 func (b *BigQueryTestHelper) countRows(tableName string) (int, error) {
-	command := fmt.Sprintf("SELECT COUNT(*) FROM `%s.%s`", b.Config.DatasetId, tableName)
+	return b.countRowsWithDataset(b.datasetName, tableName)
+}
+
+func (b *BigQueryTestHelper) countRowsWithDataset(dataset, tableName string) (int, error) {
+	command := fmt.Sprintf("SELECT COUNT(*) FROM `%s.%s`", dataset, tableName)
 	it, err := b.client.Query(command).Read(context.Background())
 	if err != nil {
 		return 0, fmt.Errorf("failed to run command: %w", err)

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -58,7 +58,7 @@ type Record interface {
 	// GetCheckPointID returns the ID of the record.
 	GetCheckPointID() int64
 	// get table name
-	GetTableName() string
+	GetDestinationTableName() string
 	// get columns and values for the record
 	GetItems() *RecordItems
 }
@@ -244,7 +244,7 @@ func (r *InsertRecord) GetCheckPointID() int64 {
 	return r.CheckPointID
 }
 
-func (r *InsertRecord) GetTableName() string {
+func (r *InsertRecord) GetDestinationTableName() string {
 	return r.DestinationTableName
 }
 
@@ -273,7 +273,7 @@ func (r *UpdateRecord) GetCheckPointID() int64 {
 }
 
 // Implement Record interface for UpdateRecord.
-func (r *UpdateRecord) GetTableName() string {
+func (r *UpdateRecord) GetDestinationTableName() string {
 	return r.DestinationTableName
 }
 
@@ -299,7 +299,7 @@ func (r *DeleteRecord) GetCheckPointID() int64 {
 	return r.CheckPointID
 }
 
-func (r *DeleteRecord) GetTableName() string {
+func (r *DeleteRecord) GetDestinationTableName() string {
 	return r.DestinationTableName
 }
 
@@ -470,8 +470,8 @@ func (r *RelationRecord) GetCheckPointID() int64 {
 	return r.CheckPointID
 }
 
-func (r *RelationRecord) GetTableName() string {
-	return r.TableSchemaDelta.SrcTableName
+func (r *RelationRecord) GetDestinationTableName() string {
+	return r.TableSchemaDelta.DstTableName
 }
 
 func (r *RelationRecord) GetItems() *RecordItems {


### PR DESCRIPTION
1) Just like Snowflake and Postgres, now BigQuery takes tables in the form of `<dataset>.<table>`. If dataset is omitted then it defaults to using the dataset specified at the time of peer creation.
2) If the dataset doesn't exist at the time of mirror creation, it is created during `SetupNormalizedTables` before the tables in the dataset.
3) A check has also been added so that two source tables cannot point to the same destination table specified in 2 different formats.