### PR TITLE
EventHub:: Handle quoted eventhub name

### DIFF
--- a/flow/connectors/eventhub/scoped_eventhub.go
+++ b/flow/connectors/eventhub/scoped_eventhub.go
@@ -19,9 +19,12 @@ func NewScopedEventhub(raw string) (ScopedEventhub, error) {
 		return ScopedEventhub{}, fmt.Errorf("invalid scoped eventhub '%s'", raw)
 	}
 
+	// support eventhub name with hyphens etc.
+	eventhubPart := strings.Trim(parts[1], `"`)
+
 	return ScopedEventhub{
 		PeerName:   parts[0],
-		Eventhub:   parts[1],
+		Eventhub:   eventhubPart,
 		Identifier: parts[2],
 	}, nil
 }


### PR DESCRIPTION
If you want to have an eventhub name with a hyphen when creating a PG -> EH mirror via SQL Layer:

```sql

CREATE MIRROR pgeh_mirror
FROM pg_peer TO eventhub_group_peer_1
WITH TABLE MAPPING (
public.oss1:ehpeer1."oss1-eventhub".oss1
)
```

