### PR TITLE
fix(telemetry): issue with aws sns

### DIFF
--- a/flow/shared/telemetry/sns_message_sender.go
+++ b/flow/shared/telemetry/sns_message_sender.go
@@ -39,11 +39,15 @@ func (s *SNSMessageSenderImpl) SendMessage(ctx context.Context, subject string, 
 	h.Write([]byte(deduplicationString))
 	deduplicationHash := hex.EncodeToString(h.Sum(nil))
 	// AWS SNS Subject constraints
-	messageSubject := strings.TrimFunc(subject, func(r rune) bool {
-		return !unicode.IsPrint(r)
-	})
-	if len(messageSubject) >= 100 {
-		messageSubject = messageSubject[:99]
+	messageSubject := ""
+	for _, char := range subject {
+		if unicode.IsPrint(char) {
+			messageSubject += string(char)
+		}
+	}
+	maxSubjectSize := 99
+	if len(messageSubject) > maxSubjectSize {
+		messageSubject = messageSubject[:maxSubjectSize]
 	}
 	publish, err := s.client.Publish(ctx, &sns.PublishInput{
 		Message: aws.String(body),

--- a/flow/shared/telemetry/sns_message_sender.go
+++ b/flow/shared/telemetry/sns_message_sender.go
@@ -42,7 +42,7 @@ func (s *SNSMessageSenderImpl) SendMessage(ctx context.Context, subject string, 
 	messageSubject := strings.TrimFunc(subject, func(r rune) bool {
 		return !unicode.IsPrint(r)
 	})
-	if len(messageSubject) > 100 {
+	if len(messageSubject) >= 100 {
 		messageSubject = messageSubject[:99]
 	}
 	publish, err := s.client.Publish(ctx, &sns.PublishInput{


### PR DESCRIPTION
`subject[:100]` is byte based, not character based, causing AWS to reject control characters

Properly limit to 100 characters, rather than 100 bytes