### PR TITLE
Split normalize changes from split-cdc-sync

### DIFF
--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -1168,7 +1168,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 		s.t.Logf("Inserted %d rows into the source table", numRows)
 	}
 
-	getWorkFlowState := func() peerflow.CDCFlowWorkflowState {
+	getWorkflowState := func() peerflow.CDCFlowWorkflowState {
 		var workflowState peerflow.CDCFlowWorkflowState
 		val, err := env.QueryWorkflow(shared.CDCFlowStateQuery)
 		e2e.EnvNoError(s.t, env, err)
@@ -1243,7 +1243,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 			return s.comparePGTables(srcTable1Name, dstTable1Name, "id,t") == nil
 		})
 
-		workflowState := getWorkFlowState()
+		workflowState := getWorkflowState()
 		assert.EqualValues(s.t, 7, workflowState.SyncFlowOptions.IdleTimeoutSeconds)
 		assert.EqualValues(s.t, 6, workflowState.SyncFlowOptions.BatchSize)
 		assert.Len(s.t, workflowState.SyncFlowOptions.TableMappings, 1)
@@ -1271,12 +1271,10 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 			e2e.EnvWaitFor(s.t, env, 1*time.Minute, "sent updates signal", func() bool {
 				return sentUpdate
 			})
-		}
 
-		// add rows to both tables before resuming - should handle
-		addRows(18)
+			// add rows to both tables before resuming - should handle
+			addRows(18)
 
-		if !s.t.Failed() {
 			e2e.EnvWaitFor(s.t, env, 1*time.Minute, "resumed workflow", func() bool {
 				return getFlowStatus() == protos.FlowStatus_STATUS_RUNNING
 			})
@@ -1286,10 +1284,8 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 			e2e.EnvWaitFor(s.t, env, 1*time.Minute, "initial load + normalize 18 records - second table", func() bool {
 				return s.comparePGTables(srcTable2Name, dstTable2Name, "id,t") == nil
 			})
-		}
 
-		if !s.t.Failed() {
-			workflowState = getWorkFlowState()
+			workflowState = getWorkflowState()
 			assert.EqualValues(s.t, 14, workflowState.SyncFlowOptions.IdleTimeoutSeconds)
 			assert.EqualValues(s.t, 12, workflowState.SyncFlowOptions.BatchSize)
 			assert.Len(s.t, workflowState.SyncFlowOptions.TableMappings, 2)

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -185,7 +185,7 @@ type SyncResponse struct {
 	CurrentSyncBatchID int64
 	// TableNameRowsMapping tells how many records need to be synced to each destination table.
 	TableNameRowsMapping map[string]uint32
-	// to be carried to parent WorkFlow
+	// to be carried to parent workflow
 	TableSchemaDeltas []*protos.TableSchemaDelta
 	// to be stored in state for future PullFlows
 	RelationMessageMapping RelationMessageMapping
@@ -195,11 +195,6 @@ type NormalizePayload struct {
 	Done                   bool
 	SyncBatchID            int64
 	TableNameSchemaMapping map[string]*protos.TableSchema
-}
-
-type NormalizeFlowResponse struct {
-	Results []NormalizeResponse
-	Errors  []string
 }
 
 type NormalizeResponse struct {

--- a/flow/model/signals.go
+++ b/flow/model/signals.go
@@ -102,22 +102,6 @@ const (
 	PauseSignal
 )
 
-var FlowSignal = TypedSignal[CDCFlowSignal]{
-	Name: "peer-flow-signal",
-}
-
-var CDCDynamicPropertiesSignal = TypedSignal[*protos.CDCFlowConfigUpdate]{
-	Name: "cdc-dynamic-properties",
-}
-
-var NormalizeSyncSignal = TypedSignal[NormalizePayload]{
-	Name: "normalize-sync",
-}
-
-var NormalizeSyncDoneSignal = TypedSignal[struct{}]{
-	Name: "normalize-sync-done",
-}
-
 func FlowSignalHandler(activeSignal CDCFlowSignal,
 	v CDCFlowSignal, logger log.Logger,
 ) CDCFlowSignal {
@@ -136,4 +120,28 @@ func FlowSignalHandler(activeSignal CDCFlowSignal,
 		}
 	}
 	return activeSignal
+}
+
+var FlowSignal = TypedSignal[CDCFlowSignal]{
+	Name: "peer-flow-signal",
+}
+
+var CDCDynamicPropertiesSignal = TypedSignal[*protos.CDCFlowConfigUpdate]{
+	Name: "cdc-dynamic-properties",
+}
+
+var NormalizeSignal = TypedSignal[NormalizePayload]{
+	Name: "normalize",
+}
+
+var NormalizeErrorSignal = TypedSignal[string]{
+	Name: "normalize-error",
+}
+
+var NormalizeResultSignal = TypedSignal[NormalizeResponse]{
+	Name: "normalize-result",
+}
+
+var NormalizeDoneSignal = TypedSignal[struct{}]{
+	Name: "normalize-done",
 }


### PR DESCRIPTION
Results/Errors are sent via signal instead of buffering & sending at end