### PR TITLE
BigQuery: Fix return mergeErr

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -494,7 +494,7 @@ func (c *BigQueryConnector) NormalizeRecords(ctx context.Context, req *model.Nor
 				SoftDelete:        req.SoftDelete,
 			})
 		if mergeErr != nil {
-			return nil, err
+			return nil, mergeErr
 		}
 
 		err = c.pgMetadata.UpdateNormalizeBatchID(ctx, req.FlowJobName, batchId)


### PR DESCRIPTION
We were returning a wrong error object in BigQuery's merge