### PR TITLE
revert SET LOCAL in replconn hold (#1530)

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -369,12 +369,13 @@ func (c *PostgresConnector) createSlotAndPublication(
 
 		c.logger.Warn(fmt.Sprintf("Creating replication slot '%s'", slot))
 
-		_, err = conn.Exec(ctx, "SET LOCAL idle_in_transaction_session_timeout=0")
+		// THIS IS NOT IN A TX!
+		_, err = conn.Exec(ctx, "SET idle_in_transaction_session_timeout=0")
 		if err != nil {
 			return fmt.Errorf("[slot] error setting idle_in_transaction_session_timeout: %w", err)
 		}
 
-		_, err = conn.Exec(ctx, "SET LOCAL lock_timeout=0")
+		_, err = conn.Exec(ctx, "SET lock_timeout=0")
 		if err != nil {
 			return fmt.Errorf("[slot] error setting lock_timeout: %w", err)
 		}


### PR DESCRIPTION
was a bug, `SET LOCAL` has no effect outside transactions, can cause replication connections to close