### PR TITLE
Numeric: adjust precision handling

### DIFF
--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	hstore_util "github.com/PeerDB-io/peer-flow/hstore"
+	"github.com/PeerDB-io/peer-flow/model/numeric"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
 )
@@ -215,7 +216,7 @@ func (r *RecordItems) toMap(hstoreAsJSON bool) (map[string]interface{}, error) {
 			if !ok {
 				return nil, errors.New("expected *big.Rat value")
 			}
-			jsonStruct[col] = bigRat.FloatString(9)
+			jsonStruct[col] = bigRat.FloatString(numeric.PeerDBNumericScale)
 		case qvalue.QValueKindFloat64:
 			floatVal, ok := v.Value.(float64)
 			if !ok {

--- a/flow/model/numeric/scale.go
+++ b/flow/model/numeric/scale.go
@@ -1,0 +1,3 @@
+package numeric
+
+const PeerDBNumericScale = 9

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	hstore_util "github.com/PeerDB-io/peer-flow/hstore"
+	"github.com/PeerDB-io/peer-flow/model/numeric"
 	"github.com/google/uuid"
 	"github.com/linkedin/goavro/v2"
 )
@@ -323,7 +324,7 @@ func (c *QValueAvroConverter) processNumeric() (interface{}, error) {
 		return nil, fmt.Errorf("invalid Numeric value: expected *big.Rat, got %T", c.Value.Value)
 	}
 
-	scale := 9
+	scale := numeric.PeerDBNumericScale
 	decimalValue := num.FloatString(scale)
 	num.SetString(decimalValue)
 	if c.Nullable {

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -323,6 +323,9 @@ func (c *QValueAvroConverter) processNumeric() (interface{}, error) {
 		return nil, fmt.Errorf("invalid Numeric value: expected *big.Rat, got %T", c.Value.Value)
 	}
 
+	scale := 9
+	decimalValue := num.FloatString(scale)
+	num.SetString(decimalValue)
 	if c.Nullable {
 		return goavro.Union("bytes.decimal", num), nil
 	}


### PR DESCRIPTION
`200` was being synced as `199.99999999` in initial load for PostgreSQL -> Snowflake. It resided in a numeric column.

Noticed that in ToJSON where we transform numerics and other types for raw table insertion, we set the scale to 9 to conform with the scale value we've chosen for Snowflake for Numeric values (Number(38,9)). And this issue isn't present in CDC.

This PR does the same at `processNumeric` in the Avro transform step where we write to Avro files