### PR TITLE
Eventhub: Fix Partitioning

### DIFF
--- a/flow/connectors/eventhub/hubmanager.go
+++ b/flow/connectors/eventhub/hubmanager.go
@@ -125,12 +125,11 @@ func (m *EventHubManager) CreateEventDataBatch(ctx context.Context, destination 
 	if err != nil {
 		return nil, err
 	}
-
+	slog.Info("creating event data batch", slog.Any("destination", destination.PartitionKeyValue))
 	opts := &azeventhubs.EventDataBatchOptions{
-		// Eventhubs internally does the routing
-		// to partition based on hash of the partition key.
-		// Same partition key is guaranteed to map to same partition.
-		PartitionKey: &destination.PartitionKeyValue,
+		// We want to route same hashed partition value
+		// to same partition.
+		PartitionID: &destination.PartitionKeyValue,
 	}
 	batch, err := hub.NewEventDataBatch(ctx, opts)
 	if err != nil {

--- a/flow/connectors/eventhub/hubmanager.go
+++ b/flow/connectors/eventhub/hubmanager.go
@@ -125,7 +125,7 @@ func (m *EventHubManager) CreateEventDataBatch(ctx context.Context, destination 
 	if err != nil {
 		return nil, err
 	}
-	slog.Info("creating event data batch", slog.Any("destination", destination.PartitionKeyValue))
+
 	opts := &azeventhubs.EventDataBatchOptions{
 		// We want to route same hashed partition value
 		// to same partition.


### PR DESCRIPTION
Eventhub's PartitionKey based routing for some reason was routing to only the first and the last partitions.
So route to PartitionID instead.