### PR TITLE
make KeysToString sort array since maps.Keys is non-deterministic

### DIFF
--- a/flow/connectors/utils/map.go
+++ b/flow/connectors/utils/map.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"slices"
+	"sort"
 	"strings"
 
 	"golang.org/x/exp/maps"
@@ -11,5 +13,8 @@ func KeysToString(m map[string]struct{}) string {
 		return ""
 	}
 
-	return strings.Join(maps.Keys(m), ",")
+	sm := maps.Keys(m)
+	sort.Strings(sm)
+	slices.Sort[[]string](sm)
+	return strings.Join(sm, ",")
 }

--- a/flow/connectors/utils/map.go
+++ b/flow/connectors/utils/map.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"slices"
-	"sort"
 	"strings"
 
 	"golang.org/x/exp/maps"
@@ -14,7 +13,6 @@ func KeysToString(m map[string]struct{}) string {
 	}
 
 	sm := maps.Keys(m)
-	sort.Strings(sm)
 	slices.Sort[[]string](sm)
 	return strings.Join(sm, ",")
 }


### PR DESCRIPTION
This could and has led to issues where the same set of unchanged toast columns could lead to different values being set for `_peerdb_unchanged_toast_columns` in the raw table, causing extra update statements to be generated.