### PR TITLE
explicitly set client_encoding to UTF8

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -52,7 +52,6 @@ func NewPostgresConnector(ctx context.Context, pgConfig *protos.PostgresConfig) 
 	}
 
 	runtimeParams := connConfig.Config.RuntimeParams
-	runtimeParams["application_name"] = "peerdb"
 	runtimeParams["idle_in_transaction_session_timeout"] = "0"
 	runtimeParams["statement_timeout"] = "0"
 
@@ -67,7 +66,6 @@ func NewPostgresConnector(ctx context.Context, pgConfig *protos.PostgresConfig) 
 	}
 
 	// ensure that replication is set to database
-	replConfig.Config.RuntimeParams["application_name"] = "peerdb"
 	replConfig.Config.RuntimeParams["replication"] = "database"
 	replConfig.Config.RuntimeParams["bytea_output"] = "hex"
 

--- a/flow/connectors/utils/postgres.go
+++ b/flow/connectors/utils/postgres.go
@@ -23,7 +23,7 @@ func GetPGConnectionString(pgConfig *protos.PostgresConfig) string {
 	passwordEscaped := url.QueryEscape(pgConfig.Password)
 	// for a url like postgres://user:password@host:port/dbname
 	connString := fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s",
+		"postgres://%s:%s@%s:%d/%s?application_name=peerdb&client_encoding=UTF8",
 		pgConfig.User,
 		passwordEscaped,
 		pgConfig.Host,


### PR DESCRIPTION
A couple of our queries [`getTableSchemaForTable` and `getChildToParentRelIDMap`] use the simple query protocol (why is this needed? not sure). pgx requires `client_encoding` to be set to `UTF8` for using the simple query protocol, but it won't be set if the database we are connecting to doesn't use the `UTF8` encoding, which isn't very likely but still possible.

Fixed by explicitly mentioning `client_encoding` in the connection string. Also moving `application_name` there.