### PR TITLE
nexus: don't send quoting to grpc

### DIFF
--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -186,10 +186,8 @@ func (c *EventHubConnector) processBatch(
 			partitionColumn := destination.PartitionKeyColumn
 			partitionValue := record.GetItems().GetColumnValue(partitionColumn).Value
 			var partitionKey string
-			if partitionValue == nil {
-				partitionKey = ""
-			} else {
-				partitionKey = fmt.Sprintf("%v", partitionValue)
+			if partitionValue != nil {
+				partitionKey = fmt.Sprint(partitionValue)
 			}
 			partitionKey = utils.HashedPartitionKey(partitionKey, numPartitions)
 			destination.SetPartitionValue(partitionKey)

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -176,11 +176,11 @@ impl<'a> StatementAnalyzer for PeerDDLAnalyzer<'a> {
                                 partition_key: table_mapping
                                     .partition_key
                                     .as_ref()
-                                    .map(|s| s.to_string()),
+                                    .map(|s| s.value.clone()),
                                 exclude: table_mapping
                                     .exclude
                                     .as_ref()
-                                    .map(|ss| ss.iter().map(|s| s.to_string()).collect())
+                                    .map(|ss| ss.iter().map(|s| s.value.clone()).collect())
                                     .unwrap_or_default(),
                             });
                         }


### PR DESCRIPTION
Ident::to_string preserves quoting, so
```
exclude:["c2"]
exclude:[c2]
```
send different things to grpc endpoint,
which expects unquoted strings

Same goes for PartitionKeyColumn