### PR TITLE
UI: filter out no canMirror

### DIFF
--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -128,7 +128,7 @@ const SchemaBox = ({
     const newRows = [...rows];
     for (let i = 0; i < newRows.length; i++) {
       const row = newRows[i];
-      if (row.schema === schemaName) {
+      if (row.schema === schemaName && row.canMirror) {
         newRows[i] = { ...row, selected: e.currentTarget.checked };
         if (e.currentTarget.checked) addTableColumns(row.source);
         else removeTableColumns(row.source);

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -122,7 +122,7 @@ export const reformattedTableMapping = (
   tableMapping: TableMapRow[]
 ): TableMapping[] => {
   const mapping = tableMapping
-    .filter((row) => row?.selected === true)
+    .filter((row) => row?.selected === true && row?.canMirror === true)
     .map((row) => ({
       sourceTableIdentifier: row.source,
       destinationTableIdentifier: row.destination,


### PR DESCRIPTION
Fixes a bug with select all where not mirrorable tables are included