### PR TITLE
Prefer to close completion channels instead of <-struct{}{}

### DIFF
--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -24,7 +24,7 @@ func (a *SnapshotActivity) CloseSlotKeepAlive(flowJobName string) error {
 	}
 
 	if s, ok := a.SnapshotConnections[flowJobName]; ok {
-		s.signal.CloneComplete <- struct{}{}
+		close(s.signal.CloneComplete)
 		s.connector.Close()
 	}
 

--- a/flow/connectors/postgres/slot_signal.go
+++ b/flow/connectors/postgres/slot_signal.go
@@ -18,6 +18,6 @@ type SlotSignal struct {
 func NewSlotSignal() SlotSignal {
 	return SlotSignal{
 		SlotCreated:   make(chan SlotCreationResult, 1),
-		CloneComplete: make(chan struct{}, 1),
+		CloneComplete: make(chan struct{}),
 	}
 }

--- a/flow/connectors/utils/heartbeat.go
+++ b/flow/connectors/utils/heartbeat.go
@@ -30,7 +30,7 @@ func HeartbeatRoutine(
 			}
 		}
 	}()
-	return func() { shutdown <- struct{}{} }
+	return func() { close(shutdown) }
 }
 
 // if the functions are being called outside the context of a Temporal workflow,

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -453,7 +453,8 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Toast_Nochanges_BQ() {
 
 	// in a separate goroutine, wait for PeerFlowStatusQuery to finish setup
 	// and execute a transaction touching toast columns
-	done := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(env, connectionGen)
 		/* transaction updating no rows */
@@ -465,10 +466,11 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Toast_Nochanges_BQ() {
 		`, srcTableName, srcTableName))
 		e2e.EnvNoError(s.t, env, err)
 		s.t.Log("Executed a transaction touching toast columns")
-		done <- struct{}{}
+		wg.Done()
 	}()
 
 	env.ExecuteWorkflow(peerflow.CDCFlowWorkflowWithConfig, flowConnConfig, &limits, nil)
+	wg.Wait()
 
 	// Verify workflow completes without error
 	require.True(s.t, env.IsWorkflowCompleted())
@@ -478,7 +480,6 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Toast_Nochanges_BQ() {
 	require.Contains(s.t, err.Error(), "continue as new")
 
 	e2e.RequireEqualTables(s, dstTableName, "id,t1,t2,k")
-	<-done
 }
 
 func (s PeerFlowE2ETestSuiteBQ) Test_Toast_Advance_1_BQ() {

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -210,7 +210,7 @@ func (s PeerFlowE2ETestSuitePG) TestSimpleSlotCreation() {
 
 	slog.Info("signaling clone complete after waiting for 2 seconds", flowLog)
 	time.Sleep(2 * time.Second)
-	signal.CloneComplete <- struct{}{}
+	close(signal.CloneComplete)
 
 	require.NoError(s.t, <-setupError)
 	slog.Info("successfully setup replication", flowLog)


### PR DESCRIPTION
Closing allows for multiple receivers & never blocks sender
It's the correct choice when one wants to signal an irreversible state change