### PR TITLE
Don't create metadata schema in a transaction

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -372,8 +372,8 @@ func (c *PostgresConnector) createSlotAndPublication(
 	return nil
 }
 
-func (c *PostgresConnector) createMetadataSchema(createSchemaTx pgx.Tx) error {
-	_, err := createSchemaTx.Exec(c.ctx, fmt.Sprintf(createSchemaSQL, c.metadataSchema))
+func (c *PostgresConnector) createMetadataSchema() error {
+	_, err := c.pool.Exec(c.ctx, fmt.Sprintf(createSchemaSQL, c.metadataSchema))
 	if err != nil && !utils.IsUniqueError(err) {
 		return fmt.Errorf("error while creating internal schema: %w", err)
 	}


### PR DESCRIPTION
When a command errors during a transaction the transaction can no longer progress, it must be rolled back. This is the case when IF NOT EXISTS errors over unique violation

We do not need schema/table creation to be transactional, so remove transaction

Corrects #942 & #905 to be effective