### PR TITLE
Add disableTls option for clickhouse

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -138,6 +138,10 @@ func NewClickhouseConnector(
 }
 
 func connect(ctx context.Context, config *protos.ClickhouseConfig) (*sql.DB, error) {
+	tlsSetting := &tls.Config{MinVersion: tls.VersionTLS13}
+	if config.DisableTls != nil && *config.DisableTls {
+		tlsSetting = nil
+	}
 	conn := clickhouse.OpenDB(&clickhouse.Options{
 		Addr: []string{fmt.Sprintf("%s:%d", config.Host, config.Port)},
 		Auth: clickhouse.Auth{
@@ -145,7 +149,7 @@ func connect(ctx context.Context, config *protos.ClickhouseConfig) (*sql.DB, err
 			Username: config.User,
 			Password: config.Password,
 		},
-		TLS:         &tls.Config{MinVersion: tls.VersionTLS13},
+		TLS:         tlsSetting,
 		Compression: &clickhouse.Compression{Method: clickhouse.CompressionLZ4},
 		ClientInfo: clickhouse.ClientInfo{
 			Products: []struct {

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -814,6 +814,9 @@ fn parse_db_options(
                     .get("region")
                     .context("no region specified")?
                     .to_string(),
+                disable_tls: opts
+                    .get("disable_tls")
+                    .map(|s| s.parse::<bool>().unwrap_or_default())
             };
             let config = Config::ClickhouseConfig(clickhouse_config);
             Some(config)

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -97,6 +97,7 @@ message ClickhouseConfig{
   string access_key_id = 7;
   string secret_access_key = 8;
   string region = 9;
+  optional bool disable_tls = 10;
 }
 
 message SqlServerConfig {

--- a/ui/app/peers/create/[peerType]/helpers/ch.ts
+++ b/ui/app/peers/create/[peerType]/helpers/ch.ts
@@ -6,15 +6,15 @@ export const clickhouseSetting: PeerSetting[] = [
     label: 'Host',
     stateHandler: (value, setter) =>
       setter((curr) => ({ ...curr, host: value as string })),
-    tips: 'Specifies the IP host name or address on which postgres is to listen for TCP/IP connections from client applications. Ensure that this host has us whitelisted so we can connect to it.',
+    tips: 'Specifies the IP host name or address on which Clickhouse is listening for TCP/IP connections from client applications.',
   },
   {
     label: 'Port',
     stateHandler: (value, setter) =>
       setter((curr) => ({ ...curr, port: parseInt(value as string, 10) })),
     type: 'number', // type for textfield
-    default: 5432,
-    tips: 'Specifies the TCP/IP port or local Unix domain socket file extension on which postgres is listening for connections from client applications.',
+    default: 9000,
+    tips: 'Specifies the TCP/IP port or local Unix domain socket file extension on which Clickhouse is listening for connections from client applications.',
   },
   {
     label: 'User',
@@ -44,7 +44,7 @@ export const clickhouseSetting: PeerSetting[] = [
     stateHandler: (value, setter) =>
       setter((curr) => ({ ...curr, disableTls: value as boolean })),
     type: 'switch',
-    tips: 'If you are using a non-TLS connection, check this box.',
+    tips: 'If you are using a non-TLS connection for Clickhouse server, check this box.',
   },
   {
     label: 'S3 Path',
@@ -78,7 +78,7 @@ export const clickhouseSetting: PeerSetting[] = [
 
 export const blankClickhouseSetting: ClickhouseConfig = {
   host: '',
-  port: 5432,
+  port: 9000,
   user: '',
   password: '',
   database: '',
@@ -86,4 +86,5 @@ export const blankClickhouseSetting: ClickhouseConfig = {
   accessKeyId: '',
   secretAccessKey: '',
   region: '',
+  disableTls: false,
 };

--- a/ui/app/peers/create/[peerType]/helpers/ch.ts
+++ b/ui/app/peers/create/[peerType]/helpers/ch.ts
@@ -5,13 +5,13 @@ export const clickhouseSetting: PeerSetting[] = [
   {
     label: 'Host',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, host: value })),
+      setter((curr) => ({ ...curr, host: value as string })),
     tips: 'Specifies the IP host name or address on which postgres is to listen for TCP/IP connections from client applications. Ensure that this host has us whitelisted so we can connect to it.',
   },
   {
     label: 'Port',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, port: parseInt(value, 10) })),
+      setter((curr) => ({ ...curr, port: parseInt(value as string, 10) })),
     type: 'number', // type for textfield
     default: 5432,
     tips: 'Specifies the TCP/IP port or local Unix domain socket file extension on which postgres is listening for connections from client applications.',
@@ -19,14 +19,14 @@ export const clickhouseSetting: PeerSetting[] = [
   {
     label: 'User',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, user: value })),
+      setter((curr) => ({ ...curr, user: value as string })),
     tips: 'Specify the user that we should use to connect to this host.',
     helpfulLink: 'https://www.postgresql.org/docs/8.0/user-manag.html',
   },
   {
     label: 'Password',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, password: value })),
+      setter((curr) => ({ ...curr, password: value as string })),
     type: 'password',
     tips: 'Password associated with the user you provided.',
     helpfulLink: 'https://www.postgresql.org/docs/current/auth-password.html',
@@ -34,21 +34,28 @@ export const clickhouseSetting: PeerSetting[] = [
   {
     label: 'Database',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, database: value })),
+      setter((curr) => ({ ...curr, database: value as string })),
     tips: 'Specify which database to associate with this peer.',
     helpfulLink:
       'https://www.postgresql.org/docs/current/sql-createdatabase.html',
   },
   {
+    label: 'Disable TLS?',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, disableTls: value as boolean })),
+    type: 'switch',
+    tips: 'If you are using a non-TLS connection, check this box.',
+  },
+  {
     label: 'S3 Path',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, s3Path: value })),
