### PR TITLE
SendableStream: remove mutex, require sync

### DIFF
--- a/nexus/peer-cursor/src/lib.rs
+++ b/nexus/peer-cursor/src/lib.rs
@@ -23,7 +23,7 @@ pub trait RecordStream: Stream<Item = PgWireResult<Record>> {
     fn schema(&self) -> SchemaRef;
 }
 
-pub type SendableStream = Pin<Box<dyn RecordStream + Send>>;
+pub type SendableStream = Pin<Box<dyn RecordStream + Send + Sync>>;
 
 pub struct Records {
     pub records: Vec<Record>,

--- a/nexus/peer-snowflake/src/cursor.rs
+++ b/nexus/peer-snowflake/src/cursor.rs
@@ -4,11 +4,10 @@ use futures::StreamExt;
 use peer_cursor::{QueryExecutor, QueryOutput, Records, SchemaRef, SendableStream};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use sqlparser::ast::Statement;
-use tokio::sync::Mutex;
 
 pub struct SnowflakeCursor {
     position: usize,
-    stream: Mutex<SendableStream>,
+    stream: SendableStream,
     schema: SchemaRef,
 }
 
@@ -39,7 +38,7 @@ impl SnowflakeCursorManager {
                 // Create a new cursor
                 let cursor = SnowflakeCursor {
                     position: 0,
-                    stream: Mutex::new(stream),
+                    stream,
                     schema,
                 };
 
@@ -72,9 +71,8 @@ impl SnowflakeCursorManager {
         let prev_end = cursor.position;
         let mut cursor_position = cursor.position;
         {
-            let mut stream = cursor.stream.lock().await;
             while cursor_position - prev_end < count {
-                match stream.next().await {
+                match cursor.stream.next().await {
                     Some(Ok(record)) => {
                         records.push(record);
                         cursor_position += 1;


### PR DESCRIPTION
Cursor is mutable so type system already knows it has exclusive access