### PR TITLE
Clickhouse: specify columns more in insert select

### DIFF
--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -133,12 +133,12 @@ func (s *ClickhouseAvroSyncMethod) SyncQRepRecords(
 			continue
 		}
 
-		selector = append(selector, colName)
+		selector = append(selector, "`"+colName+"`")
 	}
 	selectorStr := strings.Join(selector, ",")
 	//nolint:gosec
-	query := fmt.Sprintf("INSERT INTO %s(%s) SELECT * FROM s3('%s','%s','%s', 'Avro')",
-		config.DestinationTableIdentifier, selectorStr, avroFileUrl,
+	query := fmt.Sprintf("INSERT INTO %s(%s) SELECT %s FROM s3('%s','%s','%s', 'Avro')",
+		config.DestinationTableIdentifier, selectorStr, selectorStr, avroFileUrl,
 		s.connector.creds.AccessKeyID, s.connector.creds.SecretAccessKey)
 
 	_, err = s.connector.database.ExecContext(ctx, query)


### PR DESCRIPTION
This PR is an attempt to fix #1439 , by explicitly specifying the columns in `select * from s3(...)` in Qrep for Clickhouse.