### PR TITLE
BigQuery: Skip merge if no primary keys present

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -629,12 +629,16 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get tablename to unchanged cols mapping: %w", err)
 	}
-
 	// append all the statements to one list
 	c.logger.Info(fmt.Sprintf("merge raw records to corresponding tables: %s %s %v",
 		c.datasetID, rawTableName, distinctTableNames))
 
 	for _, tableName := range distinctTableNames {
+		normalizeTableSchema := req.TableNameSchemaMapping[tableName]
+		if len(normalizeTableSchema.PrimaryKeyColumns) == 0 {
+			c.logger.Info(fmt.Sprintf("skipping merge for table %s as it has no primary key", tableName))
+			continue
+		}
 		unchangedToastColumns := tableNametoUnchangedToastCols[tableName]
 		dstDatasetTable, _ := c.convertToDatasetTable(tableName)
 		mergeGen := &mergeStmtGenerator{
@@ -645,7 +649,7 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 			},
 			dstTableName:          tableName,
 			dstDatasetTable:       dstDatasetTable,
-			normalizedTableSchema: req.TableNameSchemaMapping[tableName],
+			normalizedTableSchema: normalizeTableSchema,
 			syncBatchID:           req.SyncBatchID,
 			normalizeBatchID:      normBatchID,
 			peerdbCols: &protos.PeerDBColumns{

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -41,8 +41,9 @@ const (
 	//   sync_batch_id INTEGER NOT NULL
 	//   normalize_batch_id INTEGER
 	// )
-	MirrorJobsTable      = "peerdb_mirror_jobs"
-	SyncRecordsBatchSize = 1024
+	MirrorJobsTable       = "peerdb_mirror_jobs"
+	SyncRecordsBatchSize  = 1024
+	NoPrimaryKeyMergeCase = "no_primary_key"
 )
 
 type BigQueryServiceAccount struct {
@@ -658,6 +659,10 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 		// normalize anything between last normalized batch id to last sync batchid
 		mergeStmts := mergeGen.generateMergeStmts(unchangedToastColumns)
 		for i, mergeStmt := range mergeStmts {
+			if mergeStmt == NoPrimaryKeyMergeCase {
+				c.logger.Info(fmt.Sprintf("no primary key found for table %s, skipping merge statement", tableName))
+				continue
+			}
 			c.logger.Info(fmt.Sprintf("running merge statement [%d/%d] for table %s..",
 				i+1, len(mergeStmts), tableName))
 			q := c.client.Query(mergeStmt)

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -41,9 +41,8 @@ const (
 	//   sync_batch_id INTEGER NOT NULL
 	//   normalize_batch_id INTEGER
 	// )
-	MirrorJobsTable       = "peerdb_mirror_jobs"
-	SyncRecordsBatchSize  = 1024
-	NoPrimaryKeyMergeCase = "no_primary_key"
+	MirrorJobsTable      = "peerdb_mirror_jobs"
+	SyncRecordsBatchSize = 1024
 )
 
 type BigQueryServiceAccount struct {
@@ -659,10 +658,6 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 		// normalize anything between last normalized batch id to last sync batchid
 		mergeStmts := mergeGen.generateMergeStmts(unchangedToastColumns)
 		for i, mergeStmt := range mergeStmts {
-			if mergeStmt == NoPrimaryKeyMergeCase {
-				c.logger.Info(fmt.Sprintf("no primary key found for table %s, skipping merge statement", tableName))
-				continue
-			}
 			c.logger.Info(fmt.Sprintf("running merge statement [%d/%d] for table %s..",
 				i+1, len(mergeStmts), tableName))
 			q := c.client.Query(mergeStmt)

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -636,7 +636,7 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 	for _, tableName := range distinctTableNames {
 		normalizeTableSchema := req.TableNameSchemaMapping[tableName]
 		if len(normalizeTableSchema.PrimaryKeyColumns) == 0 {
-			c.logger.Info(fmt.Sprintf("skipping merge for table %s as it has no primary key", tableName))
+			c.logger.Error(fmt.Sprintf("skipping merge for table %s as it has no primary key", tableName))
 			continue
 		}
 		unchangedToastColumns := tableNametoUnchangedToastCols[tableName]

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -636,7 +636,7 @@ func (c *BigQueryConnector) NormalizeRecords(req *model.NormalizeRecordsRequest)
 	for _, tableName := range distinctTableNames {
 		normalizeTableSchema := req.TableNameSchemaMapping[tableName]
 		if len(normalizeTableSchema.PrimaryKeyColumns) == 0 {
-			c.logger.Error(fmt.Sprintf("skipping merge for table %s as it has no primary key", tableName))
+			c.logger.Warn(fmt.Sprintf("skipping merge for table %s as it has no primary key", tableName))
 			continue
 		}
 		unchangedToastColumns := tableNametoUnchangedToastCols[tableName]

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -3,7 +3,6 @@ package connbigquery
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"cloud.google.com/go/bigquery"
@@ -126,7 +125,7 @@ func (m *mergeStmtGenerator) generateDeDupedCTE() string {
 }
 
 // generateMergeStmt generates a merge statement.
-func (m *mergeStmtGenerator) generateMergeStmt(unchangedToastColumns []string) (string, error) {
+func (m *mergeStmtGenerator) generateMergeStmt(unchangedToastColumns []string) string {
 	// comma separated list of column names
 	columnCount := len(m.normalizedTableSchema.ColumnNames)
 	backtickColNames := make([]string, 0, columnCount)
@@ -162,9 +161,6 @@ func (m *mergeStmtGenerator) generateMergeStmt(unchangedToastColumns []string) (
 	}
 	// t.<pkey1> = d.<pkey1> AND t.<pkey2> = d.<pkey2> ...
 	pkeySelectSQL := strings.Join(pkeySelectSQLArray, " AND ")
-	if pkeySelectSQL == "" {
-		return "", ErrNoPrimaryKey
-	}
 
 	deletePart := "DELETE"
 	if m.peerdbCols.SoftDelete {
@@ -181,7 +177,7 @@ func (m *mergeStmtGenerator) generateMergeStmt(unchangedToastColumns []string) (
 		"INSERT (%s) VALUES(%s) "+
 		"%s WHEN MATCHED AND _d._rt=2 THEN %s;",
 		m.dstDatasetTable.table, m.generateFlattenedCTE(), m.generateDeDupedCTE(),
-		pkeySelectSQL, insertColumnsSQL, insertValuesSQL, updateStringToastCols, deletePart), nil
+		pkeySelectSQL, insertColumnsSQL, insertValuesSQL, updateStringToastCols, deletePart)
 }
 
 func (m *mergeStmtGenerator) generateMergeStmts(allUnchangedToastColas []string) []string {
@@ -192,13 +188,7 @@ func (m *mergeStmtGenerator) generateMergeStmts(allUnchangedToastColas []string)
 
 	mergeStmts := make([]string, 0, len(partitions))
 	for _, partition := range partitions {
-		mergeStmt, err := m.generateMergeStmt(partition)
-		if err == ErrNoPrimaryKey {
-			slog.Warn("No primary key found for a table. Skipping it.",
-				slog.String("table", m.dstTableName))
-			continue
-		}
-		mergeStmts = append(mergeStmts, mergeStmt)
+		mergeStmts = append(mergeStmts, m.generateMergeStmt(partition))
 	}
 
 	return mergeStmts

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -158,6 +158,9 @@ func (m *mergeStmtGenerator) generateMergeStmt(unchangedToastColumns []string) s
 	}
 	// t.<pkey1> = d.<pkey1> AND t.<pkey2> = d.<pkey2> ...
 	pkeySelectSQL := strings.Join(pkeySelectSQLArray, " AND ")
+	if pkeySelectSQL == "" {
+		return NoPrimaryKeyMergeCase
+	}
 
 	deletePart := "DELETE"
 	if m.peerdbCols.SoftDelete {

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -1,7 +1,6 @@
 package connbigquery
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -11,8 +10,6 @@ import (
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 )
-
-var ErrNoPrimaryKey error = errors.New("no primary key found")
 
 type mergeStmtGenerator struct {
 	// dataset + raw table


### PR DESCRIPTION
Merge statements currently are syntactically incorrect for tables without a primary key. This case is ideally not seen as tables without pkey/replica identity full are filtered out the UI level but in branches where we rely on signals for adding tables, this case can go unchecked and normalize flow fails.

This PR skips a table during merge if there are no primary keys for it.