### PR TITLE
Validate Mirror: PostgreSQL Checks

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -642,6 +642,8 @@ func (a *FlowableActivity) ConsolidateQRepPartitions(ctx context.Context, config
 		return err
 	}
 
+	defer connectors.CloseConnector(dstConn)
+
 	shutdown := utils.HeartbeatRoutine(ctx, 2*time.Minute, func() string {
 		return fmt.Sprintf("consolidating partitions for job - %s", config.FlowJobName)
 	})
@@ -664,6 +666,8 @@ func (a *FlowableActivity) CleanupQRepFlow(ctx context.Context, config *protos.Q
 		a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 		return err
 	}
+
+	defer dst.Close()
 
 	return dst.CleanupQRepFlow(config)
 }

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -122,6 +122,12 @@ func (h *FlowRequestHandler) CreateCDCFlow(
 	ctx context.Context, req *protos.CreateCDCFlowRequest,
 ) (*protos.CreateCDCFlowResponse, error) {
 	cfg := req.ConnectionConfigs
+	_, validateErr := h.ValidateCDCMirror(ctx, req)
+	if validateErr != nil {
+		slog.Error("validate mirror error", slog.Any("error", validateErr))
+		return nil, fmt.Errorf("invalid mirror: %w", validateErr)
+	}
+
 	workflowID := fmt.Sprintf("%s-peerflow-%s", cfg.FlowJobName, uuid.New())
 	workflowOptions := client.StartWorkflowOptions{
 		ID:        workflowID,

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/PeerDB-io/peer-flow/connectors"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/shared"
 	peerflow "github.com/PeerDB-io/peer-flow/workflows"
@@ -560,50 +559,6 @@ func (h *FlowRequestHandler) handleWorkflowNotClosed(ctx context.Context, workfl
 	}
 
 	return nil
-}
-
-func (h *FlowRequestHandler) ValidatePeer(
-	ctx context.Context,
-	req *protos.ValidatePeerRequest,
-) (*protos.ValidatePeerResponse, error) {
-	if req.Peer == nil {
-		return &protos.ValidatePeerResponse{
-			Status:  protos.ValidatePeerStatus_INVALID,
-			Message: "no peer provided",
-		}, nil
-	}
-
-	if len(req.Peer.Name) == 0 {
-		return &protos.ValidatePeerResponse{
-			Status:  protos.ValidatePeerStatus_INVALID,
-			Message: "no peer name provided",
-		}, nil
-	}
-
-	conn, err := connectors.GetConnector(ctx, req.Peer)
-	if err != nil {
-		return &protos.ValidatePeerResponse{
-			Status: protos.ValidatePeerStatus_INVALID,
-			Message: fmt.Sprintf("peer type is missing or "+
-				"your requested configuration for %s peer %s was invalidated: %s",
-				req.Peer.Type, req.Peer.Name, err),
-		}, nil
-	}
-
-	connErr := conn.ConnectionActive()
-	if connErr != nil {
-		return &protos.ValidatePeerResponse{
-			Status: protos.ValidatePeerStatus_INVALID,
-			Message: fmt.Sprintf("failed to establish active connection to %s peer %s: %v",
-				req.Peer.Type, req.Peer.Name, connErr),
-		}, nil
-	}
-
-	return &protos.ValidatePeerResponse{
-		Status: protos.ValidatePeerStatus_VALID,
-		Message: fmt.Sprintf("%s peer %s is valid",
-			req.Peer.Type, req.Peer.Name),
-	}, nil
 }
 
 func (h *FlowRequestHandler) CreatePeer(

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -25,7 +25,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		return nil, fmt.Errorf("source peer config is nil")
 	}
 
-	// 2. Check permissions of postgres peer
+	// Check permissions of postgres peer
 	err = connpostgres.CheckReplicationPermissions(ctx, sourcePool, sourcePeerConfig.User)
 	if err != nil {
 		return &protos.ValidateCDCMirrorResponse{
@@ -33,7 +33,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		}, fmt.Errorf("failed to check replication permissions: %v", err)
 	}
 
-	// 3. Check source tables
+	// Check source tables
 	sourceTables := make([]string, 0, len(req.ConnectionConfigs.TableMappings))
 	for _, tableMapping := range req.ConnectionConfigs.TableMappings {
 		sourceTables = append(sourceTables, tableMapping.SourceTableIdentifier)

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -19,6 +19,8 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		}, fmt.Errorf("failed to create postgres connector: %v", err)
 	}
 
