### PR TITLE
Support more data types

### DIFF
--- a/flow/connectors/bigquery/avro_transform_test.go
+++ b/flow/connectors/bigquery/avro_transform_test.go
@@ -18,10 +18,6 @@ func TestAvroTransform(t *testing.T) {
 			Type: bigquery.JSONFieldType,
 		},
 		&bigquery.FieldSchema{
-			Name: "col3",
-			Type: bigquery.DateFieldType,
-		},
-		&bigquery.FieldSchema{
 			Name: "camelCol4",
 			Type: bigquery.StringFieldType,
 		},
@@ -34,7 +30,6 @@ func TestAvroTransform(t *testing.T) {
 	expectedTransformCols := []string{
 		"ST_GEOGFROMTEXT(`col1`) AS `col1`",
 		"PARSE_JSON(`col2`,wide_number_mode=>'round') AS `col2`",
-		"CAST(`col3` AS DATE) AS `col3`",
 		"`camelCol4`",
 	}
 	transformedCols := getTransformedColumns(dstSchema, "sync_col", "del_col")

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -53,7 +53,7 @@ func (m *mergeStmtGenerator) generateFlattenedCTE() string {
 		case qvalue.QValueKindBytes, qvalue.QValueKindBit:
 			castStmt = fmt.Sprintf("FROM_BASE64(JSON_VALUE(_peerdb_data,'$.%s')) AS `%s`",
 				colName, shortCol)
-		case qvalue.QValueKindArrayFloat32, qvalue.QValueKindArrayFloat64,
+		case qvalue.QValueKindArrayFloat32, qvalue.QValueKindArrayFloat64, qvalue.QValueKindArrayInt16,
 			qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64, qvalue.QValueKindArrayString,
 			qvalue.QValueKindArrayBoolean, qvalue.QValueKindArrayTimestamp, qvalue.QValueKindArrayTimestampTZ,
 			qvalue.QValueKindArrayDate:

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -54,7 +54,9 @@ func (m *mergeStmtGenerator) generateFlattenedCTE() string {
 			castStmt = fmt.Sprintf("FROM_BASE64(JSON_VALUE(_peerdb_data,'$.%s')) AS `%s`",
 				colName, shortCol)
 		case qvalue.QValueKindArrayFloat32, qvalue.QValueKindArrayFloat64,
-			qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64, qvalue.QValueKindArrayString:
+			qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64, qvalue.QValueKindArrayString,
+			qvalue.QValueKindArrayBoolean, qvalue.QValueKindArrayTimestamp, qvalue.QValueKindArrayTimestampTZ,
+			qvalue.QValueKindArrayDate:
 			castStmt = fmt.Sprintf("ARRAY(SELECT CAST(element AS %s) FROM "+
 				"UNNEST(CAST(JSON_VALUE_ARRAY(_peerdb_data, '$.%s') AS ARRAY<STRING>)) AS element WHERE element IS NOT null) AS `%s`",
 				bqType, colName, shortCol)

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -313,9 +313,9 @@ func GetAvroType(bqField *bigquery.FieldSchema) (interface{}, error) {
 			"logicalType": "timestamp-micros",
 		}
 		if bqField.Repeated {
-			return map[string]interface{}{
-				"type":  "array",
-				"items": timestampSchema,
+			return qvalue.AvroSchemaArray{
+				Type:  "array",
+				Items: timestampSchema,
 			}, nil
 		}
 		return timestampSchema, nil
@@ -325,9 +325,9 @@ func GetAvroType(bqField *bigquery.FieldSchema) (interface{}, error) {
 			"logicalType": "date",
 		}
 		if bqField.Repeated {
-			return map[string]interface{}{
-				"type":  "array",
-				"items": dateSchema,
+			return qvalue.AvroSchemaArray{
+				Type:  "array",
+				Items: dateSchema,
 			}, nil
 		}
 		return dateSchema, nil

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -308,24 +308,24 @@ func GetAvroType(bqField *bigquery.FieldSchema) (interface{}, error) {
 	case bigquery.BooleanFieldType:
 		return considerRepeated("boolean", bqField.Repeated), nil
 	case bigquery.TimestampFieldType:
-		timestampSchema := map[string]string{
-			"type":        "long",
-			"logicalType": "timestamp-micros",
+		timestampSchema := qvalue.AvroSchemaField{
+			Type:        "long",
+			LogicalType: "timestamp-micros",
 		}
 		if bqField.Repeated {
-			return qvalue.AvroSchemaArray{
+			return qvalue.AvroSchemaComplexArray{
 				Type:  "array",
 				Items: timestampSchema,
 			}, nil
 		}
 		return timestampSchema, nil
 	case bigquery.DateFieldType:
-		dateSchema := map[string]string{
-			"type":        "int",
-			"logicalType": "date",
+		dateSchema := qvalue.AvroSchemaField{
+			Type:        "int",
+			LogicalType: "date",
 		}
 		if bqField.Repeated {
-			return qvalue.AvroSchemaArray{
+			return qvalue.AvroSchemaComplexArray{
 				Type:  "array",
 				Items: dateSchema,
 			}, nil
@@ -333,52 +333,52 @@ func GetAvroType(bqField *bigquery.FieldSchema) (interface{}, error) {
 		return dateSchema, nil
 
 	case bigquery.TimeFieldType:
-		return map[string]string{
-			"type":        "long",
-			"logicalType": "timestamp-micros",
+		return qvalue.AvroSchemaField{
+			Type:        "long",
+			LogicalType: "timestamp-micros",
 		}, nil
 	case bigquery.DateTimeFieldType:
-		return map[string]interface{}{
-			"type": "record",
-			"name": "datetime",
-			"fields": []map[string]string{
+		return qvalue.AvroSchemaRecord{
+			Type: "record",
+			Name: "datetime",
+			Fields: []qvalue.AvroSchemaField{
 				{
-					"name":        "date",
-					"type":        "int",
-					"logicalType": "date",
+					Name:        "date",
+					Type:        "int",
+					LogicalType: "date",
 				},
 				{
-					"name":        "time",
-					"type":        "long",
-					"logicalType": "time-micros",
+					Name:        "time",
+					Type:        "long",
+					LogicalType: "time-micros",
 				},
 			},
 		}, nil
 	case bigquery.NumericFieldType:
-		return map[string]interface{}{
-			"type":        "bytes",
-			"logicalType": "decimal",
-			"precision":   38,
-			"scale":       9,
+		return qvalue.AvroSchemaNumeric{
+			Type:        "bytes",
+			LogicalType: "decimal",
+			Precision:   38,
+			Scale:       9,
 		}, nil
 	case bigquery.RecordFieldType:
-		avroFields := []map[string]interface{}{}
+		avroFields := []qvalue.AvroSchemaField{}
 		for _, bqSubField := range bqField.Schema {
 			avroType, err := GetAvroType(bqSubField)
 			if err != nil {
 				return nil, err
 			}
-			avroFields = append(avroFields, map[string]interface{}{
-				"name": bqSubField.Name,
-				"type": avroType,
+			avroFields = append(avroFields, qvalue.AvroSchemaField{
+				Name: bqSubField.Name,
+				Type: avroType,
 			})
 		}
-		return map[string]interface{}{
-			"type":   "record",
-			"name":   bqField.Name,
-			"fields": avroFields,
+		return qvalue.AvroSchemaRecord{
+			Type:   "record",
+			Name:   bqField.Name,
+			Fields: avroFields,
 		}, nil
-	// TODO(kaushik/sai): Add other field types as needed
+
 	default:
 		return nil, fmt.Errorf("unsupported BigQuery field type: %s", bqField.Type)
 	}

--- a/flow/connectors/bigquery/qvalue_convert.go
+++ b/flow/connectors/bigquery/qvalue_convert.go
@@ -42,10 +42,16 @@ func qValueKindToBigQueryType(colType string) bigquery.FieldType {
 	// For Arrays we return the types of the individual elements,
 	// and wherever this function is called, the 'Repeated' attribute of
 	// FieldSchema must be set to true.
-	case qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64:
+	case qvalue.QValueKindArrayInt16, qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64:
 		return bigquery.IntegerFieldType
 	case qvalue.QValueKindArrayFloat32, qvalue.QValueKindArrayFloat64:
 		return bigquery.FloatFieldType
+	case qvalue.QValueKindArrayBoolean:
+		return bigquery.BooleanFieldType
+	case qvalue.QValueKindArrayTimestamp, qvalue.QValueKindArrayTimestampTZ:
+		return bigquery.TimestampFieldType
+	case qvalue.QValueKindArrayDate:
+		return bigquery.DateFieldType
 	case qvalue.QValueKindGeography, qvalue.QValueKindGeometry, qvalue.QValueKindPoint:
 		return bigquery.GeographyFieldType
 	// rest will be strings

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -741,8 +741,8 @@ func (p *PostgresCDCSource) decodeColumnData(data []byte, dataType uint32, forma
 	var parsedData any
 	var err error
 	if dt, ok := p.typeMap.TypeForOID(dataType); ok {
-		if dt.Name == "uuid" {
-			// below is required to decode uuid to string
+		if dt.Name == "uuid" || dt.Name == "cidr" || dt.Name == "inet" || dt.Name == "macaddr" {
+			// below is required to decode above types to string
 			parsedData, err = dt.Codec.DecodeDatabaseSQLValue(p.typeMap, dataType, pgtype.TextFormatCode, data)
 		} else {
 			parsedData, err = dt.Codec.DecodeValue(p.typeMap, dataType, formatCode, data)

--- a/flow/connectors/sql/query_executor.go
+++ b/flow/connectors/sql/query_executor.go
@@ -432,6 +432,8 @@ func toQValue(kind qvalue.QValueKind, val interface{}) (qvalue.QValue, error) {
 					kind = qvalue.QValueKindArrayFloat32
 				case float64:
 					kind = qvalue.QValueKindArrayFloat64
+				case int16:
+					kind = qvalue.QValueKindArrayInt16
 				case int32:
 					kind = qvalue.QValueKindArrayInt32
 				case int64:
@@ -447,13 +449,12 @@ func toQValue(kind qvalue.QValueKind, val interface{}) (qvalue.QValue, error) {
 		return qvalue.QValue{Kind: qvalue.QValueKindJSON, Value: vstring}, nil
 
 	case qvalue.QValueKindHStore:
-		// TODO fix this.
 		return qvalue.QValue{Kind: qvalue.QValueKindHStore, Value: val}, nil
 
 	case qvalue.QValueKindArrayFloat32, qvalue.QValueKindArrayFloat64,
+		qvalue.QValueKindArrayInt16,
 		qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64,
 		qvalue.QValueKindArrayString:
-		// TODO fix this.
 		return toQValueArray(kind, val)
 	}
 
@@ -490,6 +491,20 @@ func toQValueArray(kind qvalue.QValueKind, value interface{}) (qvalue.QValue, er
 			result = float64Array
 		default:
 			return qvalue.QValue{}, fmt.Errorf("failed to parse array float64: %v", value)
+		}
+
+	case qvalue.QValueKindArrayInt16:
+		switch v := value.(type) {
+		case []int16:
+			result = v
+		case []interface{}:
+			int16Array := make([]int16, len(v))
+			for i, val := range v {
+				int16Array[i] = val.(int16)
+			}
+			result = int16Array
+		default:
+			return qvalue.QValue{}, fmt.Errorf("failed to parse array int16: %v", value)
 		}
 
 	case qvalue.QValueKindArrayInt32:

--- a/flow/e2e/bigquery/bigquery_helper.go
+++ b/flow/e2e/bigquery/bigquery_helper.go
@@ -233,7 +233,7 @@ func toQValue(bqValue bigquery.Value) (qvalue.QValue, error) {
 		}
 
 		firstElement := v[0]
-		switch firstElement.(type) {
+		switch et := firstElement.(type) {
 		case int, int32:
 			var arr []int32
 			for _, val := range v {
@@ -264,10 +264,30 @@ func toQValue(bqValue bigquery.Value) (qvalue.QValue, error) {
 				arr = append(arr, val.(string))
 			}
 			return qvalue.QValue{Kind: qvalue.QValueKindArrayString, Value: arr}, nil
+		case time.Time:
+			var arr []time.Time
+			for _, val := range v {
+				arr = append(arr, val.(time.Time))
+			}
+			return qvalue.QValue{Kind: qvalue.QValueKindArrayTimestamp, Value: arr}, nil
+		case civil.Date:
+			var arr []civil.Date
+			for _, val := range v {
+				arr = append(arr, val.(civil.Date))
+			}
+			return qvalue.QValue{Kind: qvalue.QValueKindArrayDate, Value: arr}, nil
+		case bool:
+			var arr []bool
+
+			for _, val := range v {
+				arr = append(arr, val.(bool))
+			}
+			return qvalue.QValue{Kind: qvalue.QValueKindArrayBoolean, Value: arr}, nil
+		default:
+			// If type is unsupported, return error
+			return qvalue.QValue{}, fmt.Errorf("bqHelper unsupported type %T", et)
 		}
 
-		// If type is unsupported, return error
-		return qvalue.QValue{}, fmt.Errorf("bqHelper unsupported type %T", v)
 	case nil:
 		return qvalue.QValue{Kind: qvalue.QValueKindInvalid, Value: nil}, nil
 	default:

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -709,7 +709,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 		c23 NUMERIC,c24 OID,c28 REAL,c29 SMALLINT,c30 SMALLSERIAL,c31 SERIAL,c32 TEXT,
 		c33 TIMESTAMP,c34 TIMESTAMPTZ,c35 TIME, c36 TIMETZ,c37 TSQUERY,c38 TSVECTOR,
 		c39 TXID_SNAPSHOT,c40 UUID,c41 XML, c42 INT[], c43 FLOAT[], c44 TEXT[], c45 mood, c46 HSTORE,
-		c47 DATE[], c48 TIMESTAMPTZ[], c49 TIMESTAMP[], c50 BOOLEAN[]);
+		c47 DATE[], c48 TIMESTAMPTZ[], c49 TIMESTAMP[], c50 BOOLEAN[], c51 SMALLINT[]);
 	`, srcTableName))
 	require.NoError(s.t, err)
 
@@ -750,7 +750,8 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 		'{2020-01-01, 2020-01-02}'::date[],
 		'{"2020-01-01 01:01:01+00", "2020-01-02 01:01:01+00"}'::timestamptz[],
 		'{"2020-01-01 01:01:01", "2020-01-02 01:01:01"}'::timestamp[],
-		'{true, false}'::boolean[];
+		'{true, false}'::boolean[],
+		'{1, 2}'::smallint[];
 		`, srcTableName))
 		e2e.EnvNoError(s.t, env, err)
 	}()
@@ -769,7 +770,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 		"c6", "c39", "c40", "id", "c9", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18",
 		"c21", "c22", "c23", "c24", "c28", "c29", "c30", "c31", "c33", "c34", "c35", "c36",
 		"c37", "c38", "c7", "c8", "c32", "c42", "c43", "c44", "c45", "c46", "c47", "c48",
-		"c49", "c50",
+		"c49", "c50", "c51",
 	})
 	if err != nil {
 		s.t.Log(err)

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -708,7 +708,8 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 		c14 INET,c15 INTEGER,c16 INTERVAL,c17 JSON,c18 JSONB,c21 MACADDR,c22 MONEY,
 		c23 NUMERIC,c24 OID,c28 REAL,c29 SMALLINT,c30 SMALLSERIAL,c31 SERIAL,c32 TEXT,
 		c33 TIMESTAMP,c34 TIMESTAMPTZ,c35 TIME, c36 TIMETZ,c37 TSQUERY,c38 TSVECTOR,
-		c39 TXID_SNAPSHOT,c40 UUID,c41 XML, c42 INT[], c43 FLOAT[], c44 TEXT[], c45 mood, c46 HSTORE);
+		c39 TXID_SNAPSHOT,c40 UUID,c41 XML, c42 INT[], c43 FLOAT[], c44 TEXT[], c45 mood, c46 HSTORE,
+		c47 DATE[], c48 TIMESTAMPTZ[], c49 TIMESTAMP[], c50 BOOLEAN[]);
 	`, srcTableName))
 	require.NoError(s.t, err)
 
@@ -745,7 +746,11 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 		ARRAY[10299301,2579827],
 		ARRAY[0.0003, 8902.0092],
 		ARRAY['hello','bye'],'happy',
-		'key1=>value1, key2=>NULL'::hstore
+		'key1=>value1, key2=>NULL'::hstore,
+		'{2020-01-01, 2020-01-02}'::date[],
+		'{"2020-01-01 01:01:01+00", "2020-01-02 01:01:01+00"}'::timestamptz[],
+		'{"2020-01-01 01:01:01", "2020-01-02 01:01:01"}'::timestamp[],
+		'{true, false}'::boolean[];
 		`, srcTableName))
 		e2e.EnvNoError(s.t, env, err)
 	}()
@@ -763,7 +768,8 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 		"c41", "c1", "c2", "c3", "c4",
 		"c6", "c39", "c40", "id", "c9", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18",
 		"c21", "c22", "c23", "c24", "c28", "c29", "c30", "c31", "c33", "c34", "c35", "c36",
-		"c37", "c38", "c7", "c8", "c32", "c42", "c43", "c44", "c45", "c46",
+		"c37", "c38", "c7", "c8", "c32", "c42", "c43", "c44", "c45", "c46", "c47", "c48",
+		"c49", "c50",
 	})
 	if err != nil {
 		s.t.Log(err)

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -202,7 +202,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 		c29 SMALLINT,c32 TEXT,
 		c33 TIMESTAMP,c34 TIMESTAMPTZ,c35 TIME, c36 TIMETZ,
 		c40 UUID, c42 INT[], c43 FLOAT[], c44 TEXT[],
-		c46 DATE[], c47 TIMESTAMPTZ[], c48 TIMESTAMP[], c49 BOOLEAN[]);
+		c46 DATE[], c47 TIMESTAMPTZ[], c48 TIMESTAMP[], c49 BOOLEAN[], c50 SMALLINT[]);
 	`, srcTableName))
 	require.NoError(s.t, err)
 
@@ -235,7 +235,8 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 			'{2020-01-01, 2020-01-02}'::date[],
 			'{"2020-01-01 01:01:01+00", "2020-01-02 01:01:01+00"}'::timestamptz[],
 			'{"2020-01-01 01:01:01", "2020-01-02 01:01:01"}'::timestamp[],
-			'{true, false}'::boolean[];
+			'{true, false}'::boolean[],
+			'{1,2}'::smallint[];
 			`, srcTableName))
 		e2e.EnvNoError(s.t, env, err)
 
@@ -255,7 +256,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 		"c1", "c2", "c4",
 		"c40", "id", "c9", "c11", "c12", "c13", "c14", "c15",
 		"c21", "c29", "c33", "c34", "c35", "c36",
-		"c7", "c8", "c32", "c42", "c43", "c44", "c46", "c47", "c48", "c49",
+		"c7", "c8", "c32", "c42", "c43", "c44", "c46", "c47", "c48", "c49", "c50",
 	}
 	err = s.comparePGTables(srcTableName, dstTableName, strings.Join(allCols, ","))
 	require.NoError(s.t, err)

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -221,7 +221,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 	}
 
 	go func() {
-		e2e.SetupCDCFlowStatusQuery(env, connectionGen)
+		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		_, err = s.pool.Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s SELECT 2,2,b'1',
 			true,'s','test','1.1.10.2'::cidr,

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
@@ -184,6 +185,79 @@ func (s PeerFlowE2ETestSuitePG) Test_Geospatial_PG() {
 	require.Contains(s.t, err.Error(), "continue as new")
 
 	err = s.comparePGTables(srcTableName, dstTableName, "id,gg,gm")
+	require.NoError(s.t, err)
+}
+
+func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
+	env := e2e.NewTemporalTestWorkflowEnvironment()
+	e2e.RegisterWorkflowsAndActivities(s.t, env)
+
+	srcTableName := s.attachSchemaSuffix("test_types_pg")
+	dstTableName := s.attachSchemaSuffix("test_types_pg_dst")
+
+	_, err := s.pool.Exec(context.Background(), fmt.Sprintf(`
+	CREATE TABLE IF NOT EXISTS %s (id serial PRIMARY KEY,c1 BIGINT,c2 BIT,c4 BOOLEAN,
+		c7 CHARACTER,c8 varchar,c9 CIDR,c11 DATE,c12 FLOAT,c13 DOUBLE PRECISION,
+		c14 INET,c15 INTEGER,c21 MACADDR,
+		c29 SMALLINT,c32 TEXT,
+		c33 TIMESTAMP,c34 TIMESTAMPTZ,c35 TIME, c36 TIMETZ,
+		c40 UUID, c42 INT[], c43 FLOAT[], c44 TEXT[],
+		c46 DATE[], c47 TIMESTAMPTZ[], c48 TIMESTAMP[], c49 BOOLEAN[]);
+	`, srcTableName))
+	require.NoError(s.t, err)
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("test_types_pg"),
+		TableNameMapping: map[string]string{srcTableName: dstTableName},
+		PostgresPort:     e2e.PostgresPort,
+		Destination:      s.peer,
+	}
+
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
+
+	limits := peerflow.CDCFlowLimits{
+		ExitAfterRecords: 1,
+		MaxBatchSize:     100,
+	}
+
+	go func() {
+		e2e.SetupCDCFlowStatusQuery(env, connectionGen)
+		_, err = s.pool.Exec(context.Background(), fmt.Sprintf(`
+			INSERT INTO %s SELECT 2,2,b'1',
+			true,'s','test','1.1.10.2'::cidr,
+			CURRENT_DATE,1.23,1.234,'192.168.1.5'::inet,1,
+			'08:00:2b:01:02:03'::macaddr,
+			1,'test',now(),now(),now()::time,now()::timetz,
+			'66073c38-b8df-4bdb-bbca-1c97596b8940'::uuid,
+			ARRAY[10299301,2579827],
+			ARRAY[0.0003, 8902.0092],
+			ARRAY['hello','bye'],
+			'{2020-01-01, 2020-01-02}'::date[],
+			'{"2020-01-01 01:01:01+00", "2020-01-02 01:01:01+00"}'::timestamptz[],
+			'{"2020-01-01 01:01:01", "2020-01-02 01:01:01"}'::timestamp[],
+			'{true, false}'::boolean[];
+			`, srcTableName))
+		e2e.EnvNoError(s.t, env, err)
+
+		s.t.Log("Inserted 1 row into the source table")
+	}()
+
+	env.ExecuteWorkflow(peerflow.CDCFlowWorkflowWithConfig, flowConnConfig, &limits, nil)
+
+	// Verify workflow completes without error
+	require.True(s.t, env.IsWorkflowCompleted())
+	err = env.GetWorkflowError()
+
+	// allow only continue as new error
+	require.Contains(s.t, err.Error(), "continue as new")
+
+	allCols := []string{
+		"c1", "c2", "c4",
+		"c40", "id", "c9", "c11", "c12", "c13", "c14", "c15",
+		"c21", "c29", "c33", "c34", "c35", "c36",
+		"c7", "c8", "c32", "c42", "c43", "c44", "c46", "c47", "c48", "c49",
+	}
+	err = s.comparePGTables(srcTableName, dstTableName, strings.Join(allCols, ","))
 	require.NoError(s.t, err)
 }
 

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -676,8 +676,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 		c23 NUMERIC,c24 OID,c28 REAL,c29 SMALLINT,c30 SMALLSERIAL,c31 SERIAL,c32 TEXT,
 		c33 TIMESTAMP,c34 TIMESTAMPTZ,c35 TIME, c36 TIMETZ,c37 TSQUERY,c38 TSVECTOR,
 		c39 TXID_SNAPSHOT,c40 UUID,c41 XML, c42 GEOMETRY(POINT), c43 GEOGRAPHY(POINT),
-		c44 GEOGRAPHY(POLYGON), c45 GEOGRAPHY(LINESTRING), c46 GEOMETRY(LINESTRING), c47 GEOMETRY(POLYGON), 
-		c48 mood, c49 HSTORE);
+		c44 GEOGRAPHY(POLYGON), c45 GEOGRAPHY(LINESTRING), c46 GEOMETRY(LINESTRING), c47 GEOMETRY(POLYGON),
+		c48 mood, c49 HSTORE, c50 DATE[], c51 TIMESTAMPTZ[], c52 TIMESTAMP[], c53 BOOLEAN[]);
 	`, srcTableName))
 	require.NoError(s.t, err)
 
@@ -712,7 +712,11 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 		'66073c38-b8df-4bdb-bbca-1c97596b8940'::uuid,xmlcomment('hello'),
 		'POINT(1 2)','POINT(40.7128 -74.0060)','POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))',
 		'LINESTRING(-74.0060 40.7128, -73.9352 40.7306, -73.9123 40.7831)','LINESTRING(0 0, 1 1, 2 2)',
-		'POLYGON((-74.0060 40.7128, -73.9352 40.7306, -73.9123 40.7831, -74.0060 40.7128))', 'happy','"a"=>"a\"quote\"", "b"=>NULL';
+		'POLYGON((-74.0060 40.7128, -73.9352 40.7306, -73.9123 40.7831, -74.0060 40.7128))', 'happy','"a"=>"a\"quote\"", "b"=>NULL',
+		'{2020-01-01, 2020-01-02}'::date[],
+		'{"2020-01-01 01:01:01+00", "2020-01-02 01:01:01+00"}'::timestamptz[],
+		'{"2020-01-01 01:01:01", "2020-01-02 01:01:01"}'::timestamp[],
+		'{true, false}'::boolean[];;
 		`, srcTableName))
 		e2e.EnvNoError(s.t, env, err)
 	}()
@@ -731,6 +735,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 		"c6", "c39", "c40", "id", "c9", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18",
 		"c21", "c22", "c23", "c24", "c28", "c29", "c30", "c31", "c33", "c34", "c35", "c36",
 		"c37", "c38", "c7", "c8", "c32", "c42", "c43", "c44", "c45", "c46", "c47", "c48", "c49",
+		"c50", "c51", "c52", "c53",
 	})
 	if err != nil {
 		s.t.Log(err)

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -677,7 +677,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 		c33 TIMESTAMP,c34 TIMESTAMPTZ,c35 TIME, c36 TIMETZ,c37 TSQUERY,c38 TSVECTOR,
 		c39 TXID_SNAPSHOT,c40 UUID,c41 XML, c42 GEOMETRY(POINT), c43 GEOGRAPHY(POINT),
 		c44 GEOGRAPHY(POLYGON), c45 GEOGRAPHY(LINESTRING), c46 GEOMETRY(LINESTRING), c47 GEOMETRY(POLYGON),
-		c48 mood, c49 HSTORE, c50 DATE[], c51 TIMESTAMPTZ[], c52 TIMESTAMP[], c53 BOOLEAN[]);
+		c48 mood, c49 HSTORE, c50 DATE[], c51 TIMESTAMPTZ[], c52 TIMESTAMP[], c53 BOOLEAN[],c54 SMALLINT[]);
 	`, srcTableName))
 	require.NoError(s.t, err)
 
@@ -716,7 +716,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 		'{2020-01-01, 2020-01-02}'::date[],
 		'{"2020-01-01 01:01:01+00", "2020-01-02 01:01:01+00"}'::timestamptz[],
 		'{"2020-01-01 01:01:01", "2020-01-02 01:01:01"}'::timestamp[],
-		'{true, false}'::boolean[];;
+		'{true, false}'::boolean[],
+		'{1,2}'::smallint[];
 		`, srcTableName))
 		e2e.EnvNoError(s.t, env, err)
 	}()
