### PR TITLE
go 1.22 features

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -81,7 +81,7 @@ func NewBigQueryServiceAccount(bqConfig *protos.BigqueryConfig) (*BigQueryServic
 // Validate validates a BigQueryServiceAccount, that none of the fields are empty.
 func (bqsa *BigQueryServiceAccount) Validate() error {
 	v := reflect.ValueOf(*bqsa)
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		if v.Field(i).String() == "" {
 			return fmt.Errorf("field %s is empty", v.Type().Field(i).Name)
 		}

--- a/flow/connectors/postgres/qrep_bench_test.go
+++ b/flow/connectors/postgres/qrep_bench_test.go
@@ -29,7 +29,7 @@ func BenchmarkQRepQueryExecutor(b *testing.B) {
 
 	// Run the benchmark
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		// log the iteration
 		b.Logf("iteration %d", i)
 

--- a/flow/connectors/postgres/qrep_partition_test.go
+++ b/flow/connectors/postgres/qrep_partition_test.go
@@ -197,8 +197,8 @@ func TestGetQRepPartitions(t *testing.T) {
 			expected := tc.want
 			assert.Equal(t, len(expected), len(got))
 
-			for i := 0; i < len(expected); i++ {
-				er := expected[i].Range.Range.(*protos.PartitionRange_TimestampRange).TimestampRange
+			for i, val := range expected {
+				er := val.Range.Range.(*protos.PartitionRange_TimestampRange).TimestampRange
 				gotr := got[i].Range.Range.(*protos.PartitionRange_TimestampRange).TimestampRange
 				assert.Equal(t, er.Start.AsTime(), gotr.Start.AsTime())
 				assert.Equal(t, er.End.AsTime(), gotr.End.AsTime())

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -515,9 +515,7 @@ func (c *SnowflakeConnector) NormalizeRecords(ctx context.Context, req *model.No
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(8) // limit parallel merges to 8
 
-	for _, destinationTableName := range destinationTableNames {
-		tableName := destinationTableName // local variable for the closure
-
+	for _, tableName := range destinationTableNames {
 		g.Go(func() error {
 			mergeGen := &mergeStmtGenerator{
 				rawTableName:          getRawTableIdentifier(req.FlowJobName),

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -310,7 +310,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Complete_Simple_Flow_BQ() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testKey := fmt.Sprintf("test_key_%d", i)
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
@@ -724,7 +724,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Invalid_Geo_BQ_Avro_CDC() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 4 invalid shapes and 6 valid shapes into the source table
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s (line,"polyPoly") VALUES ($1,$2)
 		`, srcTableName), "010200000001000000000000000000F03F0000000000000040",
@@ -736,7 +736,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Invalid_Geo_BQ_Avro_CDC() {
 			e2e.EnvNoError(s.t, env, err)
 		}
 		s.t.Log("Inserted 4 invalid geography rows into the source table")
-		for i := 4; i < 10; i++ {
+		for range 6 {
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s (line,"polyPoly") VALUES ($1,$2)
 		`, srcTableName), "010200000002000000000000000000F03F000000000000004000000000000008400000000000001040",
@@ -949,7 +949,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Composite_PKey_BQ() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t) VALUES ($1,$2)
@@ -1013,7 +1013,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Composite_PKey_Toast_1_BQ() {
 		e2e.EnvNoError(s.t, env, err)
 
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = rowsTx.Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t,t2) VALUES ($1,$2,random_string(9000))
@@ -1073,7 +1073,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Composite_PKey_Toast_2_BQ() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t,t2) VALUES ($1,$2,random_string(9000))

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -110,7 +110,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Simple_Flow_PG() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testKey := fmt.Sprintf("test_key_%d", i)
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
@@ -502,7 +502,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Composite_PKey_PG() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t) VALUES ($1,$2)
@@ -570,7 +570,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Composite_PKey_Toast_1_PG() {
 		e2e.EnvNoError(s.t, env, err)
 
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = rowsTx.Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t,t2) VALUES ($1,$2,%s(9000))
@@ -636,7 +636,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Composite_PKey_Toast_2_PG() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t,t2) VALUES ($1,$2,%s(9000))
@@ -1084,7 +1084,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Supported_Mixed_Case_Table() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 20 rows into the source table
-		for i := 0; i < 20; i++ {
+		for i := range 10 {
 			testKey := fmt.Sprintf("test_key_%d", i)
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
@@ -1157,7 +1157,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 	}
 
 	addRows := func(numRows int) {
-		for i := 0; i < numRows; i++ {
+		for range numRows {
 			_, err = s.Conn().Exec(context.Background(),
 				fmt.Sprintf(`INSERT INTO %s DEFAULT VALUES`, srcTable1Name))
 			e2e.EnvNoError(s.t, env, err)

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -157,7 +157,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_Simple_Flow_SF() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 20 rows into the source table
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			testKey := fmt.Sprintf("test_key_%d", i)
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
@@ -218,7 +218,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Flow_ReplicaIdentity_Index_No_Pkey() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 20 rows into the source table
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			testKey := fmt.Sprintf("test_key_%d", i)
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
@@ -270,7 +270,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Invalid_Geo_SF_Avro_CDC() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 4 invalid shapes and 6 valid shapes into the source table
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s (line,poly) VALUES ($1,$2)
 		`, srcTableName), "010200000001000000000000000000F03F0000000000000040",
@@ -282,7 +282,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Invalid_Geo_SF_Avro_CDC() {
 			e2e.EnvNoError(s.t, env, err)
 		}
 		s.t.Log("Inserted 4 invalid geography rows into the source table")
-		for i := 4; i < 10; i++ {
+		for range 6 {
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s (line,poly) VALUES ($1,$2)
 		`, srcTableName), "010200000002000000000000000000F03F000000000000004000000000000008400000000000001040",
@@ -939,7 +939,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Composite_PKey_SF() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t) VALUES ($1,$2)
@@ -1000,7 +1000,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Composite_PKey_Toast_1_SF() {
 		e2e.EnvNoError(s.t, env, err)
 
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = rowsTx.Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t,t2) VALUES ($1,$2,random_string(9000))
@@ -1061,7 +1061,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Composite_PKey_Toast_2_SF() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t,t2) VALUES ($1,$2,random_string(9000))
@@ -1130,7 +1130,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Column_Exclusion() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 
 		// insert 10 rows into the source table
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 			INSERT INTO %s(c2,t,t2) VALUES ($1,$2,random_string(100))
@@ -1510,7 +1510,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Supported_Mixed_Case_Table_SF() {
 	go func() {
 		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
 		// insert 20 rows into the source table
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			testKey := fmt.Sprintf("test_key_%d", i)
 			testValue := fmt.Sprintf("test_value_%d", i)
 			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/sqlserver/qrep_flow_sqlserver_test.go
+++ b/flow/e2e/sqlserver/qrep_flow_sqlserver_test.go
@@ -99,13 +99,14 @@ func (s PeerFlowE2ETestSuiteSQLServer) setupSQLServerTable(tableName string) {
 
 func (s PeerFlowE2ETestSuiteSQLServer) insertRowsIntoSQLServerTable(tableName string, numRows int) {
 	schemaQualified := fmt.Sprintf("%s.%s", s.sqlsHelper.SchemaName, tableName)
-	for i := 0; i < numRows; i++ {
-		params := make(map[string]interface{})
-		params["id"] = "test_id_" + strconv.Itoa(i)
-		params["card_id"] = "test_card_id_" + strconv.Itoa(i)
-		params["v_from"] = time.Now()
-		params["price"] = 100.00
-		params["status"] = 1
+	for i := range numRows {
+		params := map[string]interface{}{
+			"id":      "test_id_" + strconv.Itoa(i),
+			"card_id": "test_card_id_" + strconv.Itoa(i),
+			"v_from":  time.Now(),
+			"price":   100.00,
+			"status":  1,
+		}
 
 		_, err := s.sqlsHelper.E.NamedExec(
 			context.Background(),

--- a/flow/e2eshared/e2eshared.go
+++ b/flow/e2eshared/e2eshared.go
@@ -16,10 +16,9 @@ func RunSuite[T any](t *testing.T, setup func(t *testing.T) T, teardown func(T))
 	t.Helper()
 	t.Parallel()
 
-	// can be replaced with reflect.TypeFor[T]() in go 1.22
-	typ := reflect.TypeOf((*T)(nil)).Elem()
+	typ := reflect.TypeFor[T]()
 	mcount := typ.NumMethod()
-	for i := 0; i < mcount; i++ {
+	for i := range mcount {
 		m := typ.Method(i)
 		if strings.HasPrefix(m.Name, "Test") {
 			if m.Type.NumIn() == 1 && m.Type.NumOut() == 0 {


### PR DESCRIPTION
1. reflect.TypeOf
2. no need to copy loop variable for closure
3. `range N` replaces basic count-to-N loop

Need to update golangci, see #1386