+      setter((curr) => ({ ...curr, s3Path: value as string })),
     tips: `This is an S3 bucket/object URL field. This bucket will be used as our intermediate stage for CDC`,
   },
   {
     label: 'Access Key ID',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, accessKeyId: value })),
+      setter((curr) => ({ ...curr, accessKeyId: value as string })),
     tips: 'The AWS access key ID associated with your account.',
     helpfulLink:
       'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html',
@@ -56,7 +63,7 @@ export const clickhouseSetting: PeerSetting[] = [
   {
     label: 'Secret Access Key',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, secretAccessKey: value })),
+      setter((curr) => ({ ...curr, secretAccessKey: value as string })),
     tips: 'The AWS secret access key associated with the above bucket.',
     helpfulLink:
       'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html',
@@ -64,7 +71,7 @@ export const clickhouseSetting: PeerSetting[] = [
   {
     label: 'Region',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, region: value })),
+      setter((curr) => ({ ...curr, region: value as string })),
     tips: 'The region where your bucket is located. For example, us-east-1.',
   },
 ];

--- a/ui/app/peers/create/[peerType]/helpers/common.ts
+++ b/ui/app/peers/create/[peerType]/helpers/common.ts
@@ -7,7 +7,7 @@ import { blankSnowflakeSetting } from './sf';
 
 export interface PeerSetting {
   label: string;
-  stateHandler: (value: string, setter: PeerSetter) => void;
+  stateHandler: (value: string | boolean, setter: PeerSetter) => void;
   type?: string;
   optional?: boolean;
   tips?: string;

--- a/ui/app/peers/create/[peerType]/helpers/pg.ts
+++ b/ui/app/peers/create/[peerType]/helpers/pg.ts
@@ -6,13 +6,13 @@ export const postgresSetting: PeerSetting[] = [
   {
     label: 'Host',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, host: value })),
+      setter((curr) => ({ ...curr, host: value as string })),
     tips: 'Specifies the IP host name or address on which postgres is to listen for TCP/IP connections from client applications. Ensure that this host has us whitelisted so we can connect to it.',
   },
   {
     label: 'Port',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, port: parseInt(value, 10) })),
+      setter((curr) => ({ ...curr, port: parseInt(value as string, 10) })),
     type: 'number', // type for textfield
     default: 5432,
     tips: 'Specifies the TCP/IP port or local Unix domain socket file extension on which postgres is listening for connections from client applications.',
@@ -20,14 +20,14 @@ export const postgresSetting: PeerSetting[] = [
   {
     label: 'User',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, user: value })),
+      setter((curr) => ({ ...curr, user: value as string })),
     tips: 'Specify the user that we should use to connect to this host.',
     helpfulLink: 'https://www.postgresql.org/docs/8.0/user-manag.html',
   },
   {
     label: 'Password',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, password: value })),
+      setter((curr) => ({ ...curr, password: value as string })),
     type: 'password',
     tips: 'Password associated with the user you provided.',
     helpfulLink: 'https://www.postgresql.org/docs/current/auth-password.html',
@@ -35,7 +35,7 @@ export const postgresSetting: PeerSetting[] = [
   {
     label: 'Database',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, database: value })),
+      setter((curr) => ({ ...curr, database: value as string })),
     tips: 'Specify which database to associate with this peer.',
     helpfulLink:
       'https://www.postgresql.org/docs/current/sql-createdatabase.html',
