### PR TITLE
add lint: containedctx

### DIFF
--- a/flow/.golangci.yml
+++ b/flow/.golangci.yml
@@ -3,6 +3,7 @@ run:
     - generated
 linters:
   enable:
+    - containedctx
     - dogsled
     - durationcheck
     - errcheck

--- a/flow/cmd/api.go
+++ b/flow/cmd/api.go
@@ -119,7 +119,7 @@ func APIMain(ctx context.Context, args *APIServerParams) error {
 
 	grpcServer := grpc.NewServer()
 
-	catalogConn, err := utils.GetCatalogConnectionPoolFromEnv()
+	catalogConn, err := utils.GetCatalogConnectionPoolFromEnv(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to get catalog connection pool: %w", err)
 	}

--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -233,9 +233,9 @@ func (h *FlowRequestHandler) GetSlotInfo(
 		slog.Error("Failed to create postgres connector", slog.Any("error", err))
 		return &protos.PeerSlotResponse{SlotData: nil}, err
 	}
-	defer pgConnector.Close()
+	defer pgConnector.Close(ctx)
 
-	slotInfo, err := pgConnector.GetSlotInfo("")
+	slotInfo, err := pgConnector.GetSlotInfo(ctx, "")
 	if err != nil {
 		slog.Error("Failed to get slot info", slog.Any("error", err))
 		return &protos.PeerSlotResponse{SlotData: nil}, err

--- a/flow/cmd/snapshot_worker.go
+++ b/flow/cmd/snapshot_worker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"log/slog"
@@ -61,7 +62,7 @@ func SnapshotWorkerMain(opts *SnapshotWorkerOptions) error {
 		EnableSessionWorker: true,
 	})
 
-	conn, err := utils.GetCatalogConnectionPoolFromEnv()
+	conn, err := utils.GetCatalogConnectionPoolFromEnv(context.Background())
 	if err != nil {
 		return fmt.Errorf("unable to create catalog connection pool: %w", err)
 	}

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -30,10 +30,10 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 			Ok: false,
 		}, fmt.Errorf("failed to create postgres connector: %v", err)
 	}
-	defer pgPeer.Close()
+	defer pgPeer.Close(ctx)
 
 	// Check permissions of postgres peer
