### PR TITLE
[breaking] BQ SyncRecords now streams properly, code cleanup

### DIFF
--- a/flow/connectors/bigquery/merge_statement_generator.go
+++ b/flow/connectors/bigquery/merge_statement_generator.go
@@ -80,7 +80,6 @@ func (m *mergeStmtGenerator) generateFlattenedCTE() string {
 	flattenedProjs = append(
 		flattenedProjs,
 		"_peerdb_timestamp",
-		"_peerdb_timestamp_nanos",
 		"_peerdb_record_type",
 		"_peerdb_unchanged_toast_columns",
 	)
@@ -99,7 +98,7 @@ func (m *mergeStmtGenerator) generateDeDupedCTE() string {
 		SELECT _peerdb_ranked.*
 			FROM (
 				SELECT RANK() OVER (
-					PARTITION BY %s ORDER BY _peerdb_timestamp_nanos DESC
+					PARTITION BY %s ORDER BY _peerdb_timestamp DESC
 				) as _peerdb_rank, * FROM _peerdb_flattened
 			) _peerdb_ranked
 			WHERE _peerdb_rank = 1

--- a/flow/connectors/utils/stream.go
+++ b/flow/connectors/utils/stream.go
@@ -10,7 +10,7 @@ import (
 )
 
 func RecordsToRawTableStream(req *model.RecordsToStreamRequest) (*model.RecordsToStreamResponse, error) {
-	recordStream := model.NewQRecordStream(1 << 16)
+	recordStream := model.NewQRecordStream(1 << 17)
 	err := recordStream.SetSchema(&model.QRecordSchema{
 		Fields: []model.QField{
 			{
@@ -85,11 +85,6 @@ func recordToQRecordOrError(tableMapping map[string]uint32, batchID int64, recor
 			}
 		}
 
-		// add insert record to the raw table
-		entries[2] = qvalue.QValue{
-			Kind:  qvalue.QValueKindString,
-			Value: typedRecord.DestinationTableName,
-		}
 		entries[3] = qvalue.QValue{
 			Kind:  qvalue.QValueKindString,
 			Value: itemsJSON,
@@ -121,10 +116,6 @@ func recordToQRecordOrError(tableMapping map[string]uint32, batchID int64, recor
 			}
 		}
 
-		entries[2] = qvalue.QValue{
-			Kind:  qvalue.QValueKindString,
-			Value: typedRecord.DestinationTableName,
-		}
 		entries[3] = qvalue.QValue{
 			Kind:  qvalue.QValueKindString,
 			Value: newItemsJSON,
@@ -150,11 +141,6 @@ func recordToQRecordOrError(tableMapping map[string]uint32, batchID int64, recor
 			}
 		}
 
-		// append delete record to the raw table
-		entries[2] = qvalue.QValue{
-			Kind:  qvalue.QValueKindString,
-			Value: typedRecord.DestinationTableName,
-		}
 		entries[3] = qvalue.QValue{
 			Kind:  qvalue.QValueKindString,
 			Value: itemsJSON,
@@ -185,6 +171,10 @@ func recordToQRecordOrError(tableMapping map[string]uint32, batchID int64, recor
 	entries[1] = qvalue.QValue{
 		Kind:  qvalue.QValueKindInt64,
 		Value: time.Now().UnixNano(),
+	}
+	entries[2] = qvalue.QValue{
+		Kind:  qvalue.QValueKindString,
+		Value: record.GetDestinationTableName(),
 	}
 	entries[6] = qvalue.QValue{
 		Kind:  qvalue.QValueKindInt64,


### PR DESCRIPTION
### ⚠️ This change can break existing CDC mirrors from Postgres to BigQuery!

Fixes a bug in BigQuery CDC where a batch with number of records greater than `2 ** 20` causes the Avro file generation part to hang. This is because all records were being written to a bounded channel first and then consumed by the Avro writer instead of the 2 operations happening in parallel. With a large number of records, the channel would fill up and block before the records finished writing, leading to the loop deadlocking itself.

Fixed by switching BigQuery record generation to the mechanism used by Snowflake, where the record generation happens in another goroutine and therefore the channel consumption happens in parallel. As part of this change, some code was cleaned up and the BigQuery raw table schema was changed in a breaking manner to be similar to the SF/PG equivalent. Specifically, the column `_peerdb_timestamp` of type `TIMESTAMP` was removed and the column `_peerdb_timestamp_nanos` of type `INTEGER` was renamed to the former. Existing raw tables will need to be fixed up to match this new, simpler schema.

```
ALTER TABLE <...> DROP COLUMN _peerdb_timestamp;
ALTER TABLE <...> RENAME COLUMN _peerdb_timestamp_nanos TO _peerdb_timestamp;
``` 

Closes #908 