### PR TITLE
Remove ctx from PostgresMetadataStore & peerDBOCFWriter

### DIFF
--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -28,7 +28,7 @@ func (c *BigQueryConnector) SyncQRepRecords(
 		return 0, err
 	}
 
-	done, err := c.pgMetadata.IsQrepPartitionSynced(config.FlowJobName, partition.PartitionId)
+	done, err := c.pgMetadata.IsQrepPartitionSynced(c.ctx, config.FlowJobName, partition.PartitionId)
 	if err != nil {
 		return 0, fmt.Errorf("failed to check if partition %s is synced: %w", partition.PartitionId, err)
 	}
@@ -42,7 +42,7 @@ func (c *BigQueryConnector) SyncQRepRecords(
 		partition.PartitionId, destTable))
 
 	avroSync := NewQRepAvroSyncMethod(c, config.StagingPath, config.FlowJobName)
-	return avroSync.SyncQRepRecords(config.FlowJobName, destTable, partition,
+	return avroSync.SyncQRepRecords(c.ctx, config.FlowJobName, destTable, partition,
 		tblMetadata, stream, config.SyncedAtColName, config.SoftDeleteColName)
 }
 

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -106,7 +106,7 @@ func generateCreateTableSQLForNormalizedTable(
 func (c *ClickhouseConnector) NormalizeRecords(req *model.NormalizeRecordsRequest) (*model.NormalizeResponse, error) {
 	normBatchID, err := c.GetLastNormalizeBatchID(req.FlowJobName)
 	if err != nil {
-		c.logger.ErrorContext(c.ctx, "[clickhouse] error while getting last sync and normalize batch id", err)
+		c.logger.Error("[clickhouse] error while getting last sync and normalize batch id", "error", err)
 		return nil, err
 	}
 
@@ -125,7 +125,7 @@ func (c *ClickhouseConnector) NormalizeRecords(req *model.NormalizeRecordsReques
 		normBatchID,
 	)
 	if err != nil {
-		c.logger.ErrorContext(c.ctx, "[clickhouse] error while getting distinct table names in batch", err)
+		c.logger.Error("[clickhouse] error while getting distinct table names in batch", "error", err)
 		return nil, err
 	}
 
@@ -190,7 +190,7 @@ func (c *ClickhouseConnector) NormalizeRecords(req *model.NormalizeRecordsReques
 		insertIntoSelectQuery.WriteString(selectQuery.String())
 
 		q := insertIntoSelectQuery.String()
-		c.logger.InfoContext(c.ctx, fmt.Sprintf("[clickhouse] insert into select query %s", q))
+		c.logger.Info(fmt.Sprintf("[clickhouse] insert into select query %s", q))
 
 		_, err = c.database.ExecContext(c.ctx, q)
 		if err != nil {
@@ -199,9 +199,9 @@ func (c *ClickhouseConnector) NormalizeRecords(req *model.NormalizeRecordsReques
 	}
 
 	endNormalizeBatchId := normBatchID + 1
-	err = c.pgMetadata.UpdateNormalizeBatchID(req.FlowJobName, endNormalizeBatchId)
+	err = c.pgMetadata.UpdateNormalizeBatchID(c.ctx, req.FlowJobName, endNormalizeBatchId)
 	if err != nil {
-		c.logger.ErrorContext(c.ctx, "[clickhouse] error while updating normalize batch id", err)
+		c.logger.Error("[clickhouse] error while updating normalize batch id", "error", err)
 		return nil, err
 	}
 
@@ -253,7 +253,7 @@ func (c *ClickhouseConnector) getDistinctTableNamesInBatch(
 }
 
 func (c *ClickhouseConnector) GetLastNormalizeBatchID(flowJobName string) (int64, error) {
-	normalizeBatchID, err := c.pgMetadata.GetLastNormalizeBatchID(flowJobName)
+	normalizeBatchID, err := c.pgMetadata.GetLastNormalizeBatchID(c.ctx, flowJobName)
 	if err != nil {
 		return 0, fmt.Errorf("error while getting last normalize batch id: %w", err)
 	}

--- a/flow/connectors/clickhouse/qrep.go
+++ b/flow/connectors/clickhouse/qrep.go
@@ -49,7 +49,7 @@ func (c *ClickhouseConnector) SyncQRepRecords(
 
 	avroSync := NewClickhouseAvroSyncMethod(config, c)
 
-	return avroSync.SyncQRepRecords(config, partition, tblSchema, stream)
+	return avroSync.SyncQRepRecords(c.ctx, config, partition, tblSchema, stream)
 }
 
 func (c *ClickhouseConnector) createMetadataInsertStatement(

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -477,7 +477,7 @@ func (c *PostgresConnector) SyncQRepRecords(
 	c.logger.Info("SyncRecords called and initial checks complete.")
 
 	stagingTableSync := &QRepStagingTableSync{connector: c}
-	return stagingTableSync.SyncQRepRecords(
+	return stagingTableSync.SyncQRepRecords(c.ctx,
 		config.FlowJobName, dstTable, partition, stream,
 		config.WriteMode, config.SyncedAtColName)
 }

--- a/flow/connectors/postgres/qrep_sql_sync.go
+++ b/flow/connectors/postgres/qrep_sql_sync.go
@@ -30,6 +30,7 @@ type QRepStagingTableSync struct {
 }
 
 func (s *QRepStagingTableSync) SyncQRepRecords(
+	ctx context.Context,
 	flowJobName string,
 	dstTableName *utils.SchemaTable,
 	partition *protos.QRepPartition,
@@ -51,19 +52,19 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 	}
 
 	txConfig := s.connector.conn.Config()
-	txConn, err := pgx.ConnectConfig(s.connector.ctx, txConfig)
+	txConn, err := pgx.ConnectConfig(ctx, txConfig)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create tx pool: %w", err)
 	}
-	defer txConn.Close(s.connector.ctx)
+	defer txConn.Close(ctx)
 
-	err = utils.RegisterHStore(s.connector.ctx, txConn)
+	err = utils.RegisterHStore(ctx, txConn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to register hstore: %w", err)
 	}
 
 	// Second transaction - to handle rest of the processing
-	tx, err := txConn.Begin(s.connector.ctx)
+	tx, err := txConn.Begin(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to begin transaction: %w", err)
 	}

--- a/flow/connectors/s3/qrep.go
+++ b/flow/connectors/s3/qrep.go
@@ -63,8 +63,8 @@ func (c *S3Connector) writeToAvroFile(
 	}
 
 	s3AvroFileKey := fmt.Sprintf("%s/%s/%s.avro", s3o.Prefix, jobName, partitionID)
-	writer := avro.NewPeerDBOCFWriter(c.ctx, stream, avroSchema, avro.CompressNone, qvalue.QDWHTypeSnowflake)
-	avroFile, err := writer.WriteRecordsToS3(s3o.Bucket, s3AvroFileKey, c.creds)
+	writer := avro.NewPeerDBOCFWriter(stream, avroSchema, avro.CompressNone, qvalue.QDWHTypeSnowflake)
+	avroFile, err := writer.WriteRecordsToS3(c.ctx, s3o.Bucket, s3AvroFileKey, c.creds)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write records to S3: %w", err)
 	}

--- a/flow/connectors/snowflake/avro_file_writer_test.go
+++ b/flow/connectors/snowflake/avro_file_writer_test.go
@@ -146,9 +146,8 @@ func TestWriteRecordsToAvroFileHappyPath(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(context.Background(),
-		records, avroSchema, avro.CompressNone, qvalue.QDWHTypeSnowflake)
-	_, err = writer.WriteRecordsToAvroFile(tmpfile.Name())
+	writer := avro.NewPeerDBOCFWriter(records, avroSchema, avro.CompressNone, qvalue.QDWHTypeSnowflake)
+	_, err = writer.WriteRecordsToAvroFile(context.Background(), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty
@@ -174,9 +173,8 @@ func TestWriteRecordsToZstdAvroFileHappyPath(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(context.Background(),
-		records, avroSchema, avro.CompressZstd, qvalue.QDWHTypeSnowflake)
-	_, err = writer.WriteRecordsToAvroFile(tmpfile.Name())
+	writer := avro.NewPeerDBOCFWriter(records, avroSchema, avro.CompressZstd, qvalue.QDWHTypeSnowflake)
+	_, err = writer.WriteRecordsToAvroFile(context.Background(), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty
@@ -202,9 +200,8 @@ func TestWriteRecordsToDeflateAvroFileHappyPath(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(context.Background(),
-		records, avroSchema, avro.CompressDeflate, qvalue.QDWHTypeSnowflake)
-	_, err = writer.WriteRecordsToAvroFile(tmpfile.Name())
+	writer := avro.NewPeerDBOCFWriter(records, avroSchema, avro.CompressDeflate, qvalue.QDWHTypeSnowflake)
+	_, err = writer.WriteRecordsToAvroFile(context.Background(), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty
@@ -229,9 +226,8 @@ func TestWriteRecordsToAvroFileNonNull(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(context.Background(),
-		records, avroSchema, avro.CompressNone, qvalue.QDWHTypeSnowflake)
-	_, err = writer.WriteRecordsToAvroFile(tmpfile.Name())
+	writer := avro.NewPeerDBOCFWriter(records, avroSchema, avro.CompressNone, qvalue.QDWHTypeSnowflake)
+	_, err = writer.WriteRecordsToAvroFile(context.Background(), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty
@@ -257,9 +253,8 @@ func TestWriteRecordsToAvroFileAllNulls(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(context.Background(),
-		records, avroSchema, avro.CompressNone, qvalue.QDWHTypeSnowflake)
-	_, err = writer.WriteRecordsToAvroFile(tmpfile.Name())
+	writer := avro.NewPeerDBOCFWriter(records, avroSchema, avro.CompressNone, qvalue.QDWHTypeSnowflake)
+	_, err = writer.WriteRecordsToAvroFile(context.Background(), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -33,7 +33,7 @@ func (c *SnowflakeConnector) SyncQRepRecords(
 	}
 	c.logger.Info("Called QRep sync function and obtained table schema", flowLog)
 
-	done, err := c.pgMetadata.IsQrepPartitionSynced(config.FlowJobName, partition.PartitionId)
+	done, err := c.pgMetadata.IsQrepPartitionSynced(c.ctx, config.FlowJobName, partition.PartitionId)
 	if err != nil {
 		return 0, fmt.Errorf("failed to check if partition %s is synced: %w", partition.PartitionId, err)
 	}
@@ -44,7 +44,7 @@ func (c *SnowflakeConnector) SyncQRepRecords(
 	}
 
 	avroSync := NewSnowflakeAvroSyncHandler(config, c)
-	return avroSync.SyncQRepRecords(config, partition, tblSchema, stream)
+	return avroSync.SyncQRepRecords(c.ctx, config, partition, tblSchema, stream)
 }
 
 func (c *SnowflakeConnector) getTableSchema(tableName string) ([]*sql.ColumnType, error) {
@@ -163,7 +163,7 @@ func (c *SnowflakeConnector) ConsolidateQRepPartitions(config *protos.QRepConfig
 	stageName := c.getStageNameForJob(config.FlowJobName)
 
 	writeHandler := NewSnowflakeAvroConsolidateHandler(c, config, destTable, stageName)
-	err := writeHandler.CopyStageToDestination()
+	err := writeHandler.CopyStageToDestination(c.ctx)
 	if err != nil {
 		c.logger.Error("failed to copy stage to destination", slog.Any("error", err))
 		return fmt.Errorf("failed to copy stage to destination: %w", err)


### PR DESCRIPTION
Along with `connector.ctx` references in internal helpers

Also replace more slog.Logger with temporal log.Logger

This is the initial start to enabling containedctx lint, which moves away from coupling connectors with their constructor's context

Removing ctx from connectors will require updating interfaces, which will be done as a followup