### PR TITLE
Remove the need for metadata db in eventhub group peer

### DIFF
--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -800,11 +800,15 @@ fn parse_db_options(
     Ok(config)
 }
 
-fn parse_metadata_db_info(conn_str: Option<&str>) -> anyhow::Result<Option<PostgresConfig>> {
+fn parse_metadata_db_info(conn_str: Option<&&str>) -> anyhow::Result<Option<PostgresConfig>> {
     let conn_str = match conn_str {
         Some(conn_str) => conn_str,
         None => return Ok(None),
     };
+
+    if conn_str.is_empty() {
+        return Ok(None);
+    }
 
     let mut metadata_db = PostgresConfig::default();
     let param_pairs: Vec<&str> = conn_str.split_whitespace().collect();

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -663,7 +663,7 @@ fn parse_db_options(
             Some(config)
         }
         DbType::Eventhub => {
-            let conn_str = opts.get("metadata_db").map(|s| s.to_string());
+            let conn_str = opts.get("metadata_db");
             let metadata_db = parse_metadata_db_info(conn_str)?;
             let subscription_id = opts
                 .get("subscription_id")
@@ -708,7 +708,7 @@ fn parse_db_options(
             Some(config)
         }
         DbType::S3 => {
-            let s3_conn_str = opts.get("metadata_db").map(|s| s.to_string());
+            let s3_conn_str = opts.get("metadata_db");
             let metadata_db = parse_metadata_db_info(s3_conn_str)?;
             let s3_config = S3Config {
                 url: opts
@@ -748,7 +748,7 @@ fn parse_db_options(
             Some(config)
         }
         DbType::EventhubGroup => {
-            let conn_str = opts.get("metadata_db").map(|s| s.to_string());
+            let conn_str = opts.get("metadata_db");
             let metadata_db = parse_metadata_db_info(conn_str)?;
 
             // metadata_db is required for eventhub group
@@ -800,7 +800,7 @@ fn parse_db_options(
     Ok(config)
 }
 
-fn parse_metadata_db_info(conn_str: Option<String>) -> anyhow::Result<Option<PostgresConfig>> {
+fn parse_metadata_db_info(conn_str: Option<&str>) -> anyhow::Result<Option<PostgresConfig>> {
     let conn_str = match conn_str {
         Some(conn_str) => conn_str,
         None => return Ok(None),

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -663,11 +663,8 @@ fn parse_db_options(
             Some(config)
         }
         DbType::Eventhub => {
-            let conn_str: String = opts
-                .get("metadata_db")
-                .map(|s| s.to_string())
-                .unwrap_or_default();
-            let metadata_db = parse_metadata_db_info(&conn_str)?;
+            let conn_str = opts.get("metadata_db").map(|s| s.to_string());
+            let metadata_db = parse_metadata_db_info(conn_str)?;
             let subscription_id = opts
                 .get("subscription_id")
                 .map(|s| s.to_string())
@@ -711,11 +708,8 @@ fn parse_db_options(
             Some(config)
         }
         DbType::S3 => {
-            let s3_conn_str: String = opts
-                .get("metadata_db")
-                .map(|s| s.to_string())
-                .unwrap_or_default();
-            let metadata_db = parse_metadata_db_info(&s3_conn_str)?;
+            let s3_conn_str = opts.get("metadata_db").map(|s| s.to_string());
+            let metadata_db = parse_metadata_db_info(s3_conn_str)?;
             let s3_config = S3Config {
                 url: opts
                     .get("url")
@@ -754,9 +748,7 @@ fn parse_db_options(
             Some(config)
         }
         DbType::EventhubGroup => {
-            let conn_str = opts
-                .get("metadata_db")
-                .context("no metadata db specified")?;
+            let conn_str = opts.get("metadata_db").map(|s| s.to_string());
             let metadata_db = parse_metadata_db_info(conn_str)?;
 
             // metadata_db is required for eventhub group
@@ -808,10 +800,11 @@ fn parse_db_options(
     Ok(config)
 }
 
-fn parse_metadata_db_info(conn_str: &str) -> anyhow::Result<Option<PostgresConfig>> {
-    if conn_str.is_empty() {
-        return Ok(None);
-    }
+fn parse_metadata_db_info(conn_str: Option<String>) -> anyhow::Result<Option<PostgresConfig>> {
+    let conn_str = match conn_str {
+        Some(conn_str) => conn_str,
+        None => return Ok(None),
+    };
 
     let mut metadata_db = PostgresConfig::default();
     let param_pairs: Vec<&str> = conn_str.split_whitespace().collect();

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -664,7 +664,7 @@ fn parse_db_options(
         }
         DbType::Eventhub => {
             let conn_str = opts.get("metadata_db");
-            let metadata_db = parse_metadata_db_info(conn_str)?;
+            let metadata_db = parse_metadata_db_info(conn_str.copied())?;
             let subscription_id = opts
                 .get("subscription_id")
                 .map(|s| s.to_string())
@@ -709,7 +709,7 @@ fn parse_db_options(
         }
         DbType::S3 => {
             let s3_conn_str = opts.get("metadata_db");
-            let metadata_db = parse_metadata_db_info(s3_conn_str)?;
+            let metadata_db = parse_metadata_db_info(s3_conn_str.copied())?;
             let s3_config = S3Config {
                 url: opts
                     .get("url")
@@ -749,7 +749,7 @@ fn parse_db_options(
         }
         DbType::EventhubGroup => {
             let conn_str = opts.get("metadata_db");
-            let metadata_db = parse_metadata_db_info(conn_str)?;
+            let metadata_db = parse_metadata_db_info(conn_str.copied())?;
 
             // metadata_db is required for eventhub group
             if metadata_db.is_none() {
@@ -800,7 +800,7 @@ fn parse_db_options(
     Ok(config)
 }
 
-fn parse_metadata_db_info(conn_str: Option<&&str>) -> anyhow::Result<Option<PostgresConfig>> {
+fn parse_metadata_db_info(conn_str: Option<&str>) -> anyhow::Result<Option<PostgresConfig>> {
     let conn_str = match conn_str {
         Some(conn_str) => conn_str,
         None => return Ok(None),

--- a/nexus/flow-rs/src/grpc.rs
+++ b/nexus/flow-rs/src/grpc.rs
@@ -113,7 +113,7 @@ impl FlowGrpcClient {
             requested_flow_state: state.into(),
             source_peer: Some(workflow_details.source_peer),
             destination_peer: Some(workflow_details.destination_peer),
-            flow_state_update: None
+            flow_state_update: None,
         };
         let response = self.client.flow_state_change(state_change_req).await?;
         let state_change_response = response.into_inner();


### PR DESCRIPTION
We already use catalog in cases where this isn't passed, but validation failed for eventhub group peer.