### PR TITLE
Clickhouse peer: specify S3 fields

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -85,7 +85,7 @@ func (c *ClickhouseConnector) syncRecordsViaAvro(
 	}
 
 	qrepConfig := &protos.QRepConfig{
-		StagingPath:                c.config.S3Integration,
+		StagingPath:                c.config.S3Path,
 		FlowJobName:                req.FlowJobName,
 		DestinationTableIdentifier: strings.ToLower(rawTableIdentifier),
 	}

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -27,8 +27,6 @@ type ClickhouseConnector struct {
 }
 
 func ValidateS3(ctx context.Context, bucketUrl string, creds utils.S3PeerCredentials) error {
-	slog.Info("Validating S3 bucket", slog.String("bucketUrl", bucketUrl))
-	slog.Info("Validating S3 credentials", slog.Any("creds", creds))
 	// for validation purposes
 	s3Client, err := utils.CreateS3Client(creds)
 	if err != nil {

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -10,6 +10,8 @@ import (
 	_ "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 
 	metadataStore "github.com/PeerDB-io/peer-flow/connectors/external_metadata"
+	conns3 "github.com/PeerDB-io/peer-flow/connectors/s3"
+	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
@@ -21,12 +23,30 @@ type ClickhouseConnector struct {
 	tableSchemaMapping map[string]*protos.TableSchema
 	logger             slog.Logger
 	config             *protos.ClickhouseConfig
+	creds              utils.S3PeerCredentials
+}
+
+func ValidateS3(ctx context.Context, bucketUrl string, creds utils.S3PeerCredentials) error {
+	slog.Info("Validating S3 bucket", slog.String("bucketUrl", bucketUrl))
+	slog.Info("Validating S3 credentials", slog.Any("creds", creds))
+	// for validation purposes
+	s3Client, err := utils.CreateS3Client(creds)
+	if err != nil {
+		return fmt.Errorf("failed to create S3 client: %w", err)
+	}
+
+	validErr := conns3.ValidCheck(ctx, s3Client, bucketUrl, nil)
+	if validErr != nil {
+		return validErr
+	}
+
+	return nil
 }
 
 func NewClickhouseConnector(ctx context.Context,
-	clickhouseProtoConfig *protos.ClickhouseConfig,
+	config *protos.ClickhouseConfig,
 ) (*ClickhouseConnector, error) {
-	database, err := connect(ctx, clickhouseProtoConfig)
+	database, err := connect(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open connection to Clickhouse peer: %w", err)
 	}
@@ -37,6 +57,17 @@ func NewClickhouseConnector(ctx context.Context,
 		return nil, err
 	}
 
+	s3PeerCreds := utils.S3PeerCredentials{
+		AccessKeyID:     config.AccessKeyId,
+		SecretAccessKey: config.SecretAccessKey,
+		Region:          config.Region,
+	}
+
+	validateErr := ValidateS3(ctx, config.S3Path, s3PeerCreds)
+	if validateErr != nil {
+		return nil, fmt.Errorf("failed to validate S3 bucket: %w", validateErr)
+	}
+
 	flowName, _ := ctx.Value(shared.FlowNameKey).(string)
 	return &ClickhouseConnector{
 		ctx:                ctx,
@@ -44,7 +75,8 @@ func NewClickhouseConnector(ctx context.Context,
 		pgMetadata:         pgMetadata,
 		tableSchemaMapping: nil,
 		logger:             *slog.With(slog.String(string(shared.FlowNameKey), flowName)),
-		config:             clickhouseProtoConfig,
+		config:             config,
+		creds:              s3PeerCreds,
 	}, nil
 }
 

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -124,20 +124,17 @@ func ValidCheck(ctx context.Context, s3Client *s3.Client, bucketURL string, meta
 	}
 
 	// check if we can ping external metadata
-	err := metadataDB.Ping()
-	if err != nil {
-		return fmt.Errorf("failed to ping external metadata: %w", err)
+	if metadataDB != nil {
+		err := metadataDB.Ping()
+		if err != nil {
+			return fmt.Errorf("failed to ping external metadata: %w", err)
+		}
 	}
 
 	return nil
 }
 
 func (c *S3Connector) ConnectionActive() error {
-	_, listErr := c.client.ListBuckets(c.ctx, nil)
-	if listErr != nil {
-		return listErr
-	}
-
 	validErr := ValidCheck(c.ctx, &c.client, c.url, c.pgMetadata)
 	if validErr != nil {
 		c.logger.Error("failed to validate s3 connector:", slog.Any("error", validErr))

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -803,7 +803,22 @@ fn parse_db_options(
                     .get("database")
                     .context("no default database specified")?
                     .to_string(),
-                s3_integration: s3_int,
+                s3_path: opts
+                    .get("s3_path")
+                    .context("no s3 path specified")?
+                    .to_string(),
+                access_key_id: opts
+                    .get("access_key_id")
+                    .context("no access key id specified")?
+                    .to_string(),
+                secret_access_key: opts
+                    .get("secret_access_key")
+                    .context("no secret access key specified")?
+                    .to_string(),
+                region: opts
+                    .get("region")
+                    .context("no region specified")?
+                    .to_string(),
             };
             let config = Config::ClickhouseConfig(clickhouse_config);
             Some(config)

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -779,11 +779,6 @@ fn parse_db_options(
             Some(config)
         }
         DbType::Clickhouse => {
-            let s3_int = opts
-                .get("s3_integration")
-                .map(|s| s.to_string())
-                .unwrap_or_default();
-
             let clickhouse_config = ClickhouseConfig {
                 host: opts.get("host").context("no host specified")?.to_string(),
                 port: opts

--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::{anyhow, Context};
 use peer_cursor::{QueryExecutor, QueryOutput, Schema};
 use peer_postgres::{self, ast};
-use pgwire::error::{PgWireResult};
+use pgwire::error::PgWireResult;
 use postgres_connection::{connect_postgres, get_pg_connection_string};
 use prost::Message;
 use pt::{
@@ -165,7 +165,10 @@ impl Catalog {
     pub async fn get_peer_id_i32(&self, peer_name: &str) -> anyhow::Result<i32> {
         let stmt = self
             .pg
-            .prepare_typed("SELECT id FROM public.peers WHERE name = $1", &[types::Type::TEXT])
+            .prepare_typed(
+                "SELECT id FROM public.peers WHERE name = $1",
+                &[types::Type::TEXT],
+            )
             .await?;
 
         self.pg
@@ -179,7 +182,10 @@ impl Catalog {
     pub async fn get_peer_type_for_id(&self, peer_id: i32) -> anyhow::Result<DbType> {
         let stmt = self
             .pg
-            .prepare_typed("SELECT type FROM public.peers WHERE id = $1", &[types::Type::INT4])
+            .prepare_typed(
+                "SELECT type FROM public.peers WHERE id = $1",
+                &[types::Type::INT4],
+            )
             .await?;
 
         self.pg
@@ -251,7 +257,10 @@ impl Catalog {
     pub async fn get_peer_by_id(&self, peer_id: i32) -> anyhow::Result<Peer> {
         let stmt = self
             .pg
-            .prepare_typed("SELECT name, type, options FROM public.peers WHERE id = $1", &[])
+            .prepare_typed(
+                "SELECT name, type, options FROM public.peers WHERE id = $1",
+                &[],
+            )
             .await?;
 
         let rows = self.pg.query(&stmt, &[&peer_id]).await?;
@@ -557,7 +566,10 @@ impl Catalog {
     pub async fn delete_flow_job_entry(&self, flow_job_name: &str) -> anyhow::Result<()> {
         let rows = self
             .pg
-            .execute("DELETE FROM public.flows WHERE name = $1", &[&flow_job_name])
+            .execute(
+                "DELETE FROM public.flows WHERE name = $1",
+                &[&flow_job_name],
+            )
             .await?;
         if rows == 0 {
             return Err(anyhow!("unable to delete flow job metadata"));
@@ -568,7 +580,10 @@ impl Catalog {
     pub async fn check_peer_entry(&self, peer_name: &str) -> anyhow::Result<i64> {
         let peer_check = self
             .pg
-            .query_one("SELECT COUNT(*) FROM public.peers WHERE name = $1", &[&peer_name])
+            .query_one(
+                "SELECT COUNT(*) FROM public.peers WHERE name = $1",
+                &[&peer_name],
+            )
             .await?;
         let peer_count: i64 = peer_check.get(0);
         Ok(peer_count)
@@ -599,9 +614,7 @@ impl Catalog {
 impl QueryExecutor for Catalog {
     #[tracing::instrument(skip(self, stmt), fields(stmt = %stmt))]
     async fn execute(&self, stmt: &Statement) -> PgWireResult<QueryOutput> {
-        peer_postgres::pg_execute(&self.pg, ast::PostgresAst {
-            peername: None,
-        }, stmt).await
+        peer_postgres::pg_execute(&self.pg, ast::PostgresAst { peername: None }, stmt).await
     }
 
     async fn describe(&self, stmt: &Statement) -> PgWireResult<Option<Schema>> {

--- a/nexus/peer-postgres/src/lib.rs
+++ b/nexus/peer-postgres/src/lib.rs
@@ -44,88 +44,92 @@ async fn schema_from_query(client: &Client, query: &str) -> anyhow::Result<Schem
     Ok(Arc::new(fields))
 }
 
-pub async fn pg_execute(client: &Client, ast: ast::PostgresAst, stmt: &Statement) -> PgWireResult<QueryOutput> {
-        // if the query is a select statement, we need to fetch the rows
-        // and return them as a QueryOutput::Stream, else we return the
-        // number of affected rows.
-        match stmt {
-            Statement::Query(query) => {
-                let mut query = query.clone();
-                ast.rewrite_query(&mut query);
-                let rewritten_query = query.to_string();
+pub async fn pg_execute(
+    client: &Client,
+    ast: ast::PostgresAst,
+    stmt: &Statement,
+) -> PgWireResult<QueryOutput> {
+    // if the query is a select statement, we need to fetch the rows
+    // and return them as a QueryOutput::Stream, else we return the
+    // number of affected rows.
+    match stmt {
+        Statement::Query(query) => {
+            let mut query = query.clone();
+            ast.rewrite_query(&mut query);
+            let rewritten_query = query.to_string();
 
-                // first fetch the schema as this connection will be
-                // short lived, only then run the query as the query
-                // could hold the pin on the connection for a long time.
-                let schema = schema_from_query(client, &rewritten_query)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!("error getting schema: {}", e);
-                        PgWireError::ApiError(format!("error getting schema: {}", e).into())
-                    })?;
-
-                tracing::info!("[peer-postgres] rewritten query: {}", rewritten_query);
-                // given that there could be a lot of rows returned, we
-                // need to use a cursor to stream the rows back to the
-                // client.
-                let stream = client
-                    .query_raw(&rewritten_query, std::iter::empty::<&str>())
-                    .await
-                    .map_err(|e| {
-                        tracing::error!("error executing query: {}", e);
-                        PgWireError::ApiError(format!("error executing query: {}", e).into())
-                    })?;
-
-                // log that raw query execution has completed
-                tracing::info!("[peer-postgres] raw query execution completed");
-
-                let cursor = stream::PgRecordStream::new(stream, schema);
-                Ok(QueryOutput::Stream(Box::pin(cursor)))
-            }
-            _ => {
-                let mut rewritten_stmt = stmt.clone();
-                ast.rewrite_statement(&mut rewritten_stmt).map_err(|e| {
-                    tracing::error!("error rewriting statement: {}", e);
-                    PgWireError::ApiError(format!("error rewriting statement: {}", e).into())
+            // first fetch the schema as this connection will be
+            // short lived, only then run the query as the query
+            // could hold the pin on the connection for a long time.
+            let schema = schema_from_query(client, &rewritten_query)
+                .await
+                .map_err(|e| {
+                    tracing::error!("error getting schema: {}", e);
+                    PgWireError::ApiError(format!("error getting schema: {}", e).into())
                 })?;
-                let rewritten_query = rewritten_stmt.to_string();
-                tracing::info!("[peer-postgres] rewritten statement: {}", rewritten_query);
-                let rows_affected =
-                    client
-                        .execute(&rewritten_query, &[])
-                        .await
-                        .map_err(|e| {
-                            tracing::error!("error executing query: {}", e);
-                            PgWireError::ApiError(format!("error executing query: {}", e).into())
-                        })?;
-                Ok(QueryOutput::AffectedRows(rows_affected as usize))
-            }
-        }
 
+            tracing::info!("[peer-postgres] rewritten query: {}", rewritten_query);
+            // given that there could be a lot of rows returned, we
+            // need to use a cursor to stream the rows back to the
+            // client.
+            let stream = client
+                .query_raw(&rewritten_query, std::iter::empty::<&str>())
+                .await
+                .map_err(|e| {
+                    tracing::error!("error executing query: {}", e);
+                    PgWireError::ApiError(format!("error executing query: {}", e).into())
+                })?;
+
+            // log that raw query execution has completed
+            tracing::info!("[peer-postgres] raw query execution completed");
+
+            let cursor = stream::PgRecordStream::new(stream, schema);
+            Ok(QueryOutput::Stream(Box::pin(cursor)))
+        }
+        _ => {
+            let mut rewritten_stmt = stmt.clone();
+            ast.rewrite_statement(&mut rewritten_stmt).map_err(|e| {
+                tracing::error!("error rewriting statement: {}", e);
+                PgWireError::ApiError(format!("error rewriting statement: {}", e).into())
+            })?;
+            let rewritten_query = rewritten_stmt.to_string();
+            tracing::info!("[peer-postgres] rewritten statement: {}", rewritten_query);
+            let rows_affected = client.execute(&rewritten_query, &[]).await.map_err(|e| {
+                tracing::error!("error executing query: {}", e);
+                PgWireError::ApiError(format!("error executing query: {}", e).into())
+            })?;
+            Ok(QueryOutput::AffectedRows(rows_affected as usize))
+        }
+    }
 }
 
 pub async fn pg_describe(client: &Client, stmt: &Statement) -> PgWireResult<Option<Schema>> {
-        match stmt {
-            Statement::Query(_query) => {
-                let schema = schema_from_query(client, &stmt.to_string())
-                    .await
-                    .map_err(|e| {
-                        tracing::error!("error getting schema: {}", e);
-                        PgWireError::ApiError(format!("error getting schema: {}", e).into())
-                    })?;
-                Ok(Some(schema))
-            }
-            _ => Ok(None),
+    match stmt {
+        Statement::Query(_query) => {
+            let schema = schema_from_query(client, &stmt.to_string())
+                .await
+                .map_err(|e| {
+                    tracing::error!("error getting schema: {}", e);
+                    PgWireError::ApiError(format!("error getting schema: {}", e).into())
+                })?;
+            Ok(Some(schema))
         }
+        _ => Ok(None),
+    }
 }
 
 #[async_trait::async_trait]
 impl QueryExecutor for PostgresQueryExecutor {
     #[tracing::instrument(skip(self, stmt), fields(stmt = %stmt))]
     async fn execute(&self, stmt: &Statement) -> PgWireResult<QueryOutput> {
-        pg_execute(&self.client, ast::PostgresAst {
-            peername: Some(self.peername.clone()),
-        }, stmt).await
+        pg_execute(
+            &self.client,
+            ast::PostgresAst {
+                peername: Some(self.peername.clone()),
+            },
+            stmt,
+        )
+        .await
     }
 
     async fn describe(&self, stmt: &Statement) -> PgWireResult<Option<Schema>> {

--- a/nexus/postgres-connection/src/lib.rs
+++ b/nexus/postgres-connection/src/lib.rs
@@ -68,7 +68,9 @@ pub fn get_pg_connection_string(config: &PostgresConfig) -> String {
     write!(
         connection_string,
         "@{}:{}/{}?connect_timeout=15&application_name=peerdb_nexus",
-        config.host, config.port, urlencoding::encode(&config.database)
+        config.host,
+        config.port,
+        urlencoding::encode(&config.database)
     )
     .ok();
 

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -93,7 +93,10 @@ message ClickhouseConfig{
   string user = 3;
   string password = 4;
   string database = 5;
-  string s3_integration = 6; // staging to store avro files
+  string s3_path = 6; // path to S3 bucket which will store avro files
+  string access_key_id = 7;
+  string secret_access_key = 8;
+  string region = 9;
 }
 
 message SqlServerConfig {

--- a/ui/app/peers/create/[peerType]/helpers/ch.ts
+++ b/ui/app/peers/create/[peerType]/helpers/ch.ts
@@ -40,13 +40,32 @@ export const clickhouseSetting: PeerSetting[] = [
       'https://www.postgresql.org/docs/current/sql-createdatabase.html',
   },
   {
-    label: 'S3 Integration',
+    label: 'S3 Path',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, s3Integration: value })),
-    optional: true,
-    tips: `This is needed only if you plan to run a mirror and you wish to stage AVRO files on S3.`,
+      setter((curr) => ({ ...curr, s3Path: value })),
+    tips: `This is an S3 bucket/object URL field. This bucket will be used as our intermediate stage for CDC`,
+  },
+  {
+    label: 'Access Key ID',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, accessKeyId: value })),
+    tips: 'The AWS access key ID associated with your account.',
     helpfulLink:
-      'https://docs.snowflake.com/en/user-guide/data-load-s3-config-storage-integration',
+      'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html',
+  },
+  {
+    label: 'Secret Access Key',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, secretAccessKey: value })),
+    tips: 'The AWS secret access key associated with the above bucket.',
+    helpfulLink:
+      'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html',
+  },
+  {
+    label: 'Region',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, region: value })),
+    tips: 'The region where your bucket is located. For example, us-east-1.',
   },
 ];
 
@@ -56,5 +75,8 @@ export const blankClickhouseSetting: ClickhouseConfig = {
   user: '',
   password: '',
   database: '',
-  s3Integration: '',
+  s3Path: '',
+  accessKeyId: '',
+  secretAccessKey: '',
+  region: '',
 };

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -229,6 +229,34 @@ export const bqSchema = z.object({
     .max(1024, 'DatasetID must be less than 1025 characters'),
 });
 
+const urlSchema = z
+  .string({
+    invalid_type_error: 'URL must be a string',
+    required_error: 'URL is required',
+  })
+  .min(1, { message: 'URL must be non-empty' })
+  .refine((url) => url.startsWith('s3://'), {
+    message: 'URL must start with s3://',
+  });
+
+const accessKeySchema = z
+  .string({
+    invalid_type_error: 'Access Key ID must be a string',
+    required_error: 'Access Key ID is required',
+  })
+  .min(1, { message: 'Access Key ID must be non-empty' });
+
+const secretKeySchema = z
+  .string({
+    invalid_type_error: 'Secret Access Key must be a string',
+    required_error: 'Secret Access Key is required',
+  })
+  .min(1, { message: 'Secret Access Key must be non-empty' });
+
+const regionSchema = z.string({
+  invalid_type_error: 'Region must be a string',
+});
+
 export const chSchema = z.object({
   host: z
     .string({
@@ -266,40 +294,22 @@ export const chSchema = z.object({
     })
     .min(1, 'Password must be non-empty')
     .max(100, 'Password must be less than 100 characters'),
+  s3Path: urlSchema,
+  accessKeyId: accessKeySchema,
+  secretAccessKey: secretKeySchema,
+  region: regionSchema.min(1, { message: 'Region must be non-empty' }),
 });
 
 export const s3Schema = z.object({
-  url: z
-    .string({
-      invalid_type_error: 'URL must be a string',
-      required_error: 'URL is required',
-    })
-    .min(1, { message: 'URL must be non-empty' })
-    .refine((url) => url.startsWith('s3://'), {
-      message: 'URL must start with s3://',
-    }),
-  accessKeyId: z
-    .string({
-      invalid_type_error: 'Access Key ID must be a string',
-      required_error: 'Access Key ID is required',
-    })
-    .min(1, { message: 'Access Key ID must be non-empty' }),
-  secretAccessKey: z
-    .string({
-      invalid_type_error: 'Secret Access Key must be a string',
-      required_error: 'Secret Access Key is required',
-    })
-    .min(1, { message: 'Secret Access Key must be non-empty' }),
+  url: urlSchema,
+  accessKeyId: accessKeySchema,
+  secretAccessKey: secretKeySchema,
   roleArn: z
     .string({
       invalid_type_error: 'Role ARN must be a string',
     })
     .optional(),
-  region: z
-    .string({
-      invalid_type_error: 'Region must be a string',
-    })
-    .optional(),
+  region: regionSchema.optional(),
   endpoint: z
     .string({
       invalid_type_error: 'Endpoint must be a string',

--- a/ui/components/PeerForms/ClickhouseConfig.tsx
+++ b/ui/components/PeerForms/ClickhouseConfig.tsx
@@ -76,7 +76,7 @@ export default function ClickhouseForm({ settings, setter }: ConfigProps) {
         variant='subheadline'
         colorName='lowContrast'
       >
-        Transient Stage
+        Transient S3 Stage
       </Label>
       <Label>
         Please provide an S3 object URL and access credentials to store our

--- a/ui/components/PeerForms/ClickhouseConfig.tsx
+++ b/ui/components/PeerForms/ClickhouseConfig.tsx
@@ -1,17 +1,10 @@
 'use client';
 import { PeerSetter } from '@/app/dto/PeersDTO';
 import { PeerSetting } from '@/app/peers/create/[peerType]/helpers/common';
-import {
-  blankSSHConfig,
-  sshSetting,
-} from '@/app/peers/create/[peerType]/helpers/pg';
-import { SSHConfig } from '@/grpc_generated/peers';
 import { Label } from '@/lib/Label';
 import { RowWithTextField } from '@/lib/Layout';
-import { Switch } from '@/lib/Switch';
 import { TextField } from '@/lib/TextField';
 import { Tooltip } from '@/lib/Tooltip';
-import { useEffect, useState } from 'react';
 import { InfoPopover } from '../InfoPopover';
 interface ConfigProps {
   settings: PeerSetting[];
@@ -19,9 +12,7 @@ interface ConfigProps {
 }
 
 export default function ClickhouseForm({ settings, setter }: ConfigProps) {
-  const [showSSH, setShowSSH] = useState<boolean>(false);
-  const [sshConfig, setSSHConfig] = useState<SSHConfig>(blankSSHConfig);
-
+  const S3Labels = ['S3 Path', 'Access Key ID', 'Secret Access Key', 'Region'];
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     setting: PeerSetting
@@ -29,19 +20,71 @@ export default function ClickhouseForm({ settings, setter }: ConfigProps) {
     setting.stateHandler(e.target.value, setter);
   };
 
-  useEffect(() => {
-    setter((prev) => {
-      return {
-        ...prev,
-        sshConfig: showSSH ? sshConfig : undefined,
-      };
-    });
-  }, [sshConfig, setter, showSSH]);
-
   return (
     <>
-      {settings.map((setting, id) => {
-        return (
+      {settings
+        .filter((setting) => !S3Labels.includes(setting.label))
+        .map((setting, id) => {
+          return (
+            <RowWithTextField
+              key={id}
+              label={
+                <Label>
+                  {setting.label}{' '}
+                  {!setting.optional && (
+                    <Tooltip
+                      style={{ width: '100%' }}
+                      content={'This is a required field.'}
+                    >
+                      <Label colorName='lowContrast' colorSet='destructive'>
+                        *
+                      </Label>
+                    </Tooltip>
+                  )}
+                </Label>
+              }
+              action={
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                  }}
+                >
+                  <TextField
+                    variant='simple'
+                    type={setting.type}
+                    defaultValue={setting.default}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      handleChange(e, setting)
+                    }
+                  />
+                  {setting.tips && (
+                    <InfoPopover
+                      tips={setting.tips}
+                      link={setting.helpfulLink}
+                    />
+                  )}
+                </div>
+              }
+            />
+          );
+        })}
+      <Label
+        as='label'
+        style={{ marginTop: '1rem' }}
+        variant='subheadline'
+        colorName='lowContrast'
+      >
+        Transient Stage
+      </Label>
+      <Label>
+        Please provide an S3 object URL and access credentials to store our
+        intermediate staging files.
+      </Label>
+      {settings
+        .filter((setting) => S3Labels.includes(setting.label))
+        .map((setting, id) => (
           <RowWithTextField
             key={id}
             label={
@@ -69,81 +112,12 @@ export default function ClickhouseForm({ settings, setter }: ConfigProps) {
               >
                 <TextField
                   variant='simple'
-                  type={setting.type}
-                  defaultValue={setting.default}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     handleChange(e, setting)
                   }
+                  type={setting.type}
                 />
-                {setting.tips && (
-                  <InfoPopover tips={setting.tips} link={setting.helpfulLink} />
-                )}
-              </div>
-            }
-          />
-        );
-      })}
-
-      <Label
-        as='label'
-        style={{ marginTop: '1rem' }}
-        variant='subheadline'
-        colorName='lowContrast'
-      >
-        SSH Configuration
-      </Label>
-      <Label>
-        You may provide SSH configuration to connect to your PostgreSQL database
-        through SSH tunnel.
-      </Label>
-      <div style={{ width: '50%', display: 'flex', alignItems: 'center' }}>
-        <Label variant='subheadline'>Configure SSH Tunnel</Label>
-        <Switch onCheckedChange={(state) => setShowSSH(state)} />
-      </div>
-      {showSSH &&
-        sshSetting.map((sshParam, index) => (
-          <RowWithTextField
-            key={index}
-            label={
-              <Label>
-                {sshParam.label}{' '}
-                {!sshParam.optional && (
-                  <Tooltip
-                    style={{ width: '100%' }}
-                    content={'This is a required field.'}
-                  >
-                    <Label colorName='lowContrast' colorSet='destructive'>
-                      *
-                    </Label>
-                  </Tooltip>
-                )}
-              </Label>
-            }
-            action={
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                }}
-              >
-                <TextField
-                  variant='simple'
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    sshParam.stateHandler(e.target.value, setSSHConfig)
-                  }
-                  type={sshParam.type}
-                  defaultValue={
-                    (sshConfig as SSHConfig)[
-                      sshParam.label === 'BASE64 Private Key'
-                        ? 'privateKey'
-                        : sshParam.label === 'Host Key'
-                          ? 'hostKey'
-                          : (sshParam.label.toLowerCase() as keyof SSHConfig)
-                    ] || ''
-                  }
-                />
-                {sshParam.tips && <InfoPopover tips={sshParam.tips} />}
+                {setting.tips && <InfoPopover tips={setting.tips} />}
               </div>
             }
           />


### PR DESCRIPTION
This PR refactors the Clickhouse peer to now have the S3 fields - object path, access key id, secret key and region:

```
message ClickhouseConfig{
  string host = 1;
  uint32 port = 2;
  string user = 3;
  string password = 4;
  string database = 5;
  string s3_path = 6; // path to S3 bucket which will store avro files
  string access_key_id = 7;
  string secret_access_key = 8;
  string region = 9;
}
```

The UI for Clickhouse peer creation has been updated accordingly:
<img width="956" alt="Screenshot 2024-02-05 at 5 36 55 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/b47a8fcc-3575-4f09-8a0d-74eb9b9a986f">

Validation for the S3 stage is also added as part of validate peer for clickhouse.

Nexus code updated accordingly.

This PR has been functionally tested by validating and creating a clickhouse peer followed by performing a basic CDC PG -> CH mirror