### PR TITLE
Experiment: run flow ci with 16 cores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        runner: [ubicloud-standard-8-ubuntu-2204-arm]
+        runner: [ubicloud-standard-2-ubuntu-2204-arm]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     services:
@@ -54,6 +54,10 @@ jobs:
           name: "snowflake_creds.json"
           json: ${{ secrets.SNOWFLAKE_GH_CI_PKEY }}
           dir: "nexus/server/tests/assets/"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: nexus
 
       - name: cargo check
         run: cargo check

--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -10,6 +10,7 @@ jobs:
   docker-build:
     strategy:
       matrix:
+        # ubuntu-latest leverages larger GH runner pool & completes in ~30s instead of ~3m
         runner: [ubuntu-latest]
     runs-on: ${{ matrix.runner }}
     permissions:

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -10,7 +10,7 @@ jobs:
   flow_test:
     strategy:
       matrix:
-        runner: [ubicloud-standard-8-ubuntu-2204-arm]
+        runner: [ubicloud-standard-16-ubuntu-2204-arm]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     services:


### PR DESCRIPTION
This shaves almost a minute off flow ci, & I expect that'll improve as rest of test suite parallelizes