### PR TITLE
Nexus bq: refactor run tracked

### DIFF
--- a/nexus/peer-bigquery/src/lib.rs
+++ b/nexus/peer-bigquery/src/lib.rs
@@ -89,12 +89,10 @@ impl BigQueryQueryExecutor {
             PgWireError::ApiError(err.into())
         })?;
 
-        let result_set = result_set.map_err(|err| {
+        result_set.map_err(|err| {
             tracing::error!("error running query: {}", err);
             PgWireError::ApiError(err.into())
-        })?;
-
-        Ok(result_set)
+        })
     }
 }
 

--- a/nexus/peer-bigquery/src/lib.rs
+++ b/nexus/peer-bigquery/src/lib.rs
@@ -82,14 +82,15 @@ impl BigQueryQueryExecutor {
             .client
             .job()
             .query(&self.project_id, query_req)
-            .await
-            .map_err(|err| {
-                tracing::error!("error running query: {}", err);
-                PgWireError::ApiError(err.into())
-            })?;
+            .await;
 
         token.end().await.map_err(|err| {
             tracing::error!("error closing tracking token: {}", err);
+            PgWireError::ApiError(err.into())
+        })?;
+
+        let result_set = result_set.map_err(|err| {
+            tracing::error!("error running query: {}", err);
             PgWireError::ApiError(err.into())
         })?;
 


### PR DESCRIPTION
We close the tracker after getting the result set but if we error while obtaining the result set, the token wouldn't get closed. This PR fixes that.