### PR TITLE
Add heartbeats to account for QRepPartitionIsSynced

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -616,6 +616,9 @@ func (a *FlowableActivity) replicateQRepPartition(ctx context.Context,
 	partition *protos.QRepPartition,
 	runUUID string,
 ) error {
+	msg := fmt.Sprintf("replicating partition - %s: %d of %d total.", partition.PartitionId, idx, total)
+	activity.RecordHeartbeat(ctx, msg)
+
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
 	logger := log.With(activity.GetLogger(ctx), slog.String(string(shared.FlowNameKey), config.FlowJobName))
 
@@ -643,6 +646,7 @@ func (a *FlowableActivity) replicateQRepPartition(ctx context.Context,
 	}
 	if done {
 		logger.Info("no records to push for partition " + partition.PartitionId)
+		activity.RecordHeartbeat(ctx, "no records to push for partition "+partition.PartitionId)
 		return nil
 	}
 


### PR DESCRIPTION
When ReplicateQRepPartition fails for some reason midway after it's synced a bunch of partitions, it now enters a retry flow where it skims through partitions it's synced already, checking if they're synced and skipping if so. 
This process can take longer than the heartbeat for that activity (1 minute)
So we need to add heartbeats in this process to prevent heartbeat timeouts