### PR TITLE
UI for editing mirror parameters

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -463,7 +463,7 @@ func (h *FlowRequestHandler) FlowStateChange(
 				shared.NoopSignal,
 			)
 		} else if req.RequestedFlowState == protos.FlowStatus_STATUS_TERMINATED &&
-			(currState == protos.FlowStatus_STATUS_RUNNING || currState == protos.FlowStatus_STATUS_PAUSED) {
+			(currState != protos.FlowStatus_STATUS_TERMINATED) {
 			err = h.updateWorkflowStatus(ctx, workflowID, protos.FlowStatus_STATUS_TERMINATING)
 			if err != nil {
 				return nil, err
@@ -475,7 +475,7 @@ func (h *FlowRequestHandler) FlowStateChange(
 				DestinationPeer: req.DestinationPeer,
 				RemoveFlowEntry: false,
 			})
-		} else {
+		} else if req.RequestedFlowState != currState {
 			return nil, fmt.Errorf("illegal state change requested: %v, current state is: %v",
 				req.RequestedFlowState, currState)
 		}

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -425,47 +425,63 @@ func (h *FlowRequestHandler) FlowStateChange(
 		return nil, err
 	}
 
-	if req.RequestedFlowState == protos.FlowStatus_STATUS_PAUSED &&
-		currState == protos.FlowStatus_STATUS_RUNNING {
-		err = h.updateWorkflowStatus(ctx, workflowID, protos.FlowStatus_STATUS_PAUSING)
-		if err != nil {
-			return nil, err
-		}
+	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil {
 		err = h.temporalClient.SignalWorkflow(
 			ctx,
 			workflowID,
 			"",
-			shared.FlowSignalName,
-			shared.PauseSignal,
+			shared.CDCDynamicPropertiesSignalName,
+			req.FlowConfigUpdate.GetCdcFlowConfigUpdate(),
 		)
-	} else if req.RequestedFlowState == protos.FlowStatus_STATUS_RUNNING &&
-		currState == protos.FlowStatus_STATUS_PAUSED {
-		err = h.temporalClient.SignalWorkflow(
-			ctx,
-			workflowID,
-			"",
-			shared.FlowSignalName,
-			shared.NoopSignal,
-		)
-	} else if req.RequestedFlowState == protos.FlowStatus_STATUS_TERMINATED &&
-		(currState == protos.FlowStatus_STATUS_RUNNING || currState == protos.FlowStatus_STATUS_PAUSED) {
-		err = h.updateWorkflowStatus(ctx, workflowID, protos.FlowStatus_STATUS_TERMINATING)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to signal workflow: %w", err)
 		}
-		_, err = h.ShutdownFlow(ctx, &protos.ShutdownRequest{
-			WorkflowId:      workflowID,
-			FlowJobName:     req.FlowJobName,
-			SourcePeer:      req.SourcePeer,
-			DestinationPeer: req.DestinationPeer,
-			RemoveFlowEntry: false,
-		})
-	} else {
-		return nil, fmt.Errorf("illegal state change requested: %v, current state is: %v",
-			req.RequestedFlowState, currState)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("unable to signal workflow: %w", err)
+
+	// in case we only want to update properties without changing status
+	if req.RequestedFlowState != protos.FlowStatus_STATUS_UNKNOWN {
+		if req.RequestedFlowState == protos.FlowStatus_STATUS_PAUSED &&
+			currState == protos.FlowStatus_STATUS_RUNNING {
+			err = h.updateWorkflowStatus(ctx, workflowID, protos.FlowStatus_STATUS_PAUSING)
+			if err != nil {
+				return nil, err
+			}
+			err = h.temporalClient.SignalWorkflow(
+				ctx,
+				workflowID,
+				"",
+				shared.FlowSignalName,
+				shared.PauseSignal,
+			)
+		} else if req.RequestedFlowState == protos.FlowStatus_STATUS_RUNNING &&
+			currState == protos.FlowStatus_STATUS_PAUSED {
+			err = h.temporalClient.SignalWorkflow(
+				ctx,
+				workflowID,
+				"",
+				shared.FlowSignalName,
+				shared.NoopSignal,
+			)
+		} else if req.RequestedFlowState == protos.FlowStatus_STATUS_TERMINATED &&
+			(currState == protos.FlowStatus_STATUS_RUNNING || currState == protos.FlowStatus_STATUS_PAUSED) {
+			err = h.updateWorkflowStatus(ctx, workflowID, protos.FlowStatus_STATUS_TERMINATING)
+			if err != nil {
+				return nil, err
+			}
+			_, err = h.ShutdownFlow(ctx, &protos.ShutdownRequest{
+				WorkflowId:      workflowID,
+				FlowJobName:     req.FlowJobName,
+				SourcePeer:      req.SourcePeer,
+				DestinationPeer: req.DestinationPeer,
+				RemoveFlowEntry: false,
+			})
+		} else {
+			return nil, fmt.Errorf("illegal state change requested: %v, current state is: %v",
+				req.RequestedFlowState, currState)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("unable to signal workflow: %w", err)
+		}
 	}
 
 	return &protos.FlowStateChangeResponse{

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -18,7 +18,7 @@ const (
 	NormalizeSyncDoneSignalName    = "normalize-sync-done"
 
 	// Queries
-	CDCFlowStateQuery  = "q-cdc-flow-status"
+	CDCFlowStateQuery  = "q-cdc-flow-state"
 	QRepFlowStateQuery = "q-qrep-flow-state"
 	FlowStatusQuery    = "q-flow-status"
 

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -96,6 +96,7 @@ message QRepMirrorStatus {
   // or if we are in the continuous streaming mode.
 }
 
+// to be removed eventually
 message CDCSyncStatus {
   int64 start_lsn = 1;
   int64 end_lsn = 2;

--- a/ui/app/api/mirrors/state/route.ts
+++ b/ui/app/api/mirrors/state/route.ts
@@ -1,0 +1,23 @@
+import {
+  MirrorStatusRequest,
+  MirrorStatusResponse,
+} from '@/grpc_generated/route';
+import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
+
+export async function POST(request: Request) {
+  const body: MirrorStatusRequest = await request.json();
+  const flowServiceAddr = GetFlowHttpAddressFromEnv();
+  console.log('/mirrors/state: req:', body);
+  try {
+    const res: MirrorStatusResponse = await fetch(
+      `${flowServiceAddr}/v1/mirrors/${body.flowJobName}`,
+      { cache: 'no-store' }
+    ).then((res) => {
+      return res.json();
+    });
+
+    return new Response(JSON.stringify(res));
+  } catch (e) {
+    console.error(e);
+  }
+}

--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -69,7 +69,7 @@ const EditMirror = ({ params: { mirrorId } }: EditMirrorProps) => {
     });
     return omitAdditionalTablesMapping;
   }, [mirrorState]);
-  useMemo(() => {
+  useEffect(() => {
     setConfig((c) => ({
       ...c,
       additionalTables: reformattedTableMapping(rows),

--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -1,38 +1,177 @@
-// BOILERPLATE
 'use client';
 
 import { TableMapRow } from '@/app/dto/MirrorsDTO';
-import { DBType } from '@/grpc_generated/peers';
+import { CDCFlowConfigUpdate, FlowStatus } from '@/grpc_generated/flow';
+import {
+  FlowStateChangeRequest,
+  MirrorStatusResponse,
+} from '@/grpc_generated/route';
 import { Button } from '@/lib/Button';
 import { Label } from '@/lib/Label';
-import { useState } from 'react';
+import { RowWithTextField } from '@/lib/Layout';
+import { TextField } from '@/lib/TextField';
+import { ProgressCircle } from '@tremor/react';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import TableMapping from '../../create/cdc/tablemapping';
+import { reformattedTableMapping } from '../../create/handlers';
 
 type EditMirrorProps = {
   params: { mirrorId: string };
 };
+
 const EditMirror = ({ params: { mirrorId } }: EditMirrorProps) => {
   const [rows, setRows] = useState<TableMapRow[]>([]);
+  const [mirrorState, setMirrorState] = useState<MirrorStatusResponse>();
+  const [config, setConfig] = useState<CDCFlowConfigUpdate>({
+    batchSize: 1000000,
+    idleTimeout: 60,
+    additionalTables: [],
+  });
+  const { push } = useRouter();
+
+  const fetchStateAndUpdateDeps = useCallback(async () => {
+    await fetch('/api/mirrors/state', {
+      method: 'POST',
+      body: JSON.stringify({
+        flowJobName: mirrorId,
+      }),
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        setMirrorState(res);
+
+        setConfig({
+          batchSize:
+            (res as MirrorStatusResponse).cdcStatus?.config?.maxBatchSize ||
+            1000000,
+          idleTimeout:
+            (res as MirrorStatusResponse).cdcStatus?.config
+              ?.idleTimeoutSeconds || 60,
+          additionalTables: [],
+        });
+      });
+  }, [mirrorId]);
+
+  useEffect(() => {
+    fetchStateAndUpdateDeps();
+  }, [fetchStateAndUpdateDeps]);
+
+  const omitAdditionalTablesMapping: Map<string, string[]> = useMemo(() => {
+    const omitAdditionalTablesMapping: Map<string, string[]> = new Map();
+    mirrorState?.cdcStatus?.config?.tableMappings.forEach((value) => {
+      const sourceSchema = value.sourceTableIdentifier.split('.').at(0)!;
+      const mapVal: string[] =
+        omitAdditionalTablesMapping.get(sourceSchema) || [];
+      // needs to be schema qualified
+      mapVal.push(value.sourceTableIdentifier);
+      omitAdditionalTablesMapping.set(sourceSchema, mapVal);
+    });
+    return omitAdditionalTablesMapping;
+  }, [mirrorState]);
+  useMemo(() => {
+    setConfig((c) => ({
+      ...c,
+      additionalTables: reformattedTableMapping(rows),
+    }));
+  }, [rows]);
+
+  if (!mirrorState) {
+    return <ProgressCircle />;
+  }
+
   // todo: use mirrorId (which is mirrorName) to query flows table/temporal and get config
   // you will have to decode the config to get the table mapping. see: /mirrors/page.tsx
   return (
     <div>
       <Label variant='title3'>Edit {mirrorId}</Label>
 
-      {/* todo: add a prop to this component called alreadySelectedTables and pass the table mapping.
-        Then, at the place where we're blurring out tables on the condition of
-        pkey/replica identity (schemabox.tsx), extend the condition to include the case where table is in alreadySelectedTables */}
+      <RowWithTextField
+        key={1}
+        label={<Label>{'Pull Batch Size'} </Label>}
+        action={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+            }}
+          >
+            <TextField
+              variant='simple'
+              type={'number'}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setConfig({
+                  ...config,
+                  batchSize: e.target.valueAsNumber,
+                })
+              }
+              defaultValue={config.batchSize}
+            />
+          </div>
+        }
+      />
+
+      <RowWithTextField
+        key={2}
+        label={<Label>{'Sync Interval (Seconds)'} </Label>}
+        action={
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+            }}
+          >
+            <TextField
+              variant='simple'
+              type={'number'}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setConfig({
+                  ...config,
+                  idleTimeout: e.target.valueAsNumber,
+                })
+              }
+              defaultValue={config.idleTimeout}
+            />
+          </div>
+        }
+      />
+
       <TableMapping
-        sourcePeerName='postgres_local' // get this from config
-        peerType={DBType.SNOWFLAKE} // this is destination peer type. get it from config
+        sourcePeerName={mirrorState.cdcStatus?.config?.source?.name || ''}
+        peerType={mirrorState.cdcStatus?.config?.destination?.type}
         rows={rows}
         setRows={setRows}
+        omitAdditionalTablesMapping={omitAdditionalTablesMapping}
       />
       <Button
         style={{ marginTop: '1rem', width: '8%', height: '2.5rem' }}
         variant='normalSolid'
+        disabled={
+          config.additionalTables.length > 0 &&
+          mirrorState.currentFlowState.toString() !==
+            FlowStatus[FlowStatus.STATUS_PAUSED]
+        }
+        onClick={async () => {
+          const req: FlowStateChangeRequest = {
+            flowJobName: mirrorId,
+            sourcePeer: mirrorState.cdcStatus?.config?.source,
+            destinationPeer: mirrorState.cdcStatus?.config?.destination,
+            requestedFlowState: FlowStatus.STATUS_UNKNOWN,
+            flowConfigUpdate: {
+              cdcFlowConfigUpdate: config,
+            },
+          };
+          await fetch(`/api/mirrors/state_change`, {
+            method: 'POST',
+            body: JSON.stringify(req),
+            cache: 'no-store',
+          });
+          push(`/mirrors/${mirrorId}`);
+        }}
       >
-        Update tables
+        Edit Mirror
       </Button>
     </div>
   );

--- a/ui/app/mirrors/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/page.tsx
@@ -69,6 +69,7 @@ export default async function EditMirror({
   }
 
   let syncStatusChild = <></>;
+  let editButtonHTML = <></>;
   if (mirrorStatus.cdcStatus) {
     let rowsSynced = syncs.reduce((acc, sync) => {
       if (sync.end_time !== null) {
@@ -79,16 +80,19 @@ export default async function EditMirror({
     syncStatusChild = (
       <SyncStatus rowsSynced={rowsSynced} rows={rows} flowJobName={mirrorId} />
     );
+    editButtonHTML = (
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <Header variant='title2'>{mirrorId}</Header>
+        <EditButton toLink={`/mirrors/${mirrorId}/edit`} />
+      </div>
+    );
   } else {
     redirect(`/mirrors/status/qrep/${mirrorId}`);
   }
 
   return (
     <LayoutMain alignSelf='flex-start' justifySelf='flex-start' width='full'>
-      <div style={{ display: 'flex', alignItems: 'center' }}>
-        <Header variant='title2'>{mirrorId}</Header>
-        <EditButton toLink={`/mirrors/${mirrorId}/edit`} />
-      </div>
+      {editButtonHTML}
       <CDCMirror
         rows={rows}
         createdAt={mirrorInfo?.created_at}

--- a/ui/app/mirrors/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/page.tsx
@@ -68,8 +68,8 @@ export default async function EditMirror({
     return <NoMirror />;
   }
 
-  let syncStatusChild = <></>;
-  let editButtonHTML = <></>;
+  let syncStatusChild = null;
+  let editButtonHTML = null;
   if (mirrorStatus.cdcStatus) {
     let rowsSynced = syncs.reduce((acc, sync) => {
       if (sync.end_time !== null) {

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -113,6 +113,7 @@ export default function CDCConfigForm({
           rows={rows}
           setRows={setRows}
           peerType={mirrorConfig.destination?.type}
+          omitAdditionalTablesMapping={new Map<string, string[]>()}
         />
       </>
     );

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -148,11 +148,11 @@ const SchemaBox = ({
       if (rowsDoNotHaveSchemaTables(schemaName)) {
         setTablesLoading(true);
         fetchTables(sourcePeer, schemaName, peerType).then((newRows) => {
-          newRows.forEach((value, i, arr) => {
-            if (omitAdditionalTables?.includes(value.source)) {
-              arr.at(i)!.canMirror = false;
+          for (const row of newRows) {
+            if (omitAdditionalTables?.includes(row.source)) {
+              row.canMirror = false;
             }
-          });
+          }
           setRows((oldRows) => [
             ...oldRows.filter((oldRow) => oldRow.schema !== schema),
             ...newRows,

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -35,6 +35,7 @@ interface SchemaBoxProps {
     SetStateAction<{ tableName: string; columns: string[] }[]>
   >;
   peerType?: DBType;
+  omitAdditionalTables: string[] | undefined;
 }
 const SchemaBox = ({
   sourcePeer,
@@ -44,6 +45,7 @@ const SchemaBox = ({
   setRows,
   tableColumns,
   setTableColumns,
+  omitAdditionalTables,
 }: SchemaBoxProps) => {
   const [tablesLoading, setTablesLoading] = useState(false);
   const [columnsLoading, setColumnsLoading] = useState(false);
@@ -146,6 +148,11 @@ const SchemaBox = ({
       if (rowsDoNotHaveSchemaTables(schemaName)) {
         setTablesLoading(true);
         fetchTables(sourcePeer, schemaName, peerType).then((newRows) => {
+          newRows.forEach((value, i, arr) => {
+            if (omitAdditionalTables?.includes(value.source)) {
+              arr.at(i)!.canMirror = false;
+            }
+          });
           setRows((oldRows) => [
             ...oldRows.filter((oldRow) => oldRow.schema !== schema),
             ...newRows,

--- a/ui/app/mirrors/create/cdc/tablemapping.tsx
+++ b/ui/app/mirrors/create/cdc/tablemapping.tsx
@@ -15,6 +15,8 @@ interface TableMappingProps {
   rows: TableMapRow[];
   setRows: Dispatch<SetStateAction<TableMapRow[]>>;
   peerType?: DBType;
+  // schema -> omitted source table mapping
+  omitAdditionalTablesMapping: Map<string, string[]>;
 }
 
 const TableMapping = ({
@@ -22,6 +24,7 @@ const TableMapping = ({
   rows,
   setRows,
   peerType,
+  omitAdditionalTablesMapping,
 }: TableMappingProps) => {
   const [allSchemas, setAllSchemas] = useState<string[]>();
   const [schemaQuery, setSchemaQuery] = useState('');
@@ -88,6 +91,7 @@ const TableMapping = ({
               tableColumns={tableColumns}
               setTableColumns={setTableColumns}
               peerType={peerType}
+              omitAdditionalTables={omitAdditionalTablesMapping.get(schema)}
             />
           ))
         ) : (

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -118,7 +118,9 @@ interface TableMapping {
   partitionKey: string;
   exclude: string[];
 }
-const reformattedTableMapping = (tableMapping: TableMapRow[]) => {
+export const reformattedTableMapping = (
+  tableMapping: TableMapRow[]
+): TableMapping[] => {
   const mapping = tableMapping
     .filter((row) => row?.selected === true)
     .map((row) => ({


### PR DESCRIPTION
`IdleTimeoutSeconds` and `SyncBatchSize` can be changed anytime, tables can only be added IF mirror is paused, otherwise the button will be disabled.

Additional changes for this:
1) moved CDC dynamic properties to the main signal selector and blocking on the main signal selector while paused, so we can receive mirror edits even while paused.
2) pass `TableNameSchemaMapping` from state always to `NormalizeFlow` in case new tables were added.
3) added a new property to the tables component to disable selecting of tables already in the mirror.

There is a bug where tables added to the mirror dynamically will not reflect in the status screen, will be fixed in a follow up PR. `TableMappings` Needs to be stored in state as well.