### PR TITLE
UI: Fix caching

### DIFF
--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -262,6 +262,7 @@ export const fetchSchemas = async (peerName: string) => {
     body: JSON.stringify({
       peerName,
     }),
+    cache: 'no-store',
   }).then((res) => res.json());
   return schemasRes.schemas;
 };
@@ -278,6 +279,7 @@ export const fetchTables = async (
       peerName,
       schemaName,
     }),
+    cache: 'no-store',
   }).then((res) => res.json());
 
   let tables: TableMapRow[] = [];
@@ -320,6 +322,7 @@ export const fetchColumns = async (
       schemaName,
       tableName,
     }),
+    cache: 'no-store',
   }).then((res) => res.json());
   setLoading(false);
   return columnsRes.columns;
@@ -332,6 +335,7 @@ export const fetchAllTables = async (peerName: string) => {
     body: JSON.stringify({
       peerName,
     }),
+    cache: 'no-store',
   }).then((res) => res.json());
   return tablesRes.tables;
 };

--- a/ui/app/mirrors/create/page.tsx
+++ b/ui/app/mirrors/create/page.tsx
@@ -69,7 +69,7 @@ export default function CreateMirrors() {
     BETWEEN {{.start}} AND {{.end}}`);
 
   useEffect(() => {
-    fetch('/api/peers')
+    fetch('/api/peers', { cache: 'no-store' })
       .then((res) => res.json())
       .then((res) => {
         setPeers(res);

--- a/ui/app/mirrors/errors/[mirrorName]/page.tsx
+++ b/ui/app/mirrors/errors/[mirrorName]/page.tsx
@@ -50,6 +50,7 @@ export default function MirrorError() {
           headers: {
             'Content-Type': 'application/json',
           },
+          cache: 'no-store',
           body: JSON.stringify(req),
         });
         const data: MirrorLogsResponse = await response.json();

--- a/ui/app/peers/[peerName]/page.tsx
+++ b/ui/app/peers/[peerName]/page.tsx
@@ -15,7 +15,10 @@ const PeerData = async ({ params: { peerName } }: DataConfigProps) => {
     const flowServiceAddr = GetFlowHttpAddressFromEnv();
 
     const peerSlots: PeerSlotResponse = await fetch(
-      `${flowServiceAddr}/v1/peers/slots/${peerName}`
+      `${flowServiceAddr}/v1/peers/slots/${peerName}`,
+      {
+        cache: 'no-store',
+      }
     ).then((res) => res.json());
 
     const slotArray = peerSlots.slotData;
@@ -42,7 +45,8 @@ const PeerData = async ({ params: { peerName } }: DataConfigProps) => {
     const flowServiceAddr = GetFlowHttpAddressFromEnv();
 
     const peerStats: PeerStatResponse = await fetch(
-      `${flowServiceAddr}/v1/peers/stats/${peerName}`
+      `${flowServiceAddr}/v1/peers/stats/${peerName}`,
+      { cache: 'no-store' }
     ).then((res) => res.json());
 
     return peerStats.statData;

--- a/ui/app/peers/create/[peerType]/handlers.ts
+++ b/ui/app/peers/create/[peerType]/handlers.ts
@@ -81,6 +81,7 @@ export const handleValidate = async (
       config,
       mode: 'validate',
     }),
+    cache: 'no-store',
   }).then((res) => res.json());
   if (!valid.valid) {
     setMessage({ ok: false, msg: valid.message });
@@ -118,6 +119,7 @@ export const handleCreate = async (
       config,
       mode: 'create',
     }),
+    cache: 'no-store',
   }).then((res) => res.json());
   if (!createdPeer.created) {
     setMessage({ ok: false, msg: createdPeer.message });


### PR DESCRIPTION
Refreshing in the slot page was not updating the slot table data since we aren't disabling caching there like we are in the mirrors edit page. Same goes for mirror errors page. Also just adds `cache:no-store` in a few other fetches for safety