### PR TITLE
postgres connector: ignore unique constraint violations from IF NOT EXISTS

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -374,7 +374,7 @@ func (c *PostgresConnector) createSlotAndPublication(
 
 func (c *PostgresConnector) createMetadataSchema(createSchemaTx pgx.Tx) error {
 	_, err := createSchemaTx.Exec(c.ctx, fmt.Sprintf(createSchemaSQL, c.metadataSchema))
-	if err != nil {
+	if err != nil && !utils.IsUniqueError(err) {
 		return fmt.Errorf("error while creating internal schema: %w", err)
 	}
 	return nil

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -158,7 +158,7 @@ func (c *PostgresConnector) SetupMetadataTables() error {
 	}
 	_, err = createMetadataTablesTx.Exec(c.ctx, fmt.Sprintf(createMirrorJobsTableSQL,
 		c.metadataSchema, mirrorJobsTableIdentifier))
-	if err != nil {
+	if err != nil && !utils.IsUniqueError(err) {
 		return fmt.Errorf("error creating table %s: %w", mirrorJobsTableIdentifier, err)
 	}
 

--- a/flow/connectors/utils/postgres.go
+++ b/flow/connectors/utils/postgres.go
@@ -2,13 +2,21 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+func IsUniqueError(err error) bool {
+	var pgerr *pgconn.PgError
+	return errors.As(err, &pgerr) && pgerr.Code == pgerrcode.UniqueViolation
+}
 
 func GetPGConnectionString(pgConfig *protos.PostgresConfig) string {
 	passwordEscaped := url.QueryEscape(pgConfig.Password)


### PR DESCRIPTION
Followup from #905 now that I've seen parallel testing of pg connector (#941) running into this