### PR TITLE
parse_db_options: avoid string copy for integer options

### DIFF
--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -676,16 +676,14 @@ fn parse_db_options(
             // partition_count default to 3 if not set, parse as int
             let partition_count = opts
                 .get("partition_count")
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "3".to_string())
+                .unwrap_or(&"3")
                 .parse::<u32>()
                 .context("unable to parse partition_count as valid int")?;
 
             // message_retention_in_days default to 7 if not set, parse as int
             let message_retention_in_days = opts
                 .get("message_retention_in_days")
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "7".to_string())
+                .unwrap_or(&"7")
                 .parse::<u32>()
                 .context("unable to parse message_retention_in_days as valid int")?;
 

--- a/nexus/analyzer/src/qrep.rs
+++ b/nexus/analyzer/src/qrep.rs
@@ -115,14 +115,14 @@ pub fn process_options(
                                 anyhow::bail!("{} must be one of {:?}", name, values);
                             }
                         }
-                        opts.insert((*name).to_string(), Value::String(str.clone()));
+                        opts.insert(name.to_string(), Value::String(str.clone()));
                     } else {
                         anyhow::bail!("Invalid value for {}", name);
                     }
                 } else if *required {
                     anyhow::bail!("{} is required", name);
                 } else if let Some(default) = default_val {
-                    opts.insert((*name).to_string(), Value::String(default.to_string()));
+                    opts.insert(name.to_string(), Value::String(default.to_string()));
                 }
             }
             QRepOptionType::Int {
@@ -139,7 +139,7 @@ pub fn process_options(
                                 anyhow::bail!("{} must be greater than {}", name, min);
                             }
                         }
-                        opts.insert((*name).to_string(), Value::Number(num.into()));
+                        opts.insert(name.to_string(), Value::Number(num.into()));
                     } else {
                         anyhow::bail!("Invalid value for {}", name);
                     }
@@ -147,7 +147,7 @@ pub fn process_options(
                     anyhow::bail!("{} is required", name);
                 } else {
                     let v = *default_value;
-                    opts.insert((*name).to_string(), Value::Number(v.into()));
+                    opts.insert(name.to_string(), Value::Number(v.into()));
                 }
             }
             QRepOptionType::StringArray { name } => {
@@ -158,7 +158,7 @@ pub fn process_options(
                             .split(',')
                             .map(|s| Value::String(s.trim().to_string()))
                             .collect();
-                        opts.insert((*name).to_string(), Value::Array(values));
+                        opts.insert(name.to_string(), Value::Array(values));
                     } else {
                         anyhow::bail!("Invalid value for {}", name);
                     }
@@ -171,7 +171,7 @@ pub fn process_options(
             } => {
                 if let Some(raw_value) = raw_opts.remove(*name) {
                     if let SqlValue::Boolean(b) = raw_value {
-                        opts.insert((*name).to_string(), Value::Bool(*b));
+                        opts.insert(name.to_string(), Value::Bool(*b));
                     } else {
                         anyhow::bail!("Invalid value for {}", name);
                     }
@@ -179,7 +179,7 @@ pub fn process_options(
                     anyhow::bail!("{} is required", name);
                 } else {
                     let v = *default_value;
-                    opts.insert((*name).to_string(), Value::Bool(v));
+                    opts.insert(name.to_string(), Value::Bool(v));
                 }
             }
         }


### PR DESCRIPTION
Small refactoring noticed while reviewing #983