### PR TITLE
FIx case where table has no rows

### DIFF
--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -229,6 +229,10 @@ func (q *QRepFlowExecution) processPartitions(
 	maxParallelWorkers int,
 	partitions []*protos.QRepPartition,
 ) error {
+	if len(partitions) == 0 {
+		q.logger.Info("no partitions to process")
+		return nil
+	}
 	chunkSize := shared.DivCeil(len(partitions), maxParallelWorkers)
 	batches := make([][]*protos.QRepPartition, 0, len(partitions)/chunkSize+1)
 	for i := 0; i < len(partitions); i += chunkSize {


### PR DESCRIPTION
Currently for a table with no rows in it, initial load fails with:
```
WorkflowTaskFailed
--
  "message": "runtime error: integer divide by zero",

```
This was occurring in processPartitions in qrep_flow.go:
```golang
	chunkSize := shared.DivCeil(len(partitions), maxParallelWorkers)
	batches := make([][]*protos.QRepPartition, 0, len(partitions)/chunkSize+1) -- div by zero if no partitions
```

This PR fixes this by skipping processPartitions if there are no partitions

Functionally tested