### PR TITLE
Validate mirror: account for mixed case

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -590,7 +590,7 @@ func (c *PostgresConnector) CheckSourceTables(tableNames []string, pubName strin
 	// Check that we can select from all tables
 	for _, tableName := range tableNames {
 		var row pgx.Row
-		err := c.pool.QueryRow(c.ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 0;", tableName)).Scan(&row)
+		err := c.pool.QueryRow(c.ctx, fmt.Sprintf("SELECT * FROM \"%s\" LIMIT 0;", tableName)).Scan(&row)
 		if err != nil && err != pgx.ErrNoRows {
 			return err
 		}

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -597,8 +597,8 @@ func (c *PostgresConnector) CheckSourceTables(tableNames []string, pubName strin
 		}
 
 		quotedTableIdentifier := fmt.Sprintf("%s.%s",
-			QuoteIdentifier(schemaName),
-			QuoteIdentifier(tableName))
+			QuoteLiteral(schemaName),
+			QuoteLiteral(tableName))
 		tableArr = append(tableArr, quotedTableIdentifier)
 		err := c.pool.QueryRow(c.ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 0;", quotedTableIdentifier)).Scan(&row)
 		if err != nil && err != pgx.ErrNoRows {


### PR DESCRIPTION
Forgot to quote the source table identifiers we use in validate mirror's source table check