### PR TITLE
split and tidy up code for SF Avro consolidate

### DIFF
--- a/flow/connectors/snowflake/avro_transform_test.go
+++ b/flow/connectors/snowflake/avro_transform_test.go
@@ -11,7 +11,7 @@ func TestAvroTransform(t *testing.T) {
 		`$1:"col3" AS "COL3",` +
 		`($1:"camelCol4")::STRING AS "camelCol4",` +
 		`CURRENT_TIMESTAMP AS "SYNC_COL"`
-	transform, cols := GetTransformSQL(colNames, colTypes, "sync_col")
+	transform, cols := getTransformSQL(colNames, colTypes, "sync_col")
 	if transform != expectedTransform {
 		t.Errorf("Transform SQL is not correct. Got: %v", transform)
 	}

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -47,7 +47,7 @@ func (c *SnowflakeConnector) SyncQRepRecords(
 		return 0, nil
 	}
 
-	avroSync := NewSnowflakeAvroSyncMethod(config, c)
+	avroSync := NewSnowflakeAvroSyncHandler(config, c)
 	return avroSync.SyncQRepRecords(config, partition, tblSchema, stream)
 }
 

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -258,13 +258,8 @@ func (c *SnowflakeConnector) ConsolidateQRepPartitions(config *protos.QRepConfig
 	destTable := config.DestinationTableIdentifier
 	stageName := c.getStageNameForJob(config.FlowJobName)
 
-	colNames, _, err := c.getColsFromTable(destTable)
-	if err != nil {
-		c.logger.Error(fmt.Sprintf("failed to get columns from table %s", destTable), slog.Any("error", err))
-		return fmt.Errorf("failed to get columns from table %s: %w", destTable, err)
-	}
-
-	err = CopyStageToDestination(c, config, destTable, stageName, colNames)
+	writeHandler := NewSnowflakeAvroConsolidateHandler(c, config, destTable, stageName)
+	err := writeHandler.CopyStageToDestination()
 	if err != nil {
 		c.logger.Error("failed to copy stage to destination", slog.Any("error", err))
 		return fmt.Errorf("failed to copy stage to destination: %w", err)

--- a/flow/connectors/snowflake/qrep_avro_consolidate.go
+++ b/flow/connectors/snowflake/qrep_avro_consolidate.go
@@ -1,0 +1,237 @@
+package connsnowflake
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/PeerDB-io/peer-flow/connectors/utils"
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/shared"
+)
+
+type SnowflakeAvroConsolidateHandler struct {
+	connector    *SnowflakeConnector
+	config       *protos.QRepConfig
+	dstTableName string
+	stage        string
+	allColNames  []string
+	allColTypes  []string
+}
+
+// NewSnowflakeAvroConsolidateHandler creates a new SnowflakeAvroWriteHandler
+func NewSnowflakeAvroConsolidateHandler(
+	connector *SnowflakeConnector,
+	config *protos.QRepConfig,
+	dstTableName string,
+	stage string,
+) *SnowflakeAvroConsolidateHandler {
+	return &SnowflakeAvroConsolidateHandler{
+		connector:    connector,
+		config:       config,
+		dstTableName: dstTableName,
+		stage:        stage,
+	}
+}
+
+func (s *SnowflakeAvroConsolidateHandler) CopyStageToDestination() error {
+	s.connector.logger.Info("Copying stage to destination " + s.dstTableName)
+
+	colNames, colTypes, colsErr := s.connector.getColsFromTable(s.dstTableName)
+	if colsErr != nil {
+		return fmt.Errorf("failed to get columns from destination table: %w", colsErr)
+	}
+	s.allColNames = colNames
+	s.allColTypes = colTypes
+
+	appendMode := true
+	if s.config.WriteMode != nil {
+		writeType := s.config.WriteMode.WriteType
+		if writeType == protos.QRepWriteType_QREP_WRITE_MODE_UPSERT {
+			appendMode = false
+		}
+	}
+
+	if appendMode {
+		err := s.handleAppendMode()
+		if err != nil {
+			return fmt.Errorf("failed to handle append mode: %w", err)
+		}
+	} else {
+		err := s.handleUpsertMode()
+		if err != nil {
+			return fmt.Errorf("failed to handle upsert mode: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func getTransformSQL(colNames []string, colTypes []string, syncedAtCol string) (string, string) {
+	transformations := make([]string, 0, len(colNames))
+	columnOrder := make([]string, 0, len(colNames))
+	for idx, avroColName := range colNames {
+		colType := colTypes[idx]
+		normalizedColName := SnowflakeIdentifierNormalize(avroColName)
+		columnOrder = append(columnOrder, normalizedColName)
+		if avroColName == syncedAtCol {
+			transformations = append(transformations, fmt.Sprintf("CURRENT_TIMESTAMP AS %s", normalizedColName))
+			continue
+		}
+
+		if utils.IsUpper(avroColName) {
+			avroColName = strings.ToLower(avroColName)
+		}
+		// Avro files are written with lowercase in mind, so don't normalize it like everything else
+		switch colType {
+		case "GEOGRAPHY":
+			transformations = append(transformations,
+				fmt.Sprintf("TO_GEOGRAPHY($1:\"%s\"::string, true) AS %s", avroColName, normalizedColName))
+		case "GEOMETRY":
+			transformations = append(transformations,
+				fmt.Sprintf("TO_GEOMETRY($1:\"%s\"::string, true) AS %s", avroColName, normalizedColName))
+		case "NUMBER":
+			transformations = append(transformations,
+				fmt.Sprintf("$1:\"%s\" AS %s", avroColName, normalizedColName))
+		case "VARIANT":
+			transformations = append(transformations,
+				fmt.Sprintf("PARSE_JSON($1:\"%s\") AS %s", avroColName, normalizedColName))
+
+		default:
+			transformations = append(transformations,
+				fmt.Sprintf("($1:\"%s\")::%s AS %s", avroColName, colType, normalizedColName))
+		}
+	}
+	transformationSQL := strings.Join(transformations, ",")
+	columnsSQL := strings.Join(columnOrder, ",")
+
+	return transformationSQL, columnsSQL
+}
+
+// copy to either the actual destination table or a tempTable
+func (s *SnowflakeAvroConsolidateHandler) getCopyTransformation(copyDstTable string) string {
+	copyOpts := []string{
+		"FILE_FORMAT = (TYPE = AVRO)",
+		"PURGE = TRUE",
+		"ON_ERROR = 'CONTINUE'",
+	}
+	transformationSQL, columnsSQL := getTransformSQL(s.allColNames, s.allColTypes, s.config.SyncedAtColName)
+	return fmt.Sprintf("COPY INTO %s(%s) FROM (SELECT %s FROM @%s) %s",
+		copyDstTable, columnsSQL, transformationSQL, s.stage, strings.Join(copyOpts, ","))
+}
+
+func (s *SnowflakeAvroConsolidateHandler) handleAppendMode() error {
+	parsedDstTable, _ := utils.ParseSchemaTable(s.dstTableName)
+	copyCmd := s.getCopyTransformation(snowflakeSchemaTableNormalize(parsedDstTable))
+	s.connector.logger.Info("running copy command: " + copyCmd)
+	_, err := s.connector.database.ExecContext(s.connector.ctx, copyCmd)
+	if err != nil {
+		return fmt.Errorf("failed to run COPY INTO command: %w", err)
+	}
+
+	s.connector.logger.Info("copied file from stage " + s.stage + " to table " + s.dstTableName)
+	return nil
+}
+
+func (s *SnowflakeAvroConsolidateHandler) generateUpsertMergeCommand(
+	tempTableName string,
+) string {
+	upsertKeyCols := s.config.WriteMode.UpsertKeyColumns
+	// all cols are acquired from snowflake schema, so let us try to make upsert key cols match the case
+	// and also the watermark col, then the quoting should be fine
+	caseMatchedCols := map[string]string{}
+	for _, col := range s.allColNames {
+		caseMatchedCols[strings.ToLower(col)] = col
+	}
+
+	for i, col := range upsertKeyCols {
+		upsertKeyCols[i] = caseMatchedCols[strings.ToLower(col)]
+	}
+
+	upsertKeys := []string{}
+	partitionKeyCols := []string{}
+	for _, key := range upsertKeyCols {
+		quotedKey := utils.QuoteIdentifier(key)
+		upsertKeys = append(upsertKeys, fmt.Sprintf("dst.%s = src.%s", quotedKey, quotedKey))
+		partitionKeyCols = append(partitionKeyCols, quotedKey)
+	}
+	upsertKeyClause := strings.Join(upsertKeys, " AND ")
+
+	updateSetClauses := []string{}
+	insertColumnsClauses := []string{}
+	insertValuesClauses := []string{}
+	for _, column := range s.allColNames {
+		quotedColumn := utils.QuoteIdentifier(column)
+		updateSetClauses = append(updateSetClauses, fmt.Sprintf("%s = src.%s", quotedColumn, quotedColumn))
+		insertColumnsClauses = append(insertColumnsClauses, quotedColumn)
+		insertValuesClauses = append(insertValuesClauses, fmt.Sprintf("src.%s", quotedColumn))
+	}
+	updateSetClause := strings.Join(updateSetClauses, ", ")
+	insertColumnsClause := strings.Join(insertColumnsClauses, ", ")
+	insertValuesClause := strings.Join(insertValuesClauses, ", ")
+	selectCmd := fmt.Sprintf(`
+		SELECT *
+		FROM %s
+		QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s DESC) = 1
+	`, tempTableName, strings.Join(partitionKeyCols, ","), partitionKeyCols[0])
+
+	mergeCmd := fmt.Sprintf(`
+			MERGE INTO %s dst
+			USING (%s) src
+			ON %s
+			WHEN MATCHED THEN UPDATE SET %s
+			WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)
+		`, s.dstTableName, selectCmd, upsertKeyClause,
+		updateSetClause, insertColumnsClause, insertValuesClause)
+
+	return mergeCmd
+}
+
+// handleUpsertMode handles the upsert mode
+func (s *SnowflakeAvroConsolidateHandler) handleUpsertMode() error {
+	runID, err := shared.RandomUInt64()
+	if err != nil {
+		return fmt.Errorf("failed to generate run ID: %w", err)
+	}
+
+	tempTableName := fmt.Sprintf("%s_temp_%d", s.dstTableName, runID)
+
+	//nolint:gosec
+	createTempTableCmd := fmt.Sprintf("CREATE TEMPORARY TABLE %s AS SELECT * FROM %s LIMIT 0",
+		tempTableName, s.dstTableName)
+	if _, err := s.connector.database.ExecContext(s.connector.ctx, createTempTableCmd); err != nil {
+		return fmt.Errorf("failed to create temp table: %w", err)
+	}
+	s.connector.logger.Info("created temp table " + tempTableName)
+
+	copyCmd := s.getCopyTransformation(tempTableName)
+	_, err = s.connector.database.ExecContext(s.connector.ctx, copyCmd)
+	if err != nil {
+		return fmt.Errorf("failed to run COPY INTO command: %w", err)
+	}
+	s.connector.logger.Info("copied file from stage " + s.stage + " to temp table " + tempTableName)
+
+	mergeCmd := s.generateUpsertMergeCommand(tempTableName)
+
+	startTime := time.Now()
+	rows, err := s.connector.database.ExecContext(s.connector.ctx, mergeCmd)
+	if err != nil {
+		return fmt.Errorf("failed to merge data into destination table '%s': %w", mergeCmd, err)
+	}
+	rowCount, err := rows.RowsAffected()
+	if err == nil {
+		totalRowsAtTarget, err := s.connector.getTableCounts([]string{s.dstTableName})
+		if err != nil {
+			return err
+		}
+		s.connector.logger.Info(fmt.Sprintf("merged %d rows into destination table %s, total rows at target: %d",
+			rowCount, s.dstTableName, totalRowsAtTarget))
+	} else {
+		s.connector.logger.Error("failed to get rows affected", slog.Any("error", err))
+	}
+
+	s.connector.logger.Info(fmt.Sprintf("merged data from temp table %s into destination table %s, time taken %v",
+		tempTableName, s.dstTableName, time.Since(startTime)))
+	return nil
+}

--- a/flow/connectors/snowflake/qrep_avro_consolidate.go
+++ b/flow/connectors/snowflake/qrep_avro_consolidate.go
@@ -149,8 +149,8 @@ func (s *SnowflakeAvroConsolidateHandler) generateUpsertMergeCommand(
 		upsertKeyCols[i] = caseMatchedCols[strings.ToLower(col)]
 	}
 
-	upsertKeys := []string{}
-	partitionKeyCols := []string{}
+	upsertKeys := make([]string, 0, len(upsertKeyCols))
+	partitionKeyCols := make([]string, 0, len(upsertKeyCols))
 	for _, key := range upsertKeyCols {
 		quotedKey := utils.QuoteIdentifier(key)
 		upsertKeys = append(upsertKeys, fmt.Sprintf("dst.%s = src.%s", quotedKey, quotedKey))

--- a/flow/connectors/snowflake/qrep_avro_consolidate.go
+++ b/flow/connectors/snowflake/qrep_avro_consolidate.go
@@ -158,9 +158,9 @@ func (s *SnowflakeAvroConsolidateHandler) generateUpsertMergeCommand(
 	}
 	upsertKeyClause := strings.Join(upsertKeys, " AND ")
 
-	updateSetClauses := []string{}
-	insertColumnsClauses := []string{}
-	insertValuesClauses := []string{}
+	updateSetClauses := make([]string, 0, len(s.allColNames))
+	insertColumnsClauses := make([]string, 0, len(s.allColNames))
+	insertValuesClauses := make([]string, 0, len(s.allColNames))
 	for _, column := range s.allColNames {
 		quotedColumn := utils.QuoteIdentifier(column)
 		updateSetClauses = append(updateSetClauses, fmt.Sprintf("%s = src.%s", quotedColumn, quotedColumn))

--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -23,7 +23,7 @@ type SnowflakeAvroSyncHandler struct {
 	connector *SnowflakeConnector
 }
 
-func NewSnowflakeAvroSyncMethod(
+func NewSnowflakeAvroSyncHandler(
 	config *protos.QRepConfig,
 	connector *SnowflakeConnector,
 ) *SnowflakeAvroSyncHandler {

--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -18,12 +18,7 @@ import (
 	"go.temporal.io/sdk/activity"
 )
 
-type CopyInfo struct {
-	transformationSQL string
-	columnsSQL        string
-}
-
-type SnowflakeAvroSyncMethod struct {
+type SnowflakeAvroSyncHandler struct {
 	config    *protos.QRepConfig
 	connector *SnowflakeConnector
 }
@@ -31,14 +26,14 @@ type SnowflakeAvroSyncMethod struct {
 func NewSnowflakeAvroSyncMethod(
 	config *protos.QRepConfig,
 	connector *SnowflakeConnector,
-) *SnowflakeAvroSyncMethod {
-	return &SnowflakeAvroSyncMethod{
+) *SnowflakeAvroSyncHandler {
+	return &SnowflakeAvroSyncHandler{
 		config:    config,
 		connector: connector,
 	}
 }
 
-func (s *SnowflakeAvroSyncMethod) SyncRecords(
+func (s *SnowflakeAvroSyncHandler) SyncRecords(
 	dstTableSchema []*sql.ColumnType,
 	stream *model.QRecordStream,
 	flowJobName string,
@@ -73,18 +68,14 @@ func (s *SnowflakeAvroSyncMethod) SyncRecords(
 	}
 	s.connector.logger.Info(fmt.Sprintf("Created stage %s", stage))
 
-	colNames, _, err := s.connector.getColsFromTable(s.config.DestinationTableIdentifier)
-	if err != nil {
-		return 0, err
-	}
-
 	err = s.putFileToStage(avroFile, stage)
 	if err != nil {
 		return 0, err
 	}
 	s.connector.logger.Info("pushed avro file to stage", tableLog)
 
-	err = CopyStageToDestination(s.connector, s.config, s.config.DestinationTableIdentifier, stage, colNames)
+	writeHandler := NewSnowflakeAvroConsolidateHandler(s.connector, s.config, s.config.DestinationTableIdentifier, stage)
+	err = writeHandler.CopyStageToDestination()
 	if err != nil {
 		return 0, err
 	}
@@ -94,7 +85,7 @@ func (s *SnowflakeAvroSyncMethod) SyncRecords(
 	return avroFile.NumRecords, nil
 }
 
-func (s *SnowflakeAvroSyncMethod) SyncQRepRecords(
+func (s *SnowflakeAvroSyncHandler) SyncQRepRecords(
 	config *protos.QRepConfig,
 	partition *protos.QRepPartition,
 	dstTableSchema []*sql.ColumnType,
@@ -149,7 +140,7 @@ func (s *SnowflakeAvroSyncMethod) SyncQRepRecords(
 	return avroFile.NumRecords, nil
 }
 
-func (s *SnowflakeAvroSyncMethod) addMissingColumns(
+func (s *SnowflakeAvroSyncHandler) addMissingColumns(
 	schema *model.QRecordSchema,
 	dstTableSchema []*sql.ColumnType,
 	dstTableName string,
@@ -212,7 +203,7 @@ func (s *SnowflakeAvroSyncMethod) addMissingColumns(
 	return nil
 }
 
-func (s *SnowflakeAvroSyncMethod) getAvroSchema(
+func (s *SnowflakeAvroSyncHandler) getAvroSchema(
 	dstTableName string,
 	schema *model.QRecordSchema,
 ) (*model.QRecordAvroSchemaDefinition, error) {
@@ -225,7 +216,7 @@ func (s *SnowflakeAvroSyncMethod) getAvroSchema(
 	return avroSchema, nil
 }
 
-func (s *SnowflakeAvroSyncMethod) writeToAvroFile(
+func (s *SnowflakeAvroSyncHandler) writeToAvroFile(
 	stream *model.QRecordStream,
 	avroSchema *model.QRecordAvroSchemaDefinition,
 	partitionID string,
@@ -270,7 +261,7 @@ func (s *SnowflakeAvroSyncMethod) writeToAvroFile(
 	return nil, fmt.Errorf("unsupported staging path: %s", s.config.StagingPath)
 }
 
-func (s *SnowflakeAvroSyncMethod) putFileToStage(avroFile *avro.AvroFile, stage string) error {
+func (s *SnowflakeAvroSyncHandler) putFileToStage(avroFile *avro.AvroFile, stage string) error {
 	if avroFile.StorageLocation != avro.AvroLocalStorage {
 		s.connector.logger.Info("no file to put to stage")
 		return nil
@@ -292,106 +283,7 @@ func (s *SnowflakeAvroSyncMethod) putFileToStage(avroFile *avro.AvroFile, stage 
 	return nil
 }
 
-func GetTransformSQL(colNames []string, colTypes []string, syncedAtCol string) (string, string) {
-	transformations := make([]string, 0, len(colNames))
-	columnOrder := make([]string, 0, len(colNames))
-	for idx, avroColName := range colNames {
-		colType := colTypes[idx]
-		normalizedColName := SnowflakeIdentifierNormalize(avroColName)
-		columnOrder = append(columnOrder, normalizedColName)
-		if avroColName == syncedAtCol {
-			transformations = append(transformations, fmt.Sprintf("CURRENT_TIMESTAMP AS %s", normalizedColName))
-			continue
-		}
-
-		if utils.IsUpper(avroColName) {
-			avroColName = strings.ToLower(avroColName)
-		}
-		// Avro files are written with lowercase in mind, so don't normalize it like everything else
-		switch colType {
-		case "GEOGRAPHY":
-			transformations = append(transformations,
-				fmt.Sprintf("TO_GEOGRAPHY($1:\"%s\"::string, true) AS %s", avroColName, normalizedColName))
-		case "GEOMETRY":
-			transformations = append(transformations,
-				fmt.Sprintf("TO_GEOMETRY($1:\"%s\"::string, true) AS %s", avroColName, normalizedColName))
-		case "NUMBER":
-			transformations = append(transformations,
-				fmt.Sprintf("$1:\"%s\" AS %s", avroColName, normalizedColName))
-		case "VARIANT":
-			transformations = append(transformations,
-				fmt.Sprintf("PARSE_JSON($1:\"%s\") AS %s", avroColName, normalizedColName))
-
-		default:
-			transformations = append(transformations,
-				fmt.Sprintf("($1:\"%s\")::%s AS %s", avroColName, colType, normalizedColName))
-		}
-	}
-	transformationSQL := strings.Join(transformations, ",")
-	columnsSQL := strings.Join(columnOrder, ",")
-
-	return transformationSQL, columnsSQL
-}
-
-func (c *SnowflakeConnector) GetCopyTransformation(
-	dstTableName string,
-	syncedAtCol string,
-) (*CopyInfo, error) {
-	colNames, colTypes, colsErr := c.getColsFromTable(dstTableName)
-	if colsErr != nil {
-		return nil, fmt.Errorf("failed to get columns from destination table: %w", colsErr)
-	}
-
-	transformationSQL, columnsSQL := GetTransformSQL(colNames, colTypes, syncedAtCol)
-	return &CopyInfo{transformationSQL, columnsSQL}, nil
-}
-
-func CopyStageToDestination(
-	connector *SnowflakeConnector,
-	config *protos.QRepConfig,
-	dstTableName string,
-	stage string,
-	allCols []string,
-) error {
-	connector.logger.Info("Copying stage to destination " + dstTableName)
-	copyOpts := []string{
-		"FILE_FORMAT = (TYPE = AVRO)",
-		"PURGE = TRUE",
-		"ON_ERROR = 'CONTINUE'",
-	}
-
-	writeHandler := NewSnowflakeAvroWriteHandler(connector, dstTableName, stage, copyOpts)
-
-	appendMode := true
-	if config.WriteMode != nil {
-		writeType := config.WriteMode.WriteType
-		if writeType == protos.QRepWriteType_QREP_WRITE_MODE_UPSERT {
-			appendMode = false
-		}
-	}
-
-	copyTransformation, err := connector.GetCopyTransformation(dstTableName, config.SyncedAtColName)
-	if err != nil {
-		return fmt.Errorf("failed to get copy transformation: %w", err)
-	}
-	if appendMode {
-		err := writeHandler.HandleAppendMode(copyTransformation)
-		if err != nil {
-			return fmt.Errorf("failed to handle append mode: %w", err)
-		}
-	} else {
-		upsertKeyCols := config.WriteMode.UpsertKeyColumns
-		err := writeHandler.HandleUpsertMode(allCols, upsertKeyCols, config.WatermarkColumn,
-			config.FlowJobName, copyTransformation)
-		if err != nil {
-			return fmt.Errorf("failed to handle upsert mode: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (s *SnowflakeAvroSyncMethod) insertMetadata(
+func (s *SnowflakeAvroSyncHandler) insertMetadata(
 	partition *protos.QRepPartition,
 	flowJobName string,
 	startTime time.Time,
@@ -411,157 +303,5 @@ func (s *SnowflakeAvroSyncMethod) insertMetadata(
 	}
 
 	s.connector.logger.Info("inserted metadata for partition", partitionLog)
-	return nil
-}
-
-type SnowflakeAvroWriteHandler struct {
-	connector    *SnowflakeConnector
-	dstTableName string
-	stage        string
-	copyOpts     []string
-}
-
-// NewSnowflakeAvroWriteHandler creates a new SnowflakeAvroWriteHandler
-func NewSnowflakeAvroWriteHandler(
-	connector *SnowflakeConnector,
-	dstTableName string,
-	stage string,
-	copyOpts []string,
-) *SnowflakeAvroWriteHandler {
-	return &SnowflakeAvroWriteHandler{
-		connector:    connector,
-		dstTableName: dstTableName,
-		stage:        stage,
-		copyOpts:     copyOpts,
-	}
-}
-
-func (s *SnowflakeAvroWriteHandler) HandleAppendMode(
-	copyInfo *CopyInfo,
-) error {
-	parsedDstTable, _ := utils.ParseSchemaTable(s.dstTableName)
-	//nolint:gosec
-	copyCmd := fmt.Sprintf("COPY INTO %s(%s) FROM (SELECT %s FROM @%s) %s",
-		snowflakeSchemaTableNormalize(parsedDstTable), copyInfo.columnsSQL,
-		copyInfo.transformationSQL, s.stage, strings.Join(s.copyOpts, ","))
-	s.connector.logger.Info("running copy command: " + copyCmd)
-	_, err := s.connector.database.ExecContext(s.connector.ctx, copyCmd)
-	if err != nil {
-		return fmt.Errorf("failed to run COPY INTO command: %w", err)
-	}
-
-	s.connector.logger.Info("copied file from stage " + s.stage + " to table " + s.dstTableName)
-	return nil
-}
-
-func generateUpsertMergeCommand(
-	allCols []string,
-	upsertKeyCols []string,
-	tempTableName string,
-	dstTable string,
-) string {
-	// all cols are acquired from snowflake schema, so let us try to make upsert key cols match the case
-	// and also the watermark col, then the quoting should be fine
-	caseMatchedCols := map[string]string{}
-	for _, col := range allCols {
-		caseMatchedCols[strings.ToLower(col)] = col
-	}
-
-	for i, col := range upsertKeyCols {
-		upsertKeyCols[i] = caseMatchedCols[strings.ToLower(col)]
-	}
-
-	upsertKeys := []string{}
-	partitionKeyCols := []string{}
-	for _, key := range upsertKeyCols {
-		quotedKey := utils.QuoteIdentifier(key)
-		upsertKeys = append(upsertKeys, fmt.Sprintf("dst.%s = src.%s", quotedKey, quotedKey))
-		partitionKeyCols = append(partitionKeyCols, quotedKey)
-	}
-	upsertKeyClause := strings.Join(upsertKeys, " AND ")
-
-	updateSetClauses := []string{}
-	insertColumnsClauses := []string{}
-	insertValuesClauses := []string{}
-	for _, column := range allCols {
-		quotedColumn := utils.QuoteIdentifier(column)
-		updateSetClauses = append(updateSetClauses, fmt.Sprintf("%s = src.%s", quotedColumn, quotedColumn))
-		insertColumnsClauses = append(insertColumnsClauses, quotedColumn)
-		insertValuesClauses = append(insertValuesClauses, fmt.Sprintf("src.%s", quotedColumn))
-	}
-	updateSetClause := strings.Join(updateSetClauses, ", ")
-	insertColumnsClause := strings.Join(insertColumnsClauses, ", ")
-	insertValuesClause := strings.Join(insertValuesClauses, ", ")
-	selectCmd := fmt.Sprintf(`
-		SELECT *
-		FROM %s
-		QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s DESC) = 1
-	`, tempTableName, strings.Join(partitionKeyCols, ","), partitionKeyCols[0])
-
-	mergeCmd := fmt.Sprintf(`
-			MERGE INTO %s dst
-			USING (%s) src
-			ON %s
-			WHEN MATCHED THEN UPDATE SET %s
-			WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)
-		`, dstTable, selectCmd, upsertKeyClause,
-		updateSetClause, insertColumnsClause, insertValuesClause)
-
-	return mergeCmd
-}
-
-// HandleUpsertMode handles the upsert mode
-func (s *SnowflakeAvroWriteHandler) HandleUpsertMode(
-	allCols []string,
-	upsertKeyCols []string,
-	watermarkCol string,
-	flowJobName string,
-	copyInfo *CopyInfo,
-) error {
-	runID, err := shared.RandomUInt64()
-	if err != nil {
-		return fmt.Errorf("failed to generate run ID: %w", err)
-	}
-
-	tempTableName := fmt.Sprintf("%s_temp_%d", s.dstTableName, runID)
-
-	//nolint:gosec
-	createTempTableCmd := fmt.Sprintf("CREATE TEMPORARY TABLE %s AS SELECT * FROM %s LIMIT 0",
-		tempTableName, s.dstTableName)
-	if _, err := s.connector.database.ExecContext(s.connector.ctx, createTempTableCmd); err != nil {
-		return fmt.Errorf("failed to create temp table: %w", err)
-	}
-	s.connector.logger.Info("created temp table " + tempTableName)
-
-	//nolint:gosec
-	copyCmd := fmt.Sprintf("COPY INTO %s(%s) FROM (SELECT %s FROM @%s) %s",
-		tempTableName, copyInfo.columnsSQL, copyInfo.transformationSQL, s.stage, strings.Join(s.copyOpts, ","))
-	_, err = s.connector.database.ExecContext(s.connector.ctx, copyCmd)
-	if err != nil {
-		return fmt.Errorf("failed to run COPY INTO command: %w", err)
-	}
-	s.connector.logger.Info("copied file from stage " + s.stage + " to temp table " + tempTableName)
-
-	mergeCmd := generateUpsertMergeCommand(allCols, upsertKeyCols, tempTableName, s.dstTableName)
-
-	startTime := time.Now()
-	rows, err := s.connector.database.ExecContext(s.connector.ctx, mergeCmd)
-	if err != nil {
-		return fmt.Errorf("failed to merge data into destination table '%s': %w", mergeCmd, err)
-	}
-	rowCount, err := rows.RowsAffected()
-	if err == nil {
-		totalRowsAtTarget, err := s.connector.getTableCounts([]string{s.dstTableName})
-		if err != nil {
-			return err
-		}
-		s.connector.logger.Info(fmt.Sprintf("merged %d rows into destination table %s, total rows at target: %d",
-			rowCount, s.dstTableName, totalRowsAtTarget))
-	} else {
-		s.connector.logger.Error("failed to get rows affected", slog.Any("error", err))
-	}
-
-	s.connector.logger.Info(fmt.Sprintf("merged data from temp table %s into destination table %s, time taken %v",
-		tempTableName, s.dstTableName, time.Since(startTime)))
 	return nil
 }

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -541,7 +541,7 @@ func (c *SnowflakeConnector) syncRecordsViaAvro(
 		DestinationTableIdentifier: strings.ToLower(fmt.Sprintf("%s.%s", c.metadataSchema,
 			rawTableIdentifier)),
 	}
-	avroSyncer := NewSnowflakeAvroSyncMethod(qrepConfig, c)
+	avroSyncer := NewSnowflakeAvroSyncHandler(qrepConfig, c)
 	destinationTableSchema, err := c.getTableSchema(qrepConfig.DestinationTableIdentifier)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Quite a bit of reorganization, moved functions from connector level to `ConsolidateHandler` level, reading from struct instead of unnecessary var passing