### PR TITLE
Clickhouse: use destination columns for qrep sync

### DIFF
--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -127,7 +127,8 @@ func (s *ClickhouseAvroSyncMethod) SyncQRepRecords(
 	selector := make([]string, 0, len(dstTableSchema))
 	for _, col := range dstTableSchema {
 		colName := col.Name()
-		if strings.Contains(colName, "_peerdb_") {
+		if colName == config.SoftDeleteColName || colName == config.SyncedAtColName ||
+			colName == versionColName {
 			continue
 		}
 


### PR DESCRIPTION
Clickhouse insert-into-select for QRep used source table's schema, making column exclusion fail. This PR fixes that by using destination columns instead.
This PR has been functionally tested