### PR TITLE
Bigquery: Support JSON, FLOAT PKey For Merge

### DIFF
--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -139,7 +139,7 @@ func (m *mergeStmtGenerator) generateDeDupedCTE() string {
 	) SELECT * FROM _dd`
 
 	shortPkeys := m.transformedPkeyStrings(true)
-	pkeyColsStr := strings.Join(shortPkeys, ", '_peerdb_concat_' ")
+	pkeyColsStr := strings.Join(shortPkeys, ",")
 	return fmt.Sprintf(cte, pkeyColsStr)
 }
 

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -101,26 +101,27 @@ func (m *mergeStmtGenerator) generateFlattenedCTE() string {
 		m.syncBatchID, m.dstTableName)
 }
 
-// This function is to support datatypes like JSON which cannot be compared by BigQuery
+// This function is to support datatypes like JSON which either cannot be partitoned by or compared by BigQuery
 func (m *mergeStmtGenerator) transformedPkeyStrings(forPartition bool) []string {
 	pkeys := make([]string, 0, len(m.normalizedTableSchema.PrimaryKeyColumns))
+	transformations := map[qvalue.QValueKind]string{
+		qvalue.QValueKindJSON:    "TO_JSON_STRING(%s)",
+		qvalue.QValueKindFloat32: "CAST(%s as STRING)",
+		qvalue.QValueKindFloat64: "CAST(%s as STRING)",
+	}
+
 	for _, col := range m.normalizedTableSchema.Columns {
 		if slices.Contains(m.normalizedTableSchema.PrimaryKeyColumns, col.Name) {
 			pkeyCol := col.Name
-			switch qvalue.QValueKind(col.Type) {
-			case qvalue.QValueKindJSON:
-				if forPartition {
-					pkeys = append(pkeys, fmt.Sprintf("TO_JSON_STRING(%s)", m.shortColumn[pkeyCol]))
-				} else {
-					pkeys = append(pkeys, fmt.Sprintf("TO_JSON_STRING(_t.%s)=TO_JSON_STRING(_d.%s)",
-						pkeyCol, m.shortColumn[pkeyCol]))
-				}
-			default:
-				if forPartition {
-					pkeys = append(pkeys, m.shortColumn[pkeyCol])
-				} else {
-					pkeys = append(pkeys, fmt.Sprintf("_t.%s=_d.%s", pkeyCol, m.shortColumn[pkeyCol]))
-				}
+			transformation, exists := transformations[qvalue.QValueKind(col.Type)]
+			if !exists {
+				transformation = "%s"
+			}
+			if forPartition {
+				pkeys = append(pkeys, fmt.Sprintf(transformation, m.shortColumn[pkeyCol]))
+			} else {
+				pkeys = append(pkeys, fmt.Sprintf(transformation+"="+transformation,
+					"_t.`"+pkeyCol+"`", "_d."+m.shortColumn[pkeyCol]))
 			}
 		}
 	}

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -112,7 +112,7 @@ func (m *mergeStmtGenerator) transformedPkeyStrings(forPartition bool) []string 
 				if forPartition {
 					pkeys = append(pkeys, fmt.Sprintf("TO_JSON_STRING(%s)", m.shortColumn[pkeyCol]))
 				} else {
-					pkeys = append(pkeys, fmt.Sprintf("TO_JSON_STRING(_t.%s)=TO_JSON_STRING(_d.%s)",
+					pkeys = append(pkeys, fmt.Sprintf("TO_JSON_STRING(_t.`%s`)=TO_JSON_STRING(_d.%s)",
 						pkeyCol, m.shortColumn[pkeyCol]))
 				}
 			case qvalue.QValueKindFloat32, qvalue.QValueKindFloat64:

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -101,19 +101,20 @@ func (m *mergeStmtGenerator) generateFlattenedCTE() string {
 		m.syncBatchID, m.dstTableName)
 }
 
-// Ex: JSON columns which we set as primary key for replica identity full tables,
-// is not supported because bigquery cannot perform equality comparison between JSONs
-func (m *mergeStmtGenerator) isPkeyUnsupportedForMerge(pkey string) bool {
+func (m *mergeStmtGenerator) transformedPkeyStrings() []string {
+	pkeys := make([]string, 0, len(m.normalizedTableSchema.PrimaryKeyColumns))
 	for _, col := range m.normalizedTableSchema.Columns {
-		if slices.Contains(
-			m.normalizedTableSchema.PrimaryKeyColumns,
-			col.Name) && col.Name == pkey {
-			if qvalue.QValueKind(col.Type) == qvalue.QValueKindJSON {
-				return true
+		if slices.Contains(m.normalizedTableSchema.PrimaryKeyColumns, col.Name) {
+			pkeyCol := col.Name
+			switch qvalue.QValueKind(col.Type) {
+			case qvalue.QValueKindJSON:
+				pkeys = append(pkeys, fmt.Sprintf("TO_JSON_STRING(%s)", m.shortColumn[pkeyCol]))
+			default:
+				pkeys = append(pkeys, m.shortColumn[pkeyCol])
 			}
 		}
 	}
-	return false
+	return pkeys
 }
 
 // generateDeDupedCTE generates a de-duped CTE.
@@ -127,13 +128,7 @@ func (m *mergeStmtGenerator) generateDeDupedCTE() string {
 			WHERE _peerdb_rank=1
 	) SELECT * FROM _dd`
 