+	defer pgPeer.Close()
+
 	sourcePeerConfig := req.ConnectionConfigs.Source.GetPostgresConfig()
 	if sourcePeerConfig == nil {
 		slog.Error("/validatecdc source peer config is nil", slog.Any("peer", req.ConnectionConfigs.Source))

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func (h *FlowRequestHandler) GetPostgresVersion(ctx context.Context, pool *pgxpool.Pool) (int, error) {
+	if pool == nil {
+		return -1, fmt.Errorf("version check: pool is nil")
+	}
+
+	var versionRes string
+	err := pool.QueryRow(ctx, "SHOW server_version_num;").Scan(&versionRes)
+	if err != nil {
+		return -1, err
+	}
+
+	version, err := strconv.Atoi(versionRes)
+	if err != nil {
+		return -1, err
+	}
+
+	return version, nil
+}
+
+func (h *FlowRequestHandler) CheckReplicationPermissions(ctx context.Context, pool *pgxpool.Pool, username string) error {
+	if pool == nil {
+		return fmt.Errorf("check replication permissions: pool is nil")
+	}
+
+	var replicationRes bool
+	err := pool.QueryRow(ctx, "SELECT rolreplication FROM pg_roles WHERE rolname = $1;", username).Scan(&replicationRes)
+	if err != nil {
+		return err
+	}
+
+	if !replicationRes {
+		return fmt.Errorf("postgres user does not have replication role")
+	}
+
+	// check wal_level
+	var walLevel string
+	err = pool.QueryRow(ctx, "SHOW wal_level;").Scan(&walLevel)
+	if err != nil {
+		return err
+	}
+
+	if walLevel != "logical" {
+		return fmt.Errorf("wal_level is not logical")
+	}
+
+	// max_wal_senders must be at least 2
+	var maxWalSendersRes string
+	err = pool.QueryRow(ctx, "SHOW max_wal_senders;").Scan(&maxWalSendersRes)
+	if err != nil {
+		return err
+	}
+
+	maxWalSenders, err := strconv.Atoi(maxWalSendersRes)
+	if err != nil {
+		return err
+	}
+
+	if maxWalSenders < 2 {
+		return fmt.Errorf("max_wal_senders must be at least 1")
+	}
+
+	return nil
+}
+
+func (h *FlowRequestHandler) CheckSourceTables(ctx context.Context, pool *pgxpool.Pool, tableNames []string, pubName string) error {
+	if pool == nil {
+		return fmt.Errorf("check tables: pool is nil")
+	}
+
+	// Check that we can select from all tables
+	for _, tableName := range tableNames {
+		var row pgx.Row
+		err := pool.QueryRow(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 0;", tableName)).Scan(&row)
+		if err != nil && err != pgx.ErrNoRows {
+			return err
+		}
+	}
+
+	// Check if tables belong to publication
+	tableArr := make([]string, 0, len(tableNames))
+	for _, tableName := range tableNames {
+		tableArr = append(tableArr, fmt.Sprintf("'%s'", tableName))
+	}
+
+	tableStr := strings.Join(tableArr, ",")
+
+	if pubName != "" {
+		var pubTableCount int
+		err := pool.QueryRow(ctx, fmt.Sprintf("select COUNT(DISTINCT(schemaname||'.'||tablename)) from pg_publication_tables "+
+			"where schemaname||'.'||tablename in (%s) and pubname=$1;", tableStr), pubName).Scan(&pubTableCount)
+		if err != nil {
+			return err
+		}
+
+		if pubTableCount != len(tableNames) {
+			return fmt.Errorf("not all tables belong to publication")
+		}
+	}
+
+	return nil
+}
+
+func (h *FlowRequestHandler) ValidateCDCMirror(
+	ctx context.Context, req *protos.CreateCDCFlowRequest,
+) (*protos.ValidateCDCMirrorResponse, error) {
+	sourcePeerName := req.ConnectionConfigs.Source.Name
+	sourcePool, err := h.getPoolForPGPeer(ctx, sourcePeerName)
+	if err != nil {
+		slog.Error("/validatecdc failed to obtain peer connection", slog.Any("error", err))
+		return nil, err
+	}
+
+	// 1. Deny PG version < 12
+	version, err := h.GetPostgresVersion(ctx, sourcePool)
+	if err != nil {
+		slog.Error("/validatecdc pg version check", slog.Any("error", err))
+		return nil, err
+	}
+
+	if version < 12 {
+		return &protos.ValidateCDCMirrorResponse{
+				Ok: false,
+			}, fmt.Errorf("postgres version %d is not supported. "+
+				"Please upgrade to Postgres 12 or higher", version)
+	}
+
+	sourcePeerConfig := req.ConnectionConfigs.Source.GetPostgresConfig()
+	if sourcePeerConfig == nil {
+		slog.Error("/validatecdc source peer config is nil", slog.Any("peer", req.ConnectionConfigs.Source))
+		return nil, fmt.Errorf("source peer config is nil")
+	}
+
+	// 2. Check permissions of postgres peer
+	err = h.CheckReplicationPermissions(ctx, sourcePool, sourcePeerConfig.User)
+	if err != nil {
+		return &protos.ValidateCDCMirrorResponse{
+			Ok: false,
+		}, fmt.Errorf("failed to check replication permissions: %v", err)
+	}
+
+	// 3. Check source tables
+	sourceTables := make([]string, 0, len(req.ConnectionConfigs.TableMappings))
+	for _, tableMapping := range req.ConnectionConfigs.TableMappings {
+		sourceTables = append(sourceTables, tableMapping.SourceTableIdentifier)
+	}
+
+	err = h.CheckSourceTables(ctx, sourcePool, sourceTables, req.ConnectionConfigs.PublicationName)
+	if err != nil {
+		return &protos.ValidateCDCMirrorResponse{
+			Ok: false,
+		}, fmt.Errorf("provided source tables invalidated: %v", err)
+	}
+
+	return &protos.ValidateCDCMirrorResponse{
+		Ok: true,
+	}, nil
+}

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/PeerDB-io/peer-flow/connectors"
+	"github.com/PeerDB-io/peer-flow/connectors/utils"
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func (h *FlowRequestHandler) GetPostgresVersion(ctx context.Context, pool *pgxpool.Pool) (int, error) {
+	if pool == nil {
+		return -1, fmt.Errorf("version check: pool is nil")
+	}
+
+	var versionRes string
+	err := pool.QueryRow(ctx, "SHOW server_version_num;").Scan(&versionRes)
+	if err != nil {
+		return -1, err
+	}
+
+	version, err := strconv.Atoi(versionRes)
+	if err != nil {
+		return -1, err
+	}
+
+	return version / 10000, nil
+}
+
+func (h *FlowRequestHandler) ValidatePeer(
+	ctx context.Context,
+	req *protos.ValidatePeerRequest,
+) (*protos.ValidatePeerResponse, error) {
+	if req.Peer == nil {
+		return &protos.ValidatePeerResponse{
+			Status:  protos.ValidatePeerStatus_INVALID,
+			Message: "no peer provided",
+		}, nil
+	}
+
+	if len(req.Peer.Name) == 0 {
+		return &protos.ValidatePeerResponse{
+			Status:  protos.ValidatePeerStatus_INVALID,
+			Message: "no peer name provided",
+		}, nil
+	}
+
+	if req.Peer.Type == protos.DBType_POSTGRES {
+		slog.Info("validating postgres peer", slog.Any("peer", req.Peer))
+		pgConfigStr := utils.GetPGConnectionString(req.Peer.GetPostgresConfig())
+		if len(pgConfigStr) == 0 {
+			return &protos.ValidatePeerResponse{
+				Status:  protos.ValidatePeerStatus_INVALID,
+				Message: "no postgres config provided",
+			}, nil
+		}
+
+		peerConfig, err := pgxpool.ParseConfig(pgConfigStr)
+		if err != nil {
+			return &protos.ValidatePeerResponse{
+				Status:  protos.ValidatePeerStatus_INVALID,
+				Message: "invalid postgres config provided",
+			}, nil
+		}
+
+		// Deny PG version < 12
+		sourcePool, err := pgxpool.NewWithConfig(ctx, peerConfig)
+		if err != nil {
+			slog.Error("/peer/validate: failed to obtain peer connection", slog.Any("error", err))
+			return nil, err
+		}
+		version, err := h.GetPostgresVersion(ctx, sourcePool)
+		if err != nil {
+			slog.Error("/peer/validate: pg version check", slog.Any("error", err))
+			return nil, err
+		}
+
+		slog.Info("postgres version", slog.Any("version", version))
+		if version < 12 {
+			return &protos.ValidatePeerResponse{
+				Status: protos.ValidatePeerStatus_INVALID,
+				Message: fmt.Sprintf("%s peer %s must be of version 12 or above. Current version: %d",
+					req.Peer.Type, req.Peer.Name, version),
+			}, nil
+		}
+	}
+
+	conn, err := connectors.GetConnector(ctx, req.Peer)
+	if err != nil {
+		return &protos.ValidatePeerResponse{
+			Status: protos.ValidatePeerStatus_INVALID,
+			Message: fmt.Sprintf("peer type is missing or "+
+				"your requested configuration for %s peer %s was invalidated: %s",
+				req.Peer.Type, req.Peer.Name, err),
+		}, nil
+	}
+
+	connErr := conn.ConnectionActive()
+	if connErr != nil {
+		return &protos.ValidatePeerResponse{
+			Status: protos.ValidatePeerStatus_INVALID,
+			Message: fmt.Sprintf("failed to establish active connection to %s peer %s: %v",
+				req.Peer.Type, req.Peer.Name, connErr),
+		}, nil
+	}
+
+	return &protos.ValidatePeerResponse{
+		Status: protos.ValidatePeerStatus_VALID,
+		Message: fmt.Sprintf("%s peer %s is valid",
+			req.Peer.Type, req.Peer.Name),
+	}, nil
+}

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -38,6 +38,8 @@ func (h *FlowRequestHandler) ValidatePeer(
 		}, nil
 	}
 
+	defer conn.Close()
+
 	if req.Peer.Type == protos.DBType_POSTGRES {
 		version, err := conn.(*connpostgres.PostgresConnector).GetPostgresVersion()
 		if err != nil {

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/PeerDB-io/peer-flow/connectors"
 	connpostgres "github.com/PeerDB-io/peer-flow/connectors/postgres"
-	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func (h *FlowRequestHandler) ValidatePeer(
@@ -30,46 +28,6 @@ func (h *FlowRequestHandler) ValidatePeer(
 		}, nil
 	}
 
-	if req.Peer.Type == protos.DBType_POSTGRES {
-		slog.Info("validating postgres peer", slog.Any("peer", req.Peer))
-		pgConfigStr := utils.GetPGConnectionString(req.Peer.GetPostgresConfig())
-		if len(pgConfigStr) == 0 {
-			return &protos.ValidatePeerResponse{
-				Status:  protos.ValidatePeerStatus_INVALID,
-				Message: "no postgres config provided",
-			}, nil
-		}
-
-		peerConfig, err := pgxpool.ParseConfig(pgConfigStr)
-		if err != nil {
-			return &protos.ValidatePeerResponse{
-				Status:  protos.ValidatePeerStatus_INVALID,
-				Message: "invalid postgres config provided",
-			}, nil
-		}
-
-		// Deny PG version < 12
-		sourcePool, err := pgxpool.NewWithConfig(ctx, peerConfig)
-		if err != nil {
-			slog.Error("/peer/validate: failed to obtain peer connection", slog.Any("error", err))
-			return nil, err
-		}
-		version, err := connpostgres.GetPostgresVersion(ctx, sourcePool)
-		if err != nil {
-			slog.Error("/peer/validate: pg version check", slog.Any("error", err))
-			return nil, err
-		}
-
-		slog.Info("postgres version", slog.Any("version", version))
-		if version < 12 {
-			return &protos.ValidatePeerResponse{
-				Status: protos.ValidatePeerStatus_INVALID,
-				Message: fmt.Sprintf("%s peer %s must be of version 12 or above. Current version: %d",
-					req.Peer.Type, req.Peer.Name, version),
-			}, nil
-		}
-	}
-
 	conn, err := connectors.GetConnector(ctx, req.Peer)
 	if err != nil {
 		return &protos.ValidatePeerResponse{
@@ -78,6 +36,22 @@ func (h *FlowRequestHandler) ValidatePeer(
 				"your requested configuration for %s peer %s was invalidated: %s",
 				req.Peer.Type, req.Peer.Name, err),
 		}, nil
+	}
+
+	if req.Peer.Type == protos.DBType_POSTGRES {
+		version, err := conn.(*connpostgres.PostgresConnector).GetPostgresVersion()
+		if err != nil {
+			slog.Error("/peer/validate: pg version check", slog.Any("error", err))
+			return nil, err
+		}
+
+		if version < 12 {
+			return &protos.ValidatePeerResponse{
+				Status: protos.ValidatePeerStatus_INVALID,
+				Message: fmt.Sprintf("%s peer %s must be of version 12 or above. Current version: %d",
+					req.Peer.Type, req.Peer.Name, version),
+			}, nil
+		}
 	}
 
 	connErr := conn.ConnectionActive()

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -4,32 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strconv"
 
 	"github.com/PeerDB-io/peer-flow/connectors"
+	connpostgres "github.com/PeerDB-io/peer-flow/connectors/postgres"
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
-
-func (h *FlowRequestHandler) GetPostgresVersion(ctx context.Context, pool *pgxpool.Pool) (int, error) {
-	if pool == nil {
-		return -1, fmt.Errorf("version check: pool is nil")
-	}
-
-	var versionRes string
-	err := pool.QueryRow(ctx, "SHOW server_version_num;").Scan(&versionRes)
-	if err != nil {
-		return -1, err
-	}
-
-	version, err := strconv.Atoi(versionRes)
-	if err != nil {
-		return -1, err
-	}
-
-	return version / 10000, nil
-}
 
 func (h *FlowRequestHandler) ValidatePeer(
 	ctx context.Context,
@@ -73,7 +54,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 			slog.Error("/peer/validate: failed to obtain peer connection", slog.Any("error", err))
 			return nil, err
 		}
-		version, err := h.GetPostgresVersion(ctx, sourcePool)
+		version, err := connpostgres.GetPostgresVersion(ctx, sourcePool)
 		if err != nil {
 			slog.Error("/peer/validate: pg version check", slog.Any("error", err))
 			return nil, err

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -1,10 +1,12 @@
 package connpostgres
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
@@ -13,6 +15,7 @@ import (
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lib/pq/oid"
 )
 
@@ -571,4 +574,106 @@ func (c *PostgresConnector) getCurrentLSN() (pglogrepl.LSN, error) {
 
 func (c *PostgresConnector) getDefaultPublicationName(jobName string) string {
 	return fmt.Sprintf("peerflow_pub_%s", jobName)
+}
+
+func CheckSourceTables(ctx context.Context, pool *pgxpool.Pool, tableNames []string, pubName string) error {
+	if pool == nil {
+		return fmt.Errorf("check tables: pool is nil")
+	}
+
+	// Check that we can select from all tables
+	for _, tableName := range tableNames {
+		var row pgx.Row
+		err := pool.QueryRow(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 0;", tableName)).Scan(&row)
+		if err != nil && err != pgx.ErrNoRows {
+			return err
+		}
+	}
+
+	// Check if tables belong to publication
+	tableArr := make([]string, 0, len(tableNames))
+	for _, tableName := range tableNames {
+		tableArr = append(tableArr, fmt.Sprintf("'%s'", tableName))
+	}
+
+	tableStr := strings.Join(tableArr, ",")
+
+	if pubName != "" {
+		var pubTableCount int
+		err := pool.QueryRow(ctx, fmt.Sprintf("select COUNT(DISTINCT(schemaname||'.'||tablename)) from pg_publication_tables "+
+			"where schemaname||'.'||tablename in (%s) and pubname=$1;", tableStr), pubName).Scan(&pubTableCount)
+		if err != nil {
+			return err
+		}
+
+		if pubTableCount != len(tableNames) {
+			return fmt.Errorf("not all tables belong to publication")
+		}
+	}
+
+	return nil
+}
+
+func CheckReplicationPermissions(ctx context.Context, pool *pgxpool.Pool, username string) error {
+	if pool == nil {
+		return fmt.Errorf("check replication permissions: pool is nil")
+	}
+
+	var replicationRes bool
+	err := pool.QueryRow(ctx, "SELECT rolreplication FROM pg_roles WHERE rolname = $1;", username).Scan(&replicationRes)
+	if err != nil {
+		return err
+	}
+
+	if !replicationRes {
+		return fmt.Errorf("postgres user does not have replication role")
+	}
+
+	// check wal_level
+	var walLevel string
+	err = pool.QueryRow(ctx, "SHOW wal_level;").Scan(&walLevel)
+	if err != nil {
+		return err
+	}
+
+	if walLevel != "logical" {
+		return fmt.Errorf("wal_level is not logical")
+	}
+
+	// max_wal_senders must be at least 2
+	var maxWalSendersRes string
+	err = pool.QueryRow(ctx, "SHOW max_wal_senders;").Scan(&maxWalSendersRes)
+	if err != nil {
+		return err
+	}
+
+	maxWalSenders, err := strconv.Atoi(maxWalSendersRes)
+	if err != nil {
+		return err
+	}
+
+	if maxWalSenders < 2 {
+		return fmt.Errorf("max_wal_senders must be at least 2")
+	}
+
+	return nil
+}
+
+func GetPostgresVersion(ctx context.Context, pool *pgxpool.Pool) (int, error) {
+	if pool == nil {
+		return -1, fmt.Errorf("version check: pool is nil")
+	}
+
+	var versionRes string
+	err := pool.QueryRow(ctx, "SHOW server_version_num;").Scan(&versionRes)
+	if err != nil {
+		return -1, err
+	}
+
+	version, err := strconv.Atoi(versionRes)
+	if err != nil {
+		return -1, err
+	}
+
+	return version / 10000, nil
 }

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -197,6 +197,10 @@ message MirrorStatusResponse {
   peerdb_flow.FlowStatus current_flow_state = 5;
 }
 
+message ValidateCDCMirrorResponse{
+  bool ok = 1;
+}
+
 message FlowStateChangeRequest {
   string flow_job_name = 1;
   peerdb_flow.FlowStatus requested_flow_state = 2;
@@ -222,6 +226,12 @@ service FlowService {
   rpc ValidatePeer(ValidatePeerRequest) returns (ValidatePeerResponse) {
     option (google.api.http) = {
       post: "/v1/peers/validate",
+      body: "*"
+     };
+  }
+    rpc ValidateCDCMirror(CreateCDCFlowRequest) returns (ValidateCDCMirrorResponse) {
+    option (google.api.http) = {
+      post: "/v1/mirrors/cdc/validate",
       body: "*"
      };
   }

--- a/ui/app/api/mirrors/cdc/route.ts
+++ b/ui/app/api/mirrors/cdc/route.ts
@@ -1,8 +1,5 @@
 import { UCreateMirrorResponse } from '@/app/dto/MirrorsDTO';
-import {
-  CreateCDCFlowRequest,
-  CreateCDCFlowResponse,
-} from '@/grpc_generated/route';
+import { CreateCDCFlowRequest } from '@/grpc_generated/route';
 import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
 
 export async function POST(request: Request) {
@@ -15,18 +12,18 @@ export async function POST(request: Request) {
     createCatalogEntry: true,
   };
   try {
-    const createStatus: CreateCDCFlowResponse = await fetch(
-      `${flowServiceAddr}/v1/flows/cdc/create`,
-      {
-        method: 'POST',
-        body: JSON.stringify(req),
-      }
-    ).then((res) => {
+    const createStatus = await fetch(`${flowServiceAddr}/v1/flows/cdc/create`, {
+      method: 'POST',
+      body: JSON.stringify(req),
+    }).then((res) => {
       return res.json();
     });
 
+    if (!createStatus.worflowId) {
+      return new Response(JSON.stringify(createStatus));
+    }
     let response: UCreateMirrorResponse = {
-      created: !!createStatus.worflowId,
+      created: true,
     };
 
     return new Response(JSON.stringify(response));

--- a/ui/app/api/mirrors/cdc/validate/route.ts
+++ b/ui/app/api/mirrors/cdc/validate/route.ts
@@ -1,0 +1,31 @@
+import {
+  CreateCDCFlowRequest,
+  ValidateCDCMirrorResponse,
+} from '@/grpc_generated/route';
+import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const { config } = body;
+  console.log('/mirrors/cdc/validate config: ', config);
+  const flowServiceAddr = GetFlowHttpAddressFromEnv();
+  const req: CreateCDCFlowRequest = {
+    connectionConfigs: config,
+    createCatalogEntry: false,
+  };
+  try {
+    const validateResponse: ValidateCDCMirrorResponse = await fetch(
+      `${flowServiceAddr}/v1/mirrors/cdc/validate`,
+      {
+        method: 'POST',
+        body: JSON.stringify(req),
+      }
+    ).then((res) => {
+      return res.json();
+    });
+
+    return new Response(JSON.stringify(validateResponse));
+  } catch (e) {
+    console.log(e);
+  }
+}

--- a/ui/app/dto/MirrorsDTO.ts
+++ b/ui/app/dto/MirrorsDTO.ts
@@ -5,6 +5,11 @@ export type UCreateMirrorResponse = {
   created: boolean;
 };
 
+export type UValidateMirrorResponse = {
+  ok: boolean;
+  errorMessage: string;
+};
+
 export type UDropMirrorResponse = {
   dropped: boolean;
   errorMessage: string;

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -6,7 +6,8 @@ import { Icon } from '@/lib/Icon';
 import { Dispatch, SetStateAction, useMemo, useState } from 'react';
 import { CDCConfig, MirrorSetter, TableMapRow } from '../../../dto/MirrorsDTO';
 import { MirrorSetting } from '../helpers/common';
-import CDCFields from './fields';
+import CDCField from './fields';
+import GuideForDestinationSetup from './guide';
 import TableMapping from './tablemapping';
 
 interface MirrorConfigProps {
@@ -55,6 +56,8 @@ export default function CDCConfigForm({
     const label = setting.label.toLowerCase();
     if (
       (label.includes('snapshot') && mirrorConfig.doInitialSnapshot !== true) ||
+      (label === 'replication slot name' &&
+        mirrorConfig.doInitialSnapshot === true) ||
       (label.includes('staging path') &&
         defaultSyncMode(mirrorConfig.destination?.type) !== 'AVRO')
     ) {
@@ -66,10 +69,11 @@ export default function CDCConfigForm({
   if (mirrorConfig.source != undefined && mirrorConfig.destination != undefined)
     return (
       <>
+        <GuideForDestinationSetup dstPeerType={mirrorConfig.destination.type} />
         {normalSettings.map((setting, id) => {
           return (
             paramDisplayCondition(setting) && (
-              <CDCFields
+              <CDCField
                 key={id}
                 handleChange={handleChange}
                 setting={setting}
@@ -99,7 +103,7 @@ export default function CDCConfigForm({
         {show &&
           advancedSettings.map((setting, id) => {
             return (
-              <CDCFields
+              <CDCField
                 key={id}
                 handleChange={handleChange}
                 setting={setting}

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -7,7 +7,6 @@ import { Dispatch, SetStateAction, useMemo, useState } from 'react';
 import { CDCConfig, MirrorSetter, TableMapRow } from '../../../dto/MirrorsDTO';
 import { MirrorSetting } from '../helpers/common';
 import CDCField from './fields';
-import GuideForDestinationSetup from './guide';
 import TableMapping from './tablemapping';
 
 interface MirrorConfigProps {
@@ -69,7 +68,6 @@ export default function CDCConfigForm({
   if (mirrorConfig.source != undefined && mirrorConfig.destination != undefined)
     return (
       <>
-        <GuideForDestinationSetup dstPeerType={mirrorConfig.destination.type} />
         {normalSettings.map((setting, id) => {
           return (
             paramDisplayCondition(setting) && (

--- a/ui/app/mirrors/create/cdc/fields.tsx
+++ b/ui/app/mirrors/create/cdc/fields.tsx
@@ -12,7 +12,7 @@ interface FieldProps {
   handleChange: (val: string | boolean, setting: MirrorSetting) => void;
 }
 
-const CDCFields = ({ setting, handleChange }: FieldProps) => {
+const CDCField = ({ setting, handleChange }: FieldProps) => {
   return setting.type === 'switch' ? (
     <RowWithSwitch
       label={<Label>{setting.label}</Label>}
@@ -67,4 +67,4 @@ const CDCFields = ({ setting, handleChange }: FieldProps) => {
   );
 };
 
-export default CDCFields;
+export default CDCField;

--- a/ui/app/mirrors/create/cdc/guide.tsx
+++ b/ui/app/mirrors/create/cdc/guide.tsx
@@ -1,27 +1,29 @@
-import { DBTypeToGoodText } from '@/components/PeerTypeComponent';
-import { DBType } from '@/grpc_generated/peers';
 import { Label } from '@/lib/Label';
 import Link from 'next/link';
 
-const GuideForDestinationSetup = ({ dstPeerType }: { dstPeerType: DBType }) => {
+const GuideForDestinationSetup = ({
+  dstPeerType: peerType,
+}: {
+  dstPeerType: string;
+}) => {
   const linkForDst = () => {
-    switch (dstPeerType) {
-      case DBType.SNOWFLAKE:
+    switch (peerType) {
+      case 'SNOWFLAKE':
         return 'https://docs.peerdb.io/connect/snowflake';
-      case DBType.BIGQUERY:
+      case 'BIGQUERY':
         return 'https://docs.peerdb.io/connect/bigquery';
       default:
         return 'https://docs.peerdb.io/';
     }
   };
-  if (dstPeerType != DBType.SNOWFLAKE && dstPeerType != DBType.BIGQUERY) {
+  if (peerType != 'SNOWFLAKE' && peerType != 'BIGQUERY') {
     return <></>;
   }
   return (
     <Label variant='body' as='label' style={{ marginBottom: '1rem' }}>
       We recommend going through our{' '}
       <Link style={{ color: 'teal' }} href={linkForDst()} target='_blank'>
-        setup guide for {DBTypeToGoodText(dstPeerType)} destinations
+        setup guide for {peerType.toLowerCase()} destinations
       </Link>
       .
     </Label>

--- a/ui/app/mirrors/create/cdc/guide.tsx
+++ b/ui/app/mirrors/create/cdc/guide.tsx
@@ -1,0 +1,31 @@
+import { DBTypeToGoodText } from '@/components/PeerTypeComponent';
+import { DBType } from '@/grpc_generated/peers';
+import { Label } from '@/lib/Label';
+import Link from 'next/link';
+
+const GuideForDestinationSetup = ({ dstPeerType }: { dstPeerType: DBType }) => {
+  const linkForDst = () => {
+    switch (dstPeerType) {
+      case DBType.SNOWFLAKE:
+        return 'https://docs.peerdb.io/connect/snowflake';
+      case DBType.BIGQUERY:
+        return 'https://docs.peerdb.io/connect/bigquery';
+      default:
+        return 'https://docs.peerdb.io/';
+    }
+  };
+  if (dstPeerType != DBType.SNOWFLAKE && dstPeerType != DBType.BIGQUERY) {
+    return <></>;
+  }
+  return (
+    <Label variant='body' as='label' style={{ marginBottom: '1rem' }}>
+      We recommend going through our{' '}
+      <Link style={{ color: 'teal' }} href={linkForDst()} target='_blank'>
+        setup guide for {DBTypeToGoodText(dstPeerType)} destinations
+      </Link>
+      .
+    </Label>
+  );
+};
+
+export default GuideForDestinationSetup;

--- a/ui/app/mirrors/create/cdc/tablemapping.tsx
+++ b/ui/app/mirrors/create/cdc/tablemapping.tsx
@@ -2,6 +2,7 @@
 import { DBType } from '@/grpc_generated/peers';
 import { Label } from '@/lib/Label';
 import { SearchField } from '@/lib/SearchField';
+import Link from 'next/link';
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { BarLoader } from 'react-spinners/';
 import { TableMapRow } from '../../../dto/MirrorsDTO';
@@ -39,8 +40,22 @@ const TableMapping = ({
 
   return (
     <div style={{ marginTop: '1rem' }}>
-      <Label as='label' colorName='lowContrast' style={{ fontSize: 14 }}>
+      <Label as='label' colorName='lowContrast' style={{ fontSize: 16 }}>
         Select tables to sync
+      </Label>
+      <br></br>
+      <Label as='label' style={{ fontSize: 15 }}>
+        Before selecting tables, please make sure that{' '}
+        <Link
+          style={{ color: 'teal' }}
+          target='_blank'
+          href={
+            'https://docs.peerdb.io/connect/rds_postgres#creating-peerdb-user-and-granting-permissions'
+          }
+        >
+          these permissions
+        </Link>{' '}
+        have been granted for your tables.
       </Label>
       <div
         style={{

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -87,6 +87,11 @@ const CDCCheck = (
   if (config.doInitialSnapshot == false && config.initialSnapshotOnly == true) {
     return 'Initial Snapshot Only cannot be true if Initial Snapshot is false.';
   }
+
+  if (config.doInitialSnapshot == true && config.replicationSlotName !== '') {
+    config.replicationSlotName = '';
+  }
+
   return '';
 };
 
@@ -107,6 +112,7 @@ const validateCDCFields = (
   if (!tablesValidity.success) {
     validationErr = tablesValidity.error.issues[0].message;
   }
+
   const configValidity = cdcSchema.safeParse(config);
   if (!configValidity.success) {
     validationErr = configValidity.error.issues[0].message;

--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -2,11 +2,11 @@ import { CDCConfig } from '../../../dto/MirrorsDTO';
 import { MirrorSetting } from './common';
 export const cdcSettings: MirrorSetting[] = [
   {
-    label: 'Initial Snapshot',
+    label: 'Initial Copy',
     stateHandler: (value, setter) =>
       setter((curr: CDCConfig) => ({
         ...curr,
-        doInitialCopy: (value as boolean) ?? true,
+        doInitialSnapshot: (value as boolean) ?? true,
       })),
     tips: 'Specify if you want initial load to happen for your tables.',
     type: 'switch',
@@ -117,7 +117,7 @@ export const cdcSettings: MirrorSetting[] = [
     type: 'switch',
   },
   {
-    label: 'Initial Snapshot Only',
+    label: 'Initial Copy Only',
     stateHandler: (value, setter) =>
       setter((curr: CDCConfig) => ({
         ...curr,

--- a/ui/app/mirrors/create/schema.ts
+++ b/ui/app/mirrors/create/schema.ts
@@ -24,7 +24,18 @@ export const tableMappingSchema = z
       partitionKey: z.string().optional(),
     })
   )
-  .nonempty('At least one table mapping is required');
+  .nonempty('At least one table mapping is required')
+  .superRefine((mappingArray, ctx) => {
+    if (
+      mappingArray.map((val) => val.destinationTableIdentifier).length !==
+      new Set(mappingArray).size
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Two source tables have been mapped to the same destination table`,
+      });
+    }
+  });
 
 export const cdcSchema = z.object({
   source: z.object(

--- a/ui/app/mirrors/create/styles.tsx
+++ b/ui/app/mirrors/create/styles.tsx
@@ -1,0 +1,20 @@
+import { CSSProperties } from 'styled-components';
+const MirrorButtonStyle: CSSProperties = {
+  width: '10em',
+  height: '3em',
+  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
+  borderRadius: '2em',
+  fontWeight: 'bold',
+};
+
+const MirrorButtonContainer: CSSProperties = {
+  height: '2rem',
+  display: 'flex',
+  alignItems: 'center',
+  columnGap: '1rem',
+  position: 'fixed',
+  bottom: '5%',
+  right: '5%',
+};
+
+export { MirrorButtonContainer, MirrorButtonStyle };

--- a/ui/app/peers/create/[peerType]/page.tsx
+++ b/ui/app/peers/create/[peerType]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { PeerConfig } from '@/app/dto/PeersDTO';
+import GuideForDestinationSetup from '@/app/mirrors/create/cdc/guide';
 import BigqueryForm from '@/components/PeerForms/BigqueryConfig';
 import ClickhouseForm from '@/components/PeerForms/ClickhouseConfig';
 import PostgresForm from '@/components/PeerForms/PostgresForm';
@@ -78,6 +79,7 @@ export default function CreateConfig({
           {dbType.charAt(0).toUpperCase() + dbType.slice(1).toLowerCase()} peer
         </Label>
       </Panel>
+      <GuideForDestinationSetup dstPeerType={peerType} />
       <Panel>
         <RowWithTextField
           label={


### PR DESCRIPTION
This PR adds a Validate mirror button and corresponding logic to check if the postgres source peer and selected tables are ready to be mirrored. Moves validate peer logic to separate file

This PR covers:

- Check if replication permissions are there for user
- Check if we can do SELECT * FROM TABLE LIMIT 0. for all selected tables.
- If initial copy is selected, they can’t enter the replication slot.
- Check if publication they provide, is attached to all selected tables.
- If no tables show up, remind them check GRANT permissions.
- Validate peer: Don’t let you create < 12 version
- Link to docs in CREATE PEER page.

<img width="1275" alt="Screenshot 2024-01-19 at 7 12 21 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/df64715b-510d-4fd1-99b3-728a9e681ad0">
<img width="1275" alt="Screenshot 2024-01-19 at 7 13 03 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/437b945e-984f-4ed7-9be2-ce4d56e1af1a">
<img width="1275" alt="Screenshot 2024-01-19 at 7 55 41 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/7446e5d5-c0bb-4717-8931-bb9dfc6699b7">
