### PR TITLE
Remove redundancy between cdc state & sync flow options

### DIFF
--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -95,7 +95,7 @@ func (h *FlowRequestHandler) CDCFlowStatus(
 	if state.SyncFlowOptions != nil {
 		config.IdleTimeoutSeconds = state.SyncFlowOptions.IdleTimeoutSeconds
 		config.MaxBatchSize = state.SyncFlowOptions.BatchSize
-		config.TableMappings = state.TableMappings
+		config.TableMappings = state.SyncFlowOptions.TableMappings
 	}
 
 	var initialCopyStatus *protos.SnapshotStatus

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -1245,9 +1245,9 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 		workflowState := getWorkFlowState()
 		assert.EqualValues(s.t, 7, workflowState.SyncFlowOptions.IdleTimeoutSeconds)
 		assert.EqualValues(s.t, 6, workflowState.SyncFlowOptions.BatchSize)
-		assert.Len(s.t, workflowState.TableMappings, 1)
-		assert.Len(s.t, workflowState.SrcTableIdNameMapping, 1)
-		assert.Len(s.t, workflowState.TableNameSchemaMapping, 1)
+		assert.Len(s.t, workflowState.SyncFlowOptions.TableMappings, 1)
+		assert.Len(s.t, workflowState.SyncFlowOptions.SrcTableIdNameMapping, 1)
+		assert.Len(s.t, workflowState.SyncFlowOptions.TableNameSchemaMapping, 1)
 		// we have limited batch size to 6, so atleast 3 syncs needed
 		assert.GreaterOrEqual(s.t, len(workflowState.SyncFlowStatuses), 3)
 
@@ -1291,9 +1291,9 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 			workflowState = getWorkFlowState()
 			assert.EqualValues(s.t, 14, workflowState.SyncFlowOptions.IdleTimeoutSeconds)
 			assert.EqualValues(s.t, 12, workflowState.SyncFlowOptions.BatchSize)
-			assert.Len(s.t, workflowState.TableMappings, 2)
-			assert.Len(s.t, workflowState.SrcTableIdNameMapping, 2)
-			assert.Len(s.t, workflowState.TableNameSchemaMapping, 2)
+			assert.Len(s.t, workflowState.SyncFlowOptions.TableMappings, 2)
+			assert.Len(s.t, workflowState.SyncFlowOptions.SrcTableIdNameMapping, 2)
+			assert.Len(s.t, workflowState.SyncFlowOptions.TableNameSchemaMapping, 2)
 			// 3 from first insert of 18 rows in 1 table
 			// 1 from pre-pause
 			// 3 from second insert of 18 rows in 2 tables, batch size updated

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -106,21 +106,6 @@ message SyncFlowOptions {
   repeated TableMapping table_mappings = 6;
 }
 
-// deprecated, unused
-message LastSyncState {
-  int64 checkpoint = 1;
-}
-
-message StartFlowInput {
-  // deprecated, unused
-  LastSyncState last_sync_state = 1;
-  FlowConnectionConfigs flow_connection_configs = 2;
-  SyncFlowOptions sync_flow_options = 3;
-  map<uint32, RelationMessage> relation_message_mapping = 4;
-  map<uint32, string> src_table_id_name_mapping = 5;
-  map<string, TableSchema> table_name_schema_mapping = 6;
-}
-
 message StartNormalizeInput {
   FlowConnectionConfigs flow_connection_configs = 1;
   map<string, TableSchema> table_name_schema_mapping = 2;


### PR DESCRIPTION
Only pass config & options to StartFlow, removing StartFlowInput

In fact, while we're at it, rename StartFlow to SyncFlow,
the name doesn't really make sense anymore,
& it'll make less sense after #1211