### PR TITLE
lint: rowserrcheck

### DIFF
--- a/flow/.golangci.yml
+++ b/flow/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - nonamedreturns
     - perfsprint
     - prealloc
+    - rowserrcheck
     - staticcheck
     - stylecheck
     - sqlclosecheck

--- a/flow/connectors/clickhouse/qrep.go
+++ b/flow/connectors/clickhouse/qrep.go
@@ -79,6 +79,7 @@ func (c *ClickhouseConnector) createMetadataInsertStatement(
 func (c *ClickhouseConnector) getTableSchema(tableName string) ([]*sql.ColumnType, error) {
 	//nolint:gosec
 	queryString := fmt.Sprintf(`SELECT * FROM %s LIMIT 0`, tableName)
+	//nolint:rowserrcheck
 	rows, err := c.database.Query(queryString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -82,12 +82,9 @@ func (c *SnowflakeConnector) getTableSchema(tableName string) ([]*sql.ColumnType
 	}
 
 	//nolint:gosec
-	queryString := fmt.Sprintf(`
-	SELECT *
-	FROM %s
-	LIMIT 0
-	`, snowflakeSchemaTableNormalize(schematable))
+	queryString := fmt.Sprintf("SELECT * FROM %s LIMIT 0", snowflakeSchemaTableNormalize(schematable))
 
+	//nolint:rowserrcheck
 	rows, err := c.database.QueryContext(c.ctx, queryString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
@@ -301,6 +298,11 @@ func (c *SnowflakeConnector) getColsFromTable(tableName string) ([]string, []str
 		}
 		colNames = append(colNames, colName.String)
 		colTypes = append(colTypes, colType.String)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read rows: %w", err)
 	}
 
 	if len(colNames) == 0 {


### PR DESCRIPTION
It turns out `rows.Next()` can return false on error, avoiding error detection with `rows.Scan`

See https://github.com/golangci/golangci-lint/issues/945

Fix that. In particular, `QueryRowContext` with checking for `sql.ErrNowRows` is much simpler when expecting 0 or 1 results

Mark two false positives when only wanting schema of `LIMIT 0` query