### PR TITLE
Snapshot: do export snapshot after creating replication 

### DIFF
--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -56,8 +56,6 @@ export default function CDCConfigForm({
     const label = setting.label.toLowerCase();
     if (
       (label.includes('snapshot') && mirrorConfig.doInitialSnapshot !== true) ||
-      (label === 'replication slot name' &&
-        mirrorConfig.doInitialSnapshot === true) ||
       (label.includes('staging path') &&
         defaultSyncMode(mirrorConfig.destination?.type) !== 'AVRO')
     ) {


### PR DESCRIPTION
Doing conn.Close() after `CreateReplicationSlot` and then doing export snapshot after, setting snapshot name in our state to that.