### PR TITLE
fixes for UI and general

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -10,7 +10,7 @@ jobs:
   flow_test:
     strategy:
       matrix:
-        runner: [ubicloud-standard-16-ubuntu-2204-arm]
+        runner: [ubicloud-standard-16-ubuntu-2204-arm, ubuntu-latest]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     services:

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -10,7 +10,7 @@ jobs:
   flow_test:
     strategy:
       matrix:
-        runner: [ubicloud-standard-16-ubuntu-2204-arm, ubuntu-latest]
+        runner: [ubicloud-standard-16-ubuntu-2204-arm]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     services:

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -236,8 +236,9 @@ func (a *FlowableActivity) StartFlow(ctx context.Context,
 			TableNameMapping:      tblNameMapping,
 			LastOffset:            input.LastSyncState.Checkpoint,
 			MaxBatchSize:          input.SyncFlowOptions.BatchSize,
-			IdleTimeout: time.Duration(input.SyncFlowOptions.IdleTimeoutSeconds) *
-				time.Second,
+			IdleTimeout: peerdbenv.PeerDBCDCIdleTimeoutSeconds(
+				int(input.SyncFlowOptions.IdleTimeoutSeconds),
+			),
 			TableNameSchemaMapping:      input.TableNameSchemaMapping,
 			OverridePublicationName:     input.FlowConnectionConfigs.PublicationName,
 			OverrideReplicationSlotName: input.FlowConnectionConfigs.ReplicationSlotName,

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -188,7 +188,7 @@ func (h *FlowRequestHandler) CreateCDCFlow(
 	}
 
 	return &protos.CreateCDCFlowResponse{
-		WorflowId: workflowID,
+		WorkflowId: workflowID,
 	}, nil
 }
 
