### PR TITLE
Replace more use of default slog handler with logger from context

### DIFF
--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -106,7 +106,7 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 	// drop the staging table
 	if err := bqClient.DatasetInProject(s.connector.projectID, datasetID).Table(stagingTable).Delete(ctx); err != nil {
 		// just log the error this isn't fatal.
-		slog.Error("failed to delete staging table "+stagingTable,
+		s.connector.logger.Warn("failed to delete staging table "+stagingTable,
 			slog.Any("error", err),
 			slog.Int64("syncBatchID", syncBatchID),
 			slog.String("destinationTable", rawTableName))
@@ -220,7 +220,7 @@ func (s *QRepAvroSyncMethod) SyncQRepRecords(
 	if err := bqClient.DatasetInProject(s.connector.projectID, stagingDatasetTable.dataset).
 		Table(stagingDatasetTable.table).Delete(ctx); err != nil {
 		// just log the error this isn't fatal.
-		slog.Error("failed to delete staging table "+stagingDatasetTable.string(),
+		s.connector.logger.Warn("failed to delete staging table "+stagingDatasetTable.string(),
 			slog.Any("error", err),
 			flowLog)
 	}

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -16,6 +16,7 @@ import (
 	connsnowflake "github.com/PeerDB-io/peer-flow/connectors/snowflake"
 	connsqlserver "github.com/PeerDB-io/peer-flow/connectors/sqlserver"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/shared/alerting"
 )
@@ -285,6 +286,6 @@ func CloseConnector(ctx context.Context, conn Connector) {
 
 	err := conn.Close(ctx)
 	if err != nil {
-		slog.Error("error closing connector", slog.Any("error", err))
+		logger.LoggerFromCtx(ctx).Error("error closing connector", slog.Any("error", err))
 	}
 }

--- a/flow/connectors/eventhub/hub_batches.go
+++ b/flow/connectors/eventhub/hub_batches.go
@@ -10,6 +10,7 @@ import (
 
 	azeventhubs "github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
 
@@ -105,8 +106,8 @@ func (h *HubBatches) sendBatch(
 		return err
 	}
 
-	slog.InfoContext(ctx, "sendBatch",
-		slog.Int("events sent", int(events.NumEvents())), slog.String("event hub topic ", tblName.ToString()))
+	logger.LoggerFromCtx(ctx).Info("sendBatch",
+		slog.Int("events sent", int(events.NumEvents())), slog.String("event hub topic", tblName.ToString()))
 	return nil
 }
 
@@ -114,8 +115,9 @@ func (h *HubBatches) flushAllBatches(
 	ctx context.Context,
 	flowName string,
 ) error {
+	logger := logger.LoggerFromCtx(ctx)
 	if h.Len() == 0 {
-		slog.Info("no events to send", slog.String(string(shared.FlowNameKey), flowName))
+		logger.Info("no events to send", slog.String(string(shared.FlowNameKey), flowName))
 		return nil
 	}
 
@@ -132,7 +134,7 @@ func (h *HubBatches) flushAllBatches(
 			}
 
 			numEventsPushed.Add(numEvents)
-			slog.Info("flushAllBatches",
+			logger.Info("flushAllBatches",
 				slog.String(string(shared.FlowNameKey), flowName),
 				slog.Int("events sent", int(numEvents)),
 				slog.String("event hub topic ", destination.ToString()))
@@ -144,7 +146,7 @@ func (h *HubBatches) flushAllBatches(
 	if err != nil {
 		return fmt.Errorf("failed to flushAllBatches: %v", err)
 	}
-	slog.Info("hub batches flush",
+	logger.Info("hub batches flush",
 		slog.String(string(shared.FlowNameKey), flowName),
 		slog.Int("events sent", int(numEventsPushed.Load())))
 

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/PeerDB-io/peer-flow/connectors/utils/cdc_records"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/geo"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 	"github.com/PeerDB-io/peer-flow/shared"
@@ -232,8 +233,9 @@ func (p *PostgresCDCSource) consumeStream(
 	standbyMessageTimeout := req.IdleTimeout
 	nextStandbyMessageDeadline := time.Now().Add(standbyMessageTimeout)
 
+	logger := logger.LoggerFromCtx(ctx)
 	addRecordWithKey := func(key *model.TableWithPkey, rec model.Record) error {
-		err := cdcRecordsStorage.Set(key, rec)
+		err := cdcRecordsStorage.Set(logger, key, rec)
 		if err != nil {
 			return err
 		}

--- a/flow/connectors/postgres/qrep_query_build_test.go
+++ b/flow/connectors/postgres/qrep_query_build_test.go
@@ -1,6 +1,7 @@
 package connpostgres
 
 import (
+	"log/slog"
 	"testing"
 )
 
@@ -34,7 +35,7 @@ func TestBuildQuery(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := BuildQuery(tc.query, "test_flow")
+			actual, err := BuildQuery(slog.Default(), tc.query, "test_flow")
 			if err != nil {
 				t.Fatalf("Error returned by BuildQuery: %v", err)
 			}

--- a/flow/connectors/postgres/qrep_sql_sync.go
+++ b/flow/connectors/postgres/qrep_sql_sync.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
@@ -47,7 +48,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 	startTime := time.Now()
 	schema, err := stream.Schema()
 	if err != nil {
-		slog.Error("failed to get schema from stream", slog.Any("error", err), syncLog)
+		logger.LoggerFromCtx(ctx).Error("failed to get schema from stream", slog.Any("error", err), syncLog)
 		return 0, fmt.Errorf("failed to get schema from stream: %w", err)
 	}
 
@@ -71,7 +72,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 	defer func() {
 		if err := tx.Rollback(context.Background()); err != nil {
 			if err != pgx.ErrTxClosed {
-				slog.Error("failed to rollback transaction tx2", slog.Any("error", err), syncLog)
+				logger.LoggerFromCtx(ctx).Error("failed to rollback transaction tx2", slog.Any("error", err), syncLog)
 			}
 		}
 	}()

--- a/flow/connectors/sqlserver/qrep.go
+++ b/flow/connectors/sqlserver/qrep.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
 	"text/template"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jmoiron/sqlx"
+	"go.temporal.io/sdk/log"
 
 	utils "github.com/PeerDB-io/peer-flow/connectors/utils/partition"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
@@ -158,7 +158,7 @@ func (c *SQLServerConnector) PullQRepRecords(
 ) (*model.QRecordBatch, error) {
 	// Build the query to pull records within the range from the source table
 	// Be sure to order the results by the watermark column to ensure consistency across pulls
-	query, err := BuildQuery(config.Query)
+	query, err := BuildQuery(c.logger, config.Query)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (c *SQLServerConnector) PullQRepRecords(
 	return c.NamedExecuteAndProcessQuery(ctx, query, rangeParams)
 }
 
-func BuildQuery(query string) (string, error) {
+func BuildQuery(logger log.Logger, query string) (string, error) {
 	tmpl, err := template.New("query").Parse(query)
 	if err != nil {
 		return "", err
@@ -210,6 +210,6 @@ func BuildQuery(query string) (string, error) {
 	}
 	res := buf.String()
 
-	slog.Info("templated query: " + res)
+	logger.Info("templated query: " + res)
 	return res, nil
 }

--- a/flow/connectors/utils/cdc_records/cdc_records_storage.go
+++ b/flow/connectors/utils/cdc_records/cdc_records_storage.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"go.temporal.io/sdk/log"
 
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
@@ -103,14 +104,14 @@ func (c *cdcRecordsStore) diskSpillThresholdsExceeded() bool {
 	return false
 }
 
-func (c *cdcRecordsStore) Set(key *model.TableWithPkey, rec model.Record) error {
+func (c *cdcRecordsStore) Set(logger log.Logger, key *model.TableWithPkey, rec model.Record) error {
 	if key != nil {
 		_, ok := c.inMemoryRecords[*key]
 		if ok || !c.diskSpillThresholdsExceeded() {
 			c.inMemoryRecords[*key] = rec
 		} else {
 			if c.pebbleDB == nil {
-				slog.Info(c.thresholdReason,
+				logger.Info(c.thresholdReason,
 					slog.String(string(shared.FlowNameKey), c.flowJobName))
 				err := c.initPebbleDB()
 				if err != nil {

--- a/flow/connectors/utils/cdc_records/cdc_records_storage_test.go
+++ b/flow/connectors/utils/cdc_records/cdc_records_storage_test.go
@@ -2,6 +2,7 @@ package cdc_records
 
 import (
 	"crypto/rand"
+	"log/slog"
 	"math/big"
 	"testing"
 	"time"
@@ -81,7 +82,7 @@ func TestSingleRecord(t *testing.T) {
 	cdcRecordsStore.numRecordsSwitchThreshold = 10
 
 	key, rec := genKeyAndRec(t)
-	err := cdcRecordsStore.Set(&key, rec)
+	err := cdcRecordsStore.Set(slog.Default(), &key, rec)
 	require.NoError(t, err)
 	// should not spill into DB
 	require.Len(t, cdcRecordsStore.inMemoryRecords, 1)
@@ -103,7 +104,7 @@ func TestRecordsTillSpill(t *testing.T) {
 	// add records upto set limit
 	for i := 1; i <= 10; i++ {
 		key, rec := genKeyAndRec(t)
-		err := cdcRecordsStore.Set(&key, rec)
+		err := cdcRecordsStore.Set(slog.Default(), &key, rec)
 		require.NoError(t, err)
 		require.Len(t, cdcRecordsStore.inMemoryRecords, i)
 		require.Nil(t, cdcRecordsStore.pebbleDB)
@@ -111,7 +112,7 @@ func TestRecordsTillSpill(t *testing.T) {
 
 	// this record should be spilled to DB
 	key, rec := genKeyAndRec(t)
-	err := cdcRecordsStore.Set(&key, rec)
+	err := cdcRecordsStore.Set(slog.Default(), &key, rec)
 	require.NoError(t, err)
 	_, ok := cdcRecordsStore.inMemoryRecords[key]
 	require.False(t, ok)
@@ -132,7 +133,7 @@ func TestTimeAndRatEncoding(t *testing.T) {
 	cdcRecordsStore.numRecordsSwitchThreshold = 0
 
 	key, rec := genKeyAndRec(t)
-	err := cdcRecordsStore.Set(&key, rec)
+	err := cdcRecordsStore.Set(slog.Default(), &key, rec)
 	require.NoError(t, err)
 
 	retreived, ok, err := cdcRecordsStore.Get(key)
@@ -153,7 +154,7 @@ func TestNullKeyDoesntStore(t *testing.T) {
 	cdcRecordsStore.numRecordsSwitchThreshold = 0
 
 	key, rec := genKeyAndRec(t)
-	err := cdcRecordsStore.Set(nil, rec)
+	err := cdcRecordsStore.Set(slog.Default(), nil, rec)
 	require.NoError(t, err)
 
 	retreived, ok, err := cdcRecordsStore.Get(key)

--- a/flow/connectors/utils/monitoring/monitoring.go
+++ b/flow/connectors/utils/monitoring/monitoring.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
 
@@ -115,7 +116,7 @@ func AddCDCBatchTablesForFlow(ctx context.Context, pool *pgxpool.Pool, flowJobNa
 	defer func() {
 		err = insertBatchTablesTx.Rollback(ctx)
 		if err != pgx.ErrTxClosed && err != nil {
-			slog.Error("error during transaction rollback",
+			logger.LoggerFromCtx(ctx).Error("error during transaction rollback",
 				slog.Any("error", err),
 				slog.String(string(shared.FlowNameKey), flowJobName))
 		}
@@ -225,7 +226,7 @@ func addPartitionToQRepRun(ctx context.Context, pool *pgxpool.Pool, flowJobName 
 	runUUID string, partition *protos.QRepPartition,
 ) error {
 	if partition.Range == nil && partition.FullTablePartition {
-		slog.Info("partition"+partition.PartitionId+
+		logger.LoggerFromCtx(ctx).Info("partition"+partition.PartitionId+
 			" is a full table partition. Metrics logging is skipped.",
 			slog.String(string(shared.FlowNameKey), flowJobName))
 		return nil

--- a/flow/dynamicconf/dynamicconf.go
+++ b/flow/dynamicconf/dynamicconf.go
@@ -2,7 +2,6 @@ package dynamicconf
 
 import (
 	"context"
-	"log/slog"
 	"strconv"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	utils "github.com/PeerDB-io/peer-flow/connectors/utils/catalog"
+	"github.com/PeerDB-io/peer-flow/logger"
 )
 
 func dynamicConfKeyExists(ctx context.Context, conn *pgxpool.Pool, key string) bool {
@@ -17,7 +17,7 @@ func dynamicConfKeyExists(ctx context.Context, conn *pgxpool.Pool, key string) b
 	query := "SELECT EXISTS(SELECT 1 FROM alerting_settings WHERE config_name = $1)"
 	err := conn.QueryRow(ctx, query, key).Scan(&exists)
 	if err != nil {
-		slog.Error("Failed to check if key exists: %v", err)
+		logger.LoggerFromCtx(ctx).Error("Failed to check if key exists: %v", err)
 		return false
 	}
 
@@ -27,7 +27,7 @@ func dynamicConfKeyExists(ctx context.Context, conn *pgxpool.Pool, key string) b
 func dynamicConfUint32(ctx context.Context, key string, defaultValue uint32) uint32 {
 	conn, err := utils.GetCatalogConnectionPoolFromEnv(ctx)
 	if err != nil {
-		slog.Error("Failed to get catalog connection pool: %v", err)
+		logger.LoggerFromCtx(ctx).Error("Failed to get catalog connection pool: %v", err)
 		return defaultValue
 	}
 
@@ -39,13 +39,13 @@ func dynamicConfUint32(ctx context.Context, key string, defaultValue uint32) uin
 	query := "SELECT config_value FROM alerting_settings WHERE config_name = $1"
 	err = conn.QueryRow(ctx, query, key).Scan(&value)
 	if err != nil {
-		slog.Error("Failed to get key: %v", err)
+		logger.LoggerFromCtx(ctx).Error("Failed to get key: %v", err)
 		return defaultValue
 	}
 
 	result, err := strconv.ParseUint(value.String, 10, 32)
 	if err != nil {
-		slog.Error("Failed to parse uint32: %v", err)
+		logger.LoggerFromCtx(ctx).Error("Failed to parse uint32: %v", err)
 		return defaultValue
 	}
 

--- a/flow/model/qrecord_batch.go
+++ b/flow/model/qrecord_batch.go
@@ -22,8 +22,6 @@ type QRecordBatch struct {
 func (q *QRecordBatch) ToQRecordStream(buffer int) (*QRecordStream, error) {
 	stream := NewQRecordStream(buffer)
 
-	slog.Info(fmt.Sprintf("Converting %d records to QRecordStream", len(q.Records)))
-
 	go func() {
 		err := stream.SetSchema(q.Schema)
 		if err != nil {


### PR DESCRIPTION
Things are getting a bit messy since while https://github.com/temporalio/sdk-go/issues/1158 claims the interfaces are compatible in reality there's a mess about what the two different implementations expect from `args ...interface{}`

For now use context specific logger more to mangle output less in CI. A more correct/complete solution will have to be worked out in future