### PR TITLE
fetch peer configurations in workflow

### DIFF
--- a/flow/workflows/normalize_flow.go
+++ b/flow/workflows/normalize_flow.go
@@ -24,6 +24,11 @@ func NormalizeFlowWorkflow(ctx workflow.Context,
 	var peerConfigs *protos.FetchSourceAndDestinationConfigsOutput
 	if err := workflow.ExecuteLocalActivity(
 		fetchPeerConfigsCtx, flowable.FetchSourceAndDestinationConfigs,
+		&protos.FetchSourceAndDestinationConfigsInput{
+			FlowJobName:         config.FlowJobName,
+			SourcePeerName:      config.Source.Name,
+			DestinationPeerName: config.Destination.Name,
+		},
 	).Get(ctx, &peerConfigs); err != nil {
 		return nil, fmt.Errorf("failed to fetch peer configs: %w", err)
 	}

--- a/flow/workflows/sync_flow.go
+++ b/flow/workflows/sync_flow.go
@@ -47,6 +47,11 @@ func (s *SyncFlowExecution) executeSyncFlow(
 	var peerConfigs *protos.FetchSourceAndDestinationConfigsOutput
 	if err := workflow.ExecuteLocalActivity(
 		fetchPeerConfigsCtx, flowable.FetchSourceAndDestinationConfigs,
+		&protos.FetchSourceAndDestinationConfigsInput{
+			FlowJobName:         config.FlowJobName,
+			SourcePeerName:      config.Source.Name,
+			DestinationPeerName: config.Destination.Name,
+		},
 	).Get(ctx, &peerConfigs); err != nil {
 		return nil, fmt.Errorf("failed to fetch peer configs: %w", err)
 	}

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -401,3 +401,14 @@ message AddTablesToPublicationInput{
   repeated TableMapping additional_tables = 3;
 }
 
+message FetchSourceAndDestinationConfigsInput {
+  string source_peer_name = 1;
+  string destination_peer_name = 2;
+  string flow_job_name = 3;
+}
+
+message FetchSourceAndDestinationConfigsOutput {
+  peerdb_peers.Peer source_peer = 1;
+  peerdb_peers.Peer destination_peer = 2;
+}
+


### PR DESCRIPTION
This works towards a world where our entry point workflows can operate with just the peer name. Supporting edit-peer would also require something along these lines.