### PR TITLE
Clickhouse: Remove quote from Normalize statement

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -161,7 +161,7 @@ func (c *ClickhouseConnector) NormalizeRecords(ctx context.Context, req *model.N
 				clickhouseType = "String"
 			}
 
-			projection.WriteString(fmt.Sprintf("JSONExtract(_peerdb_data, '%s', '%s') AS '%s', ", cn, clickhouseType, cn))
+			projection.WriteString(fmt.Sprintf("JSONExtract(_peerdb_data, '%s', '%s') AS %s, ", cn, clickhouseType, cn))
 		}
 
 		// add _peerdb_sign as _peerdb_record_type / 2


### PR DESCRIPTION
We were running into a syntax error with the insert-into-select statement in normalize flow due to quoting. This PR removes that