### PR TITLE
alerting: also log to logger

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -391,7 +391,6 @@ func (a *FlowableActivity) SyncFlow(
 			StagingPath:   config.CdcStagingPath,
 		})
 		if err != nil {
-			logger.Warn("failed to push records", slog.Any("error", err))
 			a.Alerter.LogFlowError(ctx, flowName, err)
 			return fmt.Errorf("failed to push records: %w", err)
 		}

--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -63,7 +63,6 @@ func (a *SnapshotActivity) SetupReplication(
 	defer close(replicationErr)
 
 	closeConnectionForError := func(err error) {
-		logger.Error("failed to setup replication", slog.Any("error", err))
 		a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 		// it is important to close the connection here as it is not closed in CloseSlotKeepAlive
 		connectors.CloseConnector(ctx, conn)

--- a/flow/alerting/alerting.go
+++ b/flow/alerting/alerting.go
@@ -224,27 +224,32 @@ func (a *Alerter) sendTelemetryMessage(ctx context.Context, flowName string, mor
 }
 
 func (a *Alerter) LogFlowError(ctx context.Context, flowName string, err error) {
+	logger := logger.LoggerFromCtx(ctx)
 	errorWithStack := fmt.Sprintf("%+v", err)
+	logger.Error(err.Error(), slog.Any("stack", errorWithStack))
 	_, err = a.catalogPool.Exec(ctx,
 		"INSERT INTO peerdb_stats.flow_errors(flow_name,error_message,error_type) VALUES($1,$2,$3)",
 		flowName, errorWithStack, "error")
 	if err != nil {
-		logger.LoggerFromCtx(ctx).Warn("failed to insert flow error", slog.Any("error", err))
+		logger.Warn("failed to insert flow error", slog.Any("error", err))
 		return
 	}
 	a.sendTelemetryMessage(ctx, flowName, errorWithStack, telemetry.ERROR)
 }
 
 func (a *Alerter) LogFlowEvent(ctx context.Context, flowName string, info string) {
+	logger.LoggerFromCtx(ctx).Info(info)
 	a.sendTelemetryMessage(ctx, flowName, info, telemetry.INFO)
 }
 
 func (a *Alerter) LogFlowInfo(ctx context.Context, flowName string, info string) {
+	logger := logger.LoggerFromCtx(ctx)
+	logger.Info(info)
 	_, err := a.catalogPool.Exec(ctx,
 		"INSERT INTO peerdb_stats.flow_errors(flow_name,error_message,error_type) VALUES($1,$2,$3)",
 		flowName, info, "info")
 	if err != nil {
-		logger.LoggerFromCtx(ctx).Warn("failed to insert flow info", slog.Any("error", err))
+		logger.Warn("failed to insert flow info", slog.Any("error", err))
 		return
 	}
 }


### PR DESCRIPTION
Might be preferable to have these error receiving functions return that error, allowing a natural

```
return alerter.LogFlowError(ctx, flowName, fmt.Errorf("...: %w", err))
```

Instead of logging inner err & only returning the `fmt.Errorf` error. Which would also help recover some logging this PR removes while deduplicating logging error & alerter.LogFlowError