### PR TITLE
external metadata: replace IncrementID with FinishBatch

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -133,12 +133,7 @@ func (c *ClickhouseConnector) SyncRecords(req *model.SyncRecordsRequest) (*model
 		return nil, fmt.Errorf("failed to get last checkpoint: %w", err)
 	}
 
-	err = c.SetLastOffset(req.FlowJobName, lastCheckpoint)
-	if err != nil {
-		c.logger.Error("failed to update last offset for s3 cdc", slog.Any("error", err))
-		return nil, err
-	}
-	err = c.pgMetadata.IncrementID(req.FlowJobName)
+	err = c.pgMetadata.FinishBatch(req.FlowJobName, req.SyncBatchID, lastCheckpoint)
 	if err != nil {
 		c.logger.Error("failed to increment id", slog.Any("error", err))
 		return nil, err

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -236,12 +236,7 @@ func (c *EventHubConnector) SyncRecords(req *model.SyncRecordsRequest) (*model.S
 		return nil, err
 	}
 
-	err = c.SetLastOffset(req.FlowJobName, lastCheckpoint)
-	if err != nil {
-		c.logger.Error("failed to update last offset", slog.Any("error", err))
-		return nil, err
-	}
-	err = c.pgMetadata.IncrementID(req.FlowJobName)
+	err = c.pgMetadata.FinishBatch(req.FlowJobName, req.SyncBatchID, lastCheckpoint)
 	if err != nil {
 		c.logger.Error("failed to increment id", slog.Any("error", err))
 		return nil, err

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -209,12 +209,7 @@ func (c *S3Connector) SyncRecords(req *model.SyncRecordsRequest) (*model.SyncRes
 		return nil, fmt.Errorf("failed to get last checkpoint: %w", err)
 	}
 
-	err = c.SetLastOffset(req.FlowJobName, lastCheckpoint)
-	if err != nil {
-		c.logger.Error("failed to update last offset for s3 cdc", slog.Any("error", err))
-		return nil, err
-	}
-	err = c.pgMetadata.IncrementID(req.FlowJobName)
+	err = c.pgMetadata.FinishBatch(req.FlowJobName, req.SyncBatchID, lastCheckpoint)
 	if err != nil {
 		c.logger.Error("failed to increment id", slog.Any("error", err))
 		return nil, err


### PR DESCRIPTION
This stops relying on SyncBatchID being tightly sequential,
& combines SetLastOffset/IncrementID

Also remove unnecessary transaction in UpdateLastOffset