@@ -735,7 +736,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 		"c6", "c39", "c40", "id", "c9", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18",
 		"c21", "c22", "c23", "c24", "c28", "c29", "c30", "c31", "c33", "c34", "c35", "c36",
 		"c37", "c38", "c7", "c8", "c32", "c42", "c43", "c44", "c45", "c46", "c47", "c48", "c49",
-		"c50", "c51", "c52", "c53",
+		"c50", "c51", "c52", "c53", "c54",
 	})
 	if err != nil {
 		s.t.Log(err)

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -241,6 +241,10 @@ func CreateTableForQRep(pool *pgxpool.Pool, suffix string, tableName string) err
 		"f6 jsonb",
 		"f7 jsonb",
 		"f8 smallint",
+		"f9 date[]",
+		"f10 timestamp with time zone[]",
+		"f11 timestamp without time zone[]",
+		"f12 boolean[]",
 		"my_date DATE",
 		"my_mood mood",
 		"myh HSTORE",
@@ -299,7 +303,11 @@ func PopulateSourceTable(pool *pgxpool.Pool, suffix string, tableName string, ro
 						CURRENT_TIMESTAMP, 1, ARRAY['text1', 'text2'], ARRAY[123, 456], ARRAY[789, 012],
 						ARRAY['varchar1', 'varchar2'], '{"key": -8.02139037433155}',
 						'[{"key1": "value1", "key2": "value2", "key3": "value3"}]',
-						'{"key": "value"}', 15, CURRENT_DATE, 'happy', '"a"=>"b"','POINT(1 2)','POINT(40.7128 -74.0060)',
+						'{"key": "value"}', 15,'{2023-09-09,2029-08-10}',
+							'{"2024-01-15 17:00:00+00","2024-01-16 14:30:00+00"}',
+							'{"2026-01-17 10:00:00","2026-01-18 13:45:00"}',
+							'{true, false}',
+							 CURRENT_DATE, 'happy', '"a"=>"b"','POINT(1 2)','POINT(40.7128 -74.0060)',
 						'LINESTRING(0 0, 1 1, 2 2)',
 						'LINESTRING(-74.0060 40.7128, -73.9352 40.7306, -73.9123 40.7831)',
 						'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))','POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'
@@ -317,7 +325,7 @@ func PopulateSourceTable(pool *pgxpool.Pool, suffix string, tableName string, ro
 					deal_id, ethereum_transaction_id, ignore_price, card_eth_value,
 					paid_eth_price, card_bought_notified, address, account_id,
 					asset_id, status, transaction_id, settled_at, reference_id,
-					settle_at, settlement_delay_reason, f1, f2, f3, f4, f5, f6, f7, f8, my_date, my_mood, myh,
+					settle_at, settlement_delay_reason, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, my_date, my_mood, myh,
 					"geometryPoint", geography_point,geometry_linestring, geography_linestring,geometry_polygon, geography_polygon
 			) VALUES %s;
 	`, suffix, tableName, strings.Join(rows, ",")))

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -245,6 +245,7 @@ func CreateTableForQRep(pool *pgxpool.Pool, suffix string, tableName string) err
 		"f10 timestamp with time zone[]",
 		"f11 timestamp without time zone[]",
 		"f12 boolean[]",
+		"f13 smallint[]",
 		"my_date DATE",
 		"my_mood mood",
 		"myh HSTORE",
@@ -307,6 +308,7 @@ func PopulateSourceTable(pool *pgxpool.Pool, suffix string, tableName string, ro
 							'{"2024-01-15 17:00:00+00","2024-01-16 14:30:00+00"}',
 							'{"2026-01-17 10:00:00","2026-01-18 13:45:00"}',
 							'{true, false}',
+							'{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}',
 							 CURRENT_DATE, 'happy', '"a"=>"b"','POINT(1 2)','POINT(40.7128 -74.0060)',
 						'LINESTRING(0 0, 1 1, 2 2)',
 						'LINESTRING(-74.0060 40.7128, -73.9352 40.7306, -73.9123 40.7831)',
@@ -325,7 +327,7 @@ func PopulateSourceTable(pool *pgxpool.Pool, suffix string, tableName string, ro
 					deal_id, ethereum_transaction_id, ignore_price, card_eth_value,
 					paid_eth_price, card_bought_notified, address, account_id,
 					asset_id, status, transaction_id, settled_at, reference_id,
-					settle_at, settlement_delay_reason, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, my_date, my_mood, myh,
+					settle_at, settlement_delay_reason, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, my_date, my_mood, myh,
 					"geometryPoint", geography_point,geometry_linestring, geography_linestring,geometry_polygon, geography_polygon
 			) VALUES %s;
 	`, suffix, tableName, strings.Join(rows, ",")))
