### PR TITLE
CreateNormalizedTable: lift loop, make it based on separate connector

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -163,7 +163,7 @@ func (a *FlowableActivity) CreateNormalizedTable(
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup normalized tables tx: %w", err)
 	}
-	defer conn.AbortSetupNormalizedTables(ctx, tx)
+	defer conn.CleanupSetupNormalizedTables(ctx, tx)
 
 	numTablesSetup := atomic.Uint32{}
 	totalTables := uint32(len(config.TableNameSchemaMapping))

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pglogrepl"
@@ -141,25 +142,69 @@ func (a *FlowableActivity) GetTableSchema(
 	return srcConn.GetTableSchema(ctx, config)
 }
 
-// CreateNormalizedTable creates a normalized table in the destination flowable.
+// CreateNormalizedTable creates normalized tables in destination.
 func (a *FlowableActivity) CreateNormalizedTable(
 	ctx context.Context,
 	config *protos.SetupNormalizedTableBatchInput,
 ) (*protos.SetupNormalizedTableBatchOutput, error) {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowName)
-	conn, err := connectors.GetCDCSyncConnector(ctx, config.PeerConnectionConfig)
+	conn, err := connectors.GetConnectorAs[connectors.NormalizedTablesConnector](ctx, config.PeerConnectionConfig)
 	if err != nil {
+		if err == connectors.ErrUnsupportedFunctionality {
+			activity.GetLogger(ctx).Info("Connector does not implement normalized tables")
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to get connector: %w", err)
 	}
 	defer connectors.CloseConnector(ctx, conn)
 
-	setupNormalizedTablesOutput, err := conn.SetupNormalizedTables(ctx, config)
+	tx, err := conn.StartSetupNormalizedTables(ctx)
 	if err != nil {
-		a.Alerter.LogFlowError(ctx, config.FlowName, err)
-		return nil, fmt.Errorf("failed to setup normalized tables: %w", err)
+		return nil, fmt.Errorf("failed to setup normalized tables tx: %w", err)
+	}
+	defer conn.AbortSetupNormalizedTables(ctx, tx)
+
+	numTablesSetup := atomic.Uint32{}
+	totalTables := uint32(len(config.TableNameSchemaMapping))
+	shutdown := utils.HeartbeatRoutine(ctx, func() string {
+		return fmt.Sprintf("setting up normalized tables - %d of %d done",
+			numTablesSetup.Load(), totalTables)
+	})
+	defer shutdown()
+
+	logger := activity.GetLogger(ctx)
+	tableExistsMapping := make(map[string]bool)
+	for tableIdentifier, tableSchema := range config.TableNameSchemaMapping {
+		created, err := conn.SetupNormalizedTable(
+			ctx,
+			tx,
+			tableIdentifier,
+			tableSchema,
+			config.SoftDeleteColName,
+			config.SyncedAtColName,
+		)
+		if err != nil {
+			a.Alerter.LogFlowError(ctx, config.FlowName, err)
+			return nil, fmt.Errorf("failed to setup normalized table %s: %w", tableIdentifier, err)
+		}
+		tableExistsMapping[tableIdentifier] = created
+
+		numTablesSetup.Add(1)
+		if created {
+			logger.Info(fmt.Sprintf("created table %s", tableIdentifier))
+		} else {
+			logger.Info(fmt.Sprintf("table already exists %s", tableIdentifier))
+		}
 	}
 
-	return setupNormalizedTablesOutput, nil
+	err = conn.FinishSetupNormalizedTables(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to commit normalized tables tx: %w", err)
+	}
+
+	return &protos.SetupNormalizedTableBatchOutput{
+		TableExistsMapping: tableExistsMapping,
+	}, nil
 }
 
 func (a *FlowableActivity) StartFlow(ctx context.Context,

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -147,11 +147,12 @@ func (a *FlowableActivity) CreateNormalizedTable(
 	ctx context.Context,
 	config *protos.SetupNormalizedTableBatchInput,
 ) (*protos.SetupNormalizedTableBatchOutput, error) {
+	logger := activity.GetLogger(ctx)
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowName)
 	conn, err := connectors.GetConnectorAs[connectors.NormalizedTablesConnector](ctx, config.PeerConnectionConfig)
 	if err != nil {
 		if err == connectors.ErrUnsupportedFunctionality {
-			activity.GetLogger(ctx).Info("Connector does not implement normalized tables")
+			logger.Info("Connector does not implement normalized tables")
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get connector: %w", err)
@@ -172,7 +173,6 @@ func (a *FlowableActivity) CreateNormalizedTable(
 	})
 	defer shutdown()
 
-	logger := activity.GetLogger(ctx)
 	tableExistsMapping := make(map[string]bool)
 	for tableIdentifier, tableSchema := range config.TableNameSchemaMapping {
 		created, err := conn.SetupNormalizedTable(

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -521,7 +520,7 @@ func (c *BigQueryConnector) NormalizeRecords(ctx context.Context, req *model.Nor
 		unchangedToastColumns := tableNametoUnchangedToastCols[tableName]
 		dstDatasetTable, _ := c.convertToDatasetTable(tableName)
 		mergeGen := &mergeStmtGenerator{
-			rawDatasetTable: &datasetTable{
+			rawDatasetTable: datasetTable{
 				project: c.projectID,
 				dataset: c.datasetID,
 				table:   rawTableName,
@@ -648,138 +647,131 @@ func (c *BigQueryConnector) CreateRawTable(ctx context.Context, req *protos.Crea
 	}, nil
 }
 
-// SetupNormalizedTables sets up normalized tables, implementing the Connector interface.
+func (c *BigQueryConnector) StartSetupNormalizedTables(_ context.Context) (interface{}, error) {
+	// needed since CreateNormalizedTable duplicate check isn't accurate enough
+	return make(map[datasetTable]struct{}), nil
+}
+
+func (c *BigQueryConnector) FinishSetupNormalizedTables(_ context.Context) error {
+	return nil
+}
+
+func (c *BigQueryConnector) AbortSetupNormalizedTables(_ context.Context, _ interface{}) {
+}
+
 // This runs CREATE TABLE IF NOT EXISTS on bigquery, using the schema and table name provided.
-func (c *BigQueryConnector) SetupNormalizedTables(
+func (c *BigQueryConnector) SetupNormalizedTable(
 	ctx context.Context,
-	req *protos.SetupNormalizedTableBatchInput,
-) (*protos.SetupNormalizedTableBatchOutput, error) {
-	numTablesSetup := atomic.Uint32{}
-	totalTables := uint32(len(req.TableNameSchemaMapping))
+	tx interface{},
+	tableIdentifier string,
+	tableSchema *protos.TableSchema,
+	softDeleteColName string,
+	syncedAtColName string,
+) (bool, error) {
+	datasetTablesSet := tx.(map[datasetTable]struct{})
 
-	shutdown := utils.HeartbeatRoutine(ctx, func() string {
-		return fmt.Sprintf("setting up normalized tables - %d of %d done",
-			numTablesSetup.Load(), totalTables)
-	})
-	defer shutdown()
-
-	tableExistsMapping := make(map[string]bool)
-	datasetTablesSet := make(map[datasetTable]struct{})
-	for tableIdentifier, tableSchema := range req.TableNameSchemaMapping {
-		// only place where we check for parsing errors
-		datasetTable, err := c.convertToDatasetTable(tableIdentifier)
+	// only place where we check for parsing errors
+	datasetTable, err := c.convertToDatasetTable(tableIdentifier)
+	if err != nil {
+		return false, err
+	}
+	_, ok := datasetTablesSet[datasetTable]
+	if ok {
+		return false, fmt.Errorf("invalid mirror: two tables mirror to the same BigQuery table %s",
+			datasetTable.string())
+	}
+	datasetTablesSet[datasetTable] = struct{}{}
+	dataset := c.client.DatasetInProject(c.projectID, datasetTable.dataset)
+	_, err = dataset.Metadata(ctx)
+	// just assume this means dataset don't exist, and create it
+	if err != nil {
+		// if err message does not contain `notFound`, then other error happened.
+		if !strings.Contains(err.Error(), "notFound") {
+			return false, fmt.Errorf("error while checking metadata for BigQuery dataset %s: %w",
+				datasetTable.dataset, err)
+		}
+		c.logger.Info(fmt.Sprintf("creating dataset %s...", dataset.DatasetID))
+		err = dataset.Create(ctx, nil)
 		if err != nil {
-			return nil, err
+			return false, fmt.Errorf("failed to create BigQuery dataset %s: %w", dataset.DatasetID, err)
 		}
-		_, ok := datasetTablesSet[*datasetTable]
-		if ok {
-			return nil, fmt.Errorf("invalid mirror: two tables mirror to the same BigQuery table %s",
-				datasetTable.string())
-		}
-		dataset := c.client.DatasetInProject(c.projectID, datasetTable.dataset)
-		_, err = dataset.Metadata(ctx)
-		// just assume this means dataset don't exist, and create it
-		if err != nil {
-			// if err message does not contain `notFound`, then other error happened.
-			if !strings.Contains(err.Error(), "notFound") {
-				return nil, fmt.Errorf("error while checking metadata for BigQuery dataset %s: %w",
-					datasetTable.dataset, err)
-			}
-			c.logger.Info(fmt.Sprintf("creating dataset %s...", dataset.DatasetID))
-			err = dataset.Create(ctx, nil)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create BigQuery dataset %s: %w", dataset.DatasetID, err)
-			}
-		}
-		table := dataset.Table(datasetTable.table)
+	}
+	table := dataset.Table(datasetTable.table)
 
-		// check if the table exists
-		_, err = table.Metadata(ctx)
-		if err == nil {
-			// table exists, go to next table
-			tableExistsMapping[tableIdentifier] = true
-			datasetTablesSet[*datasetTable] = struct{}{}
-
-			c.logger.Info(fmt.Sprintf("table already exists %s", tableIdentifier))
-			numTablesSetup.Add(1)
-			continue
-		}
-
-		// convert the column names and types to bigquery types
-		columns := make([]*bigquery.FieldSchema, 0, len(tableSchema.Columns)+2)
-		for _, column := range tableSchema.Columns {
-			genericColType := column.Type
-			if genericColType == "numeric" {
-				precision, scale := numeric.ParseNumericTypmod(column.TypeModifier)
-				if column.TypeModifier == -1 || precision > 38 || scale > 37 {
-					precision = numeric.PeerDBNumericPrecision
-					scale = numeric.PeerDBNumericScale
-				}
-				columns = append(columns, &bigquery.FieldSchema{
-					Name:      column.Name,
-					Type:      bigquery.BigNumericFieldType,
-					Repeated:  qvalue.QValueKind(genericColType).IsArray(),
-					Precision: int64(precision),
-					Scale:     int64(scale),
-				})
-			} else {
-				columns = append(columns, &bigquery.FieldSchema{
-					Name:     column.Name,
-					Type:     qValueKindToBigQueryType(genericColType),
-					Repeated: qvalue.QValueKind(genericColType).IsArray(),
-				})
-			}
-		}
-
-		if req.SoftDeleteColName != "" {
-			columns = append(columns, &bigquery.FieldSchema{
-				Name:     req.SoftDeleteColName,
-				Type:     bigquery.BooleanFieldType,
-				Repeated: false,
-			})
-		}
-
-		if req.SyncedAtColName != "" {
-			columns = append(columns, &bigquery.FieldSchema{
-				Name:     req.SyncedAtColName,
-				Type:     bigquery.TimestampFieldType,
-				Repeated: false,
-			})
-		}
-
-		// create the table using the columns
-		schema := bigquery.Schema(columns)
-
-		// cluster by the primary key if < 4 columns.
-		var clustering *bigquery.Clustering
-		numPkeyCols := len(tableSchema.PrimaryKeyColumns)
-		if numPkeyCols > 0 && numPkeyCols < 4 {
-			clustering = &bigquery.Clustering{
-				Fields: tableSchema.PrimaryKeyColumns,
-			}
-		}
-
-		metadata := &bigquery.TableMetadata{
-			Schema:     schema,
-			Name:       datasetTable.table,
-			Clustering: clustering,
-		}
-
-		err = table.Create(ctx, metadata)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create table %s: %w", tableIdentifier, err)
-		}
-
-		tableExistsMapping[tableIdentifier] = false
-		datasetTablesSet[*datasetTable] = struct{}{}
-		// log that table was created
-		c.logger.Info(fmt.Sprintf("created table %s", tableIdentifier))
-		numTablesSetup.Add(1)
+	// check if the table exists
+	_, err = table.Metadata(ctx)
+	if err == nil {
+		// table exists, go to next table
+		return true, nil
 	}
 
-	return &protos.SetupNormalizedTableBatchOutput{
-		TableExistsMapping: tableExistsMapping,
-	}, nil
+	// convert the column names and types to bigquery types
+	columns := make([]*bigquery.FieldSchema, 0, len(tableSchema.Columns)+2)
+	for _, column := range tableSchema.Columns {
+		genericColType := column.Type
+		if genericColType == "numeric" {
+			precision, scale := numeric.ParseNumericTypmod(column.TypeModifier)
+			if column.TypeModifier == -1 || precision > 38 || scale > 37 {
+				precision = numeric.PeerDBNumericPrecision
+				scale = numeric.PeerDBNumericScale
+			}
+			columns = append(columns, &bigquery.FieldSchema{
+				Name:      column.Name,
+				Type:      bigquery.BigNumericFieldType,
+				Repeated:  qvalue.QValueKind(genericColType).IsArray(),
+				Precision: int64(precision),
+				Scale:     int64(scale),
+			})
+		} else {
+			columns = append(columns, &bigquery.FieldSchema{
+				Name:     column.Name,
+				Type:     qValueKindToBigQueryType(genericColType),
+				Repeated: qvalue.QValueKind(genericColType).IsArray(),
+			})
+		}
+	}
+
+	if softDeleteColName != "" {
+		columns = append(columns, &bigquery.FieldSchema{
+			Name:     softDeleteColName,
+			Type:     bigquery.BooleanFieldType,
+			Repeated: false,
+		})
+	}
+
+	if syncedAtColName != "" {
+		columns = append(columns, &bigquery.FieldSchema{
+			Name:     syncedAtColName,
+			Type:     bigquery.TimestampFieldType,
+			Repeated: false,
+		})
+	}
+
+	// create the table using the columns
+	schema := bigquery.Schema(columns)
+
+	// cluster by the primary key if < 4 columns.
+	var clustering *bigquery.Clustering
+	numPkeyCols := len(tableSchema.PrimaryKeyColumns)
+	if numPkeyCols > 0 && numPkeyCols < 4 {
+		clustering = &bigquery.Clustering{
+			Fields: tableSchema.PrimaryKeyColumns,
+		}
+	}
+
+	metadata := &bigquery.TableMetadata{
+		Schema:     schema,
+		Name:       datasetTable.table,
+		Clustering: clustering,
+	}
+
+	err = table.Create(ctx, metadata)
+	if err != nil {
+		return false, fmt.Errorf("failed to create table %s: %w", tableIdentifier, err)
+	}
+
+	datasetTablesSet[datasetTable] = struct{}{}
+	return false, nil
 }
 
 func (c *BigQueryConnector) SyncFlowCleanup(ctx context.Context, jobName string) error {
@@ -982,25 +974,25 @@ func (d *datasetTable) string() string {
 	return fmt.Sprintf("%s.%s.%s", d.project, d.dataset, d.table)
 }
 
-func (c *BigQueryConnector) convertToDatasetTable(tableName string) (*datasetTable, error) {
+func (c *BigQueryConnector) convertToDatasetTable(tableName string) (datasetTable, error) {
 	parts := strings.Split(tableName, ".")
 	if len(parts) == 1 {
-		return &datasetTable{
+		return datasetTable{
 			dataset: c.datasetID,
 			table:   parts[0],
 		}, nil
 	} else if len(parts) == 2 {
-		return &datasetTable{
+		return datasetTable{
 			dataset: parts[0],
 			table:   parts[1],
 		}, nil
 	} else if len(parts) == 3 {
-		return &datasetTable{
+		return datasetTable{
 			project: parts[0],
 			dataset: parts[1],
 			table:   parts[2],
 		}, nil
 	} else {
-		return nil, fmt.Errorf("invalid BigQuery table name: %s", tableName)
+		return datasetTable{}, fmt.Errorf("invalid BigQuery table name: %s", tableName)
 	}
 }

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -656,7 +656,7 @@ func (c *BigQueryConnector) FinishSetupNormalizedTables(_ context.Context, _ int
 	return nil
 }
 
-func (c *BigQueryConnector) AbortSetupNormalizedTables(_ context.Context, _ interface{}) {
+func (c *BigQueryConnector) CleanupSetupNormalizedTables(_ context.Context, _ interface{}) {
 }
 
 // This runs CREATE TABLE IF NOT EXISTS on bigquery, using the schema and table name provided.

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -652,7 +652,7 @@ func (c *BigQueryConnector) StartSetupNormalizedTables(_ context.Context) (inter
 	return make(map[datasetTable]struct{}), nil
 }
 
-func (c *BigQueryConnector) FinishSetupNormalizedTables(_ context.Context) error {
+func (c *BigQueryConnector) FinishSetupNormalizedTables(_ context.Context, _ interface{}) error {
 	return nil
 }
 

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -13,11 +13,11 @@ import (
 
 type mergeStmtGenerator struct {
 	// dataset + raw table
-	rawDatasetTable *datasetTable
+	rawDatasetTable datasetTable
 	// destination table name, used to retrieve records from raw table
 	dstTableName string
 	// dataset + destination table
-	dstDatasetTable *datasetTable
+	dstDatasetTable datasetTable
 	// last synced batchID.
 	syncBatchID int64
 	// last normalized batchID.

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -23,7 +23,7 @@ func (c *ClickhouseConnector) StartSetupNormalizedTables(_ context.Context) (int
 	return nil, nil
 }
 
-func (c *ClickhouseConnector) FinishSetupNormalizedTables(_ context.Context) error {
+func (c *ClickhouseConnector) FinishSetupNormalizedTables(_ context.Context, _ interface{}) error {
 	return nil
 }
 

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -27,7 +27,7 @@ func (c *ClickhouseConnector) FinishSetupNormalizedTables(_ context.Context, _ i
 	return nil
 }
 
-func (c *ClickhouseConnector) AbortSetupNormalizedTables(_ context.Context, _ interface{}) {
+func (c *ClickhouseConnector) CleanupSetupNormalizedTables(_ context.Context, _ interface{}) {
 }
 
 func (c *ClickhouseConnector) SetupNormalizedTable(

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -244,6 +244,11 @@ var (
 	_ CDCNormalizeConnector = &connsnowflake.SnowflakeConnector{}
 	_ CDCNormalizeConnector = &connclickhouse.ClickhouseConnector{}
 
+	_ NormalizedTablesConnector = &connpostgres.PostgresConnector{}
+	_ NormalizedTablesConnector = &connbigquery.BigQueryConnector{}
+	_ NormalizedTablesConnector = &connsnowflake.SnowflakeConnector{}
+	_ NormalizedTablesConnector = &connclickhouse.ClickhouseConnector{}
+
 	_ QRepPullConnector = &connpostgres.PostgresConnector{}
 	_ QRepPullConnector = &connsqlserver.SQLServerConnector{}
 

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -74,9 +74,9 @@ type NormalizedTablesConnector interface {
 		syncedAtColName string,
 	) (bool, error)
 
-	// AbortSetupNormalizedTables may be used to rollback transaction started by StartSetupNormalizedTables.
-	// Calling AbortSetupNormalizedTables after FinishSetupNormalizedTables must be a nop.
-	AbortSetupNormalizedTables(ctx context.Context, tx interface{})
+	// CleanupSetupNormalizedTables may be used to rollback transaction started by StartSetupNormalizedTables.
+	// Calling CleanupSetupNormalizedTables after FinishSetupNormalizedTables must be a nop.
+	CleanupSetupNormalizedTables(ctx context.Context, tx interface{})
 
 	// FinishSetupNormalizedTables may be used to finish transaction started by StartSetupNormalizedTables.
 	FinishSetupNormalizedTables(ctx context.Context, tx interface{}) error

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -261,16 +261,6 @@ func (c *EventHubConnector) ReplayTableSchemaDeltas(_ context.Context, flowJobNa
 	return nil
 }
 
-func (c *EventHubConnector) SetupNormalizedTables(
-	_ context.Context,
-	req *protos.SetupNormalizedTableBatchInput,
-) (*protos.SetupNormalizedTableBatchOutput, error) {
-	c.logger.Info("normalization for event hub is a no-op")
-	return &protos.SetupNormalizedTableBatchOutput{
-		TableExistsMapping: nil,
-	}, nil
-}
-
 func (c *EventHubConnector) SyncFlowCleanup(ctx context.Context, jobName string) error {
 	return c.pgMetadata.DropMetadata(ctx, jobName)
 }

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -644,7 +644,7 @@ func (c *PostgresConnector) StartSetupNormalizedTables(ctx context.Context) (int
 	return c.conn.Begin(ctx)
 }
 
-func (c *PostgresConnector) AbortSetupNormalizedTables(ctx context.Context, tx interface{}) {
+func (c *PostgresConnector) CleanupSetupNormalizedTables(ctx context.Context, tx interface{}) {
 	err := tx.(pgx.Tx).Rollback(ctx)
 	if err != pgx.ErrTxClosed && err != nil {
 		c.logger.Error("error rolling back transaction for creating raw table", slog.Any("error", err))

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -639,60 +639,53 @@ func (c *PostgresConnector) getTableSchemaForTable(
 	}, nil
 }
 
-// SetupNormalizedTable sets up a normalized table, implementing the Connector interface.
-func (c *PostgresConnector) SetupNormalizedTables(
-	ctx context.Context,
-	req *protos.SetupNormalizedTableBatchInput,
-) (*protos.SetupNormalizedTableBatchOutput, error) {
-	tableExistsMapping := make(map[string]bool)
+func (c *PostgresConnector) StartSetupNormalizedTables(ctx context.Context) (interface{}, error) {
 	// Postgres is cool and supports transactional DDL. So we use a transaction.
-	createNormalizedTablesTx, err := c.conn.Begin(ctx)
+	return c.conn.Begin(ctx)
+}
+
+func (c *PostgresConnector) AbortSetupNormalizedTables(ctx context.Context, tx interface{}) {
+	err := tx.(pgx.Tx).Rollback(ctx)
+	if err != pgx.ErrTxClosed && err != nil {
+		c.logger.Error("error rolling back transaction for creating raw table", slog.Any("error", err))
+	}
+}
+
+func (c *PostgresConnector) FinishSetupNormalizedTables(ctx context.Context, tx interface{}) error {
+	return tx.(pgx.Tx).Commit(ctx)
+}
+
+func (c *PostgresConnector) SetupNormalizedTable(
+	ctx context.Context,
+	tx interface{},
+	tableIdentifier string,
+	tableSchema *protos.TableSchema,
+	softDeleteColName string,
+	syncedAtColName string,
+) (bool, error) {
+	createNormalizedTablesTx := tx.(pgx.Tx)
+
+	parsedNormalizedTable, err := utils.ParseSchemaTable(tableIdentifier)
 	if err != nil {
-		return nil, fmt.Errorf("error starting transaction for creating raw table: %w", err)
+		return false, fmt.Errorf("error while parsing table schema and name: %w", err)
 	}
-
-	defer func() {
-		deferErr := createNormalizedTablesTx.Rollback(ctx)
-		if deferErr != pgx.ErrTxClosed && deferErr != nil {
-			c.logger.Error("error rolling back transaction for creating raw table", slog.Any("error", err))
-		}
-	}()
-
-	for tableIdentifier, tableSchema := range req.TableNameSchemaMapping {
-		parsedNormalizedTable, err := utils.ParseSchemaTable(tableIdentifier)
-		if err != nil {
-			return nil, fmt.Errorf("error while parsing table schema and name: %w", err)
-		}
-		tableAlreadyExists, err := c.tableExists(ctx, parsedNormalizedTable)
-		if err != nil {
-			return nil, fmt.Errorf("error occurred while checking if normalized table exists: %w", err)
-		}
-		if tableAlreadyExists {
-			tableExistsMapping[tableIdentifier] = true
-			continue
-		}
-
-		// convert the column names and types to Postgres types
-		normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(
-			parsedNormalizedTable.String(), tableSchema, req.SoftDeleteColName, req.SyncedAtColName)
-		_, err = createNormalizedTablesTx.Exec(ctx, normalizedTableCreateSQL)
-		if err != nil {
-			return nil, fmt.Errorf("error while creating normalized table: %w", err)
-		}
-
-		tableExistsMapping[tableIdentifier] = false
-		c.logger.Info(fmt.Sprintf("created table %s", tableIdentifier))
-		utils.RecordHeartbeat(ctx, fmt.Sprintf("created table %s", tableIdentifier))
-	}
-
-	err = createNormalizedTablesTx.Commit(ctx)
+	tableAlreadyExists, err := c.tableExists(ctx, parsedNormalizedTable)
 	if err != nil {
-		return nil, fmt.Errorf("error committing transaction for creating normalized tables: %w", err)
+		return false, fmt.Errorf("error occurred while checking if normalized table exists: %w", err)
+	}
+	if tableAlreadyExists {
+		return true, nil
 	}
 
-	return &protos.SetupNormalizedTableBatchOutput{
-		TableExistsMapping: tableExistsMapping,
-	}, nil
+	// convert the column names and types to Postgres types
+	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(
+		parsedNormalizedTable.String(), tableSchema, softDeleteColName, syncedAtColName)
+	_, err = createNormalizedTablesTx.Exec(ctx, normalizedTableCreateSQL)
+	if err != nil {
+		return false, fmt.Errorf("error while creating normalized table: %w", err)
+	}
+
+	return false, nil
 }
 
 // ReplayTableSchemaDelta changes a destination table to match the schema at source

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -208,14 +208,6 @@ func (c *S3Connector) ReplayTableSchemaDeltas(_ context.Context, flowJobName str
 	return nil
 }
 
-func (c *S3Connector) SetupNormalizedTables(_ context.Context, req *protos.SetupNormalizedTableBatchInput) (
-	*protos.SetupNormalizedTableBatchOutput,
-	error,
-) {
-	c.logger.Info("SetupNormalizedTables for S3 is a no-op")
-	return nil, nil
-}
-
 func (c *S3Connector) SyncFlowCleanup(ctx context.Context, jobName string) error {
 	return c.pgMetadata.DropMetadata(ctx, jobName)
 }

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -337,7 +337,7 @@ func (c *SnowflakeConnector) FinishSetupNormalizedTables(_ context.Context, _ in
 	return nil
 }
 
-func (c *SnowflakeConnector) AbortSetupNormalizedTables(_ context.Context, _ interface{}) {
+func (c *SnowflakeConnector) CleanupSetupNormalizedTables(_ context.Context, _ interface{}) {
 }
 
 func (c *SnowflakeConnector) SetupNormalizedTable(

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -333,7 +333,7 @@ func (c *SnowflakeConnector) StartSetupNormalizedTables(_ context.Context) (inte
 	return nil, nil
 }
 
-func (c *SnowflakeConnector) FinishSetupNormalizedTables(_ context.Context) error {
+func (c *SnowflakeConnector) FinishSetupNormalizedTables(_ context.Context, _ interface{}) error {
 	return nil
 }
 

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -150,8 +150,7 @@ func (q *QRepFlowExecution) SetupWatermarkTableOnDestination(ctx workflow.Contex
 		}
 
 		future := workflow.ExecuteActivity(ctx, flowable.CreateNormalizedTable, setupConfig)
-		var createNormalizedTablesOutput *protos.SetupNormalizedTableBatchOutput
-		if err := future.Get(ctx, &createNormalizedTablesOutput); err != nil {
+		if err := future.Get(ctx, nil); err != nil {
 			q.logger.Error("failed to create watermark table: ", err)
 			return fmt.Errorf("failed to create watermark table: %w", err)
 		}

--- a/flow/workflows/setup_flow.go
+++ b/flow/workflows/setup_flow.go
@@ -239,8 +239,7 @@ func (s *SetupFlowExecution) fetchTableSchemaAndSetupNormalizedTables(
 	}
 
 	future = workflow.ExecuteActivity(ctx, flowable.CreateNormalizedTable, setupConfig)
-	var createNormalizedTablesOutput *protos.SetupNormalizedTableBatchOutput
-	if err := future.Get(ctx, &createNormalizedTablesOutput); err != nil {
+	if err := future.Get(ctx, nil); err != nil {
 		s.logger.Error("failed to create normalized tables: ", err)
 		return nil, fmt.Errorf("failed to create normalized tables: %w", err)
 	}


### PR DESCRIPTION
Snowflake was sending a heartbeat for each table, BQ was using HeartbeatRoutine, clickhouse wasn't sending heartbeats. Unify on HeartbeatRoutine

Move to a separate connector interface so s3/eventhubs etc don't need to implement the start/abort/finish methods as stubs too

Also introduce a generalized GetConnectorAs, use internally for existing functions