### PR TITLE
UI: Resync button

### DIFF
--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -12,6 +12,12 @@ import (
 func (h *FlowRequestHandler) ValidateCDCMirror(
 	ctx context.Context, req *protos.CreateCDCFlowRequest,
 ) (*protos.ValidateCDCMirrorResponse, error) {
+	if req.ConnectionConfigs == nil {
+		slog.Error("/validatecdc connection configs is nil")
+		return &protos.ValidateCDCMirrorResponse{
+			Ok: false,
+		}, fmt.Errorf("connection configs is nil")
+	}
 	sourcePeerConfig := req.ConnectionConfigs.Source.GetPostgresConfig()
 	if sourcePeerConfig == nil {
 		slog.Error("/validatecdc source peer config is nil", slog.Any("peer", req.ConnectionConfigs.Source))

--- a/ui/app/mirrors/edit/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/page.tsx
@@ -1,5 +1,7 @@
 import { SyncStatusRow } from '@/app/dto/MirrorsDTO';
 import prisma from '@/app/utils/prisma';
+import { ResyncDialog } from '@/components/ResyncDialog';
+import { FlowConnectionConfigs } from '@/grpc_generated/flow';
 import { MirrorStatusResponse } from '@/grpc_generated/route';
 import { Header } from '@/lib/Header';
 import { LayoutMain } from '@/lib/Layout';
@@ -8,9 +10,6 @@ import { redirect } from 'next/navigation';
 import { CDCMirror } from './cdc';
 import NoMirror from './nomirror';
 import SyncStatus from './syncStatus';
-import { FlowConnectionConfigs, FlowStatus } from '@/grpc_generated/flow';
-import { Button } from '@/lib/Button';
-import { ResyncDialog } from '@/components/ResyncDialog';
 
 type EditMirrorProps = {
   params: { mirrorId: string };
@@ -92,11 +91,21 @@ export default async function ViewMirror({
 
   return (
     <LayoutMain alignSelf='flex-start' justifySelf='flex-start' width='full'>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent:'space-between', paddingRight:'2rem' }}>
-        <div style={{ display: 'flex', alignItems: 'center'}}>
-        <Header variant='title2'>{mirrorId}</Header>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingRight: '2rem',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <Header variant='title2'>{mirrorId}</Header>
         </div>
-        <ResyncDialog mirrorConfig={mirrorConfig} workflowId={mirrorInfo.workflow_id||''}/>
+        <ResyncDialog
+          mirrorConfig={mirrorConfig}
+          workflowId={mirrorInfo.workflow_id || ''}
+        />
       </div>
       <CDCMirror
         rows={rows}

--- a/ui/app/mirrors/edit/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/edit/[mirrorId]/page.tsx
@@ -8,6 +8,9 @@ import { redirect } from 'next/navigation';
 import { CDCMirror } from './cdc';
 import NoMirror from './nomirror';
 import SyncStatus from './syncStatus';
+import { FlowConnectionConfigs, FlowStatus } from '@/grpc_generated/flow';
+import { Button } from '@/lib/Button';
+import { ResyncDialog } from '@/components/ResyncDialog';
 
 type EditMirrorProps = {
   params: { mirrorId: string };
@@ -25,7 +28,7 @@ async function getMirrorStatus(mirrorId: string) {
   return json;
 }
 
-export default async function EditMirror({
+export default async function ViewMirror({
   params: { mirrorId },
 }: EditMirrorProps) {
   const mirrorStatus: MirrorStatusResponse = await getMirrorStatus(mirrorId);
@@ -37,6 +40,7 @@ export default async function EditMirror({
     select: {
       created_at: true,
       workflow_id: true,
+      config_proto: true,
     },
     where: {
       name: mirrorId,
@@ -67,6 +71,10 @@ export default async function EditMirror({
     return <NoMirror />;
   }
 
+  if (!mirrorInfo) {
+    return <div>No mirror info found</div>;
+  }
+  const mirrorConfig = FlowConnectionConfigs.decode(mirrorInfo.config_proto!);
   let syncStatusChild = <></>;
   if (mirrorStatus.cdcStatus) {
     let rowsSynced = syncs.reduce((acc, sync) => {
@@ -84,7 +92,12 @@ export default async function EditMirror({
 
   return (
     <LayoutMain alignSelf='flex-start' justifySelf='flex-start' width='full'>
-      <Header variant='title2'>{mirrorId}</Header>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent:'space-between', paddingRight:'2rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center'}}>
+        <Header variant='title2'>{mirrorId}</Header>
+        </div>
+        <ResyncDialog mirrorConfig={mirrorConfig} workflowId={mirrorInfo.workflow_id||''}/>
+      </div>
       <CDCMirror
         rows={rows}
         createdAt={mirrorInfo?.created_at}

--- a/ui/components/DropDialog.tsx
+++ b/ui/components/DropDialog.tsx
@@ -26,13 +26,13 @@ interface deleteAlertArgs {
   id: number | bigint;
 }
 
-export const handleDropMirror = async (dropArgs: dropMirrorArgs,
-  setLoading:Dispatch<SetStateAction<boolean>>,
-  setMsg:Dispatch<SetStateAction<string>>
-  ) => {
+export const handleDropMirror = async (
+  dropArgs: dropMirrorArgs,
+  setLoading: Dispatch<SetStateAction<boolean>>,
+  setMsg: Dispatch<SetStateAction<string>>
+) => {
   if (!dropArgs.workflowId) {
     setMsg('Workflow ID not found for this mirror.');
-    console.log('Workflow ID not found for this mirror.')
     return false;
   }
   setLoading(true);
@@ -41,7 +41,7 @@ export const handleDropMirror = async (dropArgs: dropMirrorArgs,
     body: JSON.stringify(dropArgs),
   }).then((res) => res.json());
   setLoading(false);
-  if (dropRes.dropped !== true){
+  if (dropRes.dropped !== true) {
     setMsg(
       `Unable to drop mirror ${dropArgs.flowJobName}. ${
         dropRes.errorMessage ?? ''
@@ -51,10 +51,10 @@ export const handleDropMirror = async (dropArgs: dropMirrorArgs,
   }
 
   setMsg('Mirror dropped successfully.');
-  if(!dropArgs.forResync){
+  if (!dropArgs.forResync) {
     window.location.reload();
   }
-  
+
   return true;
 };
 
@@ -147,7 +147,11 @@ export const DropDialog = ({
           <Button
             onClick={() =>
               mode === 'MIRROR'
-                ? handleDropMirror(dropArgs as dropMirrorArgs, setLoading, setMsg)
+                ? handleDropMirror(
+                    dropArgs as dropMirrorArgs,
+                    setLoading,
+                    setMsg
+                  )
                 : mode === 'PEER'
                   ? handleDropPeer(dropArgs as dropPeerArgs)
                   : handleDeleteAlert(dropArgs as deleteAlertArgs)

--- a/ui/components/ResyncDialog.tsx
+++ b/ui/components/ResyncDialog.tsx
@@ -1,0 +1,98 @@
+'use client';
+import { CDCConfig } from '@/app/dto/MirrorsDTO';
+import { Button } from '@/lib/Button';
+import { Dialog, DialogClose } from '@/lib/Dialog';
+import { Label } from '@/lib/Label';
+import { Divider } from '@tremor/react';
+import { useState } from 'react';
+import { BarLoader, ClipLoader, DotLoader } from 'react-spinners';
+import { handleDropMirror } from './DropDialog';
+
+export const ResyncDialog = ({
+  mirrorConfig,
+  workflowId,
+}: {
+  mirrorConfig:CDCConfig,
+    workflowId:string
+}) => {
+  const [syncing, setSyncing] = useState(false);
+  const [dropping, setDropping] = useState(false);
+  const [msg, setMsg] = useState('');
+
+  const handleResync = async () => {
+    setMsg('Dropping existing mirror')
+    const dropStatus = await handleDropMirror({
+        workflowId: workflowId,
+        flowJobName: mirrorConfig.flowJobName,
+        sourcePeer: mirrorConfig.source!,
+        destinationPeer: mirrorConfig.destination!,
+        forResync: true,
+    }, setDropping, setMsg);
+
+    if(!dropStatus){
+        return;
+    }
+
+    setSyncing(true)
+    setMsg('Resyncing...');
+    const createStatus = await fetch('/api/mirrors/cdc', {
+        method: 'POST',
+        body: JSON.stringify({
+          mirrorConfig,
+        }),
+      }).then((res) => res.json());
+    setSyncing(false);
+    if(!createStatus.created){
+        setMsg('Resyncing of existing mirror failed');
+        return;
+    };
+
+    setMsg('Mirror resynced successfully');
+}
+
+  return (
+    <Dialog
+      noInteract={true}
+      size='xLarge'
+      triggerButton={
+        <Button variant='normalSolid' style={{height:'2em', width:'8em'}}>
+          Resync
+        </Button>
+      }
+    >
+      <div>
+        <Label as='label' variant='action'>
+          Resync {mirrorConfig.flowJobName}
+        </Label>
+        <Divider style={{ margin: 0 }} />
+        <Label as='label' variant='body' style={{ marginTop: '0.3rem' }}>
+          Are you sure you want to resync this mirror?
+          <br></br>
+          This involves <b>dropping the existing mirror</b> and recreating it.
+        </Label>
+    <div style={{display:'flex', alignItems:'center'}}>
+        {syncing || dropping && <DotLoader size={15}/>}
+        <Label as='label' style={{ marginTop: '0.3rem' }}>
+            {msg}
+        </Label>
+    </div>
+        <div style={{ display: 'flex', marginTop: '1rem' }}>
+          <DialogClose>
+            <Button style={{ backgroundColor: '#6c757d', color: 'white' }}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            onClick={handleResync}
+            variant='normalSolid'
+            style={{
+              marginLeft: '1rem',
+            }}
+          >
+            {syncing || dropping ? <BarLoader /> : 'Resync'}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+};

--- a/ui/components/ResyncDialog.tsx
+++ b/ui/components/ResyncDialog.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogClose } from '@/lib/Dialog';
 import { Label } from '@/lib/Label';
 import { Divider } from '@tremor/react';
 import { useState } from 'react';
-import { BarLoader, ClipLoader, DotLoader } from 'react-spinners';
+import { BarLoader, DotLoader } from 'react-spinners';
 import { handleDropMirror } from './DropDialog';
 
 export const ResyncDialog = ({
@@ -38,7 +38,7 @@ export const ResyncDialog = ({
     const createStatus = await fetch('/api/mirrors/cdc', {
         method: 'POST',
         body: JSON.stringify({
-          mirrorConfig,
+          config:mirrorConfig,
         }),
       }).then((res) => res.json());
     setSyncing(false);

--- a/ui/components/ResyncDialog.tsx
+++ b/ui/components/ResyncDialog.tsx
@@ -12,50 +12,56 @@ export const ResyncDialog = ({
   mirrorConfig,
   workflowId,
 }: {
-  mirrorConfig:CDCConfig,
-    workflowId:string
+  mirrorConfig: CDCConfig;
+  workflowId: string;
 }) => {
   const [syncing, setSyncing] = useState(false);
   const [dropping, setDropping] = useState(false);
   const [msg, setMsg] = useState('');
 
   const handleResync = async () => {
-    setMsg('Dropping existing mirror')
-    const dropStatus = await handleDropMirror({
+    setMsg('Dropping existing mirror');
+    const dropStatus = await handleDropMirror(
+      {
         workflowId: workflowId,
         flowJobName: mirrorConfig.flowJobName,
         sourcePeer: mirrorConfig.source!,
         destinationPeer: mirrorConfig.destination!,
         forResync: true,
-    }, setDropping, setMsg);
+      },
+      setDropping,
+      setMsg
+    );
 
-    if(!dropStatus){
-        return;
+    if (!dropStatus) {
+      return;
     }
 
-    setSyncing(true)
+    setSyncing(true);
     setMsg('Resyncing...');
+    mirrorConfig.resync = true;
     const createStatus = await fetch('/api/mirrors/cdc', {
-        method: 'POST',
-        body: JSON.stringify({
-          config:mirrorConfig,
-        }),
-      }).then((res) => res.json());
+      method: 'POST',
+      body: JSON.stringify({
+        config: mirrorConfig,
+      }),
+    }).then((res) => res.json());
     setSyncing(false);
-    if(!createStatus.created){
-        setMsg('Resyncing of existing mirror failed');
-        return;
-    };
+    if (!createStatus.created) {
+      setMsg('Resyncing of existing mirror failed');
+      return;
+    }
 
     setMsg('Mirror resynced successfully');
-}
+    window.location.reload();
+  };
 
   return (
     <Dialog
       noInteract={true}
       size='xLarge'
       triggerButton={
-        <Button variant='normalSolid' style={{height:'2em', width:'8em'}}>
+        <Button variant='normalSolid' style={{ height: '2em', width: '8em' }}>
           Resync
         </Button>
       }
@@ -70,12 +76,12 @@ export const ResyncDialog = ({
           <br></br>
           This involves <b>dropping the existing mirror</b> and recreating it.
         </Label>
-    <div style={{display:'flex', alignItems:'center'}}>
-        {syncing || dropping && <DotLoader size={15}/>}
-        <Label as='label' style={{ marginTop: '0.3rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          {syncing || (dropping && <DotLoader size={15} />)}
+          <Label as='label' style={{ marginTop: '0.3rem' }}>
             {msg}
-        </Label>
-    </div>
+          </Label>
+        </div>
         <div style={{ display: 'flex', marginTop: '1rem' }}>
           <DialogClose>
             <Button style={{ backgroundColor: '#6c757d', color: 'white' }}>


### PR DESCRIPTION
Introduces a resync button in the specific mirror page which when clicked opens a confirmation dialog box.
The resync when done via UI:
- first calls drop mirror and drops the mirror
- kicks off a cdc mirror with the same config as the current mirror, with `resync:true` added
![Screenshot 2024-01-30 at 6 46 50 PM](https://github.com/PeerDB-io/peerdb/assets/65964360/c6ea2156-2e66-4401-9d3b-a7658e04a5a8)
