### PR TITLE
Better JSON datatype handling in BQ

### DIFF
--- a/flow/connectors/bigquery/merge_statement_generator.go
+++ b/flow/connectors/bigquery/merge_statement_generator.go
@@ -45,7 +45,7 @@ func (m *mergeStmtGenerator) generateFlattenedCTE() string {
 		switch qvalue.QValueKind(colType) {
 		case qvalue.QValueKindJSON:
 			// if the type is JSON, then just extract JSON
-			castStmt = fmt.Sprintf("CAST(JSON_VALUE(_peerdb_data, '$.%s') AS %s) AS `%s`",
+			castStmt = fmt.Sprintf("CAST(PARSE_JSON(JSON_VALUE(_peerdb_data, '$.%s')) AS %s) AS `%s`",
 				colName, bqType, colName)
 		// expecting data in BASE64 format
 		case qvalue.QValueKindBytes, qvalue.QValueKindBit:

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -119,6 +119,8 @@ func getTransformedColumns(dstTableMetadata *bigquery.TableMetadata, syncedAtCol
 		if col.Type == bigquery.GeographyFieldType {
 			transformedColumns = append(transformedColumns,
 				fmt.Sprintf("ST_GEOGFROMTEXT(`%s`) AS `%s`", col.Name, col.Name))
+		} else if col.Type == bigquery.JSONFieldType {
+			transformedColumns = append(transformedColumns, fmt.Sprintf("PARSE_JSON(`%s`) AS `%s`", col.Name, col.Name))
 		} else {
 			transformedColumns = append(transformedColumns, fmt.Sprintf("`%s`", col.Name))
 		}
@@ -280,7 +282,7 @@ func GetAvroType(bqField *bigquery.FieldSchema) (interface{}, error) {
 	}
 
 	switch bqField.Type {
-	case bigquery.StringFieldType, bigquery.GeographyFieldType:
+	case bigquery.StringFieldType, bigquery.GeographyFieldType, bigquery.JSONFieldType:
 		return considerRepeated("string", bqField.Repeated), nil
 	case bigquery.BytesFieldType:
 		return "bytes", nil

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -116,12 +116,14 @@ func getTransformedColumns(dstTableMetadata *bigquery.TableMetadata, syncedAtCol
 		if col.Name == syncedAtCol || col.Name == softDeleteCol {
 			continue
 		}
-		if col.Type == bigquery.GeographyFieldType {
+		switch col.Type {
+		case bigquery.GeographyFieldType:
 			transformedColumns = append(transformedColumns,
 				fmt.Sprintf("ST_GEOGFROMTEXT(`%s`) AS `%s`", col.Name, col.Name))
-		} else if col.Type == bigquery.JSONFieldType {
-			transformedColumns = append(transformedColumns, fmt.Sprintf("PARSE_JSON(`%s`) AS `%s`", col.Name, col.Name))
-		} else {
+		case bigquery.JSONFieldType:
+			transformedColumns = append(transformedColumns,
+				fmt.Sprintf("PARSE_JSON(`%s`) AS `%s`", col.Name, col.Name))
+		default:
 			transformedColumns = append(transformedColumns, fmt.Sprintf("`%s`", col.Name))
 		}
 	}

--- a/flow/connectors/bigquery/qvalue_convert.go
+++ b/flow/connectors/bigquery/qvalue_convert.go
@@ -25,7 +25,7 @@ func qValueKindToBigQueryType(colType string) bigquery.FieldType {
 		return bigquery.StringFieldType
 	// json also is stored as string for now
 	case qvalue.QValueKindJSON:
-		return bigquery.StringFieldType
+		return bigquery.JSONFieldType
 	// time related
 	case qvalue.QValueKindTimestamp, qvalue.QValueKindTimestampTZ:
 		return bigquery.TimestampFieldType
@@ -79,6 +79,8 @@ func BigQueryTypeToQValueKind(fieldType bigquery.FieldType) (qvalue.QValueKind, 
 		return qvalue.QValueKindNumeric, nil
 	case bigquery.GeographyFieldType:
 		return qvalue.QValueKindGeography, nil
+	case bigquery.JSONFieldType:
+		return qvalue.QValueKindJSON, nil
 	default:
 		return "", fmt.Errorf("unsupported bigquery field type: %v", fieldType)
 	}

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -756,6 +756,10 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 	// Make sure that there are no nulls
 	require.True(s.t, noNulls)
 
+	// check if JSON on bigquery side is a good JSON
+	err = s.checkJSONValue(dstTableName, "c17", "sai", "1")
+	require.NoError(s.t, err)
+
 	env.AssertExpectations(s.t)
 }
 
@@ -839,10 +843,6 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Invalid_Geo_BQ_Avro_CDC() {
 
 	require.Equal(s.t, 6, lineCount)
 	require.Equal(s.t, 6, polyCount)
-
-	// check if JSON on bigquery side is a good JSON
-	err = s.checkJSONValue(dstTableName, "c17", "sai", "1")
-	require.NoError(s.t, err)
 
 	env.AssertExpectations(s.t)
 }

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -840,7 +840,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Invalid_Geo_BQ_Avro_CDC() {
 	require.Equal(s.t, 6, lineCount)
 	require.Equal(s.t, 6, polyCount)
 
-	// check if JSON on snowflake side is a good JSON
+	// check if JSON on bigquery side is a good JSON
 	err = s.checkJSONValue(dstTableName, "c17", "sai", "1")
 	require.NoError(s.t, err)
 


### PR DESCRIPTION
Before we were creating the destination table (SetupNormalize) with the JSON column as STRING. Now it is truly JSON at the BigQuery destination