### PR TITLE
UI: set do_initial_snapshot to true for resync

### DIFF
--- a/ui/components/ResyncDialog.tsx
+++ b/ui/components/ResyncDialog.tsx
@@ -40,6 +40,7 @@ export const ResyncDialog = ({
     setSyncing(true);
     setMsg('Resyncing...');
     mirrorConfig.resync = true;
+    mirrorConfig.doInitialSnapshot = true;
     const createStatus = await fetch('/api/mirrors/cdc', {
       method: 'POST',
       body: JSON.stringify({


### PR DESCRIPTION
Always set `do_initial_snapshot` to true for resync
This has been manually tested for a mirror with that setting set to false and then resynced