@@ -446,6 +448,7 @@ func GetOwnersSchema() *model.QRecordSchema {
 			{Name: "f6", Type: qvalue.QValueKindJSON, Nullable: true},
 			{Name: "f7", Type: qvalue.QValueKindJSON, Nullable: true},
 			{Name: "f8", Type: qvalue.QValueKindInt16, Nullable: true},
+			{Name: "f13", Type: qvalue.QValueKindArrayInt16, Nullable: true},
 			{Name: "my_date", Type: qvalue.QValueKindDate, Nullable: true},
 			{Name: "my_mood", Type: qvalue.QValueKindString, Nullable: true},
 			{Name: "geometryPoint", Type: qvalue.QValueKindGeometry, Nullable: true},

--- a/flow/model/qrecord_batch.go
+++ b/flow/model/qrecord_batch.go
@@ -41,6 +41,18 @@ func (q *QRecordBatch) ToQRecordStream(buffer int) (*QRecordStream, error) {
 	return stream, nil
 }
 
+func constructArray[T any](qValue qvalue.QValue, typeName string) (*pgtype.Array[T], error) {
+	v, ok := qValue.Value.([]T)
+	if !ok {
+		return nil, fmt.Errorf("invalid %s value", typeName)
+	}
+	return &pgtype.Array[T]{
+		Elements: v,
+		Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
+		Valid:    true,
+	}, nil
+}
+
 type QRecordBatchCopyFromSource struct {
 	numRecords    int
 	stream        *QRecordStream
@@ -215,99 +227,67 @@ func (src *QRecordBatchCopyFromSource) Values() ([]interface{}, error) {
 
 			values[i] = wkb
 		case qvalue.QValueKindArrayString:
-			v, ok := qValue.Value.([]string)
-			if !ok {
-				src.err = fmt.Errorf("invalid ArrayString value")
+			v, err := constructArray[string](qValue, "ArrayString")
+			if err != nil {
+				src.err = err
 				return nil, src.err
 			}
-			values[i] = pgtype.Array[string]{
-				Elements: v,
-				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
-				Valid:    true,
-			}
+			values[i] = v
 
 		case qvalue.QValueKindArrayDate, qvalue.QValueKindArrayTimestamp, qvalue.QValueKindArrayTimestampTZ:
-			v, ok := qValue.Value.([]time.Time)
-			if !ok {
-				src.err = fmt.Errorf("invalid ArrayDate value")
+			v, err := constructArray[time.Time](qValue, "ArrayTime")
+			if err != nil {
+				src.err = err
 				return nil, src.err
 			}
-			values[i] = pgtype.Array[time.Time]{
-				Elements: v,
-				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
-				Valid:    true,
-			}
+			values[i] = v
 
 		case qvalue.QValueKindArrayInt16:
-			v, ok := qValue.Value.([]int16)
-			if !ok {
-				src.err = fmt.Errorf("invalid ArrayInt16 value")
+			v, err := constructArray[int16](qValue, "ArrayInt16")
+			if err != nil {
+				src.err = err
 				return nil, src.err
 			}
-			values[i] = pgtype.Array[int16]{
-				Elements: v,
-				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
-				Valid:    true,
-			}
+			values[i] = v
 
 		case qvalue.QValueKindArrayInt32:
-			v, ok := qValue.Value.([]int32)
-			if !ok {
-				src.err = fmt.Errorf("invalid ArrayInt32 value")
+			v, err := constructArray[int32](qValue, "ArrayInt32")
+			if err != nil {
+				src.err = err
 				return nil, src.err
 			}
-			values[i] = pgtype.Array[int32]{
-				Elements: v,
-				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
-				Valid:    true,
-			}
+			values[i] = v
 
 		case qvalue.QValueKindArrayInt64:
-			v, ok := qValue.Value.([]int64)
-			if !ok {
-				src.err = fmt.Errorf("invalid ArrayInt64 value")
+			v, err := constructArray[int64](qValue, "ArrayInt64")
+			if err != nil {
+				src.err = err
 				return nil, src.err
 			}
-			values[i] = pgtype.Array[int64]{
-				Elements: v,
-				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
-				Valid:    true,
-			}
+			values[i] = v
 
 		case qvalue.QValueKindArrayFloat32:
-			v, ok := qValue.Value.([]float32)
-			if !ok {
-				src.err = fmt.Errorf("invalid ArrayFloat32 value")
+			v, err := constructArray[float32](qValue, "ArrayFloat32")
+			if err != nil {
+				src.err = err
 				return nil, src.err
 			}
-			values[i] = pgtype.Array[float32]{
-				Elements: v,
-				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
-				Valid:    true,
-			}
+			values[i] = v
 
 		case qvalue.QValueKindArrayFloat64:
-			v, ok := qValue.Value.([]float64)
-			if !ok {
-				src.err = fmt.Errorf("invalid ArrayFloat64 value")
+			v, err := constructArray[float64](qValue, "ArrayFloat64")
+			if err != nil {
+				src.err = err
 				return nil, src.err
 			}
-			values[i] = pgtype.Array[float64]{
-				Elements: v,
-				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
-				Valid:    true,
-			}
+			values[i] = v
 		case qvalue.QValueKindArrayBoolean:
-			v, ok := qValue.Value.([]bool)
-			if !ok {
-				src.err = fmt.Errorf("invalid ArrayBoolean value")
+			v, err := constructArray[bool](qValue, "ArrayBool")
+			if err != nil {
+				src.err = err
 				return nil, src.err
 			}
-			values[i] = pgtype.Array[bool]{
-				Elements: v,
-				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
-				Valid:    true,
-			}
+			values[i] = v
 		case qvalue.QValueKindJSON:
 			v, ok := qValue.Value.(string)
 			if !ok {

--- a/flow/model/qrecord_batch.go
+++ b/flow/model/qrecord_batch.go
@@ -226,6 +226,18 @@ func (src *QRecordBatchCopyFromSource) Values() ([]interface{}, error) {
 				Valid:    true,
 			}
 
+		case qvalue.QValueKindArrayDate, qvalue.QValueKindArrayTimestamp, qvalue.QValueKindArrayTimestampTZ:
+			v, ok := qValue.Value.([]time.Time)
+			if !ok {
+				src.err = fmt.Errorf("invalid ArrayDate value")
+				return nil, src.err
+			}
+			values[i] = pgtype.Array[time.Time]{
+				Elements: v,
+				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
+				Valid:    true,
+			}
+
 		case qvalue.QValueKindArrayInt32:
 			v, ok := qValue.Value.([]int32)
 			if !ok {
@@ -273,7 +285,17 @@ func (src *QRecordBatchCopyFromSource) Values() ([]interface{}, error) {
 				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
 				Valid:    true,
 			}
-
+		case qvalue.QValueKindArrayBoolean:
+			v, ok := qValue.Value.([]bool)
+			if !ok {
+				src.err = fmt.Errorf("invalid ArrayBoolean value")
+				return nil, src.err
+			}
+			values[i] = pgtype.Array[bool]{
+				Elements: v,
+				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
+				Valid:    true,
+			}
 		case qvalue.QValueKindJSON:
 			v, ok := qValue.Value.(string)
 			if !ok {

--- a/flow/model/qrecord_batch.go
+++ b/flow/model/qrecord_batch.go
@@ -238,6 +238,18 @@ func (src *QRecordBatchCopyFromSource) Values() ([]interface{}, error) {
 				Valid:    true,
 			}
 
+		case qvalue.QValueKindArrayInt16:
+			v, ok := qValue.Value.([]int16)
+			if !ok {
+				src.err = fmt.Errorf("invalid ArrayInt16 value")
+				return nil, src.err
+			}
+			values[i] = pgtype.Array[int16]{
+				Elements: v,
+				Dims:     []pgtype.ArrayDimension{{Length: int32(len(v)), LowerBound: 1}},
+				Valid:    true,
+			}
+
 		case qvalue.QValueKindArrayInt32:
 			v, ok := qValue.Value.([]int32)
 			if !ok {

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -14,7 +14,7 @@ import (
 // https://avro.apache.org/docs/1.11.0/spec.html
 type AvroSchemaArray struct {
 	Type  string `json:"type"`
-	Items string `json:"items"`
+	Items interface{}
 }
 
 type AvroSchemaNumeric struct {

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -14,7 +14,12 @@ import (
 // https://avro.apache.org/docs/1.11.0/spec.html
 type AvroSchemaArray struct {
 	Type  string `json:"type"`
-	Items interface{}
+	Items string `json:"items"`
+}
+
+type AvroSchemaComplexArray struct {
+	Type  string          `json:"type"`
+	Items AvroSchemaField `json:"items"`
 }
 
 type AvroSchemaNumeric struct {
@@ -22,6 +27,18 @@ type AvroSchemaNumeric struct {
 	LogicalType string `json:"logicalType"`
 	Precision   int    `json:"precision"`
 	Scale       int    `json:"scale"`
+}
+
+type AvroSchemaRecord struct {
+	Type   string            `json:"type"`
+	Name   string            `json:"name"`
+	Fields []AvroSchemaField `json:"fields"`
+}
+
+type AvroSchemaField struct {
+	Name        string      `json:"name"`
+	Type        interface{} `json:"type"`
+	LogicalType string      `json:"logicalType,omitempty"`
 }
 
 // GetAvroSchemaFromQValueKind returns the Avro schema for a given QValueKind.

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -153,9 +153,9 @@ func (c *QValueAvroConverter) ToAvroValue() (interface{}, error) {
 		}
 		if c.Nullable {
 			return goavro.Union("long.timestamp-micros", t.(int64)), nil
-		} else {
-			return t.(int64), nil
 		}
+		return t.(int64), nil
+
 	case QValueKindDate:
 		t, err := c.processGoDate()
 		if err != nil || t == nil {
@@ -269,7 +269,7 @@ func (c *QValueAvroConverter) processGoDate() (interface{}, error) {
 
 	t, ok := c.Value.Value.(time.Time)
 	if !ok {
-		return nil, fmt.Errorf("invalid Time value")
+		return nil, fmt.Errorf("invalid Time value for Date")
 	}
 
 	// Snowflake has issues with avro timestamp types, returning as string form of the int64

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -152,9 +152,10 @@ func (c *QValueAvroConverter) ToAvroValue() (interface{}, error) {
 			}
 		}
 		if c.Nullable {
-			return goavro.Union("long.timestamp-micros", t), nil
+			return goavro.Union("long.timestamp-micros", t.(int64)), nil
+		} else {
+			return t.(int64), nil
 		}
-		return t, nil
 	case QValueKindDate:
 		t, err := c.processGoDate()
 		if err != nil || t == nil {
@@ -252,12 +253,13 @@ func (c *QValueAvroConverter) processGoTime() (interface{}, error) {
 		return nil, fmt.Errorf("invalid Time value")
 	}
 
-	// Snowflake has issues with avro timestamp types, returning as string
+	ret := t.UnixMicro()
+	// Snowflake has issues with avro timestamp types, returning as string form of the int64
 	// See: https://stackoverflow.com/questions/66104762/snowflake-date-column-have-incorrect-date-from-avro-file
 	if c.TargetDWH == QDWHTypeSnowflake {
-		return fmt.Sprint(t.String()), nil
+		return fmt.Sprint(ret), nil
 	}
-	return t, nil
+	return ret, nil
 }
 
 func (c *QValueAvroConverter) processGoDate() (interface{}, error) {
@@ -270,10 +272,11 @@ func (c *QValueAvroConverter) processGoDate() (interface{}, error) {
 		return nil, fmt.Errorf("invalid Time value")
 	}
 
-	// Snowflake has issues with avro timestamp types, returning as string
+	// Snowflake has issues with avro timestamp types, returning as string form of the int64
 	// See: https://stackoverflow.com/questions/66104762/snowflake-date-column-have-incorrect-date-from-avro-file
 	if c.TargetDWH == QDWHTypeSnowflake {
-		return fmt.Sprint(t.Format("2006-03-03")), nil
+		ret := t.UnixMicro()
+		return fmt.Sprint(ret), nil
 	}
 	return t, nil
 }

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -152,10 +152,9 @@ func (c *QValueAvroConverter) ToAvroValue() (interface{}, error) {
 			}
 		}
 		if c.Nullable {
-			return goavro.Union("long.timestamp-micros", t.(int64)), nil
-		} else {
-			return t.(int64), nil
+			return goavro.Union("long.timestamp-micros", t), nil
 		}
+		return t, nil
 	case QValueKindDate:
 		t, err := c.processGoDate()
 		if err != nil || t == nil {
@@ -253,13 +252,12 @@ func (c *QValueAvroConverter) processGoTime() (interface{}, error) {
 		return nil, fmt.Errorf("invalid Time value")
 	}
 
-	ret := t.UnixMicro()
-	// Snowflake has issues with avro timestamp types, returning as string form of the int64
+	// Snowflake has issues with avro timestamp types, returning as string
 	// See: https://stackoverflow.com/questions/66104762/snowflake-date-column-have-incorrect-date-from-avro-file
 	if c.TargetDWH == QDWHTypeSnowflake {
-		return fmt.Sprint(ret), nil
+		return fmt.Sprint(t.String()), nil
 	}
-	return ret, nil
+	return t, nil
 }
 
 func (c *QValueAvroConverter) processGoDate() (interface{}, error) {
@@ -272,11 +270,10 @@ func (c *QValueAvroConverter) processGoDate() (interface{}, error) {
 		return nil, fmt.Errorf("invalid Time value")
 	}
 
-	// Snowflake has issues with avro timestamp types, returning as string form of the int64
+	// Snowflake has issues with avro timestamp types, returning as string
 	// See: https://stackoverflow.com/questions/66104762/snowflake-date-column-have-incorrect-date-from-avro-file
 	if c.TargetDWH == QDWHTypeSnowflake {
-		ret := t.UnixMicro()
-		return fmt.Sprint(ret), nil
+		return fmt.Sprint(t.Format("2006-03-03")), nil
 	}
 	return t, nil
 }

--- a/flow/model/qvalue/kind.go
+++ b/flow/model/qvalue/kind.go
@@ -32,7 +32,6 @@ const (
 	QValueKindGeography   QValueKind = "geography"
 	QValueKindGeometry    QValueKind = "geometry"
 	QValueKindPoint       QValueKind = "point"
-	QValueKindMoney       QValueKind = "money"
 
 	// network types
 	QValueKindCIDR    QValueKind = "cidr"

--- a/flow/model/qvalue/kind.go
+++ b/flow/model/qvalue/kind.go
@@ -32,13 +32,24 @@ const (
 	QValueKindGeography   QValueKind = "geography"
 	QValueKindGeometry    QValueKind = "geometry"
 	QValueKindPoint       QValueKind = "point"
+	QValueKindMoney       QValueKind = "money"
+
+	// network types
+	QValueKindCIDR    QValueKind = "cidr"
+	QValueKindINET    QValueKind = "inet"
+	QValueKindMacaddr QValueKind = "macaddr"
 
 	// array types
-	QValueKindArrayFloat32 QValueKind = "array_float32"
-	QValueKindArrayFloat64 QValueKind = "array_float64"
-	QValueKindArrayInt32   QValueKind = "array_int32"
-	QValueKindArrayInt64   QValueKind = "array_int64"
-	QValueKindArrayString  QValueKind = "array_string"
+	QValueKindArrayFloat32     QValueKind = "array_float32"
+	QValueKindArrayFloat64     QValueKind = "array_float64"
+	QValueKindArrayInt16       QValueKind = "array_int16"
+	QValueKindArrayInt32       QValueKind = "array_int32"
+	QValueKindArrayInt64       QValueKind = "array_int64"
+	QValueKindArrayString      QValueKind = "array_string"
+	QValueKindArrayDate        QValueKind = "array_date"
+	QValueKindArrayTimestamp   QValueKind = "array_timestamp"
+	QValueKindArrayTimestampTZ QValueKind = "array_timestamptz"
+	QValueKindArrayBoolean     QValueKind = "array_bool"
 )
 
 func (kind QValueKind) IsArray() bool {
@@ -71,11 +82,15 @@ var QValueKindToSnowflakeTypeMap = map[QValueKind]string{
 	QValueKindPoint:       "GEOMETRY",
 
 	// array types will be mapped to VARIANT
-	QValueKindArrayFloat32: "VARIANT",
-	QValueKindArrayFloat64: "VARIANT",
-	QValueKindArrayInt32:   "VARIANT",
-	QValueKindArrayInt64:   "VARIANT",
-	QValueKindArrayString:  "VARIANT",
+	QValueKindArrayFloat32:     "VARIANT",
+	QValueKindArrayFloat64:     "VARIANT",
+	QValueKindArrayInt32:       "VARIANT",
+	QValueKindArrayInt64:       "VARIANT",
+	QValueKindArrayString:      "VARIANT",
+	QValueKindArrayDate:        "VARIANT",
+	QValueKindArrayTimestamp:   "VARIANT",
+	QValueKindArrayTimestampTZ: "VARIANT",
+	QValueKindArrayBoolean:     "VARIANT",
 }
 
 var QValueKindToClickhouseTypeMap = map[QValueKind]string{

--- a/flow/model/qvalue/kind.go
+++ b/flow/model/qvalue/kind.go
@@ -85,6 +85,7 @@ var QValueKindToSnowflakeTypeMap = map[QValueKind]string{
 	QValueKindArrayFloat64:     "VARIANT",
 	QValueKindArrayInt32:       "VARIANT",
 	QValueKindArrayInt64:       "VARIANT",
+	QValueKindArrayInt16:       "VARIANT",
 	QValueKindArrayString:      "VARIANT",
 	QValueKindArrayDate:        "VARIANT",
 	QValueKindArrayTimestamp:   "VARIANT",

--- a/flow/model/qvalue/qvalue.go
+++ b/flow/model/qvalue/qvalue.go
@@ -61,7 +61,7 @@ func (q QValue) Equals(other QValue) bool {
 		return compareNumericArrays(q.Value, other.Value)
 	case QValueKindArrayFloat64:
 		return compareNumericArrays(q.Value, other.Value)
-	case QValueKindArrayInt32:
+	case QValueKindArrayInt32, QValueKindArrayInt16:
 		return compareNumericArrays(q.Value, other.Value)
 	case QValueKindArrayInt64:
 		return compareNumericArrays(q.Value, other.Value)
@@ -281,6 +281,12 @@ func compareNumericArrays(value1, value2 interface{}) bool {
 	// Helper function to convert a value to float64
 	convertToFloat64 := func(val interface{}) []float64 {
 		switch v := val.(type) {
+		case []int16:
+			result := make([]float64, len(v))
+			for i, value := range v {
+				result[i] = float64(value)
+			}
+			return result
 		case []int32:
 			result := make([]float64, len(v))
 			for i, value := range v {


### PR DESCRIPTION
This PR adds support for the following types across PG, SF and BQ:
- Array of Boolean
- Array of Date
- Array of Timestamp(/TZ)
- Array of Int16 (smallint)
- CIDR
- MacAddr
- INET

The latter 3 is more relevant for Postgres.
This PR achieves the correct AVRO type mapping for Date in BigQuery - eliminating the hack which was being done in merge transforms. 
This PR also writes date and time values as human readable text for BQ QRep

Tests added as well

Fixes #666 
Fixes #20 