### PR TITLE
fix mirror ui

### DIFF
--- a/ui/app/mirrors/create/mirrorcards.tsx
+++ b/ui/app/mirrors/create/mirrorcards.tsx
@@ -46,7 +46,7 @@ const MirrorCards = ({
               style={{
                 padding: '0.5rem',
                 width: '35%',
-                height: '22vh',
+                minHeight: '22vh',
                 marginRight:
                   card.title === 'Query Replication' ? '0.5rem' : 'auto',
                 marginLeft:


### PR DESCRIPTION
Quick fix to fix the overflowing text problem. On smaller screens now the cards would be of different size but will not overflow

Before
<img width="692" alt="Screenshot 2024-01-19 at 5 39 49 PM" src="https://github.com/PeerDB-io/peerdb/assets/149565017/ad4476e1-786f-47f2-9ecd-e0a5ec513ec9">


After
<img width="687" alt="Screenshot 2024-01-19 at 5 43 05 PM" src="https://github.com/PeerDB-io/peerdb/assets/149565017/6a64853c-173d-4358-aeb3-0110f03ad9e6">
