### PR TITLE
Eventhub: fix logs and metadatadb requirement

### DIFF
--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -71,7 +71,7 @@ func (c *EventHubConnector) Close() error {
 
 	err = c.hubManager.Close(context.Background())
 	if err != nil {
-		slog.Error("failed to close event hub manager", slog.Any("error", err))
+		c.logger.Error("failed to close event hub manager", slog.Any("error", err))
 		allErrors = errors.Join(allErrors, err)
 	}
 
@@ -240,7 +240,7 @@ func (c *EventHubConnector) SyncRecords(req *model.SyncRecordsRequest) (*model.S
 
 	lastCheckpoint, err := req.Records.GetLastCheckpoint()
 	if err != nil {
-		c.logger.Error("failed to get last checkpoint", err)
+		c.logger.Error("failed to get last checkpoint", slog.Any("error", err))
 		return nil, err
 	}
 

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -749,11 +749,6 @@ fn parse_db_options(
             let conn_str = opts.get("metadata_db");
             let metadata_db = parse_metadata_db_info(conn_str.copied())?;
 
-            // metadata_db is required for eventhub group
-            if metadata_db.is_none() {
-                anyhow::bail!("metadata_db is required for eventhub group");
-            }
-
             // split comma separated list of columns and trim
             let unnest_columns = opts
                 .get("unnest_columns")


### PR DESCRIPTION
Removes metadatadb requirement for Eventhub Group peer as it can use catalog on its own
Fixes a few logs