### PR TITLE
SF JSON (Variant): Remove escaped quotes

### DIFF
--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -329,6 +329,10 @@ func (c *SnowflakeConnector) GetCopyTransformation(
 		case "NUMBER":
 			transformations = append(transformations,
 				fmt.Sprintf("$1:\"%s\" AS %s", avroColName, normalizedColName))
+		case "VARIANT":
+			transformations = append(transformations,
+				fmt.Sprintf("PARSE_JSON($1:\"%s\") AS %s", avroColName, normalizedColName))
+
 		default:
 			transformations = append(transformations,
 				fmt.Sprintf("($1:\"%s\")::%s AS %s", avroColName, colType, normalizedColName))

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -850,6 +850,10 @@ func (c *SnowflakeConnector) generateAndExecuteMergeStatement(
 			flattenedCastsSQLArray = append(flattenedCastsSQLArray,
 				fmt.Sprintf("TO_GEOMETRY(CAST(%s:\"%s\" AS STRING),true) AS %s,",
 					toVariantColumnName, columnName, targetColumnName))
+		case qvalue.QValueKindJSON:
+			flattenedCastsSQLArray = append(flattenedCastsSQLArray,
+				fmt.Sprintf("PARSE_JSON(CAST(%s:\"%s\" AS STRING)) AS %s,",
+					toVariantColumnName, columnName, targetColumnName))
 		// TODO: https://github.com/PeerDB-io/peerdb/issues/189 - handle time types and interval types
 		// case model.ColumnTypeTime:
 		// 	flattenedCastsSQLArray = append(flattenedCastsSQLArray, fmt.Sprintf("TIME_FROM_PARTS(0,0,0,%s:%s:"+

--- a/flow/connectors/sql/query_executor.go
+++ b/flow/connectors/sql/query_executor.go
@@ -410,7 +410,7 @@ func toQValue(kind qvalue.QValueKind, val interface{}) (qvalue.QValue, error) {
 
 	case qvalue.QValueKindJSON:
 		vraw := val.(*interface{})
-		vstring := (*vraw).(string)
+		vstring, _ := (*vraw).(string)
 
 		if strings.HasPrefix(vstring, "[") {
 			// parse the array

--- a/flow/connectors/sql/query_executor.go
+++ b/flow/connectors/sql/query_executor.go
@@ -410,7 +410,11 @@ func toQValue(kind qvalue.QValueKind, val interface{}) (qvalue.QValue, error) {
 
 	case qvalue.QValueKindJSON:
 		vraw := val.(*interface{})
-		vstring, _ := (*vraw).(string)
+		vstring, ok := (*vraw).(string)
+		if !ok {
+			return qvalue.QValue{},
+				fmt.Errorf("failed to obtain string from json, possibly due to null field value")
+		}
 
 		if strings.HasPrefix(vstring, "[") {
 			// parse the array

--- a/flow/connectors/sql/query_executor.go
+++ b/flow/connectors/sql/query_executor.go
@@ -412,8 +412,7 @@ func toQValue(kind qvalue.QValueKind, val interface{}) (qvalue.QValue, error) {
 		vraw := val.(*interface{})
 		vstring, ok := (*vraw).(string)
 		if !ok {
-			return qvalue.QValue{},
-				fmt.Errorf("failed to obtain string from json, possibly due to null field value")
+			slog.Warn("A parsed JSON value was not a string. Likely a null field value")
 		}
 
 		if strings.HasPrefix(vstring, "[") {

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -749,6 +749,11 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 	if err != nil {
 		s.t.Log(err)
 	}
+
+	// check if JSON on snowflake side is a good JSON
+	err = s.checkJSONValue(dstTableName, "c17", "sai")
+	require.NoError(s.t, err)
+
 	// Make sure that there are no nulls
 	s.Equal(noNulls, true)
 

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -751,7 +751,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 	}
 
 	// check if JSON on snowflake side is a good JSON
-	err = s.checkJSONValue(dstTableName, "c17", "sai")
+	err = s.checkJSONValue(dstTableName, "c17", "sai", "1")
 	require.NoError(s.t, err)
 
 	// Make sure that there are no nulls

--- a/flow/e2e/snowflake/qrep_flow_sf_test.go
+++ b/flow/e2e/snowflake/qrep_flow_sf_test.go
@@ -23,7 +23,7 @@ func (s PeerFlowE2ETestSuiteSF) compareTableContentsSF(tableName, selector strin
 	s.compareTableContentsWithDiffSelectorsSF(tableName, selector, selector, false)
 }
 
-func (s PeerFlowE2ETestSuiteSF) checkJSONValue(tableName, colName, fieldName string) error {
+func (s PeerFlowE2ETestSuiteSF) checkJSONValue(tableName, colName, fieldName, value string) error {
 	res, err := s.sfHelper.ExecuteAndProcessQuery(fmt.Sprintf(
 		"SELECT %s:%s FROM %s;",
 		colName, fieldName, tableName))
@@ -32,8 +32,8 @@ func (s PeerFlowE2ETestSuiteSF) checkJSONValue(tableName, colName, fieldName str
 	}
 
 	jsonVal := res.Records[0].Entries[0].Value
-	if jsonVal == "" {
-		return fmt.Errorf("bad json value in field %s of column %s: %v", fieldName, colName, jsonVal)
+	if jsonVal != value {
+		return fmt.Errorf("bad json value in field %s of column %s: %v. expected: %v", fieldName, colName, jsonVal, value)
 	}
 	return nil
 }
@@ -103,6 +103,9 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF() {
 
 	sel := e2e.GetOwnersSelectorStringsSF()
 	s.compareTableContentsWithDiffSelectorsSF(tblName, sel[0], sel[1], false)
+
+	err = s.checkJSONValue(dstSchemaQualified, "f7", "key", "\"value\"")
+	require.NoError(s.t, err)
 
 	env.AssertExpectations(s.t)
 }
@@ -262,7 +265,6 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_S3_Integration()
 		s.attachSchemaSuffix(tblName),
 		dstSchemaQualified,
 		query,
-
 		sfPeer,
 		"",
 		false,

--- a/flow/e2e/snowflake/qrep_flow_sf_test.go
+++ b/flow/e2e/snowflake/qrep_flow_sf_test.go
@@ -24,13 +24,16 @@ func (s PeerFlowE2ETestSuiteSF) compareTableContentsSF(tableName, selector strin
 }
 
 func (s PeerFlowE2ETestSuiteSF) checkJSONValue(tableName, colName, fieldName string) error {
-	res, err := s.sfHelper.ExecuteAndProcessQuery(fmt.Sprintf("SELECT c17:kk FROM %s;", tableName))
+	res, err := s.sfHelper.ExecuteAndProcessQuery(fmt.Sprintf(
+		"SELECT %s:%s FROM %s;",
+		colName, fieldName, tableName))
 	if err != nil {
 		return fmt.Errorf("json value check failed: %v", err)
 	}
 
-	if res.Records[0].Entries[0].Value == "" {
-		return fmt.Errorf("bad json value in field %s of column %s", fieldName, colName)
+	jsonVal := res.Records[0].Entries[0].Value
+	if jsonVal == "" {
+		return fmt.Errorf("bad json value in field %s of column %s: %v", fieldName, colName, jsonVal)
 	}
 	return nil
 }

--- a/flow/e2e/snowflake/qrep_flow_sf_test.go
+++ b/flow/e2e/snowflake/qrep_flow_sf_test.go
@@ -23,6 +23,18 @@ func (s PeerFlowE2ETestSuiteSF) compareTableContentsSF(tableName, selector strin
 	s.compareTableContentsWithDiffSelectorsSF(tableName, selector, selector, false)
 }
 
+func (s PeerFlowE2ETestSuiteSF) checkJSONValue(tableName, colName, fieldName string) error {
+	res, err := s.sfHelper.ExecuteAndProcessQuery(fmt.Sprintf("SELECT c17:kk FROM %s;", tableName))
+	if err != nil {
+		return fmt.Errorf("json value check failed: %v", err)
+	}
+
+	if res.Records[0].Entries[0].Value == "" {
+		return fmt.Errorf("bad json value in field %s of column %s", fieldName, colName)
+	}
+	return nil
+}
+
 func (s PeerFlowE2ETestSuiteSF) compareTableContentsWithDiffSelectorsSF(tableName, pgSelector, sfSelector string,
 	tableCaseSensitive bool,
 ) {


### PR DESCRIPTION
Similar to how #830 fixes JSON structure for BigQuery, this one does it for Snowflake by performing a [PARSE_JSON transformation](https://docs.snowflake.com/en/sql-reference/functions/parse_json) in Copy (for initial load) and Merge (CDC) steps

<img width="1111" alt="Screenshot 2024-01-01 at 5 23 52 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/03549553-56c5-475b-b668-0e83b68c8eb0">

You can now query synced Postgres JSONs by PeerDB to Snowflake Variants using:
```sql
SELECT j:tags FROM mysftable
``` 
Adds a test for this. Also tested manually

Fixes #828 