### PR TITLE
Validate Peer: Fix check condition

### DIFF
--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -47,7 +47,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 			return nil, err
 		}
 
-		if isValid {
+		if !isValid {
 			return &protos.ValidatePeerResponse{
 				Status: protos.ValidatePeerStatus_INVALID,
 				Message: fmt.Sprintf("%s peer %s must be of version 12 or above. Current version: %d",


### PR DESCRIPTION
Return error on invalid PG version instead of a valid one