### PR TITLE
RegisterHStore shouldn't fail when hstore isn't present

### DIFF
--- a/flow/connectors/utils/postgres.go
+++ b/flow/connectors/utils/postgres.go
@@ -62,6 +62,10 @@ func RegisterHStore(ctx context.Context, conn *pgx.Conn) error {
 	var hstoreOID uint32
 	err := conn.QueryRow(context.Background(), `select oid from pg_type where typname = 'hstore'`).Scan(&hstoreOID)
 	if err != nil {
+		// hstore isn't present, just proceed
+		if err == pgx.ErrNoRows {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Currently fails in initial load with something like `failed to begin transaction: no rows in result set`