### PR TITLE
Eventhub: remove parallelism, move recordheartbeat, use atomic

### DIFF
--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -156,8 +156,10 @@ func (c *EventHubConnector) processBatch(
 					return 0, err
 				}
 
-				c.logger.Info("processBatch", slog.Int("Total records sent to event hub", int(numRecords.Load())))
-				return numRecords.Load(), nil
+				currNumRecords := numRecords.Load()
+
+				c.logger.Info("processBatch", slog.Int("Total records sent to event hub", int(currNumRecords)))
+				return currNumRecords, nil
 			}
 
 			numRecords.Add(1)

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -226,11 +226,9 @@ func (c *EventHubConnector) processBatch(
 }
 
 func (c *EventHubConnector) SyncRecords(req *model.SyncRecordsRequest) (*model.SyncResponse, error) {
-	var err error
 	batch := req.Records
-	var numRecords uint32
 
-	numRecords, err = c.processBatch(req.FlowJobName, batch)
+	numRecords, err := c.processBatch(req.FlowJobName, batch)
 	if err != nil {
 		c.logger.Error("failed to process batch", slog.Any("error", err))
 		return nil, err

--- a/flow/connectors/eventhub/hub_batches.go
+++ b/flow/connectors/eventhub/hub_batches.go
@@ -118,7 +118,7 @@ func (h *HubBatches) flushAllBatches(
 		return nil
 	}
 
-	var numEventsPushed int32
+	var numEventsPushed atomic.Int32
 	err := h.ForEach(
 		func(
 			destination ScopedEventhub,
@@ -130,7 +130,7 @@ func (h *HubBatches) flushAllBatches(
 				return err
 			}
 
-			atomic.AddInt32(&numEventsPushed, numEvents)
+			numEventsPushed.Add(numEvents)
 			slog.Info("flushAllBatches",
 				slog.String(string(shared.FlowNameKey), flowName),
 				slog.Int("events sent", int(numEvents)),
@@ -145,7 +145,7 @@ func (h *HubBatches) flushAllBatches(
 	}
 	slog.Info("hub batches flush",
 		slog.String(string(shared.FlowNameKey), flowName),
-		slog.Int("events sent", int(numEventsPushed)))
+		slog.Int("events sent", int(numEventsPushed.Load())))
 
 	// clear the batches after flushing them.
 	return err

--- a/flow/connectors/eventhub/hub_batches.go
+++ b/flow/connectors/eventhub/hub_batches.go
@@ -10,7 +10,6 @@ import (
 
 	azeventhubs "github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 	"github.com/PeerDB-io/peer-flow/shared"
-	"golang.org/x/sync/errgroup"
 )
 
 // multimap from ScopedEventhub to *azeventhubs.EventDataBatch
@@ -76,10 +75,14 @@ func (h *HubBatches) Len() int {
 }
 
 // ForEach calls the given function for each ScopedEventhub and batch pair
-func (h *HubBatches) ForEach(fn func(ScopedEventhub, *azeventhubs.EventDataBatch)) {
-	for destination, batch := range h.batch {
-		fn(destination, batch)
+func (h *HubBatches) ForEach(fn func(ScopedEventhub, *azeventhubs.EventDataBatch) error) error {
+	for name, batch := range h.batch {
+		err := fn(name, batch)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (h *HubBatches) sendBatch(
@@ -108,7 +111,6 @@ func (h *HubBatches) sendBatch(
 
 func (h *HubBatches) flushAllBatches(
 	ctx context.Context,
-	maxParallelism int64,
 	flowName string,
 ) error {
 	if h.Len() == 0 {
@@ -117,12 +119,13 @@ func (h *HubBatches) flushAllBatches(
 	}
 
 	var numEventsPushed int32
-	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(int(maxParallelism))
-	h.ForEach(func(destination ScopedEventhub, eventBatch *azeventhubs.EventDataBatch) {
-		g.Go(func() error {
+	err := h.ForEach(
+		func(
+			destination ScopedEventhub,
+			eventBatch *azeventhubs.EventDataBatch,
+		) error {
 			numEvents := eventBatch.NumEvents()
-			err := h.sendBatch(gCtx, destination, eventBatch)
+			err := h.sendBatch(ctx, destination, eventBatch)
 			if err != nil {
 				return err
 			}
@@ -134,16 +137,17 @@ func (h *HubBatches) flushAllBatches(
 				slog.String("event hub topic ", destination.ToString()))
 			return nil
 		})
-	})
 
-	err := g.Wait()
+	h.Clear()
+
+	if err != nil {
+		return fmt.Errorf("failed to flushAllBatches: %v", err)
+	}
 	slog.Info("hub batches flush",
 		slog.String(string(shared.FlowNameKey), flowName),
 		slog.Int("events sent", int(numEventsPushed)))
 
 	// clear the batches after flushing them.
-	h.Clear()
-
 	return err
 }
 


### PR DESCRIPTION
- Remove push parallelism
- Move heartbeat routine inside processBatch
- use atomic int for num records