### PR TITLE
Fix Eventhub Partition Key and UI Graph

### DIFF
--- a/flow/connectors/utils/partition_hash.go
+++ b/flow/connectors/utils/partition_hash.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"fmt"
+	"hash/fnv"
+)
+
+func hashString(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
+}
+
+func HashedPartitionKey(s string, numPartitions uint32) string {
+	hashValue := hashString(s)
+	partition := hashValue % numPartitions
+	return fmt.Sprintf("%d", partition)
+}

--- a/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
+++ b/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
@@ -44,7 +44,9 @@ function aggregateCountsByInterval(
     } else if (interval === '15min') {
       N = 15;
     }
-    const date = roundUpToNearestNMinutes(timestamp, N);
+
+    const currTs = new Date(timestamp);
+    const date = roundUpToNearestNMinutes(currTs, N);
     const formattedTimestamp = moment(date).format(timeUnit);
 
     if (!aggregatedCounts[formattedTimestamp]) {

--- a/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
@@ -70,10 +70,11 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [sortDir, setSortDir] = useState<'asc' | 'dsc'>('dsc');
   const displayedRows = useMemo(() => {
-    const shownRows = allRows.filter((row: TableCloneSummary) =>
-      row.cloneTableSummary.tableName
-        ?.toLowerCase()
-        .includes(searchQuery.toLowerCase())
+    const shownRows = allRows.filter(
+      (row: TableCloneSummary) =>
+        row.cloneTableSummary.tableName
+          ?.toLowerCase()
+          .includes(searchQuery.toLowerCase())
     );
     shownRows.sort((a, b) => {
       const aValue = a[sortField];

--- a/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdc.tsx
@@ -70,11 +70,10 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [sortDir, setSortDir] = useState<'asc' | 'dsc'>('dsc');
   const displayedRows = useMemo(() => {
-    const shownRows = allRows.filter(
-      (row: TableCloneSummary) =>
-        row.cloneTableSummary.tableName
-          ?.toLowerCase()
-          .includes(searchQuery.toLowerCase())
+    const shownRows = allRows.filter((row: TableCloneSummary) =>
+      row.cloneTableSummary.tableName
+        ?.toLowerCase()
+        .includes(searchQuery.toLowerCase())
     );
     shownRows.sort((a, b) => {
       const aValue = a[sortField];

--- a/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
@@ -1,28 +1,28 @@
 'use client';
 import { SyncStatusRow } from '@/app/dto/MirrorsDTO';
-import { formatGraphLabel, timeOptions } from '@/app/utils/graph';
+import { timeOptions } from '@/app/utils/graph';
 import { Label } from '@/lib/Label';
 import { BarChart } from '@tremor/react';
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import ReactSelect from 'react-select';
 import aggregateCountsByInterval from './aggregatedCountsByInterval';
 
 function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
   let [aggregateType, setAggregateType] = useState('hour');
-  const initialCount: [string, number][] = [];
-  let [counts, setCounts] = useState(initialCount);
 
-  useEffect(() => {
-    let rows = syncs.map((sync) => ({
+  const graphValues = useMemo(()=>{
+    const rows = syncs.map((sync) => ({
       timestamp: sync.startTime,
       count: sync.numRows,
+  }));
+    let timedRowCounts = aggregateCountsByInterval(rows, aggregateType);
+    timedRowCounts = timedRowCounts.slice(0, 29);
+    timedRowCounts = timedRowCounts.reverse();
+    return timedRowCounts.map((count) => ({
+      name: count[0],
+      'Rows synced at a point in time': count[1],
     }));
-
-    let counts = aggregateCountsByInterval(rows, aggregateType);
-    counts = counts.slice(0, 29);
-    counts = counts.reverse();
-    setCounts(counts);
-  }, [aggregateType, syncs]);
+  },[syncs,aggregateType])
 
   return (
     <div>
@@ -40,10 +40,7 @@ function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
       </div>
       <BarChart
         className='mt-3'
-        data={counts.map((count) => ({
-          name: formatGraphLabel(new Date(count[0]), aggregateType),
-          'Rows synced at a point in time': count[1],
-        }))}
+        data={graphValues}
         index='name'
         categories={['Rows synced at a point in time']}
       />

--- a/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdcGraph.tsx
@@ -10,11 +10,11 @@ import aggregateCountsByInterval from './aggregatedCountsByInterval';
 function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
   let [aggregateType, setAggregateType] = useState('hour');
 
-  const graphValues = useMemo(()=>{
+  const graphValues = useMemo(() => {
     const rows = syncs.map((sync) => ({
       timestamp: sync.startTime,
       count: sync.numRows,
-  }));
+    }));
     let timedRowCounts = aggregateCountsByInterval(rows, aggregateType);
     timedRowCounts = timedRowCounts.slice(0, 29);
     timedRowCounts = timedRowCounts.reverse();
@@ -22,7 +22,7 @@ function CdcGraph({ syncs }: { syncs: SyncStatusRow[] }) {
       name: count[0],
       'Rows synced at a point in time': count[1],
     }));
-  },[syncs,aggregateType])
+  }, [syncs, aggregateType]);
 
   return (
     <div>


### PR DESCRIPTION
We now hash the partition key column value obtained from the destination table name in create mirror for PG->EH.
This is to reduce the number of Eventhub batches we create. Noticed that not doing so makes the mirror extremely slow
Also fixes some code of the UI Graph component