### PR TITLE
Clickhouse: remove nullable mapping

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -91,9 +91,6 @@ func generateCreateTableSQLForNormalizedTable(
 			}
 			stmtBuilder.WriteString(fmt.Sprintf("`%s` DECIMAL(%d, %d), ",
 				colName, precision, scale))
-		case qvalue.QValueKindTimestamp, qvalue.QValueKindTimestampTZ, qvalue.QValueKindDate:
-			// 1st Jan 1970 is not a sane default which clickhouse sets, so we use nullable
-			stmtBuilder.WriteString(fmt.Sprintf("`%s` Nullable(%s), ", colName, clickhouseType))
 		default:
 			stmtBuilder.WriteString(fmt.Sprintf("`%s` %s, ", colName, clickhouseType))
 		}


### PR DESCRIPTION
It appears timeseries performance is a common use-case for Clickhouse, wherein users often index based on a `DateTime` column. Clickhouse does not allow indexing based on `Nullable` columns.  Also having nullable columns decreases performance.
Thus, this PR chooses to stay with the original mapping of DateTime and Date (without the Nullable)

A decision is to be made in the future regarding whether we get user's preference on setting a column as Nullable or not for Clickhouse mirrors