### PR TITLE
pass github_token: ${{ secrets.GITHUB_TOKEN }} to bufbuilder action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           workspaces: nexus
 
       - uses: bufbuild/buf-setup-action@v1.28.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup protos
         run: |

--- a/.github/workflows/customer-docker.yml
+++ b/.github/workflows/customer-docker.yml
@@ -24,6 +24,8 @@ jobs:
           submodules: recursive
 
       - uses: bufbuild/buf-setup-action@v1.28.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup protos
         run: |

--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -23,6 +23,8 @@ jobs:
           submodules: recursive
 
       - uses: bufbuild/buf-setup-action@v1.28.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup protos
         run: |

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: bufbuild/buf-setup-action@v1.28.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup protos
         run: |

--- a/.github/workflows/golang-lint.yml
+++ b/.github/workflows/golang-lint.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1.28.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: setup protos
         run: |
           ./generate_protos.sh

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -22,11 +22,13 @@ jobs:
           submodules: recursive
 
       - uses: bufbuild/buf-setup-action@v1.28.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup protos
         run: |
           ./generate_protos.sh
-    
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/.github/workflows/stable-docker.yml
+++ b/.github/workflows/stable-docker.yml
@@ -21,6 +21,8 @@ jobs:
           submodules: recursive
 
       - uses: bufbuild/buf-setup-action@v1.28.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup protos
         run: |

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -19,11 +19,13 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: bufbuild/buf-setup-action@v1.28.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup protos
         run: |
           ./generate_protos.sh
-  
+
       - name: Install Node.js dependencies
         working-directory: ui
         run: npm ci

--- a/.github/workflows/ui-lint.yml
+++ b/.github/workflows/ui-lint.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: bufbuild/buf-setup-action@v1.28.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup protos
         run: |


### PR DESCRIPTION
Had a recent CI failure:
Warning: No github_token supplied, API requests will be subject to stricter rate limiting Setting up buf version "1.28.1"
Resolving the download URL for the current platform... Error: API rate limit exceeded for 20.172.2.98