### PR TITLE
[snowflake] Cache information schema queries on snowflake

### DIFF
--- a/flow/connectors/snowflake/information_schema_cache.go
+++ b/flow/connectors/snowflake/information_schema_cache.go
@@ -1,0 +1,246 @@
+package connsnowflake
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/PeerDB-io/peer-flow/connectors/utils"
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/model/qvalue"
+	"github.com/PeerDB-io/peer-flow/peerdbenv"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+const (
+	schemaExistsSQL      = "SELECT TO_BOOLEAN(COUNT(1)) FROM INFORMATION_SCHEMA.SCHEMATA WHERE UPPER(SCHEMA_NAME)=?"
+	tableExistsSQL       = `SELECT TO_BOOLEAN(COUNT(1)) FROM INFORMATION_SCHEMA.TABLES WHERE UPPER(TABLE_SCHEMA)=? and UPPER(TABLE_NAME)=?`
+	tableSchemaSQL       = `SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE UPPER(TABLE_SCHEMA)=? AND UPPER(TABLE_NAME)=? ORDER BY ORDINAL_POSITION`
+	tableSchemasInSchema = `SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE UPPER(TABLE_SCHEMA)=? ORDER BY TABLE_NAME, ORDINAL_POSITION`
+)
+
+type informationSchemaCache struct {
+	tableSchemaCache  *expirable.LRU[string, *protos.TableSchema]
+	schemaExistsCache *expirable.LRU[string, bool]
+	tableExistsCache  *expirable.LRU[string, bool]
+}
+
+func newInformationSchemaCache() *informationSchemaCache {
+	schemaExistsCache := expirable.NewLRU[string, bool](100_000, nil, time.Hour*1)
+	tableExistsCache := expirable.NewLRU[string, bool](100_000, nil, time.Hour*1)
+
+	tsCacheExpiry := peerdbenv.PeerDBSnowflakeTableSchemaCacheSeconds() * time.Second
+	tableSchemaCache := expirable.NewLRU[string, *protos.TableSchema](100_000, nil, tsCacheExpiry)
+
+	return &informationSchemaCache{
+		tableSchemaCache:  tableSchemaCache,
+		schemaExistsCache: schemaExistsCache,
+		tableExistsCache:  tableExistsCache,
+	}
+}
+
+var cache *informationSchemaCache
+var cacheInit sync.Once
+
+type SnowflakeInformationSchemaCache struct {
+	ctx      context.Context
+	database *sql.DB
+	logger   slog.Logger
+}
+
+func NewSnowflakeInformationSchemaCache(
+	ctx context.Context,
+	database *sql.DB,
+	logger slog.Logger,
+) *SnowflakeInformationSchemaCache {
+	cacheInit.Do(func() {
+		cache = newInformationSchemaCache()
+	})
+	return &SnowflakeInformationSchemaCache{
+		ctx:      ctx,
+		database: database,
+		logger:   logger,
+	}
+}
+
+// SchemaExists returns true if the schema exists in the database.
+func (c *SnowflakeInformationSchemaCache) SchemaExists(schemaName string) (bool, error) {
+	schemaName = strings.ToUpper(schemaName)
+
+	if cachedExists, ok := cache.schemaExistsCache.Get(schemaName); ok {
+		if cachedExists {
+			return true, nil
+		}
+	}
+
+	// If a schema doesn't exist in the cache, lets fall back to the database.
+	row := c.database.QueryRowContext(c.ctx, schemaExistsSQL, schemaName)
+
+	var exists bool
+	err := row.Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("error querying Snowflake peer for schema %s: %w", schemaName, err)
+	}
+
+	if exists {
+		err = c.cacheAllTablesInSchema(schemaName)
+		if err != nil {
+			return false, fmt.Errorf("error caching all tables in schema %s: %w", schemaName, err)
+		}
+	}
+
+	cache.schemaExistsCache.Add(schemaName, exists)
+
+	return exists, nil
+}
+
+// TableExists returns true if the table exists in the database.
+func (c *SnowflakeInformationSchemaCache) TableExists(schemaName string, tableName string) (bool, error) {
+	schemaName = strings.ToUpper(schemaName)
+	tableName = strings.ToUpper(tableName)
+
+	schemaTable := &utils.SchemaTable{
+		Schema: schemaName,
+		Table:  tableName,
+	}
+
+	if cachedExists, ok := cache.tableExistsCache.Get(schemaTable.String()); ok {
+		if cachedExists {
+			return true, nil
+		}
+	}
+
+	row := c.database.QueryRowContext(c.ctx, tableExistsSQL, schemaTable.Schema, schemaTable.Table)
+
+	var exists bool
+	err := row.Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("error querying Snowflake peer for table %s: %w", tableName, err)
+	}
+
+	cache.tableExistsCache.Add(schemaTable.String(), exists)
+
+	return exists, nil
+}
+
+func (c *SnowflakeInformationSchemaCache) TableSchemaForTable(tableName string) (*protos.TableSchema, error) {
+	tableName = strings.ToUpper(tableName)
+
+	schemaTable, err := utils.ParseSchemaTable(tableName)
+	if err != nil {
+		return nil, fmt.Errorf("error while parsing table schema and name: %w", err)
+	}
+
+	if cachedSchema, ok := cache.tableSchemaCache.Get(schemaTable.String()); ok {
+		return cachedSchema, nil
+	}
+
+	rows, err := c.database.QueryContext(c.ctx, tableSchemaSQL, schemaTable.Schema, schemaTable.Table)
+	if err != nil {
+		return nil, fmt.Errorf("error querying Snowflake peer for schema of table %s: %w", tableName, err)
+	}
+
+	defer func() {
+		err = rows.Close()
+		if err != nil {
+			c.logger.Error("error while closing rows for reading schema of table",
+				slog.String("tableName", tableName),
+				slog.Any("error", err))
+		}
+	}()
+
+	var columnName, columnType sql.NullString
+	columnNames := make([]string, 0, 8)
+	columnTypes := make([]string, 0, 8)
+	for rows.Next() {
+		err = rows.Scan(&columnName, &columnType)
+		if err != nil {
+			return nil, fmt.Errorf("error reading row for schema of table %s: %w", tableName, err)
+		}
+
+		genericColType, err := snowflakeTypeToQValueKind(columnType.String)
+		if err != nil {
+			// we use string for invalid types
+			genericColType = qvalue.QValueKindString
+		}
+
+		columnNames = append(columnNames, columnName.String)
+		columnTypes = append(columnTypes, string(genericColType))
+	}
+
+	tblSchema := &protos.TableSchema{
+		TableIdentifier: tableName,
+		ColumnNames:     columnNames,
+		ColumnTypes:     columnTypes,
+	}
+
+	cache.tableSchemaCache.Add(schemaTable.String(), tblSchema)
+
+	return tblSchema, nil
+}
+
+// cacheAllTablesInSchema caches all tables in a schema as exists.
+func (c *SnowflakeInformationSchemaCache) cacheAllTablesInSchema(schemaName string) error {
+	c.logger.Info("[snowflake] caching all table schemas in schema", slog.String("schemaName", schemaName))
+
+	schemaName = strings.ToUpper(schemaName)
+
+	rows, err := c.database.QueryContext(c.ctx, tableSchemasInSchema, schemaName)
+	if err != nil {
+		return fmt.Errorf("error querying Snowflake peer for schema of table %s: %w", schemaName, err)
+	}
+
+	defer func() {
+		err = rows.Close()
+		if err != nil {
+			c.logger.Error("error while closing rows for reading schema of table",
+				slog.String("schemaName", schemaName),
+				slog.Any("error", err))
+		}
+	}()
+
+	// current schema for a given table.
+	cs := make(map[string]*protos.TableSchema)
+
+	var tableName, columnName, columnType sql.NullString
+	for rows.Next() {
+		err = rows.Scan(&tableName, &columnName, &columnType)
+		if err != nil {
+			return fmt.Errorf("error reading row for schema of table %s: %w", schemaName, err)
+		}
+
+		genericColType, err := snowflakeTypeToQValueKind(columnType.String)
+		if err != nil {
+			genericColType = qvalue.QValueKindString
+		}
+
+		if _, ok := cs[tableName.String]; !ok {
+			schemaTable := &utils.SchemaTable{
+				Schema: schemaName,
+				Table:  strings.ToUpper(tableName.String),
+			}
+
+			cache.tableExistsCache.Add(schemaTable.String(), true)
+
+			cs[tableName.String] = &protos.TableSchema{
+				TableIdentifier: tableName.String,
+				ColumnNames:     make([]string, 0, 8),
+				ColumnTypes:     make([]string, 0, 8),
+			}
+		}
+
+		cs[tableName.String].ColumnNames = append(cs[tableName.String].ColumnNames, columnName.String)
+		cs[tableName.String].ColumnTypes = append(cs[tableName.String].ColumnTypes, string(genericColType))
+	}
+
+	for _, tblSchema := range cs {
+		cache.tableSchemaCache.Add(tblSchema.TableIdentifier, tblSchema)
+	}
+
+	return nil
+}

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -280,38 +280,12 @@ func (c *SnowflakeConnector) CleanupQRepFlow(config *protos.QRepConfig) error {
 }
 
 func (c *SnowflakeConnector) getColsFromTable(tableName string) ([]string, []string, error) {
-	// parse the table name to get the schema and table name
-	schemaTable, err := utils.ParseSchemaTable(tableName)
+	schema, err := c.informationSchemaCache.TableSchemaForTable(tableName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse table name: %w", err)
+		return nil, nil, fmt.Errorf("failed to get schema for table %s: %w", tableName, err)
 	}
 
-	//nolint:gosec
-	queryString := fmt.Sprintf(`
-	SELECT column_name, data_type
-	FROM information_schema.columns
-	WHERE UPPER(table_name) = '%s' AND UPPER(table_schema) = '%s'
-	ORDER BY ordinal_position
-	`, strings.ToUpper(schemaTable.Table), strings.ToUpper(schemaTable.Schema))
-
-	rows, err := c.database.QueryContext(c.ctx, queryString)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to execute query: %w", err)
-	}
-	defer rows.Close()
-
-	var colName, colType pgtype.Text
-	colNames := make([]string, 0, 8)
-	colTypes := make([]string, 0, 8)
-	for rows.Next() {
-		if err := rows.Scan(&colName, &colType); err != nil {
-			return nil, nil, fmt.Errorf("failed to scan row: %w", err)
-		}
-		colNames = append(colNames, colName.String)
-		colTypes = append(colTypes, colType.String)
-	}
-
-	return colNames, colTypes, nil
+	return schema.ColumnNames, schema.ColumnTypes, nil
 }
 
 // dropStage drops the stage for the given job.

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -58,8 +58,6 @@ const (
 	 ARRAY_AGG(DISTINCT _PEERDB_UNCHANGED_TOAST_COLUMNS) FROM %s.%s WHERE
 	 _PEERDB_BATCH_ID > %d AND _PEERDB_BATCH_ID <= %d AND _PEERDB_RECORD_TYPE != 2
 	 GROUP BY _PEERDB_DESTINATION_TABLE_NAME`
-	getTableSchemaSQL = `SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS
-	 WHERE TABLE_SCHEMA=? AND TABLE_NAME=? ORDER BY ORDINAL_POSITION`
 
 	insertJobMetadataSQL = "INSERT INTO %s.%s VALUES (?,?,?,?)"
 
@@ -67,8 +65,6 @@ const (
 	 WHERE MIRROR_JOB_NAME=?`
 	updateMetadataForNormalizeRecordsSQL = "UPDATE %s.%s SET NORMALIZE_BATCH_ID=? WHERE MIRROR_JOB_NAME=?"
 
-	checkIfTableExistsSQL = `SELECT TO_BOOLEAN(COUNT(1)) FROM INFORMATION_SCHEMA.TABLES
-	 WHERE TABLE_SCHEMA=? and TABLE_NAME=?`
 	checkIfJobMetadataExistsSQL     = "SELECT TO_BOOLEAN(COUNT(1)) FROM %s.%s WHERE MIRROR_JOB_NAME=?"
 	getLastOffsetSQL                = "SELECT OFFSET FROM %s.%s WHERE MIRROR_JOB_NAME=?"
 	setLastOffsetSQL                = "UPDATE %s.%s SET OFFSET=GREATEST(OFFSET, ?) WHERE MIRROR_JOB_NAME=?"
@@ -76,14 +72,14 @@ const (
 	getLastSyncNormalizeBatchID_SQL = "SELECT SYNC_BATCH_ID, NORMALIZE_BATCH_ID FROM %s.%s WHERE MIRROR_JOB_NAME=?"
 	dropTableIfExistsSQL            = "DROP TABLE IF EXISTS %s.%s"
 	deleteJobMetadataSQL            = "DELETE FROM %s.%s WHERE MIRROR_JOB_NAME=?"
-	checkSchemaExistsSQL            = "SELECT TO_BOOLEAN(COUNT(1)) FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME=?"
 )
 
 type SnowflakeConnector struct {
-	ctx            context.Context
-	database       *sql.DB
-	metadataSchema string
-	logger         slog.Logger
+	ctx                    context.Context
+	database               *sql.DB
+	logger                 slog.Logger
+	informationSchemaCache *SnowflakeInformationSchemaCache
+	metadataSchema         string
 }
 
 // creating this to capture array results from snowflake.
@@ -147,11 +143,16 @@ func NewSnowflakeConnector(ctx context.Context,
 	}
 
 	flowName, _ := ctx.Value(shared.FlowNameKey).(string)
+	logger := *slog.With(slog.String(string(shared.FlowNameKey), flowName))
+
+	informationSchemaCache := NewSnowflakeInformationSchemaCache(ctx, database, logger)
+
 	return &SnowflakeConnector{
-		ctx:            ctx,
-		database:       database,
-		metadataSchema: metadataSchema,
-		logger:         *slog.With(slog.String(string(shared.FlowNameKey), flowName)),
+		ctx:                    ctx,
+		database:               database,
+		metadataSchema:         metadataSchema,
+		logger:                 logger,
+		informationSchemaCache: informationSchemaCache,
 	}, nil
 }
 
