### PR TITLE
qrep: wait for new rows as a workflow

### DIFF
--- a/flow/workflows/register.go
+++ b/flow/workflows/register.go
@@ -11,6 +11,7 @@ func RegisterFlowWorkerWorkflows(w worker.WorkflowRegistry) {
 	w.RegisterWorkflow(SetupFlowWorkflow)
 	w.RegisterWorkflow(SyncFlowWorkflow)
 	w.RegisterWorkflow(QRepFlowWorkflow)
+	w.RegisterWorkflow(QRepWaitForNewRowsWorkflow)
 	w.RegisterWorkflow(QRepPartitionWorkflow)
 	w.RegisterWorkflow(XminFlowWorkflow)
 


### PR DESCRIPTION
This is a relatively big change to the fundamental logic of query replication.

Beforehand: QRep waits inside an activity and keeps the database connection open while it's doing that
- this consumes a temporal activity worker slot just per QRep
- this consumes a database connection per QRep

Both are not desirable. The design I landed on here is:
1. there is a new activity `flowable.QRepHasNewRows` (replacing the old `flowable.QRepWaitUntilNewRows`)
2. there is a new workflow `QRepWaitForNewRowsWorkflow` which runs `flowable.QRepHasNewRows` and:
 a. if there is a new row completes the workflow
 b. if there is no new row it waits for the given time and then replaces itself using the temporal continue as new feature

This has the benefit that the history size doesn't explode and that waiting for new rows across many QReps is nicely load balanced via temporal. Also, the number of open database connections is managed carefully: The other PR I opened let's one manage the maximum number of concurrent temporal activities. Hence you can control the maximum number of database connections easily.

Note: For high frequency scenarios (thousands of QReps synced multiple times a minute) temporal accumulates a lot of history in the `history_nodes` tables. For that one needs to set the retention to 1h and force temporal to clean up more often than the default value (which is twice a day).

I also changed that activities back off (exponential factor 2) when encountering errors.