### PR TITLE
Enable all govet lints besides fieldalignment/shadow

### DIFF
--- a/flow/.golangci.yml
+++ b/flow/.golangci.yml
@@ -57,6 +57,11 @@ linters-settings:
     settings:
       hugeParam:
         sizeThreshold: 512
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
   stylecheck:
     checks:
       - all

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -373,8 +373,8 @@ func (h *FlowRequestHandler) ShutdownFlow(
 	}
 
 	if req.RemoveFlowEntry {
-		delErr := h.removeFlowEntryInCatalog(ctx, req.FlowJobName)
-		if delErr != nil {
+		err := h.removeFlowEntryInCatalog(ctx, req.FlowJobName)
+		if err != nil {
 			slog.Error("unable to remove flow job entry",
 				slog.String(string(shared.FlowNameKey), req.FlowJobName),
 				slog.Any("error", err),

--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -23,9 +23,9 @@ func (h *FlowRequestHandler) getPGPeerConfig(ctx context.Context, peerName strin
 		return nil, err
 	}
 
-	unmarshalErr := proto.Unmarshal(pgPeerOptions, &pgPeerConfig)
+	err = proto.Unmarshal(pgPeerOptions, &pgPeerConfig)
 	if err != nil {
-		return nil, unmarshalErr
+		return nil, err
 	}
 
 	return &pgPeerConfig, nil

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -43,9 +43,6 @@ func (s *ClickhouseAvroSyncMethod) CopyStageToDestination(ctx context.Context, a
 	avroFileUrl := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", s3o.Bucket,
 		s.connector.creds.Region, avroFile.FilePath)
 
-	if err != nil {
-		return err
-	}
 	//nolint:gosec
 	query := fmt.Sprintf("INSERT INTO %s SELECT * FROM s3('%s','%s','%s', 'Avro')",
 		s.config.DestinationTableIdentifier, avroFileUrl,


### PR DESCRIPTION
shadow would need to ignore shadowing `err`,
& fieldalignment raises many warnings which can be evaluated in a future PR to reduce memory footprint