### PR TITLE
Optimize slot lag graph

### DIFF
--- a/ui/app/dto/PeersDTO.ts
+++ b/ui/app/dto/PeersDTO.ts
@@ -53,8 +53,8 @@ export type CatalogPeer = {
 export type PeerSetter = React.Dispatch<React.SetStateAction<PeerConfig>>;
 
 export type SlotLagPoint = {
-  updatedAt: string;
-  slotSize?: string;
+  updatedAt: number;
+  slotSize: number;
 };
 
 export type UPublicationsResponse = {


### PR DESCRIPTION
1. past month gets 8640 points, only send back at most 720 (randomly selected)
2. transmit numbers; formatting happens on client
3. always show HH:mm in timestamp