### PR TITLE
UI: Blur table if not mirror-able

### DIFF
--- a/protos/route.proto
+++ b/protos/route.proto
@@ -114,7 +114,12 @@ message SchemaTablesRequest {
 }
 
 message SchemaTablesResponse {
-  repeated string tables = 1;
+  repeated TableResponse tables = 1;
+}
+
+message TableResponse {
+  string table_name = 1;
+  bool can_mirror = 2;
 }
 
 message AllTablesResponse {

--- a/ui/app/api/alert-config/route.ts
+++ b/ui/app/api/alert-config/route.ts
@@ -1,8 +1,9 @@
 import { alertConfigType } from '@/app/alert-config/validation';
 import prisma from '@/app/utils/prisma';
+import { alerting_config } from '@prisma/client';
 
 export async function GET() {
-  const configs = await prisma.alerting_config.findMany();
+  const configs: alerting_config[] = await prisma.alerting_config.findMany();
   const serializedConfigs = configs.map((config) => ({
     ...config,
     id: String(config.id),

--- a/ui/app/api/peers/tables/all/route.ts
+++ b/ui/app/api/peers/tables/all/route.ts
@@ -1,5 +1,5 @@
-import { UTablesResponse } from '@/app/dto/PeersDTO';
-import { SchemaTablesResponse } from '@/grpc_generated/route';
+import { UTablesAllResponse } from '@/app/dto/PeersDTO';
+import { AllTablesResponse } from '@/grpc_generated/route';
 import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
 
 export async function POST(request: Request) {
@@ -7,12 +7,12 @@ export async function POST(request: Request) {
   const { peerName } = body;
   const flowServiceAddr = GetFlowHttpAddressFromEnv();
   try {
-    const tableList: SchemaTablesResponse = await fetch(
+    const tableList: AllTablesResponse = await fetch(
       `${flowServiceAddr}/v1/peers/tables/all?peer_name=${peerName}`
     ).then((res) => {
       return res.json();
     });
-    let response: UTablesResponse = {
+    let response: UTablesAllResponse = {
       tables: tableList.tables,
     };
     return new Response(JSON.stringify(response));

--- a/ui/app/dto/MirrorsDTO.ts
+++ b/ui/app/dto/MirrorsDTO.ts
@@ -20,6 +20,7 @@ export type TableMapRow = {
   partitionKey: string;
   exclude: string[];
   selected: boolean;
+  canMirror: boolean;
 };
 
 export type SyncStatusRow = {

--- a/ui/app/dto/PeersDTO.ts
+++ b/ui/app/dto/PeersDTO.ts
@@ -4,6 +4,7 @@ import {
   S3Config,
   SnowflakeConfig,
 } from '@/grpc_generated/peers';
+import { TableResponse } from '@/grpc_generated/route';
 
 export type UValidatePeerResponse = {
   valid: boolean;
@@ -20,6 +21,10 @@ export type USchemasResponse = {
 };
 
 export type UTablesResponse = {
+  tables: TableResponse[];
+};
+
+export type UTablesAllResponse = {
   tables: string[];
 };
 

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/lib/Label';
 import { RowWithCheckbox } from '@/lib/Layout';
 import { SearchField } from '@/lib/SearchField';
 import { TextField } from '@/lib/TextField';
+import { Tooltip } from '@/lib/Tooltip';
 import {
   Dispatch,
   SetStateAction,
@@ -17,7 +18,12 @@ import {
 import { BarLoader } from 'react-spinners/';
 import { fetchColumns, fetchTables } from '../handlers';
 import ColumnBox from './columnbox';
-import { expandableStyle, schemaBoxStyle, tableBoxStyle } from './styles';
+import {
+  expandableStyle,
+  schemaBoxStyle,
+  tableBoxStyle,
+  tooltipStyle,
+} from './styles';
 
 interface SchemaBoxProps {
   sourcePeer: string;
@@ -210,12 +216,29 @@ const SchemaBox = ({
                     >
                       <RowWithCheckbox
                         label={
-                          <Label as='label' style={{ fontSize: 13 }}>
-                            {row.source}
-                          </Label>
+                          <Tooltip
+                            style={{
+                              ...tooltipStyle,
+                              display: row.canMirror ? 'none' : 'block',
+                            }}
+                            content={
+                              'This table must have a primary key or replica identity to be mirrored.'
+                            }
+                          >
+                            <Label
+                              as='label'
+                              style={{
+                                fontSize: 13,
+                                color: row.canMirror ? 'black' : 'gray',
+                              }}
+                            >
+                              {row.source}
+                            </Label>
+                          </Tooltip>
                         }
                         action={
                           <Checkbox
+                            disabled={!row.canMirror}
                             checked={row.selected}
                             onCheckedChange={(state: boolean) =>
                               handleTableSelect(state, row.source)
@@ -223,30 +246,31 @@ const SchemaBox = ({
                           />
                         }
                       />
-
-                      <div
-                        style={{
-                          width: '40%',
-                          display: row.selected ? 'block' : 'none',
-                        }}
-                        key={row.source}
-                      >
-                        <p style={{ fontSize: 12 }}>Target Table:</p>
-                        <TextField
-                          key={row.source}
+                      {row.canMirror && (
+                        <div
                           style={{
-                            fontSize: 12,
-                            marginTop: '0.5rem',
-                            cursor: 'pointer',
+                            width: '40%',
+                            display: row.selected ? 'block' : 'none',
                           }}
-                          variant='simple'
-                          placeholder={'Enter target table'}
-                          defaultValue={row.destination}
-                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                            updateDestination(row.source, e.target.value)
-                          }
-                        />
-                      </div>
+                          key={row.source}
+                        >
+                          <p style={{ fontSize: 12 }}>Target Table:</p>
+                          <TextField
+                            key={row.source}
+                            style={{
+                              fontSize: 12,
+                              marginTop: '0.5rem',
+                              cursor: 'pointer',
+                            }}
+                            variant='simple'
+                            placeholder={'Enter target table'}
+                            defaultValue={row.destination}
+                            onChange={(
+                              e: React.ChangeEvent<HTMLInputElement>
+                            ) => updateDestination(row.source, e.target.value)}
+                          />
+                        </div>
+                      )}
                     </div>
 
                     {/* COLUMN BOX */}

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -246,31 +246,29 @@ const SchemaBox = ({
                           />
                         }
                       />
-                      {row.canMirror && (
-                        <div
-                          style={{
-                            width: '40%',
-                            display: row.selected ? 'block' : 'none',
-                          }}
+                      <div
+                        style={{
+                          width: '40%',
+                          display: row.selected ? 'block' : 'none',
+                        }}
+                        key={row.source}
+                      >
+                        <p style={{ fontSize: 12 }}>Target Table:</p>
+                        <TextField
                           key={row.source}
-                        >
-                          <p style={{ fontSize: 12 }}>Target Table:</p>
-                          <TextField
-                            key={row.source}
-                            style={{
-                              fontSize: 12,
-                              marginTop: '0.5rem',
-                              cursor: 'pointer',
-                            }}
-                            variant='simple'
-                            placeholder={'Enter target table'}
-                            defaultValue={row.destination}
-                            onChange={(
-                              e: React.ChangeEvent<HTMLInputElement>
-                            ) => updateDestination(row.source, e.target.value)}
-                          />
-                        </div>
-                      )}
+                          style={{
+                            fontSize: 12,
+                            marginTop: '0.5rem',
+                            cursor: 'pointer',
+                          }}
+                          variant='simple'
+                          placeholder={'Enter target table'}
+                          defaultValue={row.destination}
+                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                            updateDestination(row.source, e.target.value)
+                          }
+                        />
+                      </div>
                     </div>
 
                     {/* COLUMN BOX */}

--- a/ui/app/mirrors/create/cdc/styles.ts
+++ b/ui/app/mirrors/create/cdc/styles.ts
@@ -34,3 +34,9 @@ export const loaderContainer: CSSProperties = {
   justifyContent: 'center',
   height: '100%',
 };
+export const tooltipStyle: CSSProperties = {
+  width: '100%',
+  backgroundColor: 'white',
+  color: 'black',
+  padding: '0.5rem',
+};


### PR DESCRIPTION
If a table does not have primary key nor is it a replica identity, it is now not selectable in Create CDC UI.

<img width="1143" alt="Screenshot 2024-01-11 at 3 11 17 AM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/c589802e-437f-4f62-b351-e1def921b4f8">
