### PR TITLE
UI: Line chart for slot growth

### DIFF
--- a/ui/app/api/peers/slots/[name]/route.ts
+++ b/ui/app/api/peers/slots/[name]/route.ts
@@ -1,0 +1,34 @@
+import { SlotLagPoint } from '@/app/dto/PeersDTO';
+import prisma from '@/app/utils/prisma';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: { name: string } }
+) {
+  const lagPoints = await prisma.peer_slot_size.findMany({
+    select: {
+      updated_at: true,
+      slot_size: true,
+      wal_status: true,
+    },
+    where: {
+      slot_name: context.params.name,
+    },
+  });
+
+  // convert slot_size to string
+  const stringedLagPoints: SlotLagPoint[] = lagPoints.map((lagPoint) => {
+    return {
+      // human readable
+      updatedAt:
+        lagPoint.updated_at.toDateString() +
+        ' ' +
+        lagPoint.updated_at.toLocaleTimeString(),
+      slotSize: lagPoint.slot_size?.toString(),
+      walStatus: lagPoint.wal_status,
+    };
+  });
+
+  return NextResponse.json(stringedLagPoints);
+}

--- a/ui/app/dto/PeersDTO.ts
+++ b/ui/app/dto/PeersDTO.ts
@@ -51,3 +51,9 @@ export type CatalogPeer = {
   options: Buffer;
 };
 export type PeerSetter = React.Dispatch<React.SetStateAction<PeerConfig>>;
+
+export type SlotLagPoint = {
+  updatedAt: string;
+  slotSize?: string;
+  walStatus: string | null;
+};

--- a/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
+++ b/ui/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 type timestampType = {
-  timestamp: Date | null;
+  timestamp: Date | string | null;
   count: number;
 };
 

--- a/ui/app/peers/[peerName]/lagGraph.tsx
+++ b/ui/app/peers/[peerName]/lagGraph.tsx
@@ -1,0 +1,78 @@
+'use client';
+import { SlotLagPoint } from '@/app/dto/PeersDTO';
+import { Label } from '@/lib/Label';
+import { ProgressCircle } from '@/lib/ProgressCircle/ProgressCircle';
+import { LineChart } from '@tremor/react';
+import { useCallback, useEffect, useState } from 'react';
+import ReactSelect from 'react-select';
+import { useLocalStorage } from 'usehooks-ts';
+function LagGraph({ slotNames }: { slotNames: string[] }) {
+  const [lagPoints, setLagPoints] = useState<SlotLagPoint[]>([]);
+  const [defaultSlot, setDefaultSlot] = useLocalStorage('defaultSlot', '');
+  const [selectedSlot, setSelectedSlot] = useState<string>(defaultSlot);
+  const fetchLagPoints = useCallback(async () => {
+    if (selectedSlot == '') {
+      return;
+    }
+    const pointsRes = await fetch(`/api/peers/slots/${selectedSlot}`, {
+      cache: 'no-store',
+    });
+    const points: SlotLagPoint[] = await pointsRes.json();
+    setLagPoints(points);
+  }, [selectedSlot]);
+
+  const handleChange = (val: string) => {
+    setDefaultSlot(val);
+    setSelectedSlot(val);
+  };
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    fetchLagPoints();
+  }, [fetchLagPoints]);
+
+  if (!mounted) {
+    return (
+      <Label>
+        <ProgressCircle variant='determinate_progress_circle' />
+      </Label>
+    );
+  }
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: '1rem',
+        marginBottom: '2rem',
+      }}
+    >
+      <ReactSelect
+        className='w-1/4'
+        placeholder='Select a replication slot'
+        options={slotNames.map((slotName) => ({
+          label: slotName,
+          value: slotName,
+        }))}
+        onChange={(val, _) => val && handleChange(val.value)}
+        defaultValue={{ value: selectedSlot, label: selectedSlot }}
+      />
+      <LineChart
+        index='time'
+        data={lagPoints.map((point) => ({
+          time: point.updatedAt,
+          'Lag in MB': point.slotSize,
+          Status: point.walStatus,
+        }))}
+        categories={['Lag in MB', 'Status']}
+        colors={['rose', 'green']}
+      />
+    </div>
+  );
+}
+
+export default LagGraph;

--- a/ui/app/peers/[peerName]/lagGraph.tsx
+++ b/ui/app/peers/[peerName]/lagGraph.tsx
@@ -1,15 +1,19 @@
 'use client';
 import { SlotLagPoint } from '@/app/dto/PeersDTO';
