### PR TITLE
Fix numeric datatype

### DIFF
--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"math/big"
 	"strings"
 	"time"
@@ -525,12 +524,15 @@ func numericToRat(numVal *pgtype.Numeric) (*big.Rat, error) {
 			return nil, errors.New("numeric value is infinity")
 		}
 
-		rat := new(big.Rat)
-
-		rat.SetInt(numVal.Int)
-		divisor := new(big.Rat).SetFloat64(math.Pow10(int(-numVal.Exp)))
-		rat.Quo(rat, divisor)
-
+		rat := new(big.Rat).SetInt(numVal.Int)
+		big10 := big.NewInt(10)
+		if numVal.Exp > 0 {
+			mul := new(big.Int).Exp(big10, big.NewInt(int64(numVal.Exp)), nil)
+			rat.Mul(rat, new(big.Rat).SetInt(mul))
+		} else if numVal.Exp < 0 {
+			mul := new(big.Int).Exp(big10, big.NewInt(int64(-numVal.Exp)), nil)
+			rat.Quo(rat, new(big.Rat).SetInt(mul))
+		}
 		return rat, nil
 	}
 

--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -15,6 +15,8 @@ import (
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 )
 
+var big10 = big.NewInt(10)
+
 func postgresOIDToQValueKind(recvOID uint32) qvalue.QValueKind {
 	switch recvOID {
 	case pgtype.BoolOID:
@@ -525,7 +527,6 @@ func numericToRat(numVal *pgtype.Numeric) (*big.Rat, error) {
 		}
 
 		rat := new(big.Rat).SetInt(numVal.Int)
-		big10 := big.NewInt(10)
 		if numVal.Exp > 0 {
 			mul := new(big.Int).Exp(big10, big.NewInt(int64(numVal.Exp)), nil)
 			rat.Mul(rat, new(big.Rat).SetInt(mul))

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -298,7 +298,7 @@ func PopulateSourceTable(conn *pgx.Conn, suffix string, tableName string, rowCou
 						1, 0, 1, 'dealType1',
 						'%s', '%s', false, 1.2345,
 						1.2345, false, 200.12345678, '%s',
-						12345, 1, '%s', CURRENT_TIMESTAMP, 'refID',
+						200, 1, '%s', CURRENT_TIMESTAMP, 'refID',
 						CURRENT_TIMESTAMP, 1, ARRAY['text1', 'text2'], ARRAY[123, 456], ARRAY[789, 012],
 						ARRAY['varchar1', 'varchar2'], '{"key": -8.02139037433155}',
 						'[{"key1": "value1", "key2": "value2", "key3": "value3"}]',

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -297,7 +297,7 @@ func PopulateSourceTable(conn *pgx.Conn, suffix string, tableName string, rowCou
 						CURRENT_TIMESTAMP, E'\\\\xDEADBEEF', 'type1', '%s',
 						1, 0, 1, 'dealType1',
 						'%s', '%s', false, 1.2345,
-						1.2345, false, 12345, '%s',
+						1.2345, false, 200.12345678, '%s',
 						12345, 1, '%s', CURRENT_TIMESTAMP, 'refID',
 						CURRENT_TIMESTAMP, 1, ARRAY['text1', 'text2'], ARRAY[123, 456], ARRAY[789, 012],
 						ARRAY['varchar1', 'varchar2'], '{"key": -8.02139037433155}',

--- a/flow/model/numeric/scale.go
+++ b/flow/model/numeric/scale.go
@@ -1,3 +1,11 @@
 package numeric
 
+import "strings"
+
 const PeerDBNumericScale = 9
+
+func StripTrailingZeros(value string) string {
+	value = strings.TrimRight(value, "0")
+	value = strings.TrimSuffix(value, ".")
+	return value
+}

--- a/flow/model/qvalue/qvalue.go
+++ b/flow/model/qvalue/qvalue.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/PeerDB-io/peer-flow/geo"
 	hstore_util "github.com/PeerDB-io/peer-flow/hstore"
+	"github.com/PeerDB-io/peer-flow/model/numeric"
 )
 
 // if new types are added, register them in gob - cdc_records_storage.go
@@ -226,8 +227,8 @@ func compareNumeric(value1, value2 interface{}) bool {
 	}
 
 	// check if the values have less than or equal to 9 significant digits right of the decimal
-	str1 := rat1.FloatString(10)
-	str2 := rat2.FloatString(10)
+	str1 := numeric.StripTrailingZeros(rat1.FloatString(10))
+	str2 := numeric.StripTrailingZeros(rat2.FloatString(10))
 	if len(str1) > 2 && len(str2) > 2 {
 		decimals1 := len(str1) - strings.Index(str1, ".") - 1
 		decimals2 := len(str2) - strings.Index(str2, ".") - 1

--- a/flow/model/qvalue/qvalue.go
+++ b/flow/model/qvalue/qvalue.go
@@ -226,12 +226,12 @@ func compareNumeric(value1, value2 interface{}) bool {
 		return false
 	}
 
-	// check if the values have less than or equal to 9 significant digits right of the decimal
 	str1 := numeric.StripTrailingZeros(rat1.FloatString(10))
 	str2 := numeric.StripTrailingZeros(rat2.FloatString(10))
 	if len(str1) > 2 && len(str2) > 2 {
 		decimals1 := len(str1) - strings.Index(str1, ".") - 1
 		decimals2 := len(str2) - strings.Index(str2, ".") - 1
+		// for cases like 1.12345 or 1.12345678, check exact equality
 		if decimals1 <= 9 && decimals2 <= 9 {
 			return str1 == str2
 		} else {

--- a/flow/model/qvalue/qvalue.go
+++ b/flow/model/qvalue/qvalue.go
@@ -243,7 +243,7 @@ func compareNumeric(value1, value2 interface{}) bool {
 		}
 	}
 
-	return false
+	return str1 == str2
 }
 
 func compareString(value1, value2 interface{}) bool {

--- a/flow/model/qvalue/qvalue.go
+++ b/flow/model/qvalue/qvalue.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/civil"
@@ -224,9 +225,24 @@ func compareNumeric(value1, value2 interface{}) bool {
 		return false
 	}
 
-	// check if the difference is less than 1e-9
-	diff := new(big.Rat).Sub(rat1, rat2)
-	return diff.Abs(diff).Cmp(big.NewRat(1, 1000000000)) < 0
+	// check if the values have less than or equal to 9 significant digits right of the decimal
+	str1 := rat1.FloatString(10)
+	str2 := rat2.FloatString(10)
+	if len(str1) > 2 && len(str2) > 2 {
+		decimals1 := len(str1) - strings.Index(str1, ".") - 1
+		decimals2 := len(str2) - strings.Index(str2, ".") - 1
+		if decimals1 <= 9 && decimals2 <= 9 {
+			return str1 == str2
+		} else {
+			// check if the difference is less than 1e-9
+			diff := new(big.Rat).Sub(rat1, rat2)
+			if diff.Cmp(big.NewRat(1, 1000000000)) < 0 {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func compareString(value1, value2 interface{}) bool {


### PR DESCRIPTION
**Pull side:** The way we were converting pgtype numeric to big.Rat was incorrect. Resulted in integers being written as 200 -> 199.99999 for PG->PG Qrep. This was caught by setting better values for numerics in our qrep tests. This PR adapts the logic from [jackc's numeric.go](https://github.com/jackc/pgtype/blob/31dd0e442de8bbd1fbf0865b3c76d40708d3e429/numeric.go#L422)

**compareNumeric:** For numbers like 1.123 or 1.12345678 (less than 9 digits to the right), we now assert that they should be exactly equal. If one of the values has more than 9 digits to the right, we fall back to the difference less than 1e9 check. 

This change was tested with the old `processNumeric` code, and it caught the suboptimal conversion of 200 -> 199.9999...
