### PR TITLE
BigQuery: Skip merge if no primary keys present

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -518,7 +518,7 @@ func (c *BigQueryConnector) NormalizeRecords(ctx context.Context, req *model.Nor
 	for _, tableName := range distinctTableNames {
 		normalizeTableSchema := req.TableNameSchemaMapping[tableName]
 		if len(normalizeTableSchema.PrimaryKeyColumns) == 0 {
-			c.logger.Warn(fmt.Sprintf("skipping merge for table %s as it has no primary key", tableName))
+			c.logger.Error(fmt.Sprintf("skipping merge for table %s as it has no primary key", tableName))
 			continue
 		}
 		unchangedToastColumns := tableNametoUnchangedToastCols[tableName]


### PR DESCRIPTION
Merge statements currently are syntactically incorrect for tables without a primary key. This case is ideally not seen as tables without pkey/replica identity full are filtered out the UI level but in branches where we rely on signals for adding tables, this case can go unchecked and normalize flow fails.

This PR skips a table during merge if there are no primary keys for it.