### PR TITLE
Move ReplayTableSchemaDeltas into SyncRecords

### DIFF
--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -71,6 +71,11 @@ type CDCSyncConnector interface {
 	// CreateRawTable creates a raw table for the connector with a given name and a fixed schema.
 	CreateRawTable(req *protos.CreateRawTableInput) (*protos.CreateRawTableOutput, error)
 
+	// ReplayTableSchemaDelta changes a destination table to match the schema at source
+	// This could involve adding or dropping multiple columns.
+	// Connectors which are non-normalizing should implement this as a nop.
+	ReplayTableSchemaDeltas(flowJobName string, schemaDeltas []*protos.TableSchemaDelta) error
+
 	// SetupNormalizedTables sets up the normalized table on the connector.
 	SetupNormalizedTables(req *protos.SetupNormalizedTableBatchInput) (
 		*protos.SetupNormalizedTableBatchOutput, error)
@@ -89,10 +94,6 @@ type CDCNormalizeConnector interface {
 	// NormalizeRecords merges records pushed earlier into the destination table.
 	// This method should be idempotent, and should be able to be called multiple times with the same request.
 	NormalizeRecords(req *model.NormalizeRecordsRequest) (*model.NormalizeResponse, error)
-
-	// ReplayTableSchemaDelta changes a destination table to match the schema at source
-	// This could involve adding or dropping multiple columns.
-	ReplayTableSchemaDeltas(flowJobName string, schemaDeltas []*protos.TableSchemaDelta) error
 }
 
 type QRepPullConnector interface {

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -256,6 +256,8 @@ func (c *EventHubConnector) SyncRecords(req *model.SyncRecordsRequest) (*model.S
 		LastSyncedCheckPointID: lastCheckpoint,
 		NumRecordsSynced:       rowsSynced,
 		TableNameRowsMapping:   make(map[string]uint32),
+		TableSchemaDeltas:      req.Records.WaitForSchemaDeltas(req.TableMappings),
+		RelationMessageMapping: <-req.Records.RelationMessageMapping,
 	}, nil
 }
 
@@ -284,6 +286,11 @@ func (c *EventHubConnector) CreateRawTable(req *protos.CreateRawTableInput) (*pr
 	return &protos.CreateRawTableOutput{
 		TableIdentifier: "n/a",
 	}, nil
+}
+
+func (c *EventHubConnector) ReplayTableSchemaDeltas(flowJobName string, schemaDeltas []*protos.TableSchemaDelta) error {
+	c.logger.Info("ReplayTableSchemaDeltas for event hub is a no-op")
+	return nil
 }
 
 func (c *EventHubConnector) SetupNormalizedTables(

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -228,7 +228,14 @@ func (c *S3Connector) SyncRecords(req *model.SyncRecordsRequest) (*model.SyncRes
 		LastSyncedCheckPointID: lastCheckpoint,
 		NumRecordsSynced:       int64(numRecords),
 		TableNameRowsMapping:   tableNameRowsMapping,
+		TableSchemaDeltas:      req.Records.WaitForSchemaDeltas(req.TableMappings),
+		RelationMessageMapping: <-req.Records.RelationMessageMapping,
 	}, nil
+}
+
+func (c *S3Connector) ReplayTableSchemaDeltas(flowJobName string, schemaDeltas []*protos.TableSchemaDelta) error {
+	c.logger.Info("ReplayTableSchemaDeltas for S3 is a no-op")
+	return nil
 }
 
 func (c *S3Connector) SetupNormalizedTables(req *protos.SetupNormalizedTableBatchInput) (

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -496,6 +496,8 @@ type SyncRecordsRequest struct {
 	FlowJobName string
 	// SyncMode to use for pushing raw records
 	SyncMode protos.QRepSyncMode
+	// source:destination mappings
+	TableMappings []*protos.TableMapping
 	// Staging path for AVRO files in CDC
 	StagingPath string
 	// PushBatchSize is the number of records to push in a batch for EventHub.

--- a/flow/workflows/sync_flow.go
+++ b/flow/workflows/sync_flow.go
@@ -82,22 +82,6 @@ func (s *SyncFlowExecution) executeSyncFlow(
 	if err := fStartFlow.Get(startFlowCtx, &syncRes); err != nil {
 		return nil, fmt.Errorf("failed to flow: %w", err)
 	}
-
-	replayTableSchemaDeltaCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 30 * time.Minute,
-		WaitForCancellation: true,
-	})
-	replayTableSchemaInput := &protos.ReplayTableSchemaDeltaInput{
-		FlowConnectionConfigs: config,
-		TableSchemaDeltas:     syncRes.TableSchemaDeltas,
-	}
-
-	fReplayTableSchemaDelta := workflow.ExecuteActivity(replayTableSchemaDeltaCtx,
-		flowable.ReplayTableSchemaDeltas, replayTableSchemaInput)
-	if err := fReplayTableSchemaDelta.Get(replayTableSchemaDeltaCtx, nil); err != nil {
-		return nil, fmt.Errorf("failed to replay schema delta: %w", err)
-	}
-
 	return syncRes, nil
 }
 

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -372,11 +372,6 @@ message TableSchemaDelta {
   repeated DeltaAddedColumn added_columns = 3;
 }
 
-message ReplayTableSchemaDeltaInput {
-  FlowConnectionConfigs flow_connection_configs = 1;
-  repeated TableSchemaDelta table_schema_deltas = 2;
-}
-
 message QRepFlowState {
   QRepPartition last_partition = 1;
   uint64 num_partitions_processed = 2;


### PR DESCRIPTION
A sync batch should not be considered complete until its schema changes are processed,
this avoids failures after commit causing schema changes to be dropped,
& when decoupling normalize/sync in #893 was causing normalization to be missing values