### PR TITLE
Eventhubs: Refactor Destination Table Semantics

### DIFF
--- a/flow/connectors/eventhub/hubmanager.go
+++ b/flow/connectors/eventhub/hubmanager.go
@@ -125,7 +125,6 @@ func (m *EventHubManager) Close(ctx context.Context) error {
 
 	m.hubs.Range(func(key any, value any) bool {
 		name := key.(ScopedEventhub)
-		slog.Info(fmt.Sprintf("closing eventhub client for %v", name))
 		hub := value.(*azeventhubs.ProducerClient)
 		err := m.closeProducerClient(ctx, hub)
 		if err != nil {

--- a/flow/connectors/eventhub/scoped_eventhub.go
+++ b/flow/connectors/eventhub/scoped_eventhub.go
@@ -9,26 +9,30 @@ import (
 // partition_column is the column in the table that is used to determine
 // the partition key for the eventhub. Partition value is one such value of that column.
 type ScopedEventhub struct {
-	PeerName           string
+	EventhubNamespace  string
 	Eventhub           string
+	DestinationTable   string
 	PartitionKeyColumn string
 	PartitionKeyValue  string
 }
 
 func NewScopedEventhub(dstTableName string) (ScopedEventhub, error) {
-	// split by dot, the model is peername.eventhub.partition_key_column
+	// split by dot, the model is eventhub.eventhub_namespace.table_name.partition_key_column
 	parts := strings.Split(dstTableName, ".")
 
-	if len(parts) != 3 {
+	if len(parts) != 4 {
 		return ScopedEventhub{}, fmt.Errorf("invalid scoped eventhub '%s'", dstTableName)
 	}
 
-	// support eventhub name and partition key with hyphens etc.
-	eventhubPart := strings.Trim(parts[1], `"`)
-	partitionPart := strings.Trim(parts[2], `"`)
+	// support eventhub namespace, eventhub name, table name, partition key with hyphens etc.
+	eventhubPart := strings.Trim(parts[0], `"`)
+	namespacePart := strings.Trim(parts[1], `"`)
+	destTablePart := strings.Trim(parts[2], `"`)
+	partitionPart := strings.Trim(parts[3], `"`)
 	return ScopedEventhub{
-		PeerName:           parts[0],
+		EventhubNamespace:  namespacePart,
 		Eventhub:           eventhubPart,
+		DestinationTable:   destTablePart,
 		PartitionKeyColumn: partitionPart,
 	}, nil
 }
@@ -37,14 +41,7 @@ func (s *ScopedEventhub) SetPartitionValue(value string) {
 	s.PartitionKeyValue = value
 }
 
-func (s ScopedEventhub) Equals(other ScopedEventhub) bool {
-	return s.PeerName == other.PeerName &&
-		s.Eventhub == other.Eventhub &&
-		s.PartitionKeyColumn == other.PartitionKeyColumn &&
-		s.PartitionKeyValue == other.PartitionKeyValue
-}
-
 // ToString returns the string representation of the ScopedEventhub
 func (s ScopedEventhub) ToString() string {
-	return fmt.Sprintf("%s.%s.%s.%s", s.PeerName, s.Eventhub, s.PartitionKeyColumn, s.PartitionKeyValue)
+	return fmt.Sprintf("%s.%s.%s.%s.%s", s.EventhubNamespace, s.Eventhub, s.DestinationTable, s.PartitionKeyColumn, s.PartitionKeyValue)
 }

--- a/flow/connectors/eventhub/scoped_eventhub.go
+++ b/flow/connectors/eventhub/scoped_eventhub.go
@@ -11,7 +11,6 @@ import (
 type ScopedEventhub struct {
 	EventhubNamespace  string
 	Eventhub           string
-	DestinationTable   string
 	PartitionKeyColumn string
 	PartitionKeyValue  string
 }
@@ -24,15 +23,17 @@ func NewScopedEventhub(dstTableName string) (ScopedEventhub, error) {
 		return ScopedEventhub{}, fmt.Errorf("invalid scoped eventhub '%s'", dstTableName)
 	}
 
-	// support eventhub namespace, eventhub name, table name, partition key with hyphens etc.
+	// support eventhub namespace, eventhub name, partition key with hyphens etc.
+	// part[2] will be some table identifier.
+	// It's just so that we have distinct destination table names
+	// in create mirror's table mapping.
+	// We can ignore it.
 	eventhubPart := strings.Trim(parts[0], `"`)
 	namespacePart := strings.Trim(parts[1], `"`)
-	destTablePart := strings.Trim(parts[2], `"`)
 	partitionPart := strings.Trim(parts[3], `"`)
 	return ScopedEventhub{
 		EventhubNamespace:  namespacePart,
 		Eventhub:           eventhubPart,
-		DestinationTable:   destTablePart,
 		PartitionKeyColumn: partitionPart,
 	}, nil
 }
@@ -43,5 +44,5 @@ func (s *ScopedEventhub) SetPartitionValue(value string) {
 
 // ToString returns the string representation of the ScopedEventhub
 func (s ScopedEventhub) ToString() string {
-	return fmt.Sprintf("%s.%s.%s.%s.%s", s.EventhubNamespace, s.Eventhub, s.DestinationTable, s.PartitionKeyColumn, s.PartitionKeyValue)
+	return fmt.Sprintf("%s.%s.%s.%s", s.EventhubNamespace, s.Eventhub, s.PartitionKeyColumn, s.PartitionKeyValue)
 }


### PR DESCRIPTION
The destination table name in table mapping of Create CDC Mirror now expected to look like: 
```
<eventhub_name>.<eventhub_namespace>.<unique_identifier>.<partition_key>
```
This is to allow multiple source tables to be mapped to same eventhub partition.
`unique identifier` can be the source table name or anything else. It's purely to distinguish destination table names