### PR TITLE
adding visibility into current mirror state

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -468,7 +468,6 @@ func (c *PostgresConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 		}
 		normalizeStatements := c.generateNormalizeStatements(destinationTableName, unchangedToastColsMap[destinationTableName],
 			rawTableIdentifier, supportsMerge, &peerdbCols)
-		fmt.Println(normalizeStatements)
 		for _, normalizeStatement := range normalizeStatements {
 			mergeStatementsBatch.Queue(normalizeStatement, batchIDs.NormalizeBatchID, batchIDs.SyncBatchID, destinationTableName).Exec(
 				func(ct pgconn.CommandTag) error {

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
+	"github.com/PeerDB-io/peer-flow/shared"
 	"github.com/PeerDB-io/peer-flow/shared/alerting"
 	peerflow "github.com/PeerDB-io/peer-flow/workflows"
 	"github.com/google/uuid"
@@ -65,7 +66,7 @@ func SetupCDCFlowStatusQuery(env *testsuite.TestWorkflowEnvironment,
 	time.Sleep(5 * time.Second)
 	for {
 		response, err := env.QueryWorkflow(
-			peerflow.CDCFlowStatusQuery,
+			shared.CDCFlowStateQuery,
 			connectionGen.FlowJobName,
 		)
 		if err == nil {
@@ -75,7 +76,7 @@ func SetupCDCFlowStatusQuery(env *testsuite.TestWorkflowEnvironment,
 				slog.Error(err.Error())
 			}
 
-			if state.SnapshotComplete {
+			if state.CurrentFlowState == protos.FlowStatus_STATUS_RUNNING.Enum() {
 				break
 			}
 		} else {
@@ -95,7 +96,7 @@ func NormalizeFlowCountQuery(env *testsuite.TestWorkflowEnvironment,
 	time.Sleep(5 * time.Second)
 	for {
 		response, err := env.QueryWorkflow(
-			peerflow.CDCFlowStatusQuery,
+			shared.CDCFlowStateQuery,
 			connectionGen.FlowJobName,
 		)
 		if err == nil {

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -76,7 +76,7 @@ func SetupCDCFlowStatusQuery(env *testsuite.TestWorkflowEnvironment,
 				slog.Error(err.Error())
 			}
 
-			if state.CurrentFlowState == protos.FlowStatus_STATUS_RUNNING.Enum() {
+			if *state.CurrentFlowState == protos.FlowStatus_STATUS_RUNNING {
 				break
 			}
 		} else {

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -7,10 +7,21 @@ import (
 )
 
 const (
-	peerFlowTaskQueue              = "peer-flow-task-queue"
-	snapshotFlowTaskQueue          = "snapshot-flow-task-queue"
+	// Task Queues
+	peerFlowTaskQueue     = "peer-flow-task-queue"
+	snapshotFlowTaskQueue = "snapshot-flow-task-queue"
+
+	// Signals
 	CDCFlowSignalName              = "peer-flow-signal"
 	CDCDynamicPropertiesSignalName = "cdc-dynamic-properties"
+
+	// Queries
+	CDCFlowStateQuery  = "q-cdc-flow-status"
+	QRepFlowStateQuery = "q-qrep-flow-state"
+	FlowStatusQuery    = "q-flow-status"
+
+	// Updates
+	FlowStatusUpdate = "u-flow-status"
 )
 
 const MirrorNameSearchAttribute = "MirrorName"

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -396,9 +396,26 @@ func QRepFlowWorkflow(
 		maxParallelWorkers = int(config.MaxParallelWorkers)
 	}
 
-	// register a query to get the number of partitions processed
-	err := workflow.SetQueryHandler(ctx, "num-partitions-processed", func() (uint64, error) {
-		return state.NumPartitionsProcessed, nil
+	// Support a Query for the current state of the qrep flow.
+	err := workflow.SetQueryHandler(ctx, shared.QRepFlowStateQuery, func() (*protos.QRepFlowState, error) {
+		return state, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set `%s` query handler: %w", shared.QRepFlowStateQuery, err)
+	}
+
+	// Support a Query for the current status of the arep flow.
+	err = workflow.SetQueryHandler(ctx, shared.FlowStatusQuery, func() (*protos.FlowStatus, error) {
+		return &state.CurrentFlowState, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set `%s` query handler: %w", shared.FlowStatusQuery, err)
+	}
+
+	// Support an Update for the current status of the qrep flow.
+	err = workflow.SetUpdateHandler(ctx, shared.FlowStatusUpdate, func(status *protos.FlowStatus) error {
+		state.CurrentFlowState = *status
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to register query handler: %w", err)

--- a/nexus/flow-rs/src/grpc.rs
+++ b/nexus/flow-rs/src/grpc.rs
@@ -86,30 +86,6 @@ impl FlowGrpcClient {
         Ok(workflow_id)
     }
 
-    pub async fn shutdown_flow_job(
-        &mut self,
-        flow_job_name: &str,
-        workflow_details: WorkflowDetails,
-    ) -> anyhow::Result<()> {
-        let shutdown_flow_req = pt::peerdb_route::ShutdownRequest {
-            flow_job_name: flow_job_name.to_string(),
-            workflow_id: workflow_details.workflow_id,
-            source_peer: Some(workflow_details.source_peer),
-            destination_peer: Some(workflow_details.destination_peer),
-            remove_flow_entry: false,
-        };
-        let response = self.client.shutdown_flow(shutdown_flow_req).await?;
-        let shutdown_response = response.into_inner();
-        if shutdown_response.ok {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!(format!(
-                "failed to shutdown flow job: {:?}",
-                shutdown_response.error_message
-            )))
-        }
-    }
-
     pub async fn drop_peer(&mut self, peer_name: &str) -> anyhow::Result<()> {
         let drop_peer_req = pt::peerdb_route::DropPeerRequest {
             peer_name: String::from(peer_name),
@@ -129,25 +105,23 @@ impl FlowGrpcClient {
     pub async fn flow_state_change(
         &mut self,
         flow_job_name: &str,
-        workflow_id: &str,
-        pause: bool,
+        workflow_details: WorkflowDetails,
+        state: pt::peerdb_flow::FlowStatus,
     ) -> anyhow::Result<()> {
-        let pause_flow_req = pt::peerdb_route::FlowStateChangeRequest {
+        let state_change_req = pt::peerdb_route::FlowStateChangeRequest {
             flow_job_name: flow_job_name.to_owned(),
-            workflow_id: workflow_id.to_owned(),
-            requested_flow_state: match pause {
-                true => pt::peerdb_route::FlowState::StatePaused.into(),
-                false => pt::peerdb_route::FlowState::StateRunning.into(),
-            },
+            requested_flow_state: state.into(),
+            source_peer: Some(workflow_details.source_peer),
+            destination_peer: Some(workflow_details.destination_peer),
         };
-        let response = self.client.flow_state_change(pause_flow_req).await?;
-        let pause_response = response.into_inner();
-        if pause_response.ok {
+        let response = self.client.flow_state_change(state_change_req).await?;
+        let state_change_response = response.into_inner();
+        if state_change_response.ok {
             Ok(())
         } else {
             Err(anyhow::anyhow!(format!(
-                "failed to pause/unpause flow job: {:?}",
-                pause_response.error_message
+                "failed to change the state of flow job {}: {:?}",
+                flow_job_name, state_change_response.error_message
             )))
         }
     }

--- a/nexus/flow-rs/src/grpc.rs
+++ b/nexus/flow-rs/src/grpc.rs
@@ -113,6 +113,7 @@ impl FlowGrpcClient {
             requested_flow_state: state.into(),
             source_peer: Some(workflow_details.source_peer),
             destination_peer: Some(workflow_details.destination_peer),
+            flow_state_update: None
         };
         let response = self.client.flow_state_change(state_change_req).await?;
         let state_change_response = response.into_inner();

--- a/nexus/server/src/main.rs
+++ b/nexus/server/src/main.rs
@@ -273,7 +273,11 @@ impl NexusBackend {
                     if let Some(workflow_details) = workflow_details {
                         let mut flow_handler = self.flow_handler.as_ref().unwrap().lock().await;
                         flow_handler
-                            .shutdown_flow_job(flow_job_name, workflow_details)
+                            .flow_state_change(
+                                flow_job_name,
+                                workflow_details,
+                                pt::peerdb_flow::FlowStatus::StatusTerminated,
+                            )
                             .await
                             .map_err(|err| {
                                 PgWireError::ApiError(
@@ -693,11 +697,15 @@ impl NexusBackend {
                     if let Some(workflow_details) = workflow_details {
                         let mut flow_handler = self.flow_handler.as_ref().unwrap().lock().await;
                         flow_handler
-                            .flow_state_change(flow_job_name, &workflow_details.workflow_id, true)
+                            .flow_state_change(
+                                flow_job_name,
+                                workflow_details,
+                                pt::peerdb_flow::FlowStatus::StatusPaused,
+                            )
                             .await
                             .map_err(|err| {
                                 PgWireError::ApiError(
-                                    format!("unable to shutdown flow job: {:?}", err).into(),
+                                    format!("unable to pause flow job: {:?}", err).into(),
                                 )
                             })?;
                         let drop_mirror_success = format!("PAUSE MIRROR {}", flow_job_name);
@@ -752,11 +760,15 @@ impl NexusBackend {
                     if let Some(workflow_details) = workflow_details {
                         let mut flow_handler = self.flow_handler.as_ref().unwrap().lock().await;
                         flow_handler
-                            .flow_state_change(flow_job_name, &workflow_details.workflow_id, false)
+                            .flow_state_change(
+                                flow_job_name,
+                                workflow_details,
+                                pt::peerdb_flow::FlowStatus::StatusRunning,
+                            )
                             .await
                             .map_err(|err| {
                                 PgWireError::ApiError(
-                                    format!("unable to shutdown flow job: {:?}", err).into(),
+                                    format!("unable to resume flow job: {:?}", err).into(),
                                 )
                             })?;
                         let drop_mirror_success = format!("RESUME MIRROR {}", flow_job_name);

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -382,6 +382,7 @@ message QRepFlowState {
   uint64 num_partitions_processed = 2;
   bool needs_resync = 3;
   bool disable_wait_for_new_rows = 4;
+  FlowStatus current_flow_state = 5;
 }
 
 message PeerDBColumns {
@@ -393,4 +394,28 @@ message PeerDBColumns {
 message GetOpenConnectionsForUserResult {
   string user_name = 1;
   int64 current_open_connections = 2;
+}
+
+// UI reads current workflow status and also requests status changes using same enum
+// UI can request STATUS_PAUSED, STATUS_RUNNING and STATUS_TERMINATED
+// STATUS_RUNNING -> STATUS_PAUSED/STATUS_TERMINATED
+// STATUS_PAUSED -> STATUS_RUNNING/STATUS_TERMINATED
+// UI can read everything except STATUS_UNKNOWN
+enum FlowStatus {
+  // should never be read by UI, bail
+  STATUS_UNKNOWN = 0;
+  // enable pause and terminate buttons
+  STATUS_RUNNING = 1;
+  // pause button becomes resume button, terminate button should still be enabled
+  STATUS_PAUSED = 2;
+  // neither button should be enabled
+  STATUS_PAUSING = 3;
+  // neither button should be enabled, not reachable in QRep mirrors
+  STATUS_SETUP = 4;
+  // neither button should be enabled, not reachable in QRep mirrors
+  STATUS_SNAPSHOT = 5;
+  // neither button should be enabled
+  STATUS_TERMINATING = 6;
+  // neither button should be enabled
+  STATUS_TERMINATED = 7;
 }

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -423,7 +423,7 @@ enum FlowStatus {
 message CDCFlowStateUpdate {
 }
 
-message QRepFlowStateUpdate  {
+message QRepFlowStateUpdate {
 }
 
 message FlowStateUpdate {

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -419,3 +419,16 @@ enum FlowStatus {
   // neither button should be enabled
   STATUS_TERMINATED = 7;
 }
+
+message CDCFlowStateUpdate {
+}
+
+message QRepFlowStateUpdate  {
+}
+
+message FlowStateUpdate {
+  oneof update {
+    CDCFlowStateUpdate cdc_flow_state_update = 1;
+    QRepFlowStateUpdate qrep_flow_state_update = 2;
+  }
+}

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -188,7 +188,7 @@ message FlowStateChangeRequest {
   peerdb_peers.Peer source_peer = 3;
   peerdb_peers.Peer destination_peer = 4;
   // only can be sent in certain situations
-  peerdb_flow.FlowStateUpdate flow_state_update = 5;
+  optional peerdb_flow.FlowStateUpdate flow_state_update = 5;
 }
 
 message FlowStateChangeResponse {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -182,18 +182,13 @@ message MirrorStatusResponse {
   peerdb_flow.FlowStatus current_flow_state = 5;
 }
 
-// in the future, consider moving DropFlow to this and reduce route surface
-enum FlowState {
-  STATE_UNKNOWN = 0;
-  STATE_RUNNING = 1;
-  STATE_PAUSED = 2;
-}
-
 message FlowStateChangeRequest {
   string flow_job_name = 1;
   peerdb_flow.FlowStatus requested_flow_state = 2;
   peerdb_peers.Peer source_peer = 3;
   peerdb_peers.Peer destination_peer = 4;
+  // only can be sent in certain situations
+  peerdb_flow.FlowStateUpdate flow_state_update = 5;
 }
 
 message FlowStateChangeResponse {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -179,6 +179,7 @@ message MirrorStatusResponse {
     CDCMirrorStatus cdc_status = 3;
   }
   string error_message = 4;
+  peerdb_flow.FlowStatus current_flow_state = 5;
 }
 
 // in the future, consider moving DropFlow to this and reduce route surface
@@ -189,9 +190,10 @@ enum FlowState {
 }
 
 message FlowStateChangeRequest {
-  string workflow_id = 1;
-  string flow_job_name = 2;
-  FlowState requested_flow_state = 3;
+  string flow_job_name = 1;
+  peerdb_flow.FlowStatus requested_flow_state = 2;
+  peerdb_peers.Peer source_peer = 3;
+  peerdb_peers.Peer destination_peer = 4;
 }
 
 message FlowStateChangeResponse {

--- a/temporal-dynamicconfig/development-sql.yaml
+++ b/temporal-dynamicconfig/development-sql.yaml
@@ -4,3 +4,5 @@ limit.maxIDLength:
 system.forceSearchAttributesCacheRefreshOnRead:
   - value: true # Dev setup only. Please don't turn this on in production.
     constraints: {}
+frontend.enableUpdateWorkflowExecution:
+  - value: true # to enable external updates of workflow status [PAUSING, TERMINATING]


### PR DESCRIPTION
breaks some protos and routes for clearer naming conventions, UI needs to be updated accordingly

removes SetupComplete and SnapshotComplete booleans in CDCFlowState in favour of a CurrentFlowState that expresses all states of a CDC workflow in a single variable.

rebase of PR: https://github.com/PeerDB-io/peerdb/pull/657