### PR TITLE
Fix GCS endpoint and validation

### DIFF
--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -90,11 +90,6 @@ func (c *S3Connector) Close() error {
 }
 
 func ValidCheck(ctx context.Context, s3Client *s3.Client, bucketURL string, metadataDB *metadataStore.PostgresMetadataStore) error {
-	_, listErr := s3Client.ListBuckets(ctx, nil)
-	if listErr != nil {
-		return fmt.Errorf("failed to list buckets: %w", listErr)
-	}
-
 	reader := strings.NewReader(time.Now().Format(time.RFC3339))
 
 	bucketPrefix, parseErr := utils.NewS3BucketAndPrefix(bucketURL)

--- a/ui/components/PeerForms/S3Form.tsx
+++ b/ui/components/PeerForms/S3Form.tsx
@@ -22,7 +22,8 @@ const S3Form = ({ setter }: S3Props) => {
   };
 
   useEffect(() => {
-    const endpoint = storageType === 'S3' ? '' : 'storage.googleapis.com';
+    const endpoint =
+      storageType === 'S3' ? '' : 'https://storage.googleapis.com';
     setter((prev) => {
       return {
         ...prev,


### PR DESCRIPTION
GCS Peer validation seemingly has regressed, failing in UI peer creation.
UI was setting the endpoint without the https prefix, and also this PR removes listing buckets as part of validation for storage peers, as that isn't an operation we do as part of mirrors.

Functionally tested with peer creation and functioning CDC mirror with initial load