### PR TITLE
Numeric nil case: cdc fix

### DIFF
--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -215,6 +215,11 @@ func (r *RecordItems) toMap(hstoreAsJSON bool) (map[string]interface{}, error) {
 			if !ok {
 				return nil, errors.New("expected *big.Rat value")
 			}
+
+			if bigRat == nil {
+				jsonStruct[col] = nil
+				continue
+			}
 			jsonStruct[col] = bigRat.FloatString(numeric.PeerDBNumericScale)
 		case qvalue.QValueKindFloat64:
 			floatVal, ok := v.Value.(float64)


### PR DESCRIPTION
Checks for nil value of rat in `toMap` which is responsible for converting records to json for writing to avro files 