### PR TITLE
Validate peer: fix snowflake validate

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -608,11 +608,6 @@ func (a *FlowableActivity) replicateQRepPartition(ctx context.Context,
 	runUUID string,
 ) error {
 	logger := log.With(activity.GetLogger(ctx), slog.String(string(shared.FlowNameKey), config.FlowJobName))
-	err := monitoring.UpdateStartTimeForPartition(ctx, a.CatalogPool, runUUID, partition, time.Now())
-	if err != nil {
-		a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
-		return fmt.Errorf("failed to update start time for partition: %w", err)
-	}
 
 	srcConn, err := connectors.GetQRepPullConnector(ctx, config.SourcePeer)
 	if err != nil {

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -110,21 +110,6 @@ func TableCheck(ctx context.Context, database *sql.DB, schemaName string) error 
 		return fmt.Errorf("error while checking if schema exists: %w", err)
 	}
 
-	rows, err := database.QueryContext(ctx, "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA;")
-	if err != nil {
-		return fmt.Errorf("error while checking if schema exists: %w", err)
-	}
-
-	for rows.Next() {
-		var schema string
-		err := rows.Scan(&schema)
-		if err != nil {
-			return fmt.Errorf("error getting schema")
-		}
-
-		slog.Info(schema)
-	}
-
 	dummyTable := "PEERDB_DUMMY_TABLE_" + shared.RandomString(4)
 
 	// In a transaction, create a table, insert a row into the table and then drop the table

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -128,7 +128,6 @@ func TableCheck(ctx context.Context, database *sql.DB, schemaName string) error 
 	}()
 
 	if !schemaExists.Valid || !schemaExists.Bool {
-		slog.Info("Apparently schema " + schemaName + " doesn't exist")
 		// create schema
 		_, err = tx.ExecContext(ctx, fmt.Sprintf(createSchemaSQL, schemaName))
 		if err != nil {
@@ -190,7 +189,6 @@ func NewSnowflakeConnector(
 		return nil, fmt.Errorf("failed to get DSN from Snowflake config: %w", err)
 	}
 
-	fmt.Println(snowflakeConfig)
 	database, err := sql.Open("snowflake", snowflakeConfigDSN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open connection to Snowflake peer: %w", err)

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -102,7 +102,7 @@ type UnchangedToastColumnResult struct {
 	UnchangedToastColumns ArrayString
 }
 
-func TableCheck(ctx context.Context, database *sql.DB, schemaName string) error {
+func ValidationCheck(ctx context.Context, database *sql.DB, schemaName string) error {
 	// check if schema exists
 	var schemaExists sql.NullBool
 	err := database.QueryRowContext(ctx, checkIfSchemaExistsSQL, schemaName).Scan(&schemaExists)
@@ -205,7 +205,7 @@ func NewSnowflakeConnector(
 		rawSchema = *snowflakeProtoConfig.MetadataSchema
 	}
 
-	err = TableCheck(ctx, database, rawSchema)
+	err = ValidationCheck(ctx, database, rawSchema)
 	if err != nil {
 		return nil, fmt.Errorf("could not validate snowflake peer: %w", err)
 	}


### PR DESCRIPTION
Snowflake validate could fail if the user creates an internal schema before hand, in which case permissions for schema creation are not necessary and may not be given. Our validate for snowflake will fail as it tries to create a dummy schema

The change this PR makes is to check if the raw schema exists (see note). If it doesn't then, create it. The remaining steps - table create, insert row etc. remain the same. `create schema if not exists` does not bypass snowflake's permission checks for schema creation

Removes drop schema step as that isn't something we do in mirrors

note - this is also done at raw table creation and qrep metadata table creation where we create schemas