### PR TITLE
Fix switched up logging for table creation

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -174,7 +174,7 @@ func (a *FlowableActivity) CreateNormalizedTable(
 
 	tableExistsMapping := make(map[string]bool)
 	for tableIdentifier, tableSchema := range config.TableNameSchemaMapping {
-		created, err := conn.SetupNormalizedTable(
+		existing, err := conn.SetupNormalizedTable(
 			ctx,
 			tx,
 			tableIdentifier,
@@ -186,10 +186,10 @@ func (a *FlowableActivity) CreateNormalizedTable(
 			a.Alerter.LogFlowError(ctx, config.FlowName, err)
 			return nil, fmt.Errorf("failed to setup normalized table %s: %w", tableIdentifier, err)
 		}
-		tableExistsMapping[tableIdentifier] = created
+		tableExistsMapping[tableIdentifier] = existing
 
 		numTablesSetup.Add(1)
-		if created {
+		if !existing {
 			logger.Info(fmt.Sprintf("created table %s", tableIdentifier))
 		} else {
 			logger.Info(fmt.Sprintf("table already exists %s", tableIdentifier))


### PR DESCRIPTION
`SetupNormalize` returning true implies the table was pre-existing, not that it was now created. The logging was reversed