### PR TITLE
Set correct avro schema for clickhouse date

### DIFF
--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -85,6 +85,13 @@ func GetAvroSchemaFromQValueKind(kind QValueKind, targetDWH QDWHType, precision 
 			if kind == QValueKindTime {
 				return "string", nil
 			}
+			if kind == QValueKindDate {
+				return AvroSchemaField{
+					Name:        "date",
+					Type:        "int",
+					LogicalType: "date",
+				}, nil
+			}
 			return "long", nil
 		}
 		return "string", nil
@@ -267,7 +274,7 @@ func (c *QValueAvroConverter) ToAvroValue() (interface{}, error) {
 			}
 		}
 
-		if c.Nullable && c.TargetDWH == QDWHTypeBigQuery {
+		if c.Nullable {
 			return goavro.Union("int.date", t), nil
 		}
 		return t, nil


### PR DESCRIPTION
Use the schema for data as documented in [Avro specification](https://avro.apache.org/docs/1.8.0/spec.html#Date) (basically what we already use for bigquery date)

This PR fixes date syncing for clickhouse initial load aka qrep and has been functionally tested