### PR TITLE
Try using temporal's activity.GetLogger

### DIFF
--- a/flow/cmd/api.go
+++ b/flow/cmd/api.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,6 +23,7 @@ import (
 
 	utils "github.com/PeerDB-io/peer-flow/connectors/utils/catalog"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/shared"
 	peerflow "github.com/PeerDB-io/peer-flow/workflows"
 )
@@ -91,6 +93,7 @@ func APIMain(ctx context.Context, args *APIServerParams) error {
 	clientOptions := client.Options{
 		HostPort:  args.TemporalHostPort,
 		Namespace: args.TemporalNamespace,
+		Logger:    slog.New(logger.NewHandler(slog.NewJSONHandler(os.Stdout, nil))),
 	}
 	if args.TemporalCert != "" && args.TemporalKey != "" {
 		slog.Info("Using temporal certificate/key for authentication")

--- a/flow/cmd/snapshot_worker.go
+++ b/flow/cmd/snapshot_worker.go
@@ -3,12 +3,15 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
+	"log/slog"
+	"os"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 
 	"github.com/PeerDB-io/peer-flow/activities"
 	utils "github.com/PeerDB-io/peer-flow/connectors/utils/catalog"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/shared"
 	"github.com/PeerDB-io/peer-flow/shared/alerting"
 	peerflow "github.com/PeerDB-io/peer-flow/workflows"
@@ -25,6 +28,7 @@ func SnapshotWorkerMain(opts *SnapshotWorkerOptions) error {
 	clientOptions := client.Options{
 		HostPort:  opts.TemporalHostPort,
 		Namespace: opts.TemporalNamespace,
+		Logger:    slog.New(logger.NewHandler(slog.NewJSONHandler(os.Stdout, nil))),
 	}
 
 	if opts.TemporalCert != "" && opts.TemporalKey != "" {

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/PeerDB-io/peer-flow/activities"
 	utils "github.com/PeerDB-io/peer-flow/connectors/utils/catalog"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/shared"
 	"github.com/PeerDB-io/peer-flow/shared/alerting"
 	peerflow "github.com/PeerDB-io/peer-flow/workflows"
@@ -90,6 +91,7 @@ func WorkerMain(opts *WorkerOptions) error {
 	clientOptions := client.Options{
 		HostPort:  opts.TemporalHostPort,
 		Namespace: opts.TemporalNamespace,
+		Logger:    slog.New(logger.NewHandler(slog.NewJSONHandler(os.Stdout, nil))),
 	}
 
 	if opts.TemporalCert != "" && opts.TemporalKey != "" {

--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -34,7 +34,7 @@ func (c *BigQueryConnector) SyncQRepRecords(
 	}
 
 	if done {
-		c.logger.InfoContext(c.ctx, fmt.Sprintf("Partition %s has already been synced", partition.PartitionId))
+		c.logger.Info(fmt.Sprintf("Partition %s has already been synced", partition.PartitionId))
 		return 0, nil
 	}
 	c.logger.Info(fmt.Sprintf("QRep sync function called and partition existence checked for"+

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"go.temporal.io/sdk/log"
 
 	metadataStore "github.com/PeerDB-io/peer-flow/connectors/external_metadata"
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
-	"github.com/PeerDB-io/peer-flow/shared"
 )
 
 type EventHubConnector struct {
@@ -23,7 +24,7 @@ type EventHubConnector struct {
 	pgMetadata *metadataStore.PostgresMetadataStore
 	creds      *azidentity.DefaultAzureCredential
 	hubManager *EventHubManager
-	logger     slog.Logger
+	logger     log.Logger
 }
 
 // NewEventHubConnector creates a new EventHubConnector.
@@ -46,14 +47,13 @@ func NewEventHubConnector(
 		return nil, err
 	}
 
-	flowName, _ := ctx.Value(shared.FlowNameKey).(string)
 	return &EventHubConnector{
 		ctx:        ctx,
 		config:     config,
 		pgMetadata: pgMetadata,
 		creds:      defaultAzureCreds,
 		hubManager: hubManager,
-		logger:     *slog.With(slog.String(string(shared.FlowNameKey), flowName)),
+		logger:     logger.LoggerFromCtx(ctx),
 	}, nil
 }
 

--- a/flow/connectors/postgres/normalize_stmt_generator.go
+++ b/flow/connectors/postgres/normalize_stmt_generator.go
@@ -2,10 +2,10 @@ package connpostgres
 
 import (
 	"fmt"
-	"log/slog"
 	"slices"
 	"strings"
 
+	"go.temporal.io/sdk/log"
 	"golang.org/x/exp/maps"
 
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
@@ -28,7 +28,7 @@ type normalizeStmtGenerator struct {
 	// Postgres metadata schema
 	metadataSchema string
 	// to log fallback statement selection
-	logger slog.Logger
+	logger log.Logger
 }
 
 func (n *normalizeStmtGenerator) generateNormalizeStatements() []string {

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -13,15 +13,16 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.temporal.io/sdk/log"
 
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/connectors/utils/monitoring"
 	"github.com/PeerDB-io/peer-flow/dynamicconf"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
-	"github.com/PeerDB-io/peer-flow/shared"
 	"github.com/PeerDB-io/peer-flow/shared/alerting"
 )
 
@@ -35,7 +36,7 @@ type PostgresConnector struct {
 	replConfig         *pgx.ConnConfig
 	customTypesMapping map[uint32]string
 	metadataSchema     string
-	logger             slog.Logger
+	logger             log.Logger
 }
 
 // NewPostgresConnector creates a new instance of PostgresConnector.
@@ -80,8 +81,6 @@ func NewPostgresConnector(ctx context.Context, pgConfig *protos.PostgresConfig) 
 		metadataSchema = *pgConfig.MetadataSchema
 	}
 
-	flowName, _ := ctx.Value(shared.FlowNameKey).(string)
-	flowLog := slog.With(slog.String(string(shared.FlowNameKey), flowName))
 	return &PostgresConnector{
 		connStr:            connectionString,
 		ctx:                ctx,
@@ -91,7 +90,7 @@ func NewPostgresConnector(ctx context.Context, pgConfig *protos.PostgresConfig) 
 		replConfig:         replConfig,
 		customTypesMapping: customTypeMap,
 		metadataSchema:     metadataSchema,
-		logger:             *flowLog,
+		logger:             logger.LoggerFromCtx(ctx),
 	}, nil
 }
 

--- a/flow/connectors/postgres/qrep_partition_test.go
+++ b/flow/connectors/postgres/qrep_partition_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
+	"go.temporal.io/sdk/log"
 
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/shared"
@@ -174,7 +175,7 @@ func TestGetQRepPartitions(t *testing.T) {
 				ctx:     context.Background(),
 				config:  &protos.PostgresConfig{},
 				conn:    conn,
-				logger:  *slog.With(slog.String(string(shared.FlowNameKey), "testGetQRepPartitions")),
+				logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testGetQRepPartitions"))),
 			}
 
 			got, err := c.GetQRepPartitions(tc.config, tc.last)

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.temporal.io/sdk/log"
 
 	metadataStore "github.com/PeerDB-io/peer-flow/connectors/external_metadata"
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
-	"github.com/PeerDB-io/peer-flow/shared"
 )
 
 const (
@@ -28,7 +29,7 @@ type S3Connector struct {
 	pgMetadata *metadataStore.PostgresMetadataStore
 	client     s3.Client
 	creds      utils.S3PeerCredentials
-	logger     slog.Logger
+	logger     log.Logger
 }
 
 func NewS3Connector(ctx context.Context,
@@ -70,14 +71,13 @@ func NewS3Connector(ctx context.Context,
 		slog.ErrorContext(ctx, "failed to create postgres metadata store", slog.Any("error", err))
 		return nil, err
 	}
-	flowName, _ := ctx.Value(shared.FlowNameKey).(string)
 	return &S3Connector{
 		ctx:        ctx,
 		url:        config.Url,
 		pgMetadata: pgMetadata,
 		client:     *s3Client,
 		creds:      s3PeerCreds,
-		logger:     *slog.With(slog.String(string(shared.FlowNameKey), flowName)),
+		logger:     logger.LoggerFromCtx(ctx),
 	}, nil
 }
 

--- a/flow/connectors/sqlserver/sqlserver.go
+++ b/flow/connectors/sqlserver/sqlserver.go
@@ -3,14 +3,14 @@ package connsqlserver
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/microsoft/go-mssqldb"
+	"go.temporal.io/sdk/log"
 
 	peersql "github.com/PeerDB-io/peer-flow/connectors/sql"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
-	"github.com/PeerDB-io/peer-flow/shared"
+	"github.com/PeerDB-io/peer-flow/logger"
 )
 
 type SQLServerConnector struct {
@@ -19,7 +19,7 @@ type SQLServerConnector struct {
 	ctx    context.Context
 	config *protos.SqlServerConfig
 	db     *sqlx.DB
-	logger slog.Logger
+	logger log.Logger
 }
 
 // NewSQLServerConnector creates a new SQL Server connection
@@ -40,14 +40,12 @@ func NewSQLServerConnector(ctx context.Context, config *protos.SqlServerConfig) 
 	genericExecutor := *peersql.NewGenericSQLQueryExecutor(
 		ctx, db, sqlServerTypeToQValueKindMap, qValueKindToSQLServerTypeMap)
 
-	flowName, _ := ctx.Value(shared.FlowNameKey).(string)
-
 	return &SQLServerConnector{
 		GenericSQLQueryExecutor: genericExecutor,
 		ctx:                     ctx,
 		config:                  config,
 		db:                      db,
-		logger:                  *slog.With(slog.String(string(shared.FlowNameKey), flowName)),
+		logger:                  logger.LoggerFromCtx(ctx),
 	}, nil
 }
 

--- a/flow/connectors/utils/avro/avro_writer.go
+++ b/flow/connectors/utils/avro/avro_writer.go
@@ -211,7 +211,6 @@ func (p *peerDBOCFWriter) WriteRecordsToS3(bucketName, key string, s3Creds utils
 		slog.Error("failed to upload file: ", slog.Any("error", err), slog.Any("s3_path", s3Path))
 		return nil, fmt.Errorf("failed to upload file to path %s: %w", s3Path, err)
 	}
-	slog.Info("file uploaded to " + fmt.Sprintf("%s/%s", bucketName, key))
 
 	if !noPanic {
 		return nil, fmt.Errorf("WriteOCF panicked while writing avro to S3 %s/%s", bucketName, key)

--- a/flow/logger/from_ctx.go
+++ b/flow/logger/from_ctx.go
@@ -1,0 +1,26 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/log"
+
+	"github.com/PeerDB-io/peer-flow/shared"
+)
+
+func LoggerFromCtx(ctx context.Context) log.Logger {
+	flowName, hasName := ctx.Value(shared.FlowNameKey).(string)
+	if activity.IsActivity(ctx) {
+		if hasName {
+			return log.With(activity.GetLogger(ctx), string(shared.FlowNameKey), flowName)
+		} else {
+			return activity.GetLogger(ctx)
+		}
+	} else if hasName {
+		return slog.With(string(shared.FlowNameKey), flowName)
+	} else {
+		return slog.Default()
+	}
+}


### PR DESCRIPTION
Noticed that in e2e tests, logs of a different test appear in the current test's logs. This PR is an attempt to fix that by obtaining a temporal logger from the current context and using that in our connectors instead of the slog instance.
