### PR TITLE
Alias deduped cols to be shorter

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -605,6 +605,7 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 				SyncedAtColName:   req.SyncedAtColName,
 				SoftDelete:        req.SoftDelete,
 			},
+			shortColumn: map[string]string{},
 		}
 		// normalize anything between last normalized batch id to last sync batchid
 		mergeStmt := mergeGen.generateMergeStmt()

--- a/flow/connectors/bigquery/merge_stmt_generator_test.go
+++ b/flow/connectors/bigquery/merge_stmt_generator_test.go
@@ -9,36 +9,42 @@ import (
 )
 
 func TestGenerateUpdateStatement_WithUnchangedToastCols(t *testing.T) {
-	m := &mergeStmtGenerator{}
+	m := &mergeStmtGenerator{
+		shortColumn: map[string]string{
+			"col1": "_c0",
+			"col2": "_c1",
+			"col3": "_c2",
+		},
+	}
 	allCols := []string{"col1", "col2", "col3"}
 	unchangedToastCols := []string{"", "col2, col3", "col2", "col3"}
 
 	expected := []string{
 		"WHEN MATCHED AND _rt!=2 AND _ut=''" +
-			" THEN UPDATE SET `col1`=_d.col1,`col2`=_d.col2,`col3`=_d.col3," +
+			" THEN UPDATE SET `col1`=_d._c0,`col2`=_d._c1,`col3`=_d._c2," +
 			"`synced_at`=CURRENT_TIMESTAMP,`deleted`=FALSE",
 		"WHEN MATCHED AND _rt=2 " +
 			"AND _ut='' " +
-			"THEN UPDATE SET `col1`=_d.col1,`col2`=_d.col2," +
-			"`col3`=_d.col3,`synced_at`=CURRENT_TIMESTAMP,`deleted`=TRUE",
+			"THEN UPDATE SET `col1`=_d._c0,`col2`=_d._c1," +
+			"`col3`=_d._c2,`synced_at`=CURRENT_TIMESTAMP,`deleted`=TRUE",
 		"WHEN MATCHED AND _rt!=2 AND _ut='col2,col3' " +
-			"THEN UPDATE SET `col1`=_d.col1,`synced_at`=CURRENT_TIMESTAMP,`deleted`=FALSE ",
+			"THEN UPDATE SET `col1`=_d._c0,`synced_at`=CURRENT_TIMESTAMP,`deleted`=FALSE ",
 		"WHEN MATCHED AND _rt=2 AND _ut='col2,col3' " +
-			"THEN UPDATE SET `col1`=_d.col1,`synced_at`=CURRENT_TIMESTAMP,`deleted`=TRUE",
+			"THEN UPDATE SET `col1`=_d._c0,`synced_at`=CURRENT_TIMESTAMP,`deleted`=TRUE",
 		"WHEN MATCHED AND _rt!=2 " +
 			"AND _ut='col2' " +
-			"THEN UPDATE SET `col1`=_d.col1,`col3`=_d.col3," +
+			"THEN UPDATE SET `col1`=_d._c0,`col3`=_d._c2," +
 			"`synced_at`=CURRENT_TIMESTAMP,`deleted`=FALSE",
 		"WHEN MATCHED AND _rt=2 " +
 			"AND _ut='col2' " +
-			"THEN UPDATE SET `col1`=_d.col1,`col3`=_d.col3," +
+			"THEN UPDATE SET `col1`=_d._c0,`col3`=_d._c2," +
 			"`synced_at`=CURRENT_TIMESTAMP,`deleted`=TRUE ",
 		"WHEN MATCHED AND _rt!=2 AND _ut='col3' " +
-			"THEN UPDATE SET `col1`=_d.col1," +
-			"`col2`=_d.col2,`synced_at`=CURRENT_TIMESTAMP,`deleted`=FALSE ",
+			"THEN UPDATE SET `col1`=_d._c0," +
+			"`col2`=_d._c1,`synced_at`=CURRENT_TIMESTAMP,`deleted`=FALSE ",
 		"WHEN MATCHED AND _rt=2 AND _ut='col3' " +
-			"THEN UPDATE SET `col1`=_d.col1," +
-			"`col2`=_d.col2,`synced_at`=CURRENT_TIMESTAMP,`deleted`=TRUE",
+			"THEN UPDATE SET `col1`=_d._c0," +
+			"`col2`=_d._c1,`synced_at`=CURRENT_TIMESTAMP,`deleted`=TRUE",
 	}
 
 	result := m.generateUpdateStatements(allCols, unchangedToastCols, &protos.PeerDBColumns{
@@ -58,7 +64,13 @@ func TestGenerateUpdateStatement_WithUnchangedToastCols(t *testing.T) {
 }
 
 func TestGenerateUpdateStatement_NoUnchangedToastCols(t *testing.T) {
-	m := &mergeStmtGenerator{}
+	m := &mergeStmtGenerator{
+		shortColumn: map[string]string{
+			"col1": "_c0",
+			"col2": "_c1",
+			"col3": "_c2",
+		},
+	}
 	allCols := []string{"col1", "col2", "col3"}
 	unchangedToastCols := []string{""}
 
@@ -66,15 +78,15 @@ func TestGenerateUpdateStatement_NoUnchangedToastCols(t *testing.T) {
 		"WHEN MATCHED AND _rt!=2 " +
 			"AND _ut=''" +
 			"THEN UPDATE SET " +
-			"`col1`=_d.col1," +
-			"`col2`=_d.col2," +
-			"`col3`=_d.col3," +
+			"`col1`=_d._c0," +
+			"`col2`=_d._c1," +
+			"`col3`=_d._c2," +
 			"`synced_at`=CURRENT_TIMESTAMP," +
 			"`deleted`=FALSE",
 		"WHEN MATCHED AND" +
 			"_rt=2 AND _ut=''" +
-			"THEN UPDATE SET `col1`=_d.col1,`col2`=_d.col2, " +
-			"`col3`=_d.col3,`synced_at`=CURRENT_TIMESTAMP,`deleted`=TRUE",
+			"THEN UPDATE SET `col1`=_d._c0,`col2`=_d._c1, " +
+			"`col3`=_d._c2,`synced_at`=CURRENT_TIMESTAMP,`deleted`=TRUE",
 	}
 
 	result := m.generateUpdateStatements(allCols, unchangedToastCols,


### PR DESCRIPTION
Introduces a map - `shortColumn` in the mergeGenerator struct to map column names to shorter _c1, _c2 etc.