### PR TITLE
Fix & test cdc rollover

### DIFF
--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -1081,12 +1081,13 @@ func (s PeerFlowE2ETestSuitePG) Test_ContinueAsNew() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.MaxBatchSize = 2
+	flowConnConfig.IdleTimeoutSeconds = 10
 
 	tc := e2e.NewTemporalClient(s.t)
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 
 	e2e.SetupCDCFlowStatusQuery(s.t, env, connectionGen)
-	for i := range 180 {
+	for i := range 144 {
 		testKey := fmt.Sprintf("test_key_%d", i)
 		testValue := fmt.Sprintf("test_value_%d", i)
 		_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
@@ -1094,9 +1095,9 @@ func (s PeerFlowE2ETestSuitePG) Test_ContinueAsNew() {
 		`, srcTableName), testKey, testValue)
 		e2e.EnvNoError(s.t, env, err)
 	}
-	s.t.Log("Inserted 180 rows into the source table")
+	s.t.Log("Inserted 144 rows into the source table")
 
-	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "normalize 90 syncs", func() bool {
+	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "normalize 72 syncs", func() bool {
 		err := s.comparePGTables(srcTableName, dstTableName, "id,key,value")
 		if err != nil {
 			s.t.Log(err)

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -1098,12 +1098,7 @@ func (s PeerFlowE2ETestSuitePG) Test_ContinueAsNew() {
 	s.t.Log("Inserted 144 rows into the source table")
 
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "normalize 72 syncs", func() bool {
-		err := s.comparePGTables(srcTableName, dstTableName, "id,key,value")
-		if err != nil {
-			s.t.Log(err)
-			return false
-		}
-		return true
+		return s.comparePGTables(srcTableName, dstTableName, "id,key,value") == nil
 	})
 	env.Cancel()
 

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -1074,7 +1074,7 @@ func (s PeerFlowE2ETestSuitePG) Test_ContinueAsNew() {
 	require.NoError(s.t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix("test_simple_flow"),
+		FlowJobName:      s.attachSuffix("test_continueasnew_flow"),
 		TableNameMapping: map[string]string{srcTableName: dstTableName},
 		Destination:      s.peer,
 	}
@@ -1097,7 +1097,12 @@ func (s PeerFlowE2ETestSuitePG) Test_ContinueAsNew() {
 	s.t.Log("Inserted 180 rows into the source table")
 
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "normalize 90 syncs", func() bool {
-		return s.comparePGTables(srcTableName, dstTableName, "id,key,value") == nil
+		err := s.comparePGTables(srcTableName, dstTableName, "id,key,value")
+		if err != nil {
+			s.t.Log(err)
+			return false
+		}
+		return true
 	})
 	env.Cancel()
 

--- a/flow/e2e/snowflake/qrep_flow_sf_test.go
+++ b/flow/e2e/snowflake/qrep_flow_sf_test.go
@@ -149,7 +149,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_S3() {
 	qrepConfig.SetupWatermarkTableOnDestination = true
 
 	env := e2e.RunQrepFlowWorkflow(tc, qrepConfig)
-	e2e.EnvWaitForFinished(s.t, env, 3*time.Minute)
+	e2e.EnvWaitForFinished(s.t, env, 5*time.Minute)
 	require.NoError(s.t, env.Error())
 
 	sel := e2e.GetOwnersSelectorStringsSF()
@@ -226,7 +226,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Complete_QRep_Flow_Avro_SF_S3_Integration()
 	qrepConfig.SetupWatermarkTableOnDestination = true
 
 	env := e2e.RunQrepFlowWorkflow(tc, qrepConfig)
-	e2e.EnvWaitForFinished(s.t, env, 3*time.Minute)
+	e2e.EnvWaitForFinished(s.t, env, 5*time.Minute)
 	require.NoError(s.t, env.Error())
 
 	sel := e2e.GetOwnersSelectorStringsSF()

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -428,13 +428,15 @@ func CDCFlowWorkflow(
 		logger.Info("sync finished, finishing normalize")
 		syncFlowFuture = nil
 		restart = true
-		err = model.NormalizeSignal.SignalChildWorkflow(ctx, normFlowFuture, model.NormalizePayload{
-			Done:        true,
-			SyncBatchID: -1,
-		}).Get(ctx, nil)
-		if err != nil {
-			logger.Warn("failed to signal normalize done, finishing", slog.Any("error", err))
-			finished = true
+		if normFlowFuture != nil {
+			err = model.NormalizeSignal.SignalChildWorkflow(ctx, normFlowFuture, model.NormalizePayload{
+				Done:        true,
+				SyncBatchID: -1,
+			}).Get(ctx, nil)
+			if err != nil {
+				logger.Warn("failed to signal normalize done, finishing", slog.Any("error", err))
+				finished = true
+			}
 		}
 	})
 	mainLoopSelector.AddFuture(normFlowFuture, func(f workflow.Future) {

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -53,22 +53,6 @@ func NewCDCFlowWorkflowState(cfg *protos.FlowConnectionConfigs) *CDCFlowWorkflow
 	}
 }
 
-// CDCFlowWorkflowExecution represents the state for execution of a peer flow.
-type CDCFlowWorkflowExecution struct {
-	flowExecutionID string
-	logger          log.Logger
-	syncFlowFuture  workflow.ChildWorkflowFuture
-	normFlowFuture  workflow.ChildWorkflowFuture
-}
-
-// NewCDCFlowWorkflowExecution creates a new instance of PeerFlowWorkflowExecution.
-func NewCDCFlowWorkflowExecution(ctx workflow.Context, flowName string) *CDCFlowWorkflowExecution {
-	return &CDCFlowWorkflowExecution{
-		flowExecutionID: workflow.GetInfo(ctx).WorkflowExecution.ID,
-		logger:          log.With(workflow.GetLogger(ctx), slog.String(string(shared.FlowNameKey), flowName)),
-	}
-}
-
 func GetSideEffect[T any](ctx workflow.Context, f func(workflow.Context) T) T {
 	sideEffect := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
 		return f(ctx)
@@ -103,24 +87,26 @@ const (
 	maxSyncsPerCdcFlow = 32
 )
 
-func (w *CDCFlowWorkflowExecution) processCDCFlowConfigUpdate(ctx workflow.Context,
+func processCDCFlowConfigUpdate(
+	ctx workflow.Context,
+	logger log.Logger,
 	cfg *protos.FlowConnectionConfigs, state *CDCFlowWorkflowState,
 	mirrorNameSearch map[string]interface{},
 ) error {
 	flowConfigUpdate := state.FlowConfigUpdate
 
 	if flowConfigUpdate != nil {
-		w.logger.Info("processing CDCFlowConfigUpdate", slog.Any("updatedState", flowConfigUpdate))
+		logger.Info("processing CDCFlowConfigUpdate", slog.Any("updatedState", flowConfigUpdate))
 		if len(flowConfigUpdate.AdditionalTables) == 0 {
 			return nil
 		}
 		if shared.AdditionalTablesHasOverlap(state.SyncFlowOptions.TableMappings, flowConfigUpdate.AdditionalTables) {
-			w.logger.Warn("duplicate source/destination tables found in additionalTables")
+			logger.Warn("duplicate source/destination tables found in additionalTables")
 			return nil
 		}
 		state.CurrentFlowStatus = protos.FlowStatus_STATUS_SNAPSHOT
 
-		w.logger.Info("altering publication for additional tables")
+		logger.Info("altering publication for additional tables")
 		alterPublicationAddAdditionalTablesCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 			StartToCloseTimeout: 5 * time.Minute,
 		})
@@ -129,11 +115,11 @@ func (w *CDCFlowWorkflowExecution) processCDCFlowConfigUpdate(ctx workflow.Conte
 			flowable.AddTablesToPublication,
 			cfg, flowConfigUpdate.AdditionalTables)
 		if err := alterPublicationAddAdditionalTablesFuture.Get(ctx, nil); err != nil {
-			w.logger.Error("failed to alter publication for additional tables: ", err)
+			logger.Error("failed to alter publication for additional tables: ", err)
 			return err
 		}
 
-		w.logger.Info("additional tables added to publication")
+		logger.Info("additional tables added to publication")
 		additionalTablesUUID := GetUUID(ctx)
 		childAdditionalTablesCDCFlowID := GetChildWorkflowID("additional-cdc-flow", cfg.FlowJobName, additionalTablesUUID)
 		additionalTablesCfg := proto.Clone(cfg).(*protos.FlowConnectionConfigs)
@@ -167,13 +153,14 @@ func (w *CDCFlowWorkflowExecution) processCDCFlowConfigUpdate(ctx workflow.Conte
 		maps.Copy(state.SyncFlowOptions.TableNameSchemaMapping, res.SyncFlowOptions.TableNameSchemaMapping)
 
 		state.SyncFlowOptions.TableMappings = append(state.SyncFlowOptions.TableMappings, flowConfigUpdate.AdditionalTables...)
-		w.logger.Info("additional tables added to sync flow")
+		logger.Info("additional tables added to sync flow")
 	}
 	return nil
 }
 
-func (w *CDCFlowWorkflowExecution) addCdcPropertiesSignalListener(
+func addCdcPropertiesSignalListener(
 	ctx workflow.Context,
+	logger log.Logger,
 	selector workflow.Selector,
 	state *CDCFlowWorkflowState,
 ) {
@@ -189,19 +176,11 @@ func (w *CDCFlowWorkflowExecution) addCdcPropertiesSignalListener(
 		// do this irrespective of additional tables being present, for auto unpausing
 		state.FlowConfigUpdate = cdcConfigUpdate
 
-		w.logger.Info("CDC Signal received. Parameters on signal reception:",
+		logger.Info("CDC Signal received. Parameters on signal reception:",
 			slog.Int("BatchSize", int(state.SyncFlowOptions.BatchSize)),
 			slog.Int("IdleTimeout", int(state.SyncFlowOptions.IdleTimeoutSeconds)),
 			slog.Any("AdditionalTables", cdcConfigUpdate.AdditionalTables))
 	})
-}
-
-func (w *CDCFlowWorkflowExecution) startSyncFlow(ctx workflow.Context, config *protos.FlowConnectionConfigs, options *protos.SyncFlowOptions) {
-	w.syncFlowFuture = workflow.ExecuteChildWorkflow(ctx, SyncFlowWorkflow, config, options)
-}
-
-func (w *CDCFlowWorkflowExecution) startNormFlow(ctx workflow.Context, config *protos.FlowConnectionConfigs) {
-	w.normFlowFuture = workflow.ExecuteChildWorkflow(ctx, NormalizeFlowWorkflow, config, nil)
 }
 
 func CDCFlowWorkflow(
@@ -217,7 +196,7 @@ func CDCFlowWorkflow(
 		state = NewCDCFlowWorkflowState(cfg)
 	}
 
-	w := NewCDCFlowWorkflowExecution(ctx, cfg.FlowJobName)
+	logger := log.With(workflow.GetLogger(ctx), slog.String(string(shared.FlowNameKey), cfg.FlowJobName))
 	flowSignalChan := model.FlowSignal.GetSignalChannel(ctx)
 
 	err := workflow.SetQueryHandler(ctx, shared.CDCFlowStateQuery, func() (CDCFlowWorkflowState, error) {
@@ -248,9 +227,9 @@ func CDCFlowWorkflow(
 		selector := workflow.NewNamedSelector(ctx, "PauseLoop")
 		selector.AddReceive(ctx.Done(), func(_ workflow.ReceiveChannel, _ bool) {})
 		flowSignalChan.AddToSelector(selector, func(val model.CDCFlowSignal, _ bool) {
-			state.ActiveSignal = model.FlowSignalHandler(state.ActiveSignal, val, w.logger)
+			state.ActiveSignal = model.FlowSignalHandler(state.ActiveSignal, val, logger)
 		})
-		w.addCdcPropertiesSignalListener(ctx, selector, state)
+		addCdcPropertiesSignalListener(ctx, logger, selector, state)
 
 		startTime := workflow.Now(ctx)
 		state.CurrentFlowStatus = protos.FlowStatus_STATUS_PAUSED
@@ -258,7 +237,7 @@ func CDCFlowWorkflow(
 		for state.ActiveSignal == model.PauseSignal {
 			// only place we block on receive, so signal processing is immediate
 			for state.ActiveSignal == model.PauseSignal && state.FlowConfigUpdate == nil && ctx.Err() == nil {
-				w.logger.Info("mirror has been paused", slog.Any("duration", time.Since(startTime)))
+				logger.Info("mirror has been paused", slog.Any("duration", time.Since(startTime)))
 				selector.Select(ctx)
 			}
 			if err := ctx.Err(); err != nil {
@@ -266,18 +245,18 @@ func CDCFlowWorkflow(
 			}
 
 			if state.FlowConfigUpdate != nil {
-				err = w.processCDCFlowConfigUpdate(ctx, cfg, state, mirrorNameSearch)
+				err = processCDCFlowConfigUpdate(ctx, logger, cfg, state, mirrorNameSearch)
 				if err != nil {
 					return state, err
 				}
-				w.logger.Info("wiping flow state after state update processing")
+				logger.Info("wiping flow state after state update processing")
 				// finished processing, wipe it
 				state.FlowConfigUpdate = nil
 				state.ActiveSignal = model.NoopSignal
 			}
 		}
 
-		w.logger.Info("mirror has been resumed after ", time.Since(startTime))
+		logger.Info("mirror has been resumed after ", time.Since(startTime))
 		state.CurrentFlowStatus = protos.FlowStatus_STATUS_RUNNING
 	}
 
@@ -346,7 +325,7 @@ func CDCFlowWorkflow(
 			state.SyncFlowOptions.TableNameSchemaMapping,
 		)
 		if err := snapshotFlowFuture.Get(snapshotFlowCtx, nil); err != nil {
-			w.logger.Error("snapshot flow failed", slog.Any("error", err))
+			logger.Error("snapshot flow failed", slog.Any("error", err))
 			return state, fmt.Errorf("failed to execute snapshot workflow: %w", err)
 		}
 
@@ -385,7 +364,7 @@ func CDCFlowWorkflow(
 		}
 
 		state.CurrentFlowStatus = protos.FlowStatus_STATUS_RUNNING
-		w.logger.Info("executed setup flow and snapshot flow")
+		logger.Info("executed setup flow and snapshot flow")
 
 		// if initial_copy_only is opted for, we end the flow here.
 		if cfg.InitialSnapshotOnly {
@@ -424,65 +403,54 @@ func CDCFlowWorkflow(
 	handleError := func(name string, err error) {
 		var panicErr *temporal.PanicError
 		if errors.As(err, &panicErr) {
-			w.logger.Error(
+			logger.Error(
 				"panic in flow",
 				slog.String("name", name),
 				slog.Any("error", panicErr.Error()),
 				slog.String("stack", panicErr.StackTrace()),
 			)
 		} else {
-			w.logger.Error("error in flow", slog.String("name", name), slog.Any("error", err))
+			logger.Error("error in flow", slog.String("name", name), slog.Any("error", err))
 		}
 	}
 
+	syncFlowFuture := workflow.ExecuteChildWorkflow(syncCtx, SyncFlowWorkflow, cfg, state.SyncFlowOptions)
+	normFlowFuture := workflow.ExecuteChildWorkflow(normCtx, NormalizeFlowWorkflow, cfg, nil)
+
 	mainLoopSelector := workflow.NewNamedSelector(ctx, "MainLoop")
 	mainLoopSelector.AddReceive(ctx.Done(), func(_ workflow.ReceiveChannel, _ bool) {})
-
-	var handleNormFlow, handleSyncFlow func(workflow.Future)
-	handleSyncFlow = func(f workflow.Future) {
+	mainLoopSelector.AddFuture(syncFlowFuture, func(f workflow.Future) {
 		err := f.Get(ctx, nil)
 		if err != nil {
 			handleError("sync", err)
 		}
 
-		if restart {
-			w.logger.Info("sync finished, finishing normalize")
-			w.syncFlowFuture = nil
-			_ = model.NormalizeSignal.SignalChildWorkflow(ctx, w.normFlowFuture, model.NormalizePayload{
-				Done:        true,
-				SyncBatchID: -1,
-			}).Get(ctx, nil)
-		} else {
-			w.logger.Warn("sync flow ended, restarting", slog.Any("error", err))
-			w.startSyncFlow(syncCtx, cfg, state.SyncFlowOptions)
-			mainLoopSelector.AddFuture(w.syncFlowFuture, handleSyncFlow)
+		logger.Info("sync finished, finishing normalize")
+		syncFlowFuture = nil
+		restart = true
+		err = model.NormalizeSignal.SignalChildWorkflow(ctx, normFlowFuture, model.NormalizePayload{
+			Done:        true,
+			SyncBatchID: -1,
+		}).Get(ctx, nil)
+		if err != nil {
+			logger.Warn("failed to signal normalize done, finishing", slog.Any("error", err))
+			finished = true
 		}
-	}
-	handleNormFlow = func(f workflow.Future) {
+	})
+	mainLoopSelector.AddFuture(normFlowFuture, func(f workflow.Future) {
 		err := f.Get(ctx, nil)
 		if err != nil {
 			handleError("normalize", err)
 		}
 
-		if restart {
-			w.logger.Info("normalize finished, finishing")
-			w.normFlowFuture = nil
-			finished = true
-		} else {
-			w.logger.Warn("normalize flow ended, restarting", slog.Any("error", err))
-			w.startNormFlow(normCtx, cfg)
-			mainLoopSelector.AddFuture(w.normFlowFuture, handleNormFlow)
-		}
-	}
-
-	w.startSyncFlow(syncCtx, cfg, state.SyncFlowOptions)
-	mainLoopSelector.AddFuture(w.syncFlowFuture, handleSyncFlow)
-
-	w.startNormFlow(normCtx, cfg)
-	mainLoopSelector.AddFuture(w.normFlowFuture, handleNormFlow)
+		logger.Info("normalize finished, finishing")
+		normFlowFuture = nil
+		restart = true
+		finished = true
+	})
 
 	flowSignalChan.AddToSelector(mainLoopSelector, func(val model.CDCFlowSignal, _ bool) {
-		state.ActiveSignal = model.FlowSignalHandler(state.ActiveSignal, val, w.logger)
+		state.ActiveSignal = model.FlowSignalHandler(state.ActiveSignal, val, logger)
 	})
 
 	syncResultChan := model.SyncResultSignal.GetSignalChannel(ctx)
@@ -499,7 +467,9 @@ func CDCFlowWorkflow(
 
 	normChan := model.NormalizeSignal.GetSignalChannel(ctx)
 	normChan.AddToSelector(mainLoopSelector, func(payload model.NormalizePayload, _ bool) {
-		_ = model.NormalizeSignal.SignalChildWorkflow(ctx, w.normFlowFuture, payload).Get(ctx, nil)
+		if normFlowFuture != nil {
+			_ = model.NormalizeSignal.SignalChildWorkflow(ctx, normFlowFuture, payload).Get(ctx, nil)
+		}
 		maps.Copy(state.SyncFlowOptions.TableNameSchemaMapping, payload.TableNameSchemaMapping)
 	})
 
@@ -509,13 +479,13 @@ func CDCFlowWorkflow(
 	if !parallel {
 		normDoneChan := model.NormalizeDoneSignal.GetSignalChannel(ctx)
 		normDoneChan.AddToSelector(mainLoopSelector, func(x struct{}, _ bool) {
-			if w.syncFlowFuture != nil {
-				_ = model.NormalizeDoneSignal.SignalChildWorkflow(ctx, w.syncFlowFuture, x).Get(ctx, nil)
+			if syncFlowFuture != nil {
+				_ = model.NormalizeDoneSignal.SignalChildWorkflow(ctx, syncFlowFuture, x).Get(ctx, nil)
 			}
 		})
 	}
 
-	w.addCdcPropertiesSignalListener(ctx, mainLoopSelector, state)
+	addCdcPropertiesSignalListener(ctx, logger, mainLoopSelector, state)
 
 	state.CurrentFlowStatus = protos.FlowStatus_STATUS_RUNNING
 	for {
@@ -524,13 +494,19 @@ func CDCFlowWorkflow(
 			mainLoopSelector.Select(ctx)
 		}
 		if err := ctx.Err(); err != nil {
-			w.logger.Info("mirror canceled", slog.Any("error", err))
+			logger.Info("mirror canceled", slog.Any("error", err))
 			return state, err
 		}
 
 		if state.ActiveSignal == model.PauseSignal || syncCount >= maxSyncsPerCdcFlow {
 			restart = true
-			_ = model.SyncStopSignal.SignalChildWorkflow(ctx, w.syncFlowFuture, struct{}{}).Get(ctx, nil)
+			if syncFlowFuture != nil {
+				err := model.SyncStopSignal.SignalChildWorkflow(ctx, syncFlowFuture, struct{}{}).Get(ctx, nil)
+				if err != nil {
+					logger.Warn("failed to send sync-stop, finishing", slog.Any("error", err))
+					finished = true
+				}
+			}
 		}
 
 		if restart {
@@ -543,7 +519,7 @@ func CDCFlowWorkflow(
 			}
 
 			if err := ctx.Err(); err != nil {
-				w.logger.Info("mirror canceled", slog.Any("error", err))
+				logger.Info("mirror canceled", slog.Any("error", err))
 				return nil, err
 			}
 


### PR DESCRIPTION
Customer workflow recently got stuck after sync-stop,
add test covering cdc_flow returning ContinueAsNew multiple times

cdc_flow had custom retry logic to pass tests before they were switched to integration tests,
get rid of that, it was racy with signals, rely on temporal retries for workflow errors
& restarting cdc entirely if sync/normalize finish for whatever reason