### PR TITLE
clickhouse disable tls: non-nullable

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -138,9 +138,9 @@ func NewClickhouseConnector(
 }
 
 func connect(ctx context.Context, config *protos.ClickhouseConfig) (*sql.DB, error) {
-	tlsSetting := &tls.Config{MinVersion: tls.VersionTLS13}
-	if config.DisableTls != nil && *config.DisableTls {
-		tlsSetting = nil
+	var tlsSetting *tls.Config
+	if !config.DisableTls {
+		tlsSetting = &tls.Config{MinVersion: tls.VersionTLS13}
 	}
 	conn := clickhouse.OpenDB(&clickhouse.Options{
 		Addr: []string{fmt.Sprintf("%s:%d", config.Host, config.Port)},

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -816,7 +816,8 @@ fn parse_db_options(
                     .to_string(),
                 disable_tls: opts
                     .get("disable_tls")
-                    .map(|s| s.parse::<bool>().unwrap_or_default())
+                    .and_then(|s| s.parse::<bool>().ok())
+                    .unwrap_or_default()
             };
             let config = Config::ClickhouseConfig(clickhouse_config);
             Some(config)

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -97,7 +97,7 @@ message ClickhouseConfig{
   string access_key_id = 7;
   string secret_access_key = 8;
   string region = 9;
-  optional bool disable_tls = 10;
+  bool disable_tls = 10;
 }
 
 message SqlServerConfig {


### PR DESCRIPTION
Default false, no need for tri-value state
protobuf values default to zero value already