### PR TITLE
Add check for rds replication

### DIFF
--- a/ui/app/mirrors/edit/[mirrorId]/cdcDetails.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/cdcDetails.tsx
@@ -17,7 +17,13 @@ type props = {
   createdAt?: Date;
 };
 function CdcDetails({ syncs, createdAt, mirrorConfig }: props) {
-  let lastSyncedAt = moment(syncs[0]?.endTime).fromNow();
+  let lastSyncedAt = moment(
+    syncs.length > 1
+      ? syncs[1]?.endTime
+      : syncs.length
+        ? syncs[0]?.startTime
+        : new Date()
+  ).fromNow();
   let rowsSynced = syncs.reduce((acc, sync) => {
     if (sync.endTime !== null) {
       return acc + sync.numRows;


### PR DESCRIPTION
In RDS, you cannot add `rolreplication` to a user. Instead, RDS accepts `rds.logical_replication` :

```sql
grant rds_replication to postgres
```

This PR modifies validate mirror to allow for this