### PR TITLE
BQ merge fixes

### DIFF
--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -177,20 +177,6 @@ func (m *mergeStmtGenerator) generateMergeStmt(unchangedToastColumns []string) s
 		pkeySelectSQL, insertColumnsSQL, insertValuesSQL, updateStringToastCols, deletePart)
 }
 
-func (m *mergeStmtGenerator) generateMergeStmts(allUnchangedToastColas []string) []string {
-	// TODO (kaushik): This is so that the statement size for individual merge statements
-	// doesn't exceed the limit. We should make this configurable.
-	const batchSize = 8
-	partitions := utils.ArrayChunks(allUnchangedToastColas, batchSize)
-
-	mergeStmts := make([]string, 0, len(partitions))
-	for _, partition := range partitions {
-		mergeStmts = append(mergeStmts, m.generateMergeStmt(partition))
-	}
-
-	return mergeStmts
-}
-
 /*
 This function takes an array of unique unchanged toast column groups and an array of all column names,
 and returns suitable UPDATE statements as part of a MERGE operation.

--- a/flow/connectors/utils/array.go
+++ b/flow/connectors/utils/array.go
@@ -18,17 +18,23 @@ func ArrayMinus[T comparable](first, second []T) []T {
 	return result
 }
 
-func ArrayChunks[T any](slice []T, size int) [][]T {
-	var partitions [][]T
-
-	for size < len(slice) {
-		slice, partitions = slice[size:], append(partitions, slice[0:size])
+// Call f with subslices of slice. An empty slice will call f once with nil.
+func ArrayIterChunks[T any](slice []T, size int, f func(chunk []T) error) error {
+	if len(slice) == 0 {
+		return f(nil)
 	}
-
-	// Add the last remaining values
-	partitions = append(partitions, slice)
-
-	return partitions
+	if size <= 0 {
+		return nil
+	}
+	lo := 0
+	for lo < len(slice) {
+		hi := min(lo+size, len(slice))
+		if err := f(slice[lo:hi:hi]); err != nil {
+			return err
+		}
+		lo = hi
+	}
+	return nil
 }
 
 func ArraysHaveOverlap[T comparable](first, second []T) bool {


### PR DESCRIPTION
BQ `it.Next(&row)` seems to mutate the target,
https://github.com/googleapis/google-cloud-go/blob/f049c9751415f9fc4c81c1839a8371782cfc016c/bigquery/value.go#L490
so reallocate a fresh row each iteration

ArrayChunks: replace with ArrayIterChunks. Document behavior when input is empty slice
Also reduces allocations, since we've seen people having 1000+ columns

go 1.22 has a rangefunc experiment, so eventually we can replace this with that https://go.dev/wiki/RangefuncExperiment