### PR TITLE
Remove CDCRecordStream SchemaDeltas

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -494,7 +494,7 @@ func (c *BigQueryConnector) syncRecordsViaAvro(
 	syncBatchID int64,
 ) (*model.SyncResponse, error) {
 	tableNameRowsMapping := make(map[string]uint32)
-	streamReq := model.NewRecordsToStreamRequest(req.Records.GetRecords(), tableNameRowsMapping, syncBatchID)
+	streamReq := model.NewRecordsToStreamRequest(req.Records.GetRecords(), req.TableMappings, tableNameRowsMapping, syncBatchID)
 	streamRes, err := utils.RecordsToRawTableStream(streamReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert records to raw table stream: %w", err)
@@ -507,7 +507,7 @@ func (c *BigQueryConnector) syncRecordsViaAvro(
 	}
 
 	res, err := avroSync.SyncRecords(req, rawTableName,
-		rawTableMetadata, syncBatchID, streamRes.Stream, streamReq.TableMapping)
+		rawTableMetadata, syncBatchID, streamRes, streamReq.TableNameRowsMapping)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sync records via avro: %w", err)
 	}

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -108,8 +108,8 @@ func getChildToParentRelIDMap(ctx context.Context, pool *pgxpool.Pool) (map[uint
 				parent.oid AS parentrelid,
 				child.oid AS childrelid
 		FROM pg_inherits
-				JOIN pg_class parent            ON pg_inherits.inhparent = parent.oid
-				JOIN pg_class child             ON pg_inherits.inhrelid   = child.oid
+				JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
+				JOIN pg_class child  ON pg_inherits.inhrelid  = child.oid
 		WHERE parent.relkind='p';
 	`
 
@@ -507,7 +507,7 @@ func (p *PostgresCDCSource) consumeStream(
 					if len(tableSchemaDelta.AddedColumns) > 0 {
 						p.logger.Info(fmt.Sprintf("Detected schema change for table %s, addedColumns: %v",
 							tableSchemaDelta.SrcTableName, tableSchemaDelta.AddedColumns))
-						records.SchemaDeltas <- tableSchemaDelta
+						records.AddRecord(rec)
 					}
 				}
 			}

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -185,7 +185,7 @@ func (c *S3Connector) SetLastOffset(jobName string, offset int64) error {
 
 func (c *S3Connector) SyncRecords(req *model.SyncRecordsRequest) (*model.SyncResponse, error) {
 	tableNameRowsMapping := make(map[string]uint32)
-	streamReq := model.NewRecordsToStreamRequest(req.Records.GetRecords(), tableNameRowsMapping, req.SyncBatchID)
+	streamReq := model.NewRecordsToStreamRequest(req.Records.GetRecords(), req.TableMappings, tableNameRowsMapping, req.SyncBatchID)
 	streamRes, err := utils.RecordsToRawTableStream(streamReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert records to raw table stream: %w", err)
@@ -224,7 +224,7 @@ func (c *S3Connector) SyncRecords(req *model.SyncRecordsRequest) (*model.SyncRes
 		LastSyncedCheckpointID: lastCheckpoint,
 		NumRecordsSynced:       int64(numRecords),
 		TableNameRowsMapping:   tableNameRowsMapping,
-		TableSchemaDeltas:      req.Records.WaitForSchemaDeltas(req.TableMappings),
+		TableSchemaDeltas:      streamRes.TableSchemaDeltas,
 	}, nil
 }
 

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"slices"
 	"sync/atomic"
 	"time"
 
@@ -424,8 +423,6 @@ type TableWithPkey struct {
 type CDCRecordStream struct {
 	// Records are a list of json objects.
 	records chan Record
-	// Schema changes from the slot
-	SchemaDeltas chan *protos.TableSchemaDelta
 	// Indicates if the last checkpoint has been set.
 	lastCheckpointSet bool
 	// lastCheckpointID is the last ID of the commit that corresponds to this batch.
@@ -437,9 +434,7 @@ type CDCRecordStream struct {
 func NewCDCRecordStream() *CDCRecordStream {
 	channelBuffer := peerdbenv.PeerDBCDCChannelBufferSize()
 	return &CDCRecordStream{
-		records: make(chan Record, channelBuffer),
-		// TODO (kaushik): more than 1024 schema deltas can cause problems!
-		SchemaDeltas:      make(chan *protos.TableSchemaDelta, 1<<10),
+		records:           make(chan Record, channelBuffer),
 		emptySignal:       make(chan bool, 1),
 		lastCheckpointSet: false,
 		lastCheckpointID:  atomic.Int64{},
@@ -479,40 +474,9 @@ func (r *CDCRecordStream) WaitAndCheckEmpty() bool {
 	return isEmpty
 }
 
-func (r *CDCRecordStream) WaitForSchemaDeltas(tableMappings []*protos.TableMapping) []*protos.TableSchemaDelta {
-	schemaDeltas := make([]*protos.TableSchemaDelta, 0)
-schemaLoop:
-	for delta := range r.SchemaDeltas {
-		for _, tm := range tableMappings {
-			if delta.SrcTableName == tm.SourceTableIdentifier && delta.DstTableName == tm.DestinationTableIdentifier {
-				if len(tm.Exclude) == 0 {
-					break
-				}
-				added := make([]*protos.DeltaAddedColumn, 0, len(delta.AddedColumns))
-				for _, column := range delta.AddedColumns {
-					if !slices.Contains(tm.Exclude, column.ColumnName) {
-						added = append(added, column)
-					}
-				}
-				if len(added) != 0 {
-					schemaDeltas = append(schemaDeltas, &protos.TableSchemaDelta{
-						SrcTableName: delta.SrcTableName,
-						DstTableName: delta.DstTableName,
-						AddedColumns: added,
-					})
-				}
-				continue schemaLoop
-			}
-		}
-		schemaDeltas = append(schemaDeltas, delta)
-	}
-	return schemaDeltas
-}
-
 func (r *CDCRecordStream) Close() {
 	close(r.emptySignal)
 	close(r.records)
-	close(r.SchemaDeltas)
 	r.lastCheckpointSet = true
 }
 

--- a/flow/model/qrecord_stream.go
+++ b/flow/model/qrecord_stream.go
@@ -1,6 +1,10 @@
 package model
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+)
 
 type QRecordOrError struct {
 	Record QRecord
@@ -20,20 +24,23 @@ type QRecordStream struct {
 }
 
 type RecordsToStreamRequest struct {
-	records      <-chan Record
-	TableMapping map[string]uint32
-	BatchID      int64
+	records              <-chan Record
+	TableMappings        []*protos.TableMapping
+	TableNameRowsMapping map[string]uint32
+	BatchID              int64
 }
 
 func NewRecordsToStreamRequest(
 	records <-chan Record,
-	tableMapping map[string]uint32,
+	tableMappings []*protos.TableMapping,
+	tableNameRowsMapping map[string]uint32,
 	batchID int64,
 ) *RecordsToStreamRequest {
 	return &RecordsToStreamRequest{
-		records:      records,
-		TableMapping: tableMapping,
-		BatchID:      batchID,
+		records:              records,
+		TableMappings:        tableMappings,
+		TableNameRowsMapping: tableNameRowsMapping,
+		BatchID:              batchID,
 	}
 }
 
@@ -42,7 +49,8 @@ func (r *RecordsToStreamRequest) GetRecords() <-chan Record {
 }
 
 type RecordsToStreamResponse struct {
-	Stream *QRecordStream
+	Stream            *QRecordStream
+	TableSchemaDeltas []*protos.TableSchemaDelta
 }
 
 func NewQRecordStream(buffer int) *QRecordStream {


### PR DESCRIPTION
Instead `RelationRecord` is passed in with rest of `Records`,
where connectors handle collecting schema deltas