### PR TITLE
Always set application_name when connecting to postgres

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -51,7 +51,7 @@ func NewPostgresConnector(ctx context.Context, pgConfig *protos.PostgresConfig) 
 	}
 
 	runtimeParams := connConfig.Config.RuntimeParams
-	runtimeParams["application_name"] = "peerdb_query_executor"
+	runtimeParams["application_name"] = "peerdb"
 	runtimeParams["idle_in_transaction_session_timeout"] = "0"
 	runtimeParams["statement_timeout"] = "0"
 
@@ -66,6 +66,7 @@ func NewPostgresConnector(ctx context.Context, pgConfig *protos.PostgresConfig) 
 	}
 
 	// ensure that replication is set to database
+	replConfig.Config.RuntimeParams["application_name"] = "peerdb"
 	replConfig.Config.RuntimeParams["replication"] = "database"
 	replConfig.Config.RuntimeParams["bytea_output"] = "hex"
 

--- a/nexus/postgres-connection/src/lib.rs
+++ b/nexus/postgres-connection/src/lib.rs
@@ -58,7 +58,7 @@ impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
 pub fn get_pg_connection_string(config: &PostgresConfig) -> String {
     let mut connection_string = String::from("postgres://");
 
-    connection_string.push_str(&config.user);
+    connection_string.push_str(&urlencoding::encode(&config.user));
     if !config.password.is_empty() {
         connection_string.push(':');
         connection_string.push_str(&urlencoding::encode(&config.password));
@@ -67,8 +67,8 @@ pub fn get_pg_connection_string(config: &PostgresConfig) -> String {
     // Add the timeout as a query parameter, sslmode changes here appear to be useless
     write!(
         connection_string,
-        "@{}:{}/{}?connect_timeout=15",
-        config.host, config.port, config.database
+        "@{}:{}/{}?connect_timeout=15&application_name=peerdb_nexus",
+        config.host, config.port, urlencoding::encode(&config.database)
     )
     .ok();
 


### PR DESCRIPTION
Nexus application_name is peerdb_nexus since those queries can be user generated

Remove unused code for creating pool over ssh tunnel