@@ -290,7 +290,7 @@ func (h *FlowRequestHandler) CreateQRepFlow(
 	}
 
 	return &protos.CreateQRepFlowResponse{
-		WorflowId: workflowID,
+		WorkflowId: workflowID,
 	}, nil
 }
 

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -94,6 +94,7 @@ func (h *FlowRequestHandler) CDCFlowStatus(
 	// patching config to show latest values from state
 	config.IdleTimeoutSeconds = state.SyncFlowOptions.IdleTimeoutSeconds
 	config.MaxBatchSize = state.SyncFlowOptions.BatchSize
+	config.TableMappings = state.TableMappings
 
 	var initialCopyStatus *protos.SnapshotStatus
 

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -524,9 +524,6 @@ func (p *PostgresCDCSource) processMessage(batch *model.CDCRecordStream, xld pgl
 			return nil, nil
 		}
 
-		// TODO (kaushik): consider persistent state for a mirror job
-		// to be stored somewhere in temporal state. We might need to persist
-		// the state of the relation message somewhere
 		p.logger.Debug(fmt.Sprintf("RelationMessage => RelationID: %d, Namespace: %s, RelationName: %s, Columns: %v",
 			msg.RelationID, msg.Namespace, msg.RelationName, msg.Columns))
 		if p.relationMessageMapping[msg.RelationID] == nil {

--- a/flow/peerdbenv/config.go
+++ b/flow/peerdbenv/config.go
@@ -29,6 +29,18 @@ func PeerDBEventhubFlushTimeoutSeconds() time.Duration {
 	return time.Duration(x) * time.Second
 }
 
+// env variable doesn't exist anymore, but tests appear to depend on this
+// in lieu of an actual value of IdleTimeoutSeconds
+func PeerDBCDCIdleTimeoutSeconds(providedValue int) time.Duration {
+	var x int
+	if providedValue > 0 {
+		x = providedValue
+	} else {
+		x = getEnvInt("", 10)
+	}
+	return time.Duration(x) * time.Second
+}
+
 // PEERDB_CDC_DISK_SPILL_THRESHOLD
 func PeerDBCDCDiskSpillThreshold() int {
 	return getEnvInt("PEERDB_CDC_DISK_SPILL_THRESHOLD", 1_000_000)

--- a/flow/peerdbenv/config.go
+++ b/flow/peerdbenv/config.go
@@ -29,17 +29,6 @@ func PeerDBEventhubFlushTimeoutSeconds() time.Duration {
 	return time.Duration(x) * time.Second
 }
 
-// PEERDB_CDC_IDLE_TIMEOUT_SECONDS
-func PeerDBCDCIdleTimeoutSeconds(providedValue int) time.Duration {
-	var x int
-	if providedValue > 0 {
-		x = providedValue
-	} else {
-		x = getEnvInt("PEERDB_CDC_IDLE_TIMEOUT_SECONDS", 60)
-	}
-	return time.Duration(x) * time.Second
-}
-
 // PEERDB_CDC_DISK_SPILL_THRESHOLD
 func PeerDBCDCDiskSpillThreshold() int {
 	return getEnvInt("PEERDB_CDC_DISK_SPILL_THRESHOLD", 1_000_000)

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -477,7 +477,7 @@ func CDCFlowWorkflowWithConfig(
 			state.CurrentFlowStatus = protos.FlowStatus_STATUS_PAUSED
 
 			for state.ActiveSignal == shared.PauseSignal {
-				w.logger.Info("mirror has been paused for ", slog.Any("duration", time.Since(startTime)))
+				w.logger.Info("mirror has been paused", slog.Any("duration", time.Since(startTime)))
 				// only place we block on receive, so signal processing is immediate
 				mainLoopSelector.Select(ctx)
 				if state.ActiveSignal == shared.NoopSignal {

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -57,10 +57,16 @@ type CDCFlowWorkflowState struct {
 	SyncFlowOptions *protos.SyncFlowOptions
 	// options passed to all NormalizeFlows
 	NormalizeFlowOptions *protos.NormalizeFlowOptions
+	// initially copied from config, all changes are made here though
+	TableMappings []*protos.TableMapping
 }
 
 // returns a new empty PeerFlowState
-func NewCDCFlowWorkflowState(numTables int) *CDCFlowWorkflowState {
+func NewCDCFlowWorkflowState(cfgTableMappings []*protos.TableMapping) *CDCFlowWorkflowState {
+	tableMappings := make([]*protos.TableMapping, 0, len(cfgTableMappings))
+	for _, tableMapping := range cfgTableMappings {
+		tableMappings = append(tableMappings, proto.Clone(tableMapping).(*protos.TableMapping))
+	}
 	return &CDCFlowWorkflowState{
 		Progress:              []string{"started"},
 		SyncFlowStatuses:      nil,
@@ -81,6 +87,7 @@ func NewCDCFlowWorkflowState(numTables int) *CDCFlowWorkflowState {
 		FlowConfigUpdates:      nil,
 		SyncFlowOptions:        nil,
 		NormalizeFlowOptions:   nil,
+		TableMappings:          tableMappings,
 	}
 }
 
@@ -151,7 +158,7 @@ func (w *CDCFlowWorkflowExecution) processCDCFlowConfigUpdates(ctx workflow.Cont
 		if len(flowConfigUpdate.AdditionalTables) == 0 {
 			continue
 		}
-		if shared.AdditionalTablesHasOverlap(cfg.TableMappings, flowConfigUpdate.AdditionalTables) {
+		if shared.AdditionalTablesHasOverlap(state.TableMappings, flowConfigUpdate.AdditionalTables) {
 			return fmt.Errorf("duplicate source/destination tables found in additionalTables")
 		}
 
@@ -173,7 +180,7 @@ func (w *CDCFlowWorkflowExecution) processCDCFlowConfigUpdates(ctx workflow.Cont
 		additionalTablesWorkflowCfg.TableMappings = flowConfigUpdate.AdditionalTables
 
 		childAdditionalTablesCDCFlowID,
-			err := GetChildWorkflowID(ctx, "cdc-flow", additionalTablesWorkflowCfg.FlowJobName)
+			err := GetChildWorkflowID(ctx, "additional-cdc-flow", additionalTablesWorkflowCfg.FlowJobName)
 		if err != nil {
 			return err
 		}
@@ -207,7 +214,8 @@ func (w *CDCFlowWorkflowExecution) processCDCFlowConfigUpdates(ctx workflow.Cont
 		for tableName, tableSchema := range res.TableNameSchemaMapping {
 			state.TableNameSchemaMapping[tableName] = tableSchema
 		}
-		cfg.TableMappings = append(cfg.TableMappings, flowConfigUpdate.AdditionalTables...)
+		state.TableMappings = append(state.TableMappings, flowConfigUpdate.AdditionalTables...)
+		state.SyncFlowOptions.TableMappings = state.TableMappings
 		// finished processing, wipe it
 		state.FlowConfigUpdates = nil
 	}
@@ -224,7 +232,7 @@ func CDCFlowWorkflowWithConfig(
 		return nil, fmt.Errorf("invalid connection configs")
 	}
 	if state == nil {
-		state = NewCDCFlowWorkflowState(len(cfg.TableMappings))
+		state = NewCDCFlowWorkflowState(cfg.TableMappings)
 	}
 
 	w := NewCDCFlowWorkflowExecution(ctx)
@@ -260,7 +268,7 @@ func CDCFlowWorkflowWithConfig(
 		// if resync is true, alter the table name schema mapping to temporarily add
 		// a suffix to the table names.
 		if cfg.Resync {
-			for _, mapping := range cfg.TableMappings {
+			for _, mapping := range state.TableMappings {
 				oldName := mapping.DestinationTableIdentifier
 				newName := fmt.Sprintf("%s_resync", oldName)
 				mapping.DestinationTableIdentifier = newName
@@ -328,7 +336,7 @@ func CDCFlowWorkflowWithConfig(
 			}
 			renameOpts.SyncedAtColName = &cfg.SyncedAtColName
 			correctedTableNameSchemaMapping := make(map[string]*protos.TableSchema)
-			for _, mapping := range cfg.TableMappings {
+			for _, mapping := range state.TableMappings {
 				oldName := mapping.DestinationTableIdentifier
 				newName := strings.TrimSuffix(oldName, "_resync")
 				renameOpts.RenameTableOptions = append(renameOpts.RenameTableOptions, &protos.RenameTableOption{
@@ -368,6 +376,7 @@ func CDCFlowWorkflowWithConfig(
 		IdleTimeoutSeconds:     cfg.IdleTimeoutSeconds,
 		SrcTableIdNameMapping:  state.SrcTableIdNameMapping,
 		TableNameSchemaMapping: state.TableNameSchemaMapping,
+		TableMappings:          state.TableMappings,
 	}
 	state.NormalizeFlowOptions = &protos.NormalizeFlowOptions{
 		TableNameSchemaMapping: state.TableNameSchemaMapping,
@@ -468,7 +477,7 @@ func CDCFlowWorkflowWithConfig(
 			state.CurrentFlowStatus = protos.FlowStatus_STATUS_PAUSED
 
 			for state.ActiveSignal == shared.PauseSignal {
-				w.logger.Info("mirror has been paused for ", time.Since(startTime))
+				w.logger.Info("mirror has been paused for ", slog.Any("duration", time.Since(startTime)))
 				// only place we block on receive, so signal processing is immediate
 				mainLoopSelector.Select(ctx)
 				if state.ActiveSignal == shared.NoopSignal {
@@ -539,7 +548,8 @@ func CDCFlowWorkflowWithConfig(
 				state.SyncFlowStatuses = append(state.SyncFlowStatuses, childSyncFlowRes)
 				state.RelationMessageMapping = childSyncFlowRes.RelationMessageMapping
 				totalRecordsSynced += childSyncFlowRes.NumRecordsSynced
-				w.logger.Info("Total records synced: ", totalRecordsSynced)
+				w.logger.Info("Total records synced: ",
+					slog.Int64("totalRecordsSynced", totalRecordsSynced))
 			}
 
 			if childSyncFlowRes != nil {

--- a/flow/workflows/normalize_flow.go
+++ b/flow/workflows/normalize_flow.go
@@ -2,6 +2,7 @@ package peerflow
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"go.temporal.io/sdk/workflow"
@@ -65,7 +66,7 @@ func NormalizeFlowWorkflow(ctx workflow.Context,
 		if lastSyncBatchID != syncBatchID {
 			lastSyncBatchID = syncBatchID
 
-			logger.Info("executing normalize - ", config.FlowJobName)
+			logger.Info("executing normalize - ", slog.String("flowName", config.FlowJobName))
 			startNormalizeInput := &protos.StartNormalizeInput{
 				FlowConnectionConfigs:  config,
 				TableNameSchemaMapping: tableNameSchemaMapping,

--- a/flow/workflows/normalize_flow.go
+++ b/flow/workflows/normalize_flow.go
@@ -66,7 +66,7 @@ func NormalizeFlowWorkflow(ctx workflow.Context,
 		if lastSyncBatchID != syncBatchID {
 			lastSyncBatchID = syncBatchID
 
-			logger.Info("executing normalize - ", slog.String("flowName", config.FlowJobName))
+			logger.Info("executing normalize", slog.String("flowName", config.FlowJobName))
 			startNormalizeInput := &protos.StartNormalizeInput{
 				FlowConnectionConfigs:  config,
 				TableNameSchemaMapping: tableNameSchemaMapping,

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -3,6 +3,7 @@ package peerflow
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -471,7 +472,7 @@ func QRepFlowWorkflow(
 		return err
 	}
 
-	logger.Info("consolidating partitions for peer flow - ", config.FlowJobName)
+	logger.Info("consolidating partitions for peer flow - ", slog.String("flowName", config.FlowJobName))
 	if err = q.consolidatePartitions(ctx); err != nil {
 		return err
 	}
@@ -515,7 +516,7 @@ func QRepFlowWorkflow(
 		var signalVal shared.CDCFlowSignal
 
 		for q.activeSignal == shared.PauseSignal {
-			q.logger.Info("mirror has been paused for ", time.Since(startTime))
+			q.logger.Info("mirror has been paused for ", slog.Any("duration", time.Since(startTime)))
 			// only place we block on receive, so signal processing is immediate
 			ok, _ := signalChan.ReceiveWithTimeout(ctx, 1*time.Minute, &signalVal)
 			if ok {

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -516,7 +516,7 @@ func QRepFlowWorkflow(
 		var signalVal shared.CDCFlowSignal
 
 		for q.activeSignal == shared.PauseSignal {
-			q.logger.Info("mirror has been paused for ", slog.Any("duration", time.Since(startTime)))
+			q.logger.Info("mirror has been paused", slog.Any("duration", time.Since(startTime)))
 			// only place we block on receive, so signal processing is immediate
 			ok, _ := signalChan.ReceiveWithTimeout(ctx, 1*time.Minute, &signalVal)
 			if ok {

--- a/flow/workflows/setup_flow.go
+++ b/flow/workflows/setup_flow.go
@@ -2,6 +2,7 @@ package peerflow
 
 import (
 	"fmt"
+	"log/slog"
 	"slices"
 	"sort"
 	"time"
@@ -253,7 +254,7 @@ func (s *SetupFlowExecution) executeSetupFlow(
 	ctx workflow.Context,
 	config *protos.FlowConnectionConfigs,
 ) (*protos.SetupFlowOutput, error) {
-	s.logger.Info("executing setup flow - ", s.cdcFlowName)
+	s.logger.Info("executing setup flow", slog.String("flowName", s.cdcFlowName))
 
 	// first check the connectionsAndSetupMetadataTables
 	if err := s.checkConnectionsAndSetupMetadataTables(ctx, config); err != nil {

--- a/flow/workflows/sync_flow.go
+++ b/flow/workflows/sync_flow.go
@@ -39,7 +39,7 @@ func (s *SyncFlowExecution) executeSyncFlow(
 	opts *protos.SyncFlowOptions,
 	relationMessageMapping model.RelationMessageMapping,
 ) (*model.SyncResponse, error) {
-	s.logger.Info("executing sync flow - ", slog.String("flowName", s.CDCFlowName))
+	s.logger.Info("executing sync flow", slog.String("flowName", s.CDCFlowName))
 
 	syncMetaCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
 		StartToCloseTimeout: 1 * time.Minute,

--- a/flow/workflows/sync_flow.go
+++ b/flow/workflows/sync_flow.go
@@ -2,6 +2,7 @@ package peerflow
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"go.temporal.io/sdk/log"
@@ -38,7 +39,7 @@ func (s *SyncFlowExecution) executeSyncFlow(
 	opts *protos.SyncFlowOptions,
 	relationMessageMapping model.RelationMessageMapping,
 ) (*model.SyncResponse, error) {
-	s.logger.Info("executing sync flow - ", s.CDCFlowName)
+	s.logger.Info("executing sync flow - ", slog.String("flowName", s.CDCFlowName))
 
 	syncMetaCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
 		StartToCloseTimeout: 1 * time.Minute,

--- a/flow/workflows/xmin_flow.go
+++ b/flow/workflows/xmin_flow.go
@@ -3,6 +3,7 @@ package peerflow
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -100,7 +101,7 @@ func XminFlowWorkflow(
 		var signalVal shared.CDCFlowSignal
 
 		for q.activeSignal == shared.PauseSignal {
-			q.logger.Info("mirror has been paused for ", time.Since(startTime))
+			q.logger.Info("mirror has been paused for ", slog.Any("duration", time.Since(startTime)))
 			// only place we block on receive, so signal processing is immediate
 			ok, _ := signalChan.ReceiveWithTimeout(ctx, 1*time.Minute, &signalVal)
 			if ok {

--- a/flow/workflows/xmin_flow.go
+++ b/flow/workflows/xmin_flow.go
@@ -101,7 +101,7 @@ func XminFlowWorkflow(
 		var signalVal shared.CDCFlowSignal
 
 		for q.activeSignal == shared.PauseSignal {
-			q.logger.Info("mirror has been paused for ", slog.Any("duration", time.Since(startTime)))
+			q.logger.Info("mirror has been paused", slog.Any("duration", time.Since(startTime)))
 			// only place we block on receive, so signal processing is immediate
 			ok, _ := signalChan.ReceiveWithTimeout(ctx, 1*time.Minute, &signalVal)
 			if ok {

--- a/nexus/flow-rs/src/grpc.rs
+++ b/nexus/flow-rs/src/grpc.rs
@@ -51,7 +51,7 @@ impl FlowGrpcClient {
             create_catalog_entry: false,
         };
         let response = self.client.create_q_rep_flow(create_qrep_flow_req).await?;
-        let workflow_id = response.into_inner().worflow_id;
+        let workflow_id = response.into_inner().workflow_id;
         Ok(workflow_id)
     }
 
@@ -82,7 +82,7 @@ impl FlowGrpcClient {
             create_catalog_entry: false,
         };
         let response = self.client.create_cdc_flow(create_peer_flow_req).await?;
-        let workflow_id = response.into_inner().worflow_id;
+        let workflow_id = response.into_inner().workflow_id;
         Ok(workflow_id)
     }
 

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -42,7 +42,7 @@ message FlowConnectionConfigs {
   peerdb_peers.Peer destination = 3;
 
   // config for the CDC flow itself
-  // currently, MaxBatchSize and IdleTimeoutSeconds are dynamic via Temporal signals
+  // currently, TableMappings, MaxBatchSize and IdleTimeoutSeconds are dynamic via Temporal signals
   repeated TableMapping table_mappings = 4;
   uint32 max_batch_size = 5;
   uint64 idle_timeout_seconds = 6;
@@ -103,6 +103,7 @@ message SyncFlowOptions {
   uint64 idle_timeout_seconds = 3;
   map<uint32, string> src_table_id_name_mapping = 4;
   map<string, TableSchema> table_name_schema_mapping = 5;
+  repeated TableMapping table_mappings = 6;
 }
 
 message NormalizeFlowOptions {
@@ -363,22 +364,20 @@ message GetOpenConnectionsForUserResult {
 // STATUS_RUNNING -> STATUS_PAUSED/STATUS_TERMINATED
 // STATUS_PAUSED -> STATUS_RUNNING/STATUS_TERMINATED
 // UI can read everything except STATUS_UNKNOWN
+// terminate button should always be enabled
 enum FlowStatus {
   // should never be read by UI, bail
   STATUS_UNKNOWN = 0;
   // enable pause and terminate buttons
   STATUS_RUNNING = 1;
-  // pause button becomes resume button, terminate button should still be enabled
+  // pause button becomes resume button
   STATUS_PAUSED = 2;
-  // neither button should be enabled
   STATUS_PAUSING = 3;
-  // neither button should be enabled, not reachable in QRep mirrors
+  // not reachable in QRep mirrors
   STATUS_SETUP = 4;
-  // neither button should be enabled, not reachable in QRep mirrors
+  // not reachable in QRep mirrors
   STATUS_SNAPSHOT = 5;
-  // neither button should be enabled
   STATUS_TERMINATING = 6;
-  // neither button should be enabled
   STATUS_TERMINATED = 7;
 }
 

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -14,7 +14,7 @@ message CreateCDCFlowRequest {
 }
 
 message CreateCDCFlowResponse {
-  string worflow_id = 1;
+  string workflow_id = 1;
 }
 
 message CreateQRepFlowRequest {
@@ -23,7 +23,7 @@ message CreateQRepFlowRequest {
 }
 
 message CreateQRepFlowResponse {
-  string worflow_id = 1;
+  string workflow_id = 1;
 }
 
 message ShutdownRequest {

--- a/ui/app/api/mirrors/cdc/route.ts
+++ b/ui/app/api/mirrors/cdc/route.ts
@@ -1,5 +1,5 @@
 import { UCreateMirrorResponse } from '@/app/dto/MirrorsDTO';
-import { CreateCDCFlowRequest } from '@/grpc_generated/route';
+import { CreateCDCFlowRequest, CreateCDCFlowResponse } from '@/grpc_generated/route';
 import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
 
 export async function POST(request: Request) {
@@ -12,14 +12,14 @@ export async function POST(request: Request) {
     createCatalogEntry: true,
   };
   try {
-    const createStatus = await fetch(`${flowServiceAddr}/v1/flows/cdc/create`, {
+    const createStatus: CreateCDCFlowResponse = await fetch(`${flowServiceAddr}/v1/flows/cdc/create`, {
       method: 'POST',
       body: JSON.stringify(req),
     }).then((res) => {
       return res.json();
     });
 
-    if (!createStatus.worflowId) {
+    if (!createStatus.workflowId) {
       return new Response(JSON.stringify(createStatus));
     }
     let response: UCreateMirrorResponse = {

--- a/ui/app/api/mirrors/cdc/route.ts
+++ b/ui/app/api/mirrors/cdc/route.ts
@@ -1,5 +1,8 @@
 import { UCreateMirrorResponse } from '@/app/dto/MirrorsDTO';
-import { CreateCDCFlowRequest, CreateCDCFlowResponse } from '@/grpc_generated/route';
+import {
+  CreateCDCFlowRequest,
+  CreateCDCFlowResponse,
+} from '@/grpc_generated/route';
 import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
 
 export async function POST(request: Request) {
@@ -12,10 +15,13 @@ export async function POST(request: Request) {
     createCatalogEntry: true,
   };
   try {
-    const createStatus: CreateCDCFlowResponse = await fetch(`${flowServiceAddr}/v1/flows/cdc/create`, {
-      method: 'POST',
-      body: JSON.stringify(req),
-    }).then((res) => {
+    const createStatus: CreateCDCFlowResponse = await fetch(
+      `${flowServiceAddr}/v1/flows/cdc/create`,
+      {
+        method: 'POST',
+        body: JSON.stringify(req),
+      }
+    ).then((res) => {
       return res.json();
     });
 

--- a/ui/app/api/mirrors/qrep/route.ts
+++ b/ui/app/api/mirrors/qrep/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
       return res.json();
     });
     let response: UCreateMirrorResponse = {
-      created: !!createStatus.worflowId,
+      created: !!createStatus.workflowId,
     };
 
     return new Response(JSON.stringify(response));

--- a/ui/app/mirrors/[mirrorId]/cdc.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdc.tsx
@@ -248,7 +248,7 @@ export function CDCMirror({
     setSelectedTab(index);
   };
 
-  let snapshot = <></>;
+  let snapshot = null;
   if (status.cdcStatus?.snapshotStatus) {
     snapshot = (
       <SnapshotStatusTable status={status.cdcStatus?.snapshotStatus} />

--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -173,7 +173,7 @@ const EditMirror = ({ params: { mirrorId } }: EditMirrorProps) => {
           }}
           variant='normalSolid'
           disabled={
-            config.additionalTables.length > 0 &&
+            additionalTables.length > 0 &&
             mirrorState.currentFlowState.toString() !==
               FlowStatus[FlowStatus.STATUS_PAUSED]
           }


### PR DESCRIPTION
1. `TableMappings` is now cloned and stored in state, and modifications affect only state version. Pass it through to `SyncFlow`.
2. Fixed some logs
3. removed env var for idle timeout seconds, but retaining function for tests.
4. Renamed mispelt proto field.
5. bug in UI, wasn't looking at the correct version of `additionalTables`
6. optimization - don't store records from CDC in some cases
7. don't heartbeat after every record.