### PR TITLE
Import sync in bq test file

### DIFF
--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 


### PR DESCRIPTION
Seems like `peer_flow_bq_test.go` was missing the sync import