### PR TITLE
MaintainPull: ReplPing error is non retryable

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -237,7 +237,7 @@ func (a *FlowableActivity) MaintainPull(
 				a.CdcCacheRw.Lock()
 				delete(a.CdcCache, sessionID)
 				a.CdcCacheRw.Unlock()
-				return err
+				return temporal.NewNonRetryableApplicationError("connection to source down", "disconnect", err)
 			}
 		case <-ctx.Done():
 			a.CdcCacheRw.Lock()

--- a/flow/workflows/sync_flow.go
+++ b/flow/workflows/sync_flow.go
@@ -37,13 +37,13 @@ func SyncFlowWorkflow(
 	defer workflow.CompleteSession(syncSessionCtx)
 	sessionInfo := workflow.GetSessionInfo(syncSessionCtx)
 
-	syncCtx := workflow.WithActivityOptions(syncSessionCtx, workflow.ActivityOptions{
+	maintainCtx := workflow.WithActivityOptions(syncSessionCtx, workflow.ActivityOptions{
 		StartToCloseTimeout: 14 * 24 * time.Hour,
 		HeartbeatTimeout:    time.Minute,
 		WaitForCancellation: true,
 	})
 	fMaintain := workflow.ExecuteActivity(
-		syncCtx,
+		maintainCtx,
 		flowable.MaintainPull,
 		config,
 		sessionInfo.SessionID,

--- a/flow/workflows/sync_flow.go
+++ b/flow/workflows/sync_flow.go
@@ -179,7 +179,7 @@ func SyncFlowWorkflow(
 			}
 		})
 
-		for ctx.Err() == nil && (syncErr || !syncDone || selector.HasPending()) {
+		for ctx.Err() == nil && ((!syncDone && !syncErr) || selector.HasPending()) {
 			selector.Select(ctx)
 		}
 		if ctx.Err() != nil {


### PR DESCRIPTION
Turns out no retry policy means unlimited retries

When MaintainPull ReplPing fails, sync flow should be restarted

Tested this by calling `pg_terminate_backend` on source's `START REPLICATION` connection