### PR TITLE
Avoid log.Fatalf in connector code, return error instead

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -897,7 +897,7 @@ func (p *PostgresCDCSource) recToTablePKey(req *model.PullRecordsRequest,
 		if err != nil {
 			return nil, fmt.Errorf("error getting pkey column value: %w", err)
 		}
-		pkeyColsMerged = append(pkeyColsMerged, []byte(fmt.Sprintf("%v", pkeyColVal.Value))...)
+		pkeyColsMerged = append(pkeyColsMerged, []byte(fmt.Sprint(pkeyColVal.Value))...)
 	}
 
 	return &model.TableWithPkey{

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -505,12 +505,7 @@ func NewTStructuredLogger(logger slog.Logger) *TStructuredLogger {
 }
 
 func (l *TStructuredLogger) keyvalsToFields(keyvals []interface{}) slog.Attr {
-	var attrs []any
-	for i := 0; i < len(keyvals); i += 1 {
-		key := fmt.Sprintf("%v", keyvals[i])
-		attrs = append(attrs, key)
-	}
-	return slog.Group("test-log", attrs...)
+	return slog.Group("test-log", keyvals...)
 }
 
 func (l *TStructuredLogger) Debug(msg string, keyvals ...interface{}) {

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -235,13 +235,9 @@ func (q *QRepFlowExecution) processPartitions(
 		chunkSize = 1
 	}
 
-	batches := make([][]*protos.QRepPartition, 0)
+	batches := make([][]*protos.QRepPartition, 0, len(partitions)/chunkSize+1)
 	for i := 0; i < len(partitions); i += chunkSize {
-		end := i + chunkSize
-		if end > len(partitions) {
-			end = len(partitions)
-		}
-
+		end := min(i+chunkSize, len(partitions))
 		batches = append(batches, partitions[i:end])
 	}
 


### PR DESCRIPTION
We don't want temporal activities calling `os.Exit`

Also prefer `fmt.Sprint(x)` to `fmt.Sprintf("%v", x)`