@@ -57,7 +57,7 @@ export const sshSetting: SSHSetting[] = [
   {
     label: 'Host',
     stateHandler: (value: string, setter: sshSetter) =>
-      setter((curr: SSHConfig) => ({ ...curr, host: value })),
+      setter((curr: SSHConfig) => ({ ...curr, host: value as string })),
     tips: 'Specifies the IP host name or address of your instance.',
   },
   {
@@ -71,13 +71,13 @@ export const sshSetting: SSHSetting[] = [
   {
     label: 'User',
     stateHandler: (value: string, setter: sshSetter) =>
-      setter((curr) => ({ ...curr, user: value })),
+      setter((curr) => ({ ...curr, user: value as string })),
     tips: 'Specify the user that we should use to connect to this host.',
   },
   {
     label: 'Password',
     stateHandler: (value: string, setter: sshSetter) =>
-      setter((curr) => ({ ...curr, password: value })),
+      setter((curr) => ({ ...curr, password: value as string })),
     type: 'password',
     optional: true,
     tips: 'Password associated with the user you provided.',
@@ -85,7 +85,7 @@ export const sshSetting: SSHSetting[] = [
   {
     label: 'SSH Private Key',
     stateHandler: (value: string, setter: sshSetter) =>
-      setter((curr) => ({ ...curr, privateKey: value })),
+      setter((curr) => ({ ...curr, privateKey: value as string })),
     optional: true,
     type: 'file',
     tips: 'Private key for authentication in order to SSH into your machine.',
@@ -93,7 +93,7 @@ export const sshSetting: SSHSetting[] = [
   {
     label: "Host's Public Key",
     stateHandler: (value: string, setter: sshSetter) =>
-      setter((curr) => ({ ...curr, hostKey: value })),
+      setter((curr) => ({ ...curr, hostKey: value as string })),
     optional: true,
     type: 'textarea',
     tips: 'Public key of host to mitigate MITM attacks when SSHing into your machine. It generally resides at /etc/ssh/ssh_host_[algo]_key.pub',

--- a/ui/app/peers/create/[peerType]/helpers/s3.ts
+++ b/ui/app/peers/create/[peerType]/helpers/s3.ts
@@ -5,7 +5,7 @@ export const s3Setting: PeerSetting[] = [
   {
     label: 'Bucket URL',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, url: value })),
+      setter((curr) => ({ ...curr, url: value as string })),
     tips: 'The URL of your existing S3/GCS bucket along with a prefix of your choice. It begins with s3://',
     helpfulLink:
       'https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html#accessing-a-bucket-using-S3-format',
@@ -14,7 +14,7 @@ export const s3Setting: PeerSetting[] = [
   {
     label: 'Access Key ID',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, accessKeyId: value })),
+      setter((curr) => ({ ...curr, accessKeyId: value as string })),
     tips: 'The AWS access key ID associated with your account. In case of GCS, this is the HMAC access key ID.',
     helpfulLink:
       'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html',
@@ -22,7 +22,7 @@ export const s3Setting: PeerSetting[] = [
   {
     label: 'Secret Access Key',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, secretAccessKey: value })),
+      setter((curr) => ({ ...curr, secretAccessKey: value as string })),
     tips: 'The AWS secret access key associated with your account. In case of GCS, this is the HMAC secret.',
     helpfulLink:
       'https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html',
@@ -30,13 +30,13 @@ export const s3Setting: PeerSetting[] = [
   {
     label: 'Region',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, region: value })),
+      setter((curr) => ({ ...curr, region: value as string })),
     tips: 'The region where your bucket is located. For example, us-east-1. In case of GCS, this will be set to auto, which detects where your bucket it.',
   },
   {
     label: 'Role ARN',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, roleArn: value })),
+      setter((curr) => ({ ...curr, roleArn: value as string })),
     type: 'password',
     tips: 'If set, the role ARN will be used to assume the role before accessing the bucket.',
     helpfulLink:

--- a/ui/app/peers/create/[peerType]/helpers/sf.ts
+++ b/ui/app/peers/create/[peerType]/helpers/sf.ts
@@ -5,7 +5,7 @@ export const snowflakeSetting: PeerSetting[] = [
   {
     label: 'Account ID',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, accountId: value })),
+      setter((curr) => ({ ...curr, accountId: value as string })),
     tips: 'This is the unique identifier for your Snowflake account. It has a URL-like format',
     helpfulLink:
       'https://docs.snowflake.com/en/user-guide/admin-account-identifier',
@@ -13,7 +13,7 @@ export const snowflakeSetting: PeerSetting[] = [
   {
     label: 'Username',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, username: value })),
+      setter((curr) => ({ ...curr, username: value as string })),
     tips: 'This is the username you use to login to your Snowflake account.',
     helpfulLink:
       'https://docs.snowflake.com/en/user-guide/admin-user-management',
@@ -21,7 +21,7 @@ export const snowflakeSetting: PeerSetting[] = [
   {
     label: 'Private Key',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, privateKey: value })),
