### PR TITLE
Maintain replication connection between sync flows

### DIFF
--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -39,6 +39,10 @@ type CDCPullConnector interface {
 		*protos.EnsurePullabilityBatchOutput, error)
 
 	// Methods related to retrieving and pushing records for this connector as a source and destination.
+	SetupReplConn(context.Context) error
+
+	// Ping source to keep connection alive. Can be called concurrently with PullRecords; skips ping in that case.
+	ReplPing(context.Context) error
 
 	// PullRecords pulls records from the source, and returns a RecordBatch.
 	// This method should be idempotent, and should be able to be called multiple times with the same request.

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -145,9 +145,11 @@ func (c *PostgresConnector) MaybeStartReplication(
 	if c.replState != nil && (c.replState.Offset != req.LastOffset ||
 		c.replState.Slot != slotName ||
 		c.replState.Publication != publicationName) {
-		return fmt.Errorf("replState changed, reset connector. slot name: old=%s new=%s, publication: old=%s new=%s, offset: old=%d new=%d",
+		msg := fmt.Sprintf("replState changed, reset connector. slot name: old=%s new=%s, publication: old=%s new=%s, offset: old=%d new=%d",
 			c.replState.Slot, slotName, c.replState.Publication, publicationName, c.replState.Offset, req.LastOffset,
 		)
+		c.logger.Info(msg)
+		return errors.New(msg)
 	}
 
 	if c.replState == nil {

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -20,8 +20,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 
 	"github.com/PeerDB-io/peer-flow/activities"
+	"github.com/PeerDB-io/peer-flow/connectors"
 	connpostgres "github.com/PeerDB-io/peer-flow/connectors/postgres"
 	connsnowflake "github.com/PeerDB-io/peer-flow/connectors/snowflake"
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
@@ -67,6 +69,7 @@ func RegisterWorkflowsAndActivities(t *testing.T, env *testsuite.TestWorkflowEnv
 	env.RegisterActivity(&activities.FlowableActivity{
 		CatalogPool: conn,
 		Alerter:     alerter,
+		CdcCache:    make(map[string]connectors.CDCPullConnector),
 	})
 	env.RegisterActivity(&activities.SnapshotActivity{
 		Alerter: alerter,
@@ -546,6 +549,7 @@ func NewTemporalTestWorkflowEnvironment(t *testing.T) *testsuite.TestWorkflowEnv
 	testSuite.SetLogger(&TStructuredLogger{logger: logger})
 
 	env := testSuite.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{EnableSessionWorker: true})
 	RegisterWorkflowsAndActivities(t, env)
 	env.RegisterWorkflow(peerflow.SnapshotFlowWorkflow)
 	return env

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -366,7 +366,7 @@ func CDCFlowWorkflowWithConfig(
 	sessionInfo := workflow.GetSessionInfo(syncSessionCtx)
 
 	syncCtx := workflow.WithActivityOptions(syncSessionCtx, workflow.ActivityOptions{
-		StartToCloseTimeout: 72 * time.Hour,
+		StartToCloseTimeout: 14 * 24 * time.Hour,
 		HeartbeatTimeout:    time.Minute,
 		WaitForCancellation: true,
 	})


### PR DESCRIPTION
Currently we reconnect with each sync flow, requiring repeatedly starting replication. This can take an exceedingly long time for some workloads on some databases

Fix: use temporal session to share state between activities, use a single source connector throughout cdc flow, & move replication connection back into source connection