### PR TITLE
Adds idletimeout to flow config, ui and temporal signal

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -228,12 +228,14 @@ func (a *FlowableActivity) StartFlow(ctx context.Context,
 	flowName := input.FlowConnectionConfigs.FlowJobName
 	errGroup.Go(func() error {
 		return srcConn.PullRecords(a.CatalogPool, &model.PullRecordsRequest{
-			FlowJobName:                 flowName,
-			SrcTableIDNameMapping:       input.FlowConnectionConfigs.SrcTableIdNameMapping,
-			TableNameMapping:            tblNameMapping,
-			LastOffset:                  input.LastSyncState.Checkpoint,
-			MaxBatchSize:                uint32(input.SyncFlowOptions.BatchSize),
-			IdleTimeout:                 peerdbenv.PeerDBCDCIdleTimeoutSeconds(),
+			FlowJobName:           flowName,
+			SrcTableIDNameMapping: input.FlowConnectionConfigs.SrcTableIdNameMapping,
+			TableNameMapping:      tblNameMapping,
+			LastOffset:            input.LastSyncState.Checkpoint,
+			MaxBatchSize:          uint32(input.SyncFlowOptions.BatchSize),
+			IdleTimeout: peerdbenv.PeerDBCDCIdleTimeoutSeconds(
+				int(input.FlowConnectionConfigs.IdleTimeoutSeconds),
+			),
 			TableNameSchemaMapping:      input.FlowConnectionConfigs.TableNameSchemaMapping,
 			OverridePublicationName:     input.FlowConnectionConfigs.PublicationName,
 			OverrideReplicationSlotName: input.FlowConnectionConfigs.ReplicationSlotName,

--- a/flow/peerdbenv/config.go
+++ b/flow/peerdbenv/config.go
@@ -30,8 +30,13 @@ func PeerDBEventhubFlushTimeoutSeconds() time.Duration {
 }
 
 // PEERDB_CDC_IDLE_TIMEOUT_SECONDS
-func PeerDBCDCIdleTimeoutSeconds() time.Duration {
-	x := getEnvInt("PEERDB_CDC_IDLE_TIMEOUT_SECONDS", 60)
+func PeerDBCDCIdleTimeoutSeconds(providedValue int) time.Duration {
+	var x int
+	if providedValue > 0 {
+		x = providedValue
+	} else {
+		x = getEnvInt("PEERDB_CDC_IDLE_TIMEOUT_SECONDS", 60)
+	}
 	return time.Duration(x) * time.Second
 }
 

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -7,10 +7,10 @@ import (
 )
 
 const (
-	peerFlowTaskQueue      = "peer-flow-task-queue"
-	snapshotFlowTaskQueue  = "snapshot-flow-task-queue"
-	CDCFlowSignalName      = "peer-flow-signal"
-	CDCBatchSizeSignalName = "cdc-batch-size-signal"
+	peerFlowTaskQueue              = "peer-flow-task-queue"
+	snapshotFlowTaskQueue          = "snapshot-flow-task-queue"
+	CDCFlowSignalName              = "peer-flow-signal"
+	CDCDynamicPropertiesSignalName = "cdc-dynamic-properties"
 )
 
 const MirrorNameSearchAttribute = "MirrorName"

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -78,6 +78,8 @@ message FlowConnectionConfigs {
   string synced_at_col_name = 25;
 
   bool initial_copy_only = 26;
+
+  int64 idle_timeout_seconds = 27;
 }
 
 message RenameTableOption {
@@ -111,6 +113,7 @@ message CreateTablesFromExistingOutput {
 message SyncFlowOptions {
   int32 batch_size = 1;
   map<uint32, RelationMessage> relation_message_mapping = 2;
+  int64 idle_timeout_seconds = 3;
 }
 
 message NormalizeFlowOptions {

--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -17,12 +17,24 @@ export const cdcSettings: MirrorSetting[] = [
     stateHandler: (value, setter) =>
       setter((curr: CDCConfig) => ({
         ...curr,
-        maxBatchSize: (value as boolean) || false,
+        maxBatchSize: (value as number) || 100000,
       })),
     tips: 'The number of rows PeerDB will pull from source at a time. If left empty, the default value is 100,000 rows.',
     type: 'number',
     default: '100000',
     advanced: true,
+  },
+  {
+    label: 'Idle Timeout (Seconds)',
+    stateHandler: (value, setter) =>
+      setter((curr: CDCConfig) => ({
+        ...curr,
+        idleTimeoutSeconds: (value as number) || 100000,
+      })),
+    tips: 'Time after which a Sync flow ends, if it happens before pull batch size is reached. Defaults to 60 seconds.',
+    helpfulLink: 'https://docs.peerdb.io/metrics/important_cdc_configs',
+    type: 'number',
+    default: '60',
   },
   {
     label: 'Publication Name',

--- a/ui/app/mirrors/create/helpers/common.ts
+++ b/ui/app/mirrors/create/helpers/common.ts
@@ -46,6 +46,7 @@ export const blankCDCSetting: FlowConnectionConfigs = {
   softDeleteColName: '',
   syncedAtColName: '',
   initialCopyOnly: false,
+  idleTimeoutSeconds: 60,
 };
 
 export const blankQRepSetting = {


### PR DESCRIPTION
- Refactors our signal receptor in CDC to take in a struct of two values - `BatchSize` and `IdleTimeout`.

You can send a signal by going to peerflow in Temporal UI, clicking on the down-arrow in the Request Cancellation button on the right, click on `Send Signal`, and then enter like this:

<img width="1670" alt="Screenshot 2024-01-02 at 2 07 34 AM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/9e175f3d-8ade-48f9-a61e-880753f8d006">

You can set one of the two at a time as well.

Note that the name of the signal must be  `cdc-dynamic-properties`

- Adds Idle Timeout to UI and an info tip with explanation and link to https://docs.peerdb.io/metrics/important_cdc_configs
<img width="1203" alt="Screenshot 2024-01-02 at 2 12 11 AM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/4f8101f7-161f-4595-8d7e-e12e70026e1d">
