### PR TITLE
Set proper waitForBatches activity timeout 

### DIFF
--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -302,9 +302,14 @@ func (q *QRepFlowExecution) consolidatePartitions(ctx workflow.Context) error {
 func (q *QRepFlowExecution) waitForNewRows(ctx workflow.Context, lastPartition *protos.QRepPartition) error {
 	q.logger.Info("idling until new rows are detected")
 
+	waitActivityTimeout := 5 * time.Minute
+	if q.config.WaitBetweenBatchesSeconds > 300 {
+		timeGap := 60
+		waitActivityTimeout = time.Duration(q.config.WaitBetweenBatchesSeconds+uint32(timeGap)) * time.Second
+	}
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 16 * 365 * 24 * time.Hour, // 16 years
-		HeartbeatTimeout:    5 * time.Minute,
+		HeartbeatTimeout:    waitActivityTimeout,
 	})
 
 	if err := workflow.ExecuteActivity(ctx, flowable.QRepWaitUntilNewRows, q.config,

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -303,7 +303,7 @@ func (q *QRepFlowExecution) waitForNewRows(ctx workflow.Context, lastPartition *
 	q.logger.Info("idling until new rows are detected")
 
 	waitActivityTimeout := 5 * time.Minute
-	if q.config.WaitBetweenBatchesSeconds > 300 {
+	if q.config.WaitBetweenBatchesSeconds >= 300 {
 		timeGap := 60
 		waitActivityTimeout = time.Duration(q.config.WaitBetweenBatchesSeconds+uint32(timeGap)) * time.Second
 	}

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -302,11 +302,7 @@ func (q *QRepFlowExecution) consolidatePartitions(ctx workflow.Context) error {
 func (q *QRepFlowExecution) waitForNewRows(ctx workflow.Context, lastPartition *protos.QRepPartition) error {
 	q.logger.Info("idling until new rows are detected")
 
-	waitActivityTimeout := 5 * time.Minute
-	if q.config.WaitBetweenBatchesSeconds >= 300 {
-		timeGap := 60
-		waitActivityTimeout = time.Duration(q.config.WaitBetweenBatchesSeconds+uint32(timeGap)) * time.Second
-	}
+	waitActivityTimeout := time.Duration(q.config.WaitBetweenBatchesSeconds+60) * time.Second
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 16 * 365 * 24 * time.Hour, // 16 years
 		HeartbeatTimeout:    waitActivityTimeout,


### PR DESCRIPTION
In `waitForNewRows` in our QRep logic, we blindly set activity timeout to 5 minutes, when actually it is very much dependent on what the user set as `waitBetweenBatches`.

This PR sets the activity timeout based on the waitBetweenBatches value