### PR TITLE
Fixes to potentially aid drop mirror

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -368,7 +368,7 @@ func (h *FlowRequestHandler) ShutdownFlow(
 				ErrorMessage: fmt.Sprintf("DropFlow workflow did not execute successfully: %v", err),
 			}, fmt.Errorf("DropFlow workflow did not execute successfully: %w", err)
 		}
-	case <-time.After(1 * time.Minute):
+	case <-time.After(5 * time.Minute):
 		err := h.handleCancelWorkflow(ctx, workflowID, "")
 		if err != nil {
 			slog.Error("unable to wait for DropFlow workflow to close",

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -179,10 +179,12 @@ func (p *PostgresCDCSource) consumeStream(
 	records *model.CDCRecordStream,
 ) error {
 	defer func() {
-		err := conn.Close(ctx)
+		timeout, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		err := conn.Close(timeout)
 		if err != nil {
 			p.logger.Error("error closing replication connection", slog.Any("error", err))
 		}
+		cancel()
 	}()
 
 	// clientXLogPos is the last checkpoint id, we need to ack that we have processed

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -850,9 +850,9 @@ func (c *PostgresConnector) PullFlowCleanup(ctx context.Context, jobName string)
 		return fmt.Errorf("error dropping publication: %w", err)
 	}
 
-	err = c.conn.QueryRow(ctx, `SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
-	 WHERE slot_name=$1`, slotName).Scan(nil)
-	if err != nil && err != pgx.ErrNoRows {
+	_, err = c.conn.Exec(ctx, `SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
+	 WHERE slot_name=$1`, slotName)
+	if err != nil {
 		return fmt.Errorf("error dropping replication slot: %w", err)
 	}
 

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -850,9 +850,9 @@ func (c *PostgresConnector) PullFlowCleanup(ctx context.Context, jobName string)
 		return fmt.Errorf("error dropping publication: %w", err)
 	}
 
-	_, err = c.conn.Exec(ctx, `SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
-	 WHERE slot_name=$1`, slotName)
-	if err != nil {
+	err = c.conn.QueryRow(ctx, `SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
+	 WHERE slot_name=$1`, slotName).Scan(nil)
+	if err != nil && err != pgx.ErrNoRows {
 		return fmt.Errorf("error dropping replication slot: %w", err)
 	}
 


### PR DESCRIPTION
Cancelling drop flow after a minute isn't a good idea. Slot remains active after sync flow dies (i.e it is fully cancelled, not waiting) for more than a minute (for some reason) causing drop flow to cancel and the slot surviving. Bumped it up to 5 minutes.
