### PR TITLE
Drop Mirror Fix: Prevent continueasnew

### DIFF
--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -614,5 +614,9 @@ func CDCFlowWorkflowWithConfig(
 
 	finishNormalize()
 	state.TruncateProgress(w.logger)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	return state, workflow.NewContinueAsNewError(ctx, CDCFlowWorkflowWithConfig, cfg, limits, state)
 }

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -525,7 +525,9 @@ func QRepFlowWorkflow(
 			}
 		}
 	}
-
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// Continue the workflow with new state
 	return workflow.NewContinueAsNewError(ctx, QRepFlowWorkflow, config, state)
 }

--- a/flow/workflows/xmin_flow.go
+++ b/flow/workflows/xmin_flow.go
@@ -111,6 +111,9 @@ func XminFlowWorkflow(
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// Continue the workflow with new state
 	return workflow.NewContinueAsNewError(ctx, XminFlowWorkflow, config, state)
 }


### PR DESCRIPTION
An issue with drop mirror was seen where the peer flow would continue as new and sync, normalize flows would be spawned
This PR catches erred contexts before returning ContinueAsNew in CDC, qrep and xmin flows
This has been manually tested