-	err = pgPeer.CheckReplicationPermissions(sourcePeerConfig.User)
+	err = pgPeer.CheckReplicationPermissions(ctx, sourcePeerConfig.User)
 	if err != nil {
 		return &protos.ValidateCDCMirrorResponse{
 			Ok: false,
@@ -46,7 +46,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		sourceTables = append(sourceTables, tableMapping.SourceTableIdentifier)
 	}
 
-	err = pgPeer.CheckSourceTables(sourceTables, req.ConnectionConfigs.PublicationName)
+	err = pgPeer.CheckSourceTables(ctx, sourceTables, req.ConnectionConfigs.PublicationName)
 	if err != nil {
 		return &protos.ValidateCDCMirrorResponse{
 			Ok: false,

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -37,10 +37,10 @@ func (h *FlowRequestHandler) ValidatePeer(
 		}, nil
 	}
 
-	defer conn.Close()
+	defer conn.Close(ctx)
 
 	if req.Peer.Type == protos.DBType_POSTGRES {
-		isValid, version, err := conn.(*connpostgres.PostgresConnector).MajorVersionCheck(connpostgres.POSTGRES_12)
+		isValid, version, err := conn.(*connpostgres.PostgresConnector).MajorVersionCheck(ctx, connpostgres.POSTGRES_12)
 		if err != nil {
 			slog.Error("/peer/validate: pg version check", slog.Any("error", err))
 			return nil, err
@@ -55,7 +55,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 		}
 	}
 
-	connErr := conn.ConnectionActive()
+	connErr := conn.ConnectionActive(ctx)
 	if connErr != nil {
 		return &protos.ValidatePeerResponse{
 			Status: protos.ValidatePeerStatus_INVALID,

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"log"
@@ -109,7 +110,7 @@ func WorkerMain(opts *WorkerOptions) error {
 		clientOptions.ConnectionOptions = connOptions
 	}
 
-	conn, err := utils.GetCatalogConnectionPoolFromEnv()
+	conn, err := utils.GetCatalogConnectionPoolFromEnv(context.Background())
 	if err != nil {
 		return fmt.Errorf("unable to create catalog connection pool: %w", err)
 	}

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -50,7 +50,6 @@ type BigQueryServiceAccount struct {
 
 // BigQueryConnector is a Connector implementation for BigQuery.
 type BigQueryConnector struct {
-	ctx           context.Context
 	bqConfig      *protos.BigqueryConfig
 	client        *bigquery.Client
 	storageClient *storage.Client
@@ -223,13 +222,12 @@ func NewBigQueryConnector(ctx context.Context, config *protos.BigqueryConfig) (*
 		return nil, fmt.Errorf("failed to create Storage client: %v", err)
 	}
 
-	catalogPool, err := cc.GetCatalogConnectionPoolFromEnv()
+	catalogPool, err := cc.GetCatalogConnectionPoolFromEnv(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog connection pool: %v", err)
 	}
 
 	return &BigQueryConnector{
-		ctx:           ctx,
 		bqConfig:      config,
 		client:        client,
 		datasetID:     datasetID,
@@ -242,7 +240,7 @@ func NewBigQueryConnector(ctx context.Context, config *protos.BigqueryConfig) (*
 }
 
 // Close closes the BigQuery driver.
-func (c *BigQueryConnector) Close() error {
+func (c *BigQueryConnector) Close(_ context.Context) error {
 	if c == nil || c.client == nil {
 		return nil
 	}
@@ -250,8 +248,8 @@ func (c *BigQueryConnector) Close() error {
 }
 
 // ConnectionActive returns true if the connection is active.
-func (c *BigQueryConnector) ConnectionActive() error {
-	_, err := c.client.DatasetInProject(c.projectID, c.datasetID).Metadata(c.ctx)
+func (c *BigQueryConnector) ConnectionActive(ctx context.Context) error {
+	_, err := c.client.DatasetInProject(c.projectID, c.datasetID).Metadata(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get dataset metadata: %v", err)
 	}
@@ -262,11 +260,11 @@ func (c *BigQueryConnector) ConnectionActive() error {
 	return nil
 }
 
-func (c *BigQueryConnector) NeedsSetupMetadataTables() bool {
+func (c *BigQueryConnector) NeedsSetupMetadataTables(_ context.Context) bool {
 	return false
 }
 
-func (c *BigQueryConnector) waitForTableReady(datasetTable *datasetTable) error {
+func (c *BigQueryConnector) waitForTableReady(ctx context.Context, datasetTable *datasetTable) error {
 	table := c.client.DatasetInProject(c.projectID, datasetTable.dataset).Table(datasetTable.table)
 	maxDuration := 5 * time.Minute
 	deadline := time.Now().Add(maxDuration)
@@ -278,7 +276,7 @@ func (c *BigQueryConnector) waitForTableReady(datasetTable *datasetTable) error 
 			return fmt.Errorf("timeout reached while waiting for table %s to be ready", datasetTable)
 		}
 
-		_, err := table.Metadata(c.ctx)
+		_, err := table.Metadata(ctx)
 		if err == nil {
 			return nil
 		}
@@ -292,7 +290,9 @@ func (c *BigQueryConnector) waitForTableReady(datasetTable *datasetTable) error 
 
 // ReplayTableSchemaDeltas changes a destination table to match the schema at source
 // This could involve adding or dropping multiple columns.
-func (c *BigQueryConnector) ReplayTableSchemaDeltas(flowJobName string,
+func (c *BigQueryConnector) ReplayTableSchemaDeltas(
+	ctx context.Context,
+	flowJobName string,
 	schemaDeltas []*protos.TableSchemaDelta,
 ) error {
 	for _, schemaDelta := range schemaDeltas {
@@ -308,7 +308,7 @@ func (c *BigQueryConnector) ReplayTableSchemaDeltas(flowJobName string,
 				qValueKindToBigQueryType(addedColumn.ColumnType)))
 			query.DefaultProjectID = c.projectID
 			query.DefaultDatasetID = dstDatasetTable.dataset
-			_, err := query.Read(c.ctx)
+			_, err := query.Read(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.ColumnName,
 					schemaDelta.DstTableName, err)
@@ -321,27 +321,30 @@ func (c *BigQueryConnector) ReplayTableSchemaDeltas(flowJobName string,
 	return nil
 }
 
-func (c *BigQueryConnector) SetupMetadataTables() error {
+func (c *BigQueryConnector) SetupMetadataTables(_ context.Context) error {
 	return nil
 }
 
-func (c *BigQueryConnector) GetLastOffset(jobName string) (int64, error) {
-	return c.pgMetadata.FetchLastOffset(c.ctx, jobName)
+func (c *BigQueryConnector) GetLastOffset(ctx context.Context, jobName string) (int64, error) {
+	return c.pgMetadata.FetchLastOffset(ctx, jobName)
 }
 
-func (c *BigQueryConnector) SetLastOffset(jobName string, offset int64) error {
-	return c.pgMetadata.UpdateLastOffset(c.ctx, jobName, offset)
+func (c *BigQueryConnector) SetLastOffset(ctx context.Context, jobName string, offset int64) error {
+	return c.pgMetadata.UpdateLastOffset(ctx, jobName, offset)
 }
 
-func (c *BigQueryConnector) GetLastSyncBatchID(jobName string) (int64, error) {
-	return c.pgMetadata.GetLastBatchID(c.ctx, jobName)
+func (c *BigQueryConnector) GetLastSyncBatchID(ctx context.Context, jobName string) (int64, error) {
+	return c.pgMetadata.GetLastBatchID(ctx, jobName)
 }
 
-func (c *BigQueryConnector) GetLastNormalizeBatchID(jobName string) (int64, error) {
-	return c.pgMetadata.GetLastNormalizeBatchID(c.ctx, jobName)
+func (c *BigQueryConnector) GetLastNormalizeBatchID(ctx context.Context, jobName string) (int64, error) {
+	return c.pgMetadata.GetLastNormalizeBatchID(ctx, jobName)
 }
 
-func (c *BigQueryConnector) getDistinctTableNamesInBatch(flowJobName string, syncBatchID int64,
+func (c *BigQueryConnector) getDistinctTableNamesInBatch(
+	ctx context.Context,
+	flowJobName string,
+	syncBatchID int64,
 	normalizeBatchID int64,
 ) ([]string, error) {
 	rawTableName := c.getRawTableName(flowJobName)
@@ -354,7 +357,7 @@ func (c *BigQueryConnector) getDistinctTableNamesInBatch(flowJobName string, syn
 	q := c.client.Query(query)
 	q.DefaultProjectID = c.projectID
 	q.DefaultDatasetID = c.datasetID
-	it, err := q.Read(c.ctx)
+	it, err := q.Read(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to run query %s on BigQuery:\n %w", query, err)
 		return nil, err
@@ -380,7 +383,10 @@ func (c *BigQueryConnector) getDistinctTableNamesInBatch(flowJobName string, syn
 	return distinctTableNames, nil
 }
 
-func (c *BigQueryConnector) getTableNametoUnchangedCols(flowJobName string, syncBatchID int64,
+func (c *BigQueryConnector) getTableNametoUnchangedCols(
+	ctx context.Context,
+	flowJobName string,
+	syncBatchID int64,
 	normalizeBatchID int64,
 ) (map[string][]string, error) {
 	rawTableName := c.getRawTableName(flowJobName)
@@ -398,7 +404,7 @@ func (c *BigQueryConnector) getTableNametoUnchangedCols(flowJobName string, sync
 	q := c.client.Query(query)
 	q.DefaultDatasetID = c.datasetID
 	q.DefaultProjectID = c.projectID
-	it, err := q.Read(c.ctx)
+	it, err := q.Read(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to run query %s on BigQuery:\n %w", query, err)
 		return nil, err
@@ -427,12 +433,12 @@ func (c *BigQueryConnector) getTableNametoUnchangedCols(flowJobName string, sync
 // SyncRecords pushes records to the destination.
 // Currently only supports inserts, updates, and deletes.
 // More record types will be added in the future.
-func (c *BigQueryConnector) SyncRecords(req *model.SyncRecordsRequest) (*model.SyncResponse, error) {
+func (c *BigQueryConnector) SyncRecords(ctx context.Context, req *model.SyncRecordsRequest) (*model.SyncResponse, error) {
 	rawTableName := c.getRawTableName(req.FlowJobName)
 
 	c.logger.Info(fmt.Sprintf("pushing records to %s.%s...", c.datasetID, rawTableName))
 
-	res, err := c.syncRecordsViaAvro(req, rawTableName, req.SyncBatchID)
+	res, err := c.syncRecordsViaAvro(ctx, req, rawTableName, req.SyncBatchID)
 	if err != nil {
 		return nil, err
 	}
@@ -442,6 +448,7 @@ func (c *BigQueryConnector) SyncRecords(req *model.SyncRecordsRequest) (*model.S
 }
 
 func (c *BigQueryConnector) syncRecordsViaAvro(
+	ctx context.Context,
 	req *model.SyncRecordsRequest,
 	rawTableName string,
 	syncBatchID int64,
@@ -454,12 +461,12 @@ func (c *BigQueryConnector) syncRecordsViaAvro(
 	}
 
 	avroSync := NewQRepAvroSyncMethod(c, req.StagingPath, req.FlowJobName)
-	rawTableMetadata, err := c.client.DatasetInProject(c.projectID, c.datasetID).Table(rawTableName).Metadata(c.ctx)
+	rawTableMetadata, err := c.client.DatasetInProject(c.projectID, c.datasetID).Table(rawTableName).Metadata(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get metadata of destination table: %w", err)
 	}
 
-	res, err := avroSync.SyncRecords(c.ctx, req, rawTableName,
+	res, err := avroSync.SyncRecords(ctx, req, rawTableName,
 		rawTableMetadata, syncBatchID, streamRes.Stream, streamReq.TableMapping)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sync records via avro: %w", err)
@@ -469,10 +476,10 @@ func (c *BigQueryConnector) syncRecordsViaAvro(
 }
 
 // NormalizeRecords normalizes raw table to destination table.
-func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest) (*model.NormalizeResponse, error) {
+func (c *BigQueryConnector) NormalizeRecords(ctx context.Context, req *model.NormalizeRecordsRequest) (*model.NormalizeResponse, error) {
 	rawTableName := c.getRawTableName(req.FlowJobName)
 
-	normBatchID, err := c.GetLastNormalizeBatchID(req.FlowJobName)
+	normBatchID, err := c.GetLastNormalizeBatchID(ctx, req.FlowJobName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get batch for the current mirror: %v", err)
 	}
@@ -487,6 +494,7 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 	}
 
 	distinctTableNames, err := c.getDistinctTableNamesInBatch(
+		ctx,
 		req.FlowJobName,
 		req.SyncBatchID,
 		normBatchID,
@@ -496,6 +504,7 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 	}
 
 	tableNametoUnchangedToastCols, err := c.getTableNametoUnchangedCols(
+		ctx,
 		req.FlowJobName,
 		req.SyncBatchID,
 		normBatchID,
@@ -537,14 +546,14 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 			q := c.client.Query(mergeStmt)
 			q.DefaultProjectID = c.projectID
 			q.DefaultDatasetID = dstDatasetTable.dataset
-			_, err = q.Read(c.ctx)
+			_, err = q.Read(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to execute merge statement %s: %v", mergeStmt, err)
 			}
 		}
 	}
 
-	err = c.pgMetadata.UpdateNormalizeBatchID(c.ctx, req.FlowJobName, req.SyncBatchID)
+	err = c.pgMetadata.UpdateNormalizeBatchID(ctx, req.FlowJobName, req.SyncBatchID)
 	if err != nil {
 		return nil, err
 	}
@@ -563,7 +572,7 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 // _peerdb_data STRING
 // _peerdb_record_type INT - 0 for insert, 1 for update, 2 for delete
 // _peerdb_match_data STRING - json of the match data (only for update and delete)
-func (c *BigQueryConnector) CreateRawTable(req *protos.CreateRawTableInput) (*protos.CreateRawTableOutput, error) {
+func (c *BigQueryConnector) CreateRawTable(ctx context.Context, req *protos.CreateRawTableInput) (*protos.CreateRawTableOutput, error) {
 	rawTableName := c.getRawTableName(req.FlowJobName)
 
 	schema := bigquery.Schema{
@@ -581,7 +590,7 @@ func (c *BigQueryConnector) CreateRawTable(req *protos.CreateRawTableInput) (*pr
 	table := c.client.DatasetInProject(c.projectID, c.datasetID).Table(rawTableName)
 
 	// check if the table exists
-	tableRef, err := table.Metadata(c.ctx)
+	tableRef, err := table.Metadata(ctx)
 	if err == nil {
 		// table exists, check if the schema matches
 		if !reflect.DeepEqual(tableRef.Schema, schema) {
@@ -618,7 +627,7 @@ func (c *BigQueryConnector) CreateRawTable(req *protos.CreateRawTableInput) (*pr
 	}
 
 	// table does not exist, create it
-	err = table.Create(c.ctx, metadata)
+	err = table.Create(ctx, metadata)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create table %s.%s: %w", c.datasetID, rawTableName, err)
 	}
@@ -631,12 +640,13 @@ func (c *BigQueryConnector) CreateRawTable(req *protos.CreateRawTableInput) (*pr
 // SetupNormalizedTables sets up normalized tables, implementing the Connector interface.
 // This runs CREATE TABLE IF NOT EXISTS on bigquery, using the schema and table name provided.
 func (c *BigQueryConnector) SetupNormalizedTables(
+	ctx context.Context,
 	req *protos.SetupNormalizedTableBatchInput,
 ) (*protos.SetupNormalizedTableBatchOutput, error) {
 	numTablesSetup := atomic.Uint32{}
 	totalTables := uint32(len(req.TableNameSchemaMapping))
 
-	shutdown := utils.HeartbeatRoutine(c.ctx, func() string {
+	shutdown := utils.HeartbeatRoutine(ctx, func() string {
 		return fmt.Sprintf("setting up normalized tables - %d of %d done",
 			numTablesSetup.Load(), totalTables)
 	})
@@ -656,7 +666,7 @@ func (c *BigQueryConnector) SetupNormalizedTables(
 				datasetTable.string())
 		}
 		dataset := c.client.DatasetInProject(c.projectID, datasetTable.dataset)
-		_, err = dataset.Metadata(c.ctx)
+		_, err = dataset.Metadata(ctx)
 		// just assume this means dataset don't exist, and create it
 		if err != nil {
 			// if err message does not contain `notFound`, then other error happened.
@@ -665,7 +675,7 @@ func (c *BigQueryConnector) SetupNormalizedTables(
 					datasetTable.dataset, err)
 			}
 			c.logger.Info(fmt.Sprintf("creating dataset %s...", dataset.DatasetID))
-			err = dataset.Create(c.ctx, nil)
+			err = dataset.Create(ctx, nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create BigQuery dataset %s: %w", dataset.DatasetID, err)
 			}
@@ -673,7 +683,7 @@ func (c *BigQueryConnector) SetupNormalizedTables(
 		table := dataset.Table(datasetTable.table)
 
 		// check if the table exists
-		_, err = table.Metadata(c.ctx)
+		_, err = table.Metadata(ctx)
 		if err == nil {
 			// table exists, go to next table
 			tableExistsMapping[tableIdentifier] = true
@@ -744,7 +754,7 @@ func (c *BigQueryConnector) SetupNormalizedTables(
 			Clustering: clustering,
 		}
 
-		err = table.Create(c.ctx, metadata)
+		err = table.Create(ctx, metadata)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create table %s: %w", tableIdentifier, err)
 		}
@@ -761,15 +771,15 @@ func (c *BigQueryConnector) SetupNormalizedTables(
 	}, nil
 }
 
-func (c *BigQueryConnector) SyncFlowCleanup(jobName string) error {
-	err := c.pgMetadata.DropMetadata(c.ctx, jobName)
+func (c *BigQueryConnector) SyncFlowCleanup(ctx context.Context, jobName string) error {
+	err := c.pgMetadata.DropMetadata(ctx, jobName)
 	if err != nil {
 		return fmt.Errorf("unable to clear metadata for sync flow cleanup: %w", err)
 	}
 
 	dataset := c.client.DatasetInProject(c.projectID, c.datasetID)
 	// deleting PeerDB specific tables
-	err = dataset.Table(c.getRawTableName(jobName)).Delete(c.ctx)
+	err = dataset.Table(c.getRawTableName(jobName)).Delete(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to delete raw table: %w", err)
 	}
@@ -784,7 +794,7 @@ func (c *BigQueryConnector) getRawTableName(flowJobName string) string {
 	return fmt.Sprintf("_peerdb_raw_%s", flowJobName)
 }
 
-func (c *BigQueryConnector) RenameTables(req *protos.RenameTablesInput) (*protos.RenameTablesOutput, error) {
+func (c *BigQueryConnector) RenameTables(ctx context.Context, req *protos.RenameTablesInput) (*protos.RenameTablesOutput, error) {
 	// BigQuery doesn't really do transactions properly anyway so why bother?
 	for _, renameRequest := range req.RenameTableOptions {
 		srcDatasetTable, _ := c.convertToDatasetTable(renameRequest.CurrentName)
@@ -792,7 +802,7 @@ func (c *BigQueryConnector) RenameTables(req *protos.RenameTablesInput) (*protos
 		c.logger.Info(fmt.Sprintf("renaming table '%s' to '%s'...", srcDatasetTable.string(),
 			dstDatasetTable.string()))
 
-		activity.RecordHeartbeat(c.ctx, fmt.Sprintf("renaming table '%s' to '%s'...", srcDatasetTable.string(),
+		activity.RecordHeartbeat(ctx, fmt.Sprintf("renaming table '%s' to '%s'...", srcDatasetTable.string(),
 			dstDatasetTable.string()))
 
 		columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
@@ -806,7 +816,7 @@ func (c *BigQueryConnector) RenameTables(req *protos.RenameTablesInput) (*protos
 
 			c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", dstDatasetTable.string()))
 
-			activity.RecordHeartbeat(c.ctx, fmt.Sprintf("handling soft-deletes for table '%s'...", dstDatasetTable.string()))
+			activity.RecordHeartbeat(ctx, fmt.Sprintf("handling soft-deletes for table '%s'...", dstDatasetTable.string()))
 
 			c.logger.Info(fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s WHERE (%s) NOT IN (SELECT %s FROM %s)",
 				srcDatasetTable.string(), fmt.Sprintf("%s,%s", allCols, *req.SoftDeleteColName),
@@ -820,7 +830,7 @@ func (c *BigQueryConnector) RenameTables(req *protos.RenameTablesInput) (*protos
 
 			query.DefaultProjectID = c.projectID
 			query.DefaultDatasetID = c.datasetID
-			_, err := query.Read(c.ctx)
+			_, err := query.Read(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("unable to handle soft-deletes for table %s: %w", dstDatasetTable.string(), err)
 			}
@@ -829,7 +839,7 @@ func (c *BigQueryConnector) RenameTables(req *protos.RenameTablesInput) (*protos
 		if req.SyncedAtColName != nil {
 			c.logger.Info(fmt.Sprintf("setting synced at column for table '%s'...", srcDatasetTable.string()))
 
-			activity.RecordHeartbeat(c.ctx, fmt.Sprintf("setting synced at column for table '%s'...",
+			activity.RecordHeartbeat(ctx, fmt.Sprintf("setting synced at column for table '%s'...",
 				srcDatasetTable.string()))
 
 			c.logger.Info(
@@ -841,7 +851,7 @@ func (c *BigQueryConnector) RenameTables(req *protos.RenameTablesInput) (*protos
 
 			query.DefaultProjectID = c.projectID
 			query.DefaultDatasetID = c.datasetID
-			_, err := query.Read(c.ctx)
+			_, err := query.Read(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("unable to set synced at column for table %s: %w", srcDatasetTable.string(), err)
 			}
@@ -854,7 +864,7 @@ func (c *BigQueryConnector) RenameTables(req *protos.RenameTablesInput) (*protos
 			dstDatasetTable.string()))
 		dropQuery.DefaultProjectID = c.projectID
 		dropQuery.DefaultDatasetID = c.datasetID
-		_, err := dropQuery.Read(c.ctx)
+		_, err := dropQuery.Read(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to drop table %s: %w", dstDatasetTable.string(), err)
 		}
@@ -866,7 +876,7 @@ func (c *BigQueryConnector) RenameTables(req *protos.RenameTablesInput) (*protos
 			srcDatasetTable.string(), dstDatasetTable.table))
 		query.DefaultProjectID = c.projectID
 		query.DefaultDatasetID = c.datasetID
-		_, err = query.Read(c.ctx)
+		_, err = query.Read(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to rename table %s to %s: %w", srcDatasetTable.string(),
 				dstDatasetTable.string(), err)
@@ -881,22 +891,23 @@ func (c *BigQueryConnector) RenameTables(req *protos.RenameTablesInput) (*protos
 	}, nil
 }
 
-func (c *BigQueryConnector) CreateTablesFromExisting(req *protos.CreateTablesFromExistingInput) (
-	*protos.CreateTablesFromExistingOutput, error,
-) {
+func (c *BigQueryConnector) CreateTablesFromExisting(
+	ctx context.Context,
+	req *protos.CreateTablesFromExistingInput,
+) (*protos.CreateTablesFromExistingOutput, error) {
 	for newTable, existingTable := range req.NewToExistingTableMapping {
 		newDatasetTable, _ := c.convertToDatasetTable(newTable)
 		existingDatasetTable, _ := c.convertToDatasetTable(existingTable)
 		c.logger.Info(fmt.Sprintf("creating table '%s' similar to '%s'", newTable, existingTable))
 
-		activity.RecordHeartbeat(c.ctx, fmt.Sprintf("creating table '%s' similar to '%s'", newTable, existingTable))
+		activity.RecordHeartbeat(ctx, fmt.Sprintf("creating table '%s' similar to '%s'", newTable, existingTable))
 
 		// rename the src table to dst
 		query := c.client.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS `%s` LIKE `%s`",
 			newDatasetTable.string(), existingDatasetTable.string()))
 		query.DefaultProjectID = c.projectID
 		query.DefaultDatasetID = c.datasetID
-		_, err := query.Read(c.ctx)
+		_, err := query.Read(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create table %s: %w", newTable, err)
 		}

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -85,7 +85,7 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 			req.FlowJobName, rawTableName, syncBatchID),
 	)
 
-	err = s.connector.ReplayTableSchemaDeltas(req.FlowJobName, req.Records.SchemaDeltas)
+	err = s.connector.ReplayTableSchemaDeltas(ctx, req.FlowJobName, req.Records.SchemaDeltas)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sync schema changes: %w", err)
 	}
@@ -487,7 +487,7 @@ func (s *QRepAvroSyncMethod) writeToStage(
 	}
 	s.connector.logger.Info(fmt.Sprintf("Pushed from %s to BigQuery", avroFile.FilePath), idLog)
 
-	err = s.connector.waitForTableReady(stagingTable)
+	err = s.connector.waitForTableReady(ctx, stagingTable)
 	if err != nil {
 		return 0, fmt.Errorf("failed to wait for table to be ready: %w", err)
 	}

--- a/flow/connectors/clickhouse/client.go
+++ b/flow/connectors/clickhouse/client.go
@@ -8,14 +8,12 @@ import (
 
 	peersql "github.com/PeerDB-io/peer-flow/connectors/sql"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 )
 
 type ClickhouseClient struct {
 	peersql.GenericSQLQueryExecutor
-	// ctx is the context.
-	ctx context.Context
-	// config is the Snowflake config.
 	Config *protos.ClickhouseConfig
 }
 
@@ -28,11 +26,10 @@ func NewClickhouseClient(ctx context.Context, config *protos.ClickhouseConfig) (
 	}
 
 	genericExecutor := *peersql.NewGenericSQLQueryExecutor(
-		ctx, database, clickhouseTypeToQValueKindMap, qvalue.QValueKindToSnowflakeTypeMap)
+		logger.LoggerFromCtx(ctx), database, clickhouseTypeToQValueKindMap, qvalue.QValueKindToSnowflakeTypeMap)
 
 	return &ClickhouseClient{
 		GenericSQLQueryExecutor: genericExecutor,
-		ctx:                     ctx,
 		Config:                  config,
 	}, nil
 }

--- a/flow/connectors/external_metadata/store.go
+++ b/flow/connectors/external_metadata/store.go
@@ -14,6 +14,7 @@ import (
 
 	cc "github.com/PeerDB-io/peer-flow/connectors/utils/catalog"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 )
 
 const (
@@ -26,15 +27,15 @@ type PostgresMetadataStore struct {
 	logger log.Logger
 }
 
-func NewPostgresMetadataStore(logger log.Logger) (*PostgresMetadataStore, error) {
-	pool, err := cc.GetCatalogConnectionPoolFromEnv()
+func NewPostgresMetadataStore(ctx context.Context) (*PostgresMetadataStore, error) {
+	pool, err := cc.GetCatalogConnectionPoolFromEnv(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog connection pool: %w", err)
 	}
 
 	return &PostgresMetadataStore{
 		pool:   pool,
-		logger: logger,
+		logger: logger.LoggerFromCtx(ctx),
 	}, nil
 }
 

--- a/flow/connectors/postgres/postgres_schema_delta_test.go
+++ b/flow/connectors/postgres/postgres_schema_delta_test.go
@@ -63,7 +63,7 @@ func (s PostgresSchemaDeltaTestSuite) TestSimpleAddColumn() {
 		fmt.Sprintf("CREATE TABLE %s(id INT PRIMARY KEY)", tableName))
 	require.NoError(s.t, err)
 
-	err = s.connector.ReplayTableSchemaDeltas("schema_delta_flow", []*protos.TableSchemaDelta{{
+	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: []*protos.DeltaAddedColumn{{
@@ -73,7 +73,7 @@ func (s PostgresSchemaDeltaTestSuite) TestSimpleAddColumn() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 		TableIdentifiers: []string{tableName},
 	})
 	require.NoError(s.t, err)
@@ -116,14 +116,14 @@ func (s PostgresSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 		}
 	}
 
-	err = s.connector.ReplayTableSchemaDeltas("schema_delta_flow", []*protos.TableSchemaDelta{{
+	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: addedColumns,
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 		TableIdentifiers: []string{tableName},
 	})
 	require.NoError(s.t, err)
@@ -151,14 +151,14 @@ func (s PostgresSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
 		}
 	}
 
-	err = s.connector.ReplayTableSchemaDeltas("schema_delta_flow", []*protos.TableSchemaDelta{{
+	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: addedColumns,
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 		TableIdentifiers: []string{tableName},
 	})
 	require.NoError(s.t, err)
@@ -186,14 +186,14 @@ func (s PostgresSchemaDeltaTestSuite) TestAddDropWhitespaceColumnNames() {
 		}
 	}
 
-	err = s.connector.ReplayTableSchemaDeltas("schema_delta_flow", []*protos.TableSchemaDelta{{
+	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: addedColumns,
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 		TableIdentifiers: []string{tableName},
 	})
 	require.NoError(s.t, err)
@@ -216,9 +216,9 @@ func TestPostgresSchemaDeltaTestSuite(t *testing.T) {
 		err = teardownTx.Commit(context.Background())
 		require.NoError(s.t, err)
 
-		require.NoError(s.t, s.connector.ConnectionActive())
-		err = s.connector.Close()
+		require.NoError(s.t, s.connector.ConnectionActive(context.Background()))
+		err = s.connector.Close(context.Background())
 		require.NoError(s.t, err)
-		require.Error(s.t, s.connector.ConnectionActive())
+		require.Error(s.t, s.connector.ConnectionActive(context.Background()))
 	})
 }

--- a/flow/connectors/postgres/qrep_bench_test.go
+++ b/flow/connectors/postgres/qrep_bench_test.go
@@ -30,7 +30,7 @@ func BenchmarkQRepQueryExecutor(b *testing.B) {
 		b.Logf("iteration %d", i)
 
 		// Execute the query and process the rows
-		_, err := qe.ExecuteAndProcessQuery(query)
+		_, err := qe.ExecuteAndProcessQuery(ctx, query)
 		if err != nil {
 			b.Fatalf("failed to execute query: %v", err)
 		}

--- a/flow/connectors/postgres/qrep_partition_test.go
+++ b/flow/connectors/postgres/qrep_partition_test.go
@@ -170,13 +170,12 @@ func TestGetQRepPartitions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &PostgresConnector{
 				connStr: connStr,
-				ctx:     context.Background(),
 				config:  &protos.PostgresConfig{},
 				conn:    conn,
 				logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testGetQRepPartitions"))),
 			}
 
-			got, err := c.GetQRepPartitions(tc.config, tc.last)
+			got, err := c.GetQRepPartitions(context.Background(), tc.config, tc.last)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("GetQRepPartitions() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/flow/connectors/postgres/qrep_query_executor_test.go
+++ b/flow/connectors/postgres/qrep_query_executor_test.go
@@ -70,7 +70,7 @@ func TestExecuteAndProcessQuery(t *testing.T) {
 	qe.SetTestEnv(true)
 
 	query = fmt.Sprintf("SELECT * FROM %s.test;", schemaName)
-	batch, err := qe.ExecuteAndProcessQuery(query)
+	batch, err := qe.ExecuteAndProcessQuery(context.Background(), query)
 	if err != nil {
 		t.Fatalf("error while executing and processing query: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestAllDataTypes(t *testing.T) {
 	qe := NewQRepQueryExecutor(conn, ctx, "test flow", "test part")
 	// Select the row back out of the table
 	query = fmt.Sprintf("SELECT * FROM %s.test;", schemaName)
-	rows, err := qe.ExecuteQuery(query)
+	rows, err := qe.ExecuteQuery(context.Background(), query)
 	if err != nil {
 		t.Fatalf("error while executing query: %v", err)
 	}

--- a/flow/connectors/s3/qrep.go
+++ b/flow/connectors/s3/qrep.go
@@ -1,6 +1,7 @@
 package conns3
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -13,6 +14,7 @@ import (
 )
 
 func (c *S3Connector) SyncQRepRecords(
+	ctx context.Context,
 	config *protos.QRepConfig,
 	partition *protos.QRepPartition,
 	stream *model.QRecordStream,
@@ -31,7 +33,7 @@ func (c *S3Connector) SyncQRepRecords(
 		return 0, err
 	}
 
-	numRecords, err := c.writeToAvroFile(stream, avroSchema, partition.PartitionId, config.FlowJobName)
+	numRecords, err := c.writeToAvroFile(ctx, stream, avroSchema, partition.PartitionId, config.FlowJobName)
 	if err != nil {
 		return 0, err
 	}
@@ -52,6 +54,7 @@ func getAvroSchema(
 }
 
 func (c *S3Connector) writeToAvroFile(
+	ctx context.Context,
 	stream *model.QRecordStream,
 	avroSchema *model.QRecordAvroSchemaDefinition,
 	partitionID string,
@@ -64,7 +67,7 @@ func (c *S3Connector) writeToAvroFile(
 
 	s3AvroFileKey := fmt.Sprintf("%s/%s/%s.avro", s3o.Prefix, jobName, partitionID)
 	writer := avro.NewPeerDBOCFWriter(stream, avroSchema, avro.CompressNone, qvalue.QDWHTypeSnowflake)
-	avroFile, err := writer.WriteRecordsToS3(c.ctx, s3o.Bucket, s3AvroFileKey, c.creds)
+	avroFile, err := writer.WriteRecordsToS3(ctx, s3o.Bucket, s3AvroFileKey, c.creds)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write records to S3: %w", err)
 	}
@@ -74,7 +77,7 @@ func (c *S3Connector) writeToAvroFile(
 }
 
 // S3 just sets up destination, not metadata tables
-func (c *S3Connector) SetupQRepMetadataTables(config *protos.QRepConfig) error {
+func (c *S3Connector) SetupQRepMetadataTables(_ context.Context, config *protos.QRepConfig) error {
 	c.logger.Info("QRep metadata setup not needed for S3.")
 	return nil
 }

--- a/flow/connectors/snowflake/client.go
+++ b/flow/connectors/snowflake/client.go
@@ -13,15 +13,13 @@ import (
 	peersql "github.com/PeerDB-io/peer-flow/connectors/sql"
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
 
 type SnowflakeClient struct {
 	peersql.GenericSQLQueryExecutor
-	// ctx is the context.
-	ctx context.Context
-	// config is the Snowflake config.
 	Config *protos.SnowflakeConfig
 }
 
@@ -58,24 +56,24 @@ func NewSnowflakeClient(ctx context.Context, config *protos.SnowflakeConfig) (*S
 		return nil, fmt.Errorf("failed to open connection to Snowflake peer: %w", err)
 	}
 
+	logger := logger.LoggerFromCtx(ctx)
 	genericExecutor := *peersql.NewGenericSQLQueryExecutor(
-		ctx, database, snowflakeTypeToQValueKindMap, qvalue.QValueKindToSnowflakeTypeMap)
+		logger, database, snowflakeTypeToQValueKindMap, qvalue.QValueKindToSnowflakeTypeMap)
 
 	return &SnowflakeClient{
 		GenericSQLQueryExecutor: genericExecutor,
-		ctx:                     ctx,
 		Config:                  config,
 	}, nil
 }
 
-func (c *SnowflakeConnector) getTableCounts(tables []string) (int64, error) {
+func (c *SnowflakeConnector) getTableCounts(ctx context.Context, tables []string) (int64, error) {
 	var totalRecords int64
 	for _, table := range tables {
 		_, err := utils.ParseSchemaTable(table)
 		if err != nil {
 			return 0, fmt.Errorf("failed to parse table name %s: %w", table, err)
 		}
-		row := c.database.QueryRowContext(c.ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table))
+		row := c.database.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table))
 		var count pgtype.Int8
 		err = row.Scan(&count)
 		if err != nil {

--- a/flow/connectors/snowflake/get_schema_for_tests.go
+++ b/flow/connectors/snowflake/get_schema_for_tests.go
@@ -1,6 +1,7 @@
 package connsnowflake
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
@@ -8,8 +9,8 @@ import (
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 )
 
-func (c *SnowflakeConnector) getTableSchemaForTable(tableName string) (*protos.TableSchema, error) {
-	colNames, colTypes, err := c.getColsFromTable(tableName)
+func (c *SnowflakeConnector) getTableSchemaForTable(ctx context.Context, tableName string) (*protos.TableSchema, error) {
+	colNames, colTypes, err := c.getColsFromTable(ctx, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -37,16 +38,17 @@ func (c *SnowflakeConnector) getTableSchemaForTable(tableName string) (*protos.T
 
 // only used for testing atm. doesn't return info about pkey or ReplicaIdentity [which is PG specific anyway].
 func (c *SnowflakeConnector) GetTableSchema(
+	ctx context.Context,
 	req *protos.GetTableSchemaBatchInput,
 ) (*protos.GetTableSchemaBatchOutput, error) {
 	res := make(map[string]*protos.TableSchema, len(req.TableIdentifiers))
 	for _, tableName := range req.TableIdentifiers {
-		tableSchema, err := c.getTableSchemaForTable(tableName)
+		tableSchema, err := c.getTableSchemaForTable(ctx, tableName)
 		if err != nil {
 			return nil, err
 		}
 		res[tableName] = tableSchema
-		utils.RecordHeartbeat(c.ctx, fmt.Sprintf("fetched schema for table %s", tableName))
+		utils.RecordHeartbeat(ctx, fmt.Sprintf("fetched schema for table %s", tableName))
 	}
 
 	return &protos.GetTableSchemaBatchOutput{

--- a/flow/connectors/snowflake/qrep_avro_consolidate.go
+++ b/flow/connectors/snowflake/qrep_avro_consolidate.go
@@ -39,7 +39,7 @@ func NewSnowflakeAvroConsolidateHandler(
 func (s *SnowflakeAvroConsolidateHandler) CopyStageToDestination(ctx context.Context) error {
 	s.connector.logger.Info("Copying stage to destination " + s.dstTableName)
 
-	colNames, colTypes, colsErr := s.connector.getColsFromTable(s.dstTableName)
+	colNames, colTypes, colsErr := s.connector.getColsFromTable(ctx, s.dstTableName)
 	if colsErr != nil {
 		return fmt.Errorf("failed to get columns from destination table: %w", colsErr)
 	}
@@ -228,7 +228,7 @@ func (s *SnowflakeAvroConsolidateHandler) handleUpsertMode(ctx context.Context) 
 	}
 	rowCount, err := rows.RowsAffected()
 	if err == nil {
-		totalRowsAtTarget, err := s.connector.getTableCounts([]string{s.dstTableName})
+		totalRowsAtTarget, err := s.connector.getTableCounts(ctx, []string{s.dstTableName})
 		if err != nil {
 			return err
 		}

--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -65,7 +65,7 @@ func (s *SnowflakeAvroSyncHandler) SyncRecords(
 	s.connector.logger.Info(fmt.Sprintf("written %d records to Avro file", avroFile.NumRecords), tableLog)
 
 	stage := s.connector.getStageNameForJob(s.config.FlowJobName)
-	err = s.connector.createStage(stage, s.config)
+	err = s.connector.createStage(ctx, stage, s.config)
 	if err != nil {
 		return 0, err
 	}

--- a/flow/connectors/sql/query_executor.go
+++ b/flow/connectors/sql/query_executor.go
@@ -13,56 +13,53 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jmoiron/sqlx"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/log"
 
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
-	"github.com/PeerDB-io/peer-flow/shared"
 )
 
 type SQLQueryExecutor interface {
-	ConnectionActive() error
-	Close() error
+	ConnectionActive(context.Context) error
+	Close(context.Context) error
 
-	CreateSchema(schemaName string) error
-	DropSchema(schemaName string) error
-	CheckSchemaExists(schemaName string) (bool, error)
-	RecreateSchema(schemaName string) error
+	CreateSchema(ctx context.Context, schemaName string) error
+	DropSchema(ctx context.Context, schemaName string) error
+	CheckSchemaExists(ctx context.Context, schemaName string) (bool, error)
+	RecreateSchema(ctx context.Context, schemaName string) error
 
-	CreateTable(schema *model.QRecordSchema, schemaName string, tableName string) error
-	CountRows(schemaName string, tableName string) (int64, error)
+	CreateTable(ctx context.Context, schema *model.QRecordSchema, schemaName string, tableName string) error
+	CountRows(ctx context.Context, schemaName string, tableName string) (int64, error)
 
-	ExecuteAndProcessQuery(query string, args ...interface{}) (*model.QRecordBatch, error)
-	NamedExecuteAndProcessQuery(query string, arg interface{}) (*model.QRecordBatch, error)
-	ExecuteQuery(query string, args ...interface{}) error
-	NamedExec(query string, arg interface{}) (sql.Result, error)
+	ExecuteAndProcessQuery(ctx context.Context, query string, args ...interface{}) (*model.QRecordBatch, error)
+	NamedExecuteAndProcessQuery(ctx context.Context, query string, arg interface{}) (*model.QRecordBatch, error)
+	ExecuteQuery(ctx context.Context, query string, args ...interface{}) error
+	NamedExec(ctx context.Context, query string, arg interface{}) (sql.Result, error)
 }
 
 type GenericSQLQueryExecutor struct {
-	ctx                context.Context
 	db                 *sqlx.DB
 	dbtypeToQValueKind map[string]qvalue.QValueKind
 	qvalueKindToDBType map[qvalue.QValueKind]string
-	logger             slog.Logger
+	logger             log.Logger
 }
 
 func NewGenericSQLQueryExecutor(
-	ctx context.Context,
+	logger log.Logger,
 	db *sqlx.DB,
 	dbtypeToQValueKind map[string]qvalue.QValueKind,
 	qvalueKindToDBType map[qvalue.QValueKind]string,
 ) *GenericSQLQueryExecutor {
-	flowName, _ := ctx.Value(shared.FlowNameKey).(string)
 	return &GenericSQLQueryExecutor{
-		ctx:                ctx,
 		db:                 db,
 		dbtypeToQValueKind: dbtypeToQValueKind,
 		qvalueKindToDBType: qvalueKindToDBType,
-		logger:             *slog.With(slog.String(string(shared.FlowNameKey), flowName)),
+		logger:             logger,
 	}
 }
 
-func (g *GenericSQLQueryExecutor) ConnectionActive() bool {
-	err := g.db.PingContext(g.ctx)
+func (g *GenericSQLQueryExecutor) ConnectionActive(ctx context.Context) bool {
+	err := g.db.PingContext(ctx)
 	return err == nil
 }
 
@@ -70,32 +67,32 @@ func (g *GenericSQLQueryExecutor) Close() error {
 	return g.db.Close()
 }
 
-func (g *GenericSQLQueryExecutor) CreateSchema(schemaName string) error {
-	_, err := g.db.ExecContext(g.ctx, "CREATE SCHEMA "+schemaName)
+func (g *GenericSQLQueryExecutor) CreateSchema(ctx context.Context, schemaName string) error {
+	_, err := g.db.ExecContext(ctx, "CREATE SCHEMA "+schemaName)
 	return err
 }
 
-func (g *GenericSQLQueryExecutor) DropSchema(schemaName string) error {
-	_, err := g.db.ExecContext(g.ctx, "DROP SCHEMA IF EXISTS "+schemaName+" CASCADE")
+func (g *GenericSQLQueryExecutor) DropSchema(ctx context.Context, schemaName string) error {
+	_, err := g.db.ExecContext(ctx, "DROP SCHEMA IF EXISTS "+schemaName+" CASCADE")
 	return err
 }
 
 // the SQL query this function executes appears to be MySQL/MariaDB specific.
-func (g *GenericSQLQueryExecutor) CheckSchemaExists(schemaName string) (bool, error) {
+func (g *GenericSQLQueryExecutor) CheckSchemaExists(ctx context.Context, schemaName string) (bool, error) {
 	var exists pgtype.Bool
 	// use information schemata to check if schema exists
-	err := g.db.QueryRowxContext(g.ctx,
+	err := g.db.QueryRowxContext(ctx,
 		"SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)", schemaName).Scan(&exists)
 	return exists.Bool, err
 }
 
-func (g *GenericSQLQueryExecutor) RecreateSchema(schemaName string) error {
-	err := g.DropSchema(schemaName)
+func (g *GenericSQLQueryExecutor) RecreateSchema(ctx context.Context, schemaName string) error {
+	err := g.DropSchema(ctx, schemaName)
 	if err != nil {
 		return fmt.Errorf("failed to drop schema: %w", err)
 	}
 
-	err = g.CreateSchema(schemaName)
+	err = g.CreateSchema(ctx, schemaName)
 	if err != nil {
 		return fmt.Errorf("failed to create schema: %w", err)
 	}
@@ -103,7 +100,7 @@ func (g *GenericSQLQueryExecutor) RecreateSchema(schemaName string) error {
 	return nil
 }
 
-func (g *GenericSQLQueryExecutor) CreateTable(schema *model.QRecordSchema, schemaName string, tableName string) error {
+func (g *GenericSQLQueryExecutor) CreateTable(ctx context.Context, schema *model.QRecordSchema, schemaName string, tableName string) error {
 	fields := make([]string, 0, len(schema.Fields))
 	for _, field := range schema.Fields {
 		dbType, ok := g.qvalueKindToDBType[field.Type]
@@ -115,7 +112,7 @@ func (g *GenericSQLQueryExecutor) CreateTable(schema *model.QRecordSchema, schem
 
 	command := fmt.Sprintf("CREATE TABLE %s.%s (%s)", schemaName, tableName, strings.Join(fields, ", "))
 
-	_, err := g.db.ExecContext(g.ctx, command)
+	_, err := g.db.ExecContext(ctx, command)
 	if err != nil {
 		return fmt.Errorf("failed to create table: %w", err)
 	}
@@ -123,20 +120,21 @@ func (g *GenericSQLQueryExecutor) CreateTable(schema *model.QRecordSchema, schem
 	return nil
 }
 
-func (g *GenericSQLQueryExecutor) CountRows(schemaName string, tableName string) (int64, error) {
+func (g *GenericSQLQueryExecutor) CountRows(ctx context.Context, schemaName string, tableName string) (int64, error) {
 	var count pgtype.Int8
-	err := g.db.QueryRowx("SELECT COUNT(*) FROM " + schemaName + "." + tableName).Scan(&count)
+	err := g.db.QueryRowxContext(ctx, "SELECT COUNT(*) FROM "+schemaName+"."+tableName).Scan(&count)
 	return count.Int64, err
 }
 
 func (g *GenericSQLQueryExecutor) CountNonNullRows(
+	ctx context.Context,
 	schemaName string,
 	tableName string,
 	columnName string,
 ) (int64, error) {
 	var count pgtype.Int8
-	err := g.db.QueryRowx("SELECT COUNT(CASE WHEN " + columnName +
-		" IS NOT NULL THEN 1 END) AS non_null_count FROM " + schemaName + "." + tableName).Scan(&count)
+	err := g.db.QueryRowxContext(ctx, "SELECT COUNT(CASE WHEN "+columnName+
+		" IS NOT NULL THEN 1 END) AS non_null_count FROM "+schemaName+"."+tableName).Scan(&count)
 	return count.Int64, err
 }
 
@@ -155,7 +153,7 @@ func (g *GenericSQLQueryExecutor) columnTypeToQField(ct *sql.ColumnType) (model.
 	}, nil
 }
 
-func (g *GenericSQLQueryExecutor) processRows(rows *sqlx.Rows) (*model.QRecordBatch, error) {
+func (g *GenericSQLQueryExecutor) processRows(ctx context.Context, rows *sqlx.Rows) (*model.QRecordBatch, error) {
 	dbColTypes, err := rows.ColumnTypes()
 	if err != nil {
 		return nil, err
@@ -241,7 +239,7 @@ func (g *GenericSQLQueryExecutor) processRows(rows *sqlx.Rows) (*model.QRecordBa
 		totalRowsProcessed += 1
 
 		if totalRowsProcessed%heartBeatNumRows == 0 {
-			activity.RecordHeartbeat(g.ctx, fmt.Sprintf("processed %d rows", totalRowsProcessed))
+			activity.RecordHeartbeat(ctx, fmt.Sprintf("processed %d rows", totalRowsProcessed))
 		}
 	}
 
@@ -258,46 +256,50 @@ func (g *GenericSQLQueryExecutor) processRows(rows *sqlx.Rows) (*model.QRecordBa
 }
 
 func (g *GenericSQLQueryExecutor) ExecuteAndProcessQuery(
-	query string, args ...interface{},
+	ctx context.Context,
+	query string,
+	args ...interface{},
 ) (*model.QRecordBatch, error) {
-	rows, err := g.db.QueryxContext(g.ctx, query, args...)
+	rows, err := g.db.QueryxContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	return g.processRows(rows)
+	return g.processRows(ctx, rows)
 }
 
 func (g *GenericSQLQueryExecutor) NamedExecuteAndProcessQuery(
-	query string, arg interface{},
+	ctx context.Context,
+	query string,
+	arg interface{},
 ) (*model.QRecordBatch, error) {
-	rows, err := g.db.NamedQueryContext(g.ctx, query, arg)
+	rows, err := g.db.NamedQueryContext(ctx, query, arg)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	return g.processRows(rows)
+	return g.processRows(ctx, rows)
 }
 
-func (g *GenericSQLQueryExecutor) ExecuteQuery(query string, args ...interface{}) error {
-	_, err := g.db.ExecContext(g.ctx, query, args...)
+func (g *GenericSQLQueryExecutor) ExecuteQuery(ctx context.Context, query string, args ...interface{}) error {
+	_, err := g.db.ExecContext(ctx, query, args...)
 	return err
 }
 
-func (g *GenericSQLQueryExecutor) NamedExec(query string, arg interface{}) (sql.Result, error) {
-	return g.db.NamedExecContext(g.ctx, query, arg)
+func (g *GenericSQLQueryExecutor) NamedExec(ctx context.Context, query string, arg interface{}) (sql.Result, error) {
+	return g.db.NamedExecContext(ctx, query, arg)
 }
 
 // returns true if any of the columns are null in value
-func (g *GenericSQLQueryExecutor) CheckNull(schema string, tableName string, colNames []string) (bool, error) {
+func (g *GenericSQLQueryExecutor) CheckNull(ctx context.Context, schema string, tableName string, colNames []string) (bool, error) {
 	var count pgtype.Int8
 	joinedString := strings.Join(colNames, " is null or ") + " is null"
 	query := fmt.Sprintf("SELECT COUNT(*) FROM %s.%s WHERE %s",
 		schema, tableName, joinedString)
 
-	err := g.db.QueryRowxContext(g.ctx, query).Scan(&count)
+	err := g.db.QueryRowxContext(ctx, query).Scan(&count)
 	if err != nil {
 		return false, err
 	}

--- a/flow/connectors/utils/catalog/env.go
+++ b/flow/connectors/utils/catalog/env.go
@@ -17,20 +17,20 @@ var (
 	pool      *pgxpool.Pool
 )
 
-func GetCatalogConnectionPoolFromEnv() (*pgxpool.Pool, error) {
+func GetCatalogConnectionPoolFromEnv(ctx context.Context) (*pgxpool.Pool, error) {
 	var err error
 
 	poolMutex.Lock()
 	defer poolMutex.Unlock()
 	if pool == nil {
 		catalogConnectionString := genCatalogConnectionString()
-		pool, err = pgxpool.New(context.Background(), catalogConnectionString)
+		pool, err = pgxpool.New(ctx, catalogConnectionString)
 		if err != nil {
 			return nil, fmt.Errorf("unable to establish connection with catalog: %w", err)
 		}
 	}
 
-	err = pool.Ping(context.Background())
+	err = pool.Ping(ctx)
 	if err != nil {
 		return pool, fmt.Errorf("unable to establish connection with catalog: %w", err)
 	}

--- a/flow/dynamicconf/dynamicconf.go
+++ b/flow/dynamicconf/dynamicconf.go
@@ -25,7 +25,7 @@ func dynamicConfKeyExists(ctx context.Context, conn *pgxpool.Pool, key string) b
 }
 
 func dynamicConfUint32(ctx context.Context, key string, defaultValue uint32) uint32 {
-	conn, err := utils.GetCatalogConnectionPoolFromEnv()
+	conn, err := utils.GetCatalogConnectionPoolFromEnv(ctx)
 	if err != nil {
 		slog.Error("Failed to get catalog connection pool: %v", err)
 		return defaultValue

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -60,7 +60,7 @@ func (s PeerFlowE2ETestSuitePG) WaitForSchema(
 	s.t.Helper()
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, reason, func() bool {
 		s.t.Helper()
-		output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+		output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 			TableIdentifiers: []string{dstTableName},
 		})
 		if err != nil {

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -207,7 +207,7 @@ func (s PeerFlowE2ETestSuitePG) TestSimpleSlotCreation() {
 
 	setupError := make(chan error)
 	go func() {
-		setupError <- s.connector.SetupReplication(signal, setupReplicationInput)
+		setupError <- s.connector.SetupReplication(context.Background(), signal, setupReplicationInput)
 	}()
 
 	s.t.Log("waiting for slot creation to complete: ", flowJobName)

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -65,7 +65,7 @@ func TestPeerFlowE2ETestSuiteSF(t *testing.T) {
 			}
 		}
 
-		err := s.connector.Close()
+		err := s.connector.Close(context.Background())
 		if err != nil {
 			s.t.Fatalf("failed to close Snowflake connector: %v", err)
 		}
@@ -747,7 +747,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Simple_Schema_Changes_SF() {
 				},
 			},
 		}
-		output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+		output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 			TableIdentifiers: []string{dstTableName},
 		})
 		e2e.EnvNoError(s.t, env, err)
@@ -790,7 +790,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Simple_Schema_Changes_SF() {
 				},
 			},
 		}
-		output, err = s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+		output, err = s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 			TableIdentifiers: []string{dstTableName},
 		})
 		e2e.EnvNoError(s.t, env, err)
@@ -839,7 +839,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Simple_Schema_Changes_SF() {
 				},
 			},
 		}
-		output, err = s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+		output, err = s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 			TableIdentifiers: []string{dstTableName},
 		})
 		e2e.EnvNoError(s.t, env, err)
@@ -888,7 +888,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Simple_Schema_Changes_SF() {
 				},
 			},
 		}
-		output, err = s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+		output, err = s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 			TableIdentifiers: []string{dstTableName},
 		})
 		e2e.EnvNoError(s.t, env, err)

--- a/flow/e2e/snowflake/snowflake_helper.go
+++ b/flow/e2e/snowflake/snowflake_helper.go
@@ -60,7 +60,7 @@ func NewSnowflakeTestHelper() (*SnowflakeTestHelper, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Snowflake client: %w", err)
 	}
-	err = adminClient.ExecuteQuery(fmt.Sprintf("CREATE DATABASE %s", testDatabaseName))
+	err = adminClient.ExecuteQuery(context.Background(), fmt.Sprintf("CREATE DATABASE %s", testDatabaseName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Snowflake test database: %w", err)
 	}
@@ -99,7 +99,7 @@ func (s *SnowflakeTestHelper) Cleanup() error {
 	if err != nil {
 		return err
 	}
-	err = s.adminClient.ExecuteQuery(fmt.Sprintf("DROP DATABASE %s", s.testDatabaseName))
+	err = s.adminClient.ExecuteQuery(context.Background(), fmt.Sprintf("DROP DATABASE %s", s.testDatabaseName))
 	if err != nil {
 		return err
 	}
@@ -108,12 +108,12 @@ func (s *SnowflakeTestHelper) Cleanup() error {
 
 // RunCommand runs the given command.
 func (s *SnowflakeTestHelper) RunCommand(command string) error {
-	return s.testClient.ExecuteQuery(command)
+	return s.testClient.ExecuteQuery(context.Background(), command)
 }
 
 // CountRows(tableName) returns the number of rows in the given table.
 func (s *SnowflakeTestHelper) CountRows(tableName string) (int, error) {
-	res, err := s.testClient.CountRows(s.testSchemaName, tableName)
+	res, err := s.testClient.CountRows(context.Background(), s.testSchemaName, tableName)
 	if err != nil {
 		return 0, err
 	}
@@ -123,7 +123,7 @@ func (s *SnowflakeTestHelper) CountRows(tableName string) (int, error) {
 
 // CountRows(tableName) returns the non-null number of rows in the given table.
 func (s *SnowflakeTestHelper) CountNonNullRows(tableName string, columnName string) (int, error) {
-	res, err := s.testClient.CountNonNullRows(s.testSchemaName, tableName, columnName)
+	res, err := s.testClient.CountNonNullRows(context.Background(), s.testSchemaName, tableName, columnName)
 	if err != nil {
 		return 0, err
 	}
@@ -132,20 +132,20 @@ func (s *SnowflakeTestHelper) CountNonNullRows(tableName string, columnName stri
 }
 
 func (s *SnowflakeTestHelper) CheckNull(tableName string, colNames []string) (bool, error) {
-	return s.testClient.CheckNull(s.testSchemaName, tableName, colNames)
+	return s.testClient.CheckNull(context.Background(), s.testSchemaName, tableName, colNames)
 }
 
 func (s *SnowflakeTestHelper) ExecuteAndProcessQuery(query string) (*model.QRecordBatch, error) {
-	return s.testClient.ExecuteAndProcessQuery(query)
+	return s.testClient.ExecuteAndProcessQuery(context.Background(), query)
 }
 
 func (s *SnowflakeTestHelper) CreateTable(tableName string, schema *model.QRecordSchema) error {
-	return s.testClient.CreateTable(schema, s.testSchemaName, tableName)
+	return s.testClient.CreateTable(context.Background(), schema, s.testSchemaName, tableName)
 }
 
 // runs a query that returns an int result
 func (s *SnowflakeTestHelper) RunIntQuery(query string) (int, error) {
-	rows, err := s.testClient.ExecuteAndProcessQuery(query)
+	rows, err := s.testClient.ExecuteAndProcessQuery(context.Background(), query)
 	if err != nil {
 		return 0, err
 	}
@@ -179,7 +179,7 @@ func (s *SnowflakeTestHelper) RunIntQuery(query string) (int, error) {
 
 // runs a query that returns an int result
 func (s *SnowflakeTestHelper) checkSyncedAt(query string) error {
-	recordBatch, err := s.testClient.ExecuteAndProcessQuery(query)
+	recordBatch, err := s.testClient.ExecuteAndProcessQuery(context.Background(), query)
 	if err != nil {
 		return err
 	}

--- a/flow/e2e/snowflake/snowflake_schema_delta_test.go
+++ b/flow/e2e/snowflake/snowflake_schema_delta_test.go
@@ -50,7 +50,7 @@ func (s SnowflakeSchemaDeltaTestSuite) TestSimpleAddColumn() {
 	err := s.sfTestHelper.RunCommand(fmt.Sprintf("CREATE TABLE %s(ID TEXT PRIMARY KEY)", tableName))
 	require.NoError(s.t, err)
 
-	err = s.connector.ReplayTableSchemaDeltas("schema_delta_flow", []*protos.TableSchemaDelta{{
+	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: []*protos.DeltaAddedColumn{{
@@ -60,7 +60,7 @@ func (s SnowflakeSchemaDeltaTestSuite) TestSimpleAddColumn() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 		TableIdentifiers: []string{tableName},
 	})
 	require.NoError(s.t, err)
@@ -157,14 +157,14 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 		}
 	}
 
-	err = s.connector.ReplayTableSchemaDeltas("schema_delta_flow", []*protos.TableSchemaDelta{{
+	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: addedColumns,
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 		TableIdentifiers: []string{tableName},
 	})
 	require.NoError(s.t, err)
@@ -236,14 +236,14 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
 		}
 	}
 
-	err = s.connector.ReplayTableSchemaDeltas("schema_delta_flow", []*protos.TableSchemaDelta{{
+	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: addedColumns,
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 		TableIdentifiers: []string{tableName},
 	})
 	require.NoError(s.t, err)
@@ -290,14 +290,14 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddWhitespaceColumnNames() {
 		}
 	}
 
-	err = s.connector.ReplayTableSchemaDeltas("schema_delta_flow", []*protos.TableSchemaDelta{{
+	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: addedColumns,
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(&protos.GetTableSchemaBatchInput{
+	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
 		TableIdentifiers: []string{tableName},
 	})
 	require.NoError(s.t, err)
@@ -307,6 +307,6 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddWhitespaceColumnNames() {
 func TestSnowflakeSchemaDeltaTestSuite(t *testing.T) {
 	e2eshared.RunSuite(t, setupSchemaDeltaSuite, func(s SnowflakeSchemaDeltaTestSuite) {
 		require.NoError(s.t, s.sfTestHelper.Cleanup())
-		require.NoError(s.t, s.connector.Close())
+		require.NoError(s.t, s.connector.Close(context.Background()))
 	})
 }

--- a/flow/e2e/sqlserver/qrep_flow_sqlserver_test.go
+++ b/flow/e2e/sqlserver/qrep_flow_sqlserver_test.go
@@ -103,6 +103,7 @@ func (s PeerFlowE2ETestSuiteSQLServer) insertRowsIntoSQLServerTable(tableName st
 		params["status"] = 1
 
 		_, err := s.sqlsHelper.E.NamedExec(
+			context.Background(),
 			"INSERT INTO "+schemaQualified+" (id, card_id, v_from, price, status) VALUES (:id, :card_id, :v_from, :price, :status)",
 			params,
 		)

--- a/flow/e2e/sqlserver/sqlserver_helper.go
+++ b/flow/e2e/sqlserver/sqlserver_helper.go
@@ -41,7 +41,7 @@ func NewSQLServerHelper(name string) (*SQLServerHelper, error) {
 		return nil, err
 	}
 
-	connErr := connector.ConnectionActive()
+	connErr := connector.ConnectionActive(context.Background())
 	if connErr != nil {
 		return nil, fmt.Errorf("invalid connection configs: %v", connErr)
 	}
@@ -52,7 +52,7 @@ func NewSQLServerHelper(name string) (*SQLServerHelper, error) {
 	}
 
 	testSchema := fmt.Sprintf("e2e_test_%d", rndNum)
-	err = connector.CreateSchema(testSchema)
+	err = connector.CreateSchema(context.Background(), testSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func NewSQLServerHelper(name string) (*SQLServerHelper, error) {
 }
 
 func (h *SQLServerHelper) CreateTable(schema *model.QRecordSchema, tableName string) error {
-	err := h.E.CreateTable(schema, h.SchemaName, tableName)
+	err := h.E.CreateTable(context.Background(), schema, h.SchemaName, tableName)
 	if err != nil {
 		return err
 	}
@@ -87,14 +87,14 @@ func (h *SQLServerHelper) GetPeer() *protos.Peer {
 
 func (h *SQLServerHelper) CleanUp() error {
 	for _, tbl := range h.tables {
-		err := h.E.ExecuteQuery(fmt.Sprintf("DROP TABLE %s.%s", h.SchemaName, tbl))
+		err := h.E.ExecuteQuery(context.Background(), fmt.Sprintf("DROP TABLE %s.%s", h.SchemaName, tbl))
 		if err != nil {
 			return err
 		}
 	}
 
 	if h.SchemaName != "" {
-		return h.E.ExecuteQuery(fmt.Sprintf("DROP SCHEMA %s", h.SchemaName))
+		return h.E.ExecuteQuery(context.Background(), fmt.Sprintf("DROP SCHEMA %s", h.SchemaName))
 	}
 
 	return nil

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -98,6 +98,7 @@ func GetPgRows(conn *pgx.Conn, suffix string, table string, cols string) (*model
 	pgQueryExecutor.SetTestEnv(true)
 
 	return pgQueryExecutor.ExecuteAndProcessQuery(
+		context.Background(),
 		fmt.Sprintf(`SELECT %s FROM e2e_test_%s."%s" ORDER BY id`, cols, suffix, table),
 	)
 }

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -51,8 +51,6 @@ type PullRecordsRequest struct {
 	RelationMessageMapping RelationMessageMapping
 	// record batch for pushing changes into
 	RecordStream *CDCRecordStream
-	// last offset may be forwarded while processing records
-	SetLastOffset func(int64) error
 }
 
 type Record interface {


### PR DESCRIPTION
Required updating connector interfaces. Bit annoying `ctx` everywhere, but that's ultimately the correct way. Was running into context complications in #1211 with connector being shared between activities

Putting context in struct essentially makes that struct a context, but this is not the context we necessarily want. For more context, see https://zenhorace.dev/blog/context-control-go

Some changes were made:
1. GetCatalog takes a context now instead of using `context.Background()`
2. eventhubs processBatch now takes context instead of using `context.Background()`
3. many instances of `Query`/`Exec` in snowflake/clickhouse converted to `QueryContext`/`ExecContext`
4. got rid of cancel context in ssh tunnel, context being passed in is sufficient

Followup to #1238