+import aggregateCountsByInterval from '@/app/mirrors/edit/[mirrorId]/aggregatedCountsByInterval';
+import { formatGraphLabel, timeOptions } from '@/app/utils/graph';
 import { Label } from '@/lib/Label';
 import { ProgressCircle } from '@/lib/ProgressCircle/ProgressCircle';
 import { LineChart } from '@tremor/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import ReactSelect from 'react-select';
 import { useLocalStorage } from 'usehooks-ts';
+
 function LagGraph({ slotNames }: { slotNames: string[] }) {
   const [lagPoints, setLagPoints] = useState<SlotLagPoint[]>([]);
   const [defaultSlot, setDefaultSlot] = useLocalStorage('defaultSlot', '');
   const [selectedSlot, setSelectedSlot] = useState<string>(defaultSlot);
+  let [aggregateType, setAggregateType] = useState('hour');
   const fetchLagPoints = useCallback(async () => {
     if (selectedSlot == '') {
       return;
@@ -25,6 +29,22 @@ function LagGraph({ slotNames }: { slotNames: string[] }) {
     setDefaultSlot(val);
     setSelectedSlot(val);
   };
+
+  const graphValues = useMemo(() => {
+    let lagDataDot = aggregateCountsByInterval(
+      lagPoints.map((point) => ({
+        timestamp: point.updatedAt,
+        count: parseInt(point.slotSize || '0', 10) || 0,
+      })),
+      aggregateType
+    );
+    lagDataDot = lagDataDot.slice(0, 29);
+    lagDataDot = lagDataDot.reverse();
+    return lagDataDot.map((data) => ({
+      time: formatGraphLabel(new Date(data[0]), aggregateType),
+      'Lag in MB': data[1],
+    }));
+  }, [lagPoints, aggregateType]);
 
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
@@ -51,25 +71,37 @@ function LagGraph({ slotNames }: { slotNames: string[] }) {
         marginBottom: '2rem',
       }}
     >
-      <ReactSelect
-        className='w-1/4'
-        placeholder='Select a replication slot'
-        options={slotNames.map((slotName) => ({
-          label: slotName,
-          value: slotName,
-        }))}
-        onChange={(val, _) => val && handleChange(val.value)}
-        defaultValue={{ value: selectedSlot, label: selectedSlot }}
-      />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <ReactSelect
+          className='w-1/4'
+          placeholder='Select a replication slot'
+          options={slotNames.map((slotName) => ({
+            label: slotName,
+            value: slotName,
+          }))}
+          onChange={(val, _) => val && handleChange(val.value)}
+          defaultValue={{ value: selectedSlot, label: selectedSlot }}
+        />
+
+        <ReactSelect
+          id={aggregateType}
+          placeholder='Select a timeframe'
+          options={timeOptions}
+          defaultValue={{ label: 'hour', value: 'hour' }}
+          onChange={(val, _) => val && setAggregateType(val.value)}
+        />
+      </div>
       <LineChart
         index='time'
-        data={lagPoints.map((point) => ({
-          time: point.updatedAt,
-          'Lag in MB': point.slotSize,
-          Status: point.walStatus,
-        }))}
-        categories={['Lag in MB', 'Status']}
-        colors={['rose', 'green']}
+        data={graphValues}
+        categories={['Lag in MB']}
+        colors={['rose']}
       />
     </div>
   );

--- a/ui/app/peers/[peerName]/page.tsx
+++ b/ui/app/peers/[peerName]/page.tsx
@@ -2,6 +2,7 @@ import ReloadButton from '@/components/ReloadButton';
 import { PeerSlotResponse, PeerStatResponse } from '@/grpc_generated/route';
 import { Label } from '@/lib/Label';
 import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
+import LagGraph from './lagGraph';
 import PeerDetails from './peerDetails';
 import SlotTable from './slottable';
 import StatTable from './stattable';
@@ -65,6 +66,7 @@ const PeerData = async ({ params: { peerName } }: DataConfigProps) => {
       {slots && stats ? (
         <div>
           <SlotTable data={slots} />
+          <LagGraph slotNames={slots.map((slot) => slot.slotName)} />
           <StatTable data={stats} />
         </div>
       ) : (


### PR DESCRIPTION

<img width="1726" alt="Screenshot 2024-01-31 at 9 12 34 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/73b9c41b-6b8c-42f2-8bd6-fb2233ca9450">



Note: the line chart above was generated by a random series of slot sizes for representation purposes
The selected slot name is persisted in local storage