### PR TITLE
revert change to Temporal database plugin

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -56,7 +56,7 @@ services:
       catalog:
         condition: service_healthy
     environment:
-      - DB=postgresql
+      - DB=postgres12
       - DB_PORT=5432
       - POSTGRES_USER=postgres
       - POSTGRES_PWD=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       catalog:
         condition: service_healthy
     environment:
-      - DB=postgresql
+      - DB=postgres12
       - DB_PORT=5432
       - POSTGRES_USER=postgres
       - POSTGRES_PWD=postgres


### PR DESCRIPTION
`postgresql` appears to be a plugin that doesn't support Temporal [advanced visibility](https://docs.temporal.io/visibility#advanced-visibility) which we use in `flow-api`. It now crashes on startup.

Reverting the change made in #1388 