### PR TITLE
Remove hardcoded link

### DIFF
--- a/ui/app/mirrors/create/mirrorcards.tsx
+++ b/ui/app/mirrors/create/mirrorcards.tsx
@@ -75,7 +75,7 @@ const MirrorCards = ({
                 as={Link}
                 target='_blank'
                 style={{ color: 'teal', cursor: 'pointer' }}
-                href='https://docs.peerdb.io/usecases/Real-time%20CDC/overview'
+                href={card.link}
               >
                 Learn more
               </Label>


### PR DESCRIPTION
Create Mirror cards had Learn More link all pointing to the same page