### PR TITLE
BQ: Handle NaN in Merge

### DIFF
--- a/flow/connectors/bigquery/merge_statement_generator.go
+++ b/flow/connectors/bigquery/merge_statement_generator.go
@@ -58,7 +58,7 @@ func (m *mergeStmtGenerator) generateFlattenedCTE() string {
 		case qvalue.QValueKindArrayFloat32, qvalue.QValueKindArrayFloat64,
 			qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64, qvalue.QValueKindArrayString:
 			castStmt = fmt.Sprintf("ARRAY(SELECT CAST(element AS %s) FROM "+
-				"UNNEST(CAST(JSON_VALUE_ARRAY(_peerdb_data, '$.%s') AS ARRAY<STRING>)) AS element) AS `%s`",
+				"UNNEST(CAST(JSON_VALUE_ARRAY(_peerdb_data, '$.%s') AS ARRAY<STRING>)) AS element WHERE element IS NOT null) AS `%s`",
 				bqType, colName, shortCol)
 		case qvalue.QValueKindGeography, qvalue.QValueKindGeometry, qvalue.QValueKindPoint:
 			castStmt = fmt.Sprintf("CAST(ST_GEOGFROMTEXT(JSON_VALUE(_peerdb_data, '$.%s')) AS %s) AS `%s`",

--- a/flow/e2e/bigquery/bigquery_helper.go
+++ b/flow/e2e/bigquery/bigquery_helper.go
@@ -396,6 +396,35 @@ func (b *BigQueryTestHelper) CheckNull(tableName string, ColName []string) (bool
 	}
 }
 
+// check if NaN, Inf double values are null
+func (b *BigQueryTestHelper) CheckDoubleValues(tableName string, ColName []string) (bool, error) {
+	csep := strings.Join(ColName, ",")
+	command := fmt.Sprintf("SELECT %s FROM `%s.%s`",
+		csep, b.Config.DatasetId, tableName)
+	it, err := b.client.Query(command).Read(context.Background())
+	if err != nil {
+		return false, fmt.Errorf("failed to run command: %w", err)
+	}
+
+	var row []bigquery.Value
+	for {
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return false, fmt.Errorf("failed to iterate over query results: %w", err)
+		}
+	}
+
+	floatArr, _ := row[1].([]float64)
+	if row[0] != nil || len(floatArr) > 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func qValueKindToBqColTypeString(val qvalue.QValueKind) (string, error) {
 	switch val {
 	case qvalue.QValueKindInt16:


### PR DESCRIPTION
json.Marshall does not support NaN , so we have to nullfy them, but:
NULLs are aren't allowed when inserting arrays in bigquery. 
So in the Merge statement we skip nulls
Fixes #1029 