+      setter((curr) => ({ ...curr, privateKey: value as string })),
     type: 'file',
     tips: 'This can be of any file extension. If you are using an encrypted key, you must fill the below password field for decryption.',
     helpfulLink: 'https://docs.snowflake.com/en/user-guide/key-pair-auth',
@@ -29,21 +29,21 @@ export const snowflakeSetting: PeerSetting[] = [
   {
     label: 'Warehouse',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, warehouse: value })),
+      setter((curr) => ({ ...curr, warehouse: value as string })),
     tips: 'Warehouses denote a cluster of snowflake resources.',
     helpfulLink: 'https://docs.snowflake.com/en/user-guide/warehouses',
   },
   {
     label: 'Database',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, database: value })),
+      setter((curr) => ({ ...curr, database: value as string })),
     tips: 'Specify which database to associate with this peer.',
     helpfulLink: 'https://docs.snowflake.com/en/sql-reference/snowflake-db',
   },
   {
     label: 'Role',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, role: value })),
+      setter((curr) => ({ ...curr, role: value as string })),
     tips: 'You could use a default role, or setup a role with the required permissions.',
     helpfulLink:
       'https://docs.snowflake.com/en/user-guide/security-access-control-overview#roles',
@@ -51,13 +51,13 @@ export const snowflakeSetting: PeerSetting[] = [
   {
     label: 'Password',
     stateHandler: (value, setter) => {
-      if (!value.length) {
+      if (!value) {
         // remove password key from state if empty
         setter((curr) => {
           delete (curr as SnowflakeConfig)['password'];
           return curr;
         });
-      } else setter((curr) => ({ ...curr, password: value }));
+      } else setter((curr) => ({ ...curr, password: value as string }));
     },
     type: 'password',
     optional: true,

--- a/ui/components/PeerForms/ClickhouseConfig.tsx
+++ b/ui/components/PeerForms/ClickhouseConfig.tsx
@@ -2,7 +2,8 @@
 import { PeerSetter } from '@/app/dto/PeersDTO';
 import { PeerSetting } from '@/app/peers/create/[peerType]/helpers/common';
 import { Label } from '@/lib/Label';
-import { RowWithTextField } from '@/lib/Layout';
+import { RowWithSwitch, RowWithTextField } from '@/lib/Layout';
+import { Switch } from '@/lib/Switch';
 import { TextField } from '@/lib/TextField';
 import { Tooltip } from '@/lib/Tooltip';
 import { InfoPopover } from '../InfoPopover';
@@ -13,11 +14,8 @@ interface ConfigProps {
 
 export default function ClickhouseForm({ settings, setter }: ConfigProps) {
   const S3Labels = ['S3 Path', 'Access Key ID', 'Secret Access Key', 'Region'];
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
-    setting: PeerSetting
-  ) => {
-    setting.stateHandler(e.target.value, setter);
+  const handleChange = (val: string | boolean, setting: PeerSetting) => {
+    setting.stateHandler(val, setter);
   };
 
   return (
@@ -25,7 +23,41 @@ export default function ClickhouseForm({ settings, setter }: ConfigProps) {
       {settings
         .filter((setting) => !S3Labels.includes(setting.label))
         .map((setting, id) => {
-          return (
+          return setting.type == 'switch' ? (
+            <RowWithSwitch
+              key={id}
+              label={
+                <Label>
+                  {setting.label}{' '}
+                  {!setting.optional && (
+                    <Tooltip
+                      style={{ width: '100%' }}
+                      content={'This is a required field.'}
+                    >
+                      <Label colorName='lowContrast' colorSet='destructive'>
+                        *
+                      </Label>
+                    </Tooltip>
+                  )}
+                </Label>
+              }
+              action={
+                <div>
+                  <Switch
+                    onCheckedChange={(state: boolean) =>
+                      handleChange(state, setting)
+                    }
+                  />
+                  {setting.tips && (
+                    <InfoPopover
+                      tips={setting.tips}
+                      link={setting.helpfulLink}
+                    />
+                  )}
+                </div>
+              }
+            />
+          ) : (
             <RowWithTextField
               key={id}
               label={
@@ -56,7 +88,7 @@ export default function ClickhouseForm({ settings, setter }: ConfigProps) {
                     type={setting.type}
                     defaultValue={setting.default}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      handleChange(e, setting)
+                      handleChange(e.target.value, setting)
                     }
                   />
                   {setting.tips && (
@@ -95,7 +127,7 @@ export default function ClickhouseForm({ settings, setter }: ConfigProps) {
                 <TextField
                   variant='simple'
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    handleChange(e, setting)
+                    handleChange(e.target.value, setting)
                   }
                   type={setting.type}
                 />


### PR DESCRIPTION
For a clickhouse server running without tls (for example clickhouse docker), mirror fails and we would need to comment out the tls setting. This PR adds a flag - disableTls - to the clickhouse peer so that this is not needed. This can be configured in UI and query layer for create peer