### PR TITLE
Sync flow: don't connect to destination when no incoming rows

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -355,7 +355,7 @@ func (a *FlowableActivity) SyncFlow(
 
 		dstConnForSchemaChange, connErr := connectors.GetCDCSyncConnector(ctx, config.Destination)
 		if connErr != nil {
-			return nil, fmt.Errorf("failed to get destination connector for last offset fetch: %w", connErr)
+			return nil, fmt.Errorf("failed to get destination connector for schema changes: %w", connErr)
 		}
 		defer connectors.CloseConnector(ctx, dstConnForSchemaChange)
 		err := dstConnForSchemaChange.ReplayTableSchemaDeltas(ctx, flowName, recordBatch.SchemaDeltas)


### PR DESCRIPTION
When we are waiting for the first row, we are still holding on to a connection to the destination data store which we created to fetch the last offset. This may not be ideal in case the destination charges for connection time. 
This PR aims to not have a destination connection maintained if not needed