@@ -223,7 +224,7 @@ func (c *SnowflakeConnector) GetTableSchema(
 ) (*protos.GetTableSchemaBatchOutput, error) {
 	res := make(map[string]*protos.TableSchema)
 	for _, tableName := range req.TableIdentifiers {
-		tableSchema, err := c.getTableSchemaForTable(strings.ToUpper(tableName))
+		tableSchema, err := c.informationSchemaCache.TableSchemaForTable(tableName)
 		if err != nil {
 			return nil, err
 		}
@@ -233,49 +234,6 @@ func (c *SnowflakeConnector) GetTableSchema(
 
 	return &protos.GetTableSchemaBatchOutput{
 		TableNameSchemaMapping: res,
-	}, nil
-}
-
-func (c *SnowflakeConnector) getTableSchemaForTable(tableName string) (*protos.TableSchema, error) {
-	schemaTable, err := utils.ParseSchemaTable(tableName)
-	if err != nil {
-		return nil, fmt.Errorf("error while parsing table schema and name: %w", err)
-	}
-	rows, err := c.database.QueryContext(c.ctx, getTableSchemaSQL, schemaTable.Schema, schemaTable.Table)
-	if err != nil {
-		return nil, fmt.Errorf("error querying Snowflake peer for schema of table %s: %w", tableName, err)
-	}
-	defer func() {
-		err = rows.Close()
-		if err != nil {
-			c.logger.Error("error while closing rows for reading schema of table",
-				slog.String("tableName", tableName),
-				slog.Any("error", err))
-		}
-	}()
-
-	var columnName, columnType pgtype.Text
-	columnNames := make([]string, 0, 8)
-	columnTypes := make([]string, 0, 8)
-	for rows.Next() {
-		err = rows.Scan(&columnName, &columnType)
-		if err != nil {
-			return nil, fmt.Errorf("error reading row for schema of table %s: %w", tableName, err)
-		}
-		genericColType, err := snowflakeTypeToQValueKind(columnType.String)
-		if err != nil {
-			// we use string for invalid types
-			genericColType = qvalue.QValueKindString
-		}
-
-		columnNames = append(columnNames, columnName.String)
-		columnTypes = append(columnTypes, string(genericColType))
-	}
-
-	return &protos.TableSchema{
-		TableIdentifier: tableName,
-		ColumnNames:     columnNames,
-		ColumnTypes:     columnTypes,
 	}, nil
 }
 
@@ -749,14 +707,12 @@ func (c *SnowflakeConnector) SyncFlowCleanup(jobName string) error {
 		}
 	}()
 
-	row := syncFlowCleanupTx.QueryRowContext(c.ctx, checkSchemaExistsSQL, c.metadataSchema)
-	var schemaExists pgtype.Bool
-	err = row.Scan(&schemaExists)
+	metadataSchemaExists, err := c.informationSchemaCache.SchemaExists(c.metadataSchema)
 	if err != nil {
 		return fmt.Errorf("unable to check if internal schema exists: %w", err)
 	}
 
-	if schemaExists.Bool {
+	if metadataSchemaExists {
 		_, err = syncFlowCleanupTx.ExecContext(c.ctx, fmt.Sprintf(dropTableIfExistsSQL, c.metadataSchema,
 			getRawTableIdentifier(jobName)))
 		if err != nil {
@@ -783,12 +739,7 @@ func (c *SnowflakeConnector) SyncFlowCleanup(jobName string) error {
 }
 
 func (c *SnowflakeConnector) checkIfTableExists(schemaIdentifier string, tableIdentifier string) (bool, error) {
-	var result pgtype.Bool
-	err := c.database.QueryRowContext(c.ctx, checkIfTableExistsSQL, schemaIdentifier, tableIdentifier).Scan(&result)
-	if err != nil {
-		return false, fmt.Errorf("error while reading result row: %w", err)
-	}
-	return result.Bool, nil
+	return c.informationSchemaCache.TableExists(schemaIdentifier, tableIdentifier)
 }
 
 func generateCreateTableSQLForNormalizedTable(
@@ -910,15 +861,12 @@ func (c *SnowflakeConnector) updateNormalizeMetadata(flowJobName string, normali
 }
 
 func (c *SnowflakeConnector) createPeerDBInternalSchema(createSchemaTx *sql.Tx) error {
-	// check if the internal schema exists
-	row := createSchemaTx.QueryRowContext(c.ctx, checkSchemaExistsSQL, c.metadataSchema)
-	var schemaExists pgtype.Bool
-	err := row.Scan(&schemaExists)
+	metaSchemaExists, err := c.informationSchemaCache.SchemaExists(c.metadataSchema)
 	if err != nil {
-		return fmt.Errorf("error while reading result row: %w", err)
+		return fmt.Errorf("unable to check if internal schema exists: %w", err)
 	}
 
-	if schemaExists.Bool {
+	if metaSchemaExists {
 		c.logger.Info(fmt.Sprintf("internal schema %s already exists", c.metadataSchema))
 		return nil
 	}

--- a/flow/go.mod
+++ b/flow/go.mod
@@ -126,6 +126,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect

--- a/flow/go.sum
+++ b/flow/go.sum
@@ -257,6 +257,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 h1:Wqo399gCIufwto+VfwCSvsnfGpF
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=

--- a/flow/peerdbenv/config.go
+++ b/flow/peerdbenv/config.go
@@ -74,3 +74,9 @@ func PeerDBCatalogDatabase() string {
 func PeerDBEnableWALHeartbeat() bool {
 	return getEnvBool("PEERDB_ENABLE_WAL_HEARTBEAT", false)
 }
+
+// PEERDB_SNOWFLAKE_TABLE_SCHEMA_CACHE_SECONDS
+func PeerDBSnowflakeTableSchemaCacheSeconds() time.Duration {
+	x := getEnvInt("PEERDB_SNOWFLAKE_TABLE_SCHEMA_CACHE_SECONDS", 600)
+	return time.Duration(x) * time.Second
+}


### PR DESCRIPTION
In cases there are thousands of tables, PeerDB runs A LOT of INFORMATION_SCHEMA queries to Snowflake’s INFORMATION_SCHEMA which counts as Cloud Service usage. This results in very high credit consumption w/ ~1:25 ratio of regular credit consumed to cloud services credits consumed (see screenshot) — so even if an XSMALL or SMALL warehouse is used (1, 2 credits/hour respectively) we still end up consuming ~50 credits an hour.

![image](https://github.com/PeerDB-io/peerdb/assets/1006071/89bcbebe-aadf-4847-87b1-ab30cddd235d)
