### PR TITLE
Initial copy only : change param name

### DIFF
--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -121,7 +121,7 @@ export const cdcSettings: MirrorSetting[] = [
     stateHandler: (value, setter) =>
       setter((curr: CDCConfig) => ({
         ...curr,
-        initialCopyOnly: (value as boolean) || false,
+        initialSnapshotOnly: (value as boolean) || false,
       })),
     tips: 'If set, PeerDB will only perform initial load and will not perform CDC sync.',
     type: 'switch',


### PR DESCRIPTION
Changes UI's setting name of the initialSnapshotOnly parameter