-	shortPkeys := make([]string, 0, len(m.normalizedTableSchema.PrimaryKeyColumns))
-	for _, pkeyCol := range m.normalizedTableSchema.PrimaryKeyColumns {
-		if m.isPkeyUnsupportedForMerge(pkeyCol) {
-			continue
-		}
-		shortPkeys = append(shortPkeys, m.shortColumn[pkeyCol])
-	}
+	shortPkeys := m.transformedPkeyStrings()
 	pkeyColsStr := fmt.Sprintf("(CONCAT(%s))", strings.Join(shortPkeys,
 		", '_peerdb_concat_', "))
 	return fmt.Sprintf(cte, pkeyColsStr)
@@ -171,9 +166,6 @@ func (m *mergeStmtGenerator) generateMergeStmt(unchangedToastColumns []string) s
 
 	pkeySelectSQLArray := make([]string, 0, len(m.normalizedTableSchema.PrimaryKeyColumns))
 	for _, pkeyColName := range m.normalizedTableSchema.PrimaryKeyColumns {
-		if m.isPkeyUnsupportedForMerge(pkeyColName) {
-			continue
-		}
 		pkeySelectSQLArray = append(pkeySelectSQLArray, fmt.Sprintf("_t.%s=_d.%s",
 			pkeyColName, m.shortColumn[pkeyColName]))
 	}

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -101,7 +101,7 @@ func (m *mergeStmtGenerator) generateFlattenedCTE() string {
 		m.syncBatchID, m.dstTableName)
 }
 
-// This function is to handle
+// This function is to support datatypes like JSON which cannot be compared by BigQuery
 func (m *mergeStmtGenerator) transformedPkeyStrings(forPartition bool) []string {
 	pkeys := make([]string, 0, len(m.normalizedTableSchema.PrimaryKeyColumns))
 	for _, col := range m.normalizedTableSchema.Columns {

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -1514,3 +1514,56 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Soft_Delete_Insert_After_Delete() {
 	require.NoError(s.t, err)
 	require.Equal(s.t, int64(0), numNewRows)
 }
+
+func (s PeerFlowE2ETestSuiteBQ) Test_JSON_PKey_BQ() {
+	env := e2e.NewTemporalTestWorkflowEnvironment(s.t)
+
+	srcTableName := s.attachSchemaSuffix("test_json_pkey_bq")
+	dstTableName := "test_json_pkey_bq"
+
+	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
+	CREATE TABLE IF NOT EXISTS %s (
+		id SERIAL NOT NULL,
+		j JSON NOT NULL,
+		key TEXT NOT NULL,
+		value TEXT NOT NULL
+	);
+	`, srcTableName))
+	require.NoError(s.t, err)
+
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+		ALTER TABLE %s REPLICA IDENTITY FULL
+		`, srcTableName))
+	require.NoError(s.t, err)
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("test_json_pkey_flow"),
+		TableNameMapping: map[string]string{srcTableName: dstTableName},
+		Destination:      s.bqHelper.Peer,
+		CdcStagingPath:   "",
+	}
+
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
+	flowConnConfig.MaxBatchSize = 100
+
+	go func() {
+		e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
+		// insert 10 rows into the source table
+		for i := range 10 {
+			testKey := fmt.Sprintf("test_key_%d", i)
+			testValue := fmt.Sprintf("test_value_%d", i)
+			testJson := `'{"name":"jack", "age":12, "spouse":null}'::json`
+			_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+			INSERT INTO %s(key, value, j) VALUES ($1, $2, %s)
+		`, srcTableName, testJson), testKey, testValue)
+			e2e.EnvNoError(s.t, env, err)
+		}
+		s.t.Log("Inserted 10 rows into the source table")
+
+		e2e.EnvWaitForEqualTables(env, s, "normalize inserts", dstTableName, "id,key,value,j")
+		env.CancelWorkflow()
+	}()
+
+	env.ExecuteWorkflow(peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	e2e.RequireEnvCanceled(s.t, env)
+}


### PR DESCRIPTION
Float, JSON (and other [non-groupable types in bigquery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#groupable_data_types )) as primary key is not supported by our merge statement in BigQuery as during our primary key comparison, BigQuery cannot compare, for example, JSON values:
```
googleapi: Error 400: Equality is not defined for arguments of type JSON
```

This PR makes a step towards supporting such columns in primary keys for BigQuery merge by transforming it to string there for `PARTITION BY` and comparison
Test added 