### PR TITLE
Close replication connection faster

### DIFF
--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/PeerDB-io/peer-flow/activities"
 	"github.com/PeerDB-io/peer-flow/alerting"
-	"github.com/PeerDB-io/peer-flow/connectors"
 	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
 	"github.com/PeerDB-io/peer-flow/shared"
@@ -132,7 +131,7 @@ func WorkerMain(opts *WorkerOptions) (client.Client, worker.Worker, error) {
 	w.RegisterActivity(&activities.FlowableActivity{
 		CatalogPool: conn,
 		Alerter:     alerting.NewAlerter(context.Background(), conn),
-		CdcCache:    make(map[string]connectors.CDCPullConnector),
+		CdcCache:    make(map[string]activities.CdcCacheEntry),
 	})
 
 	return c, w, nil


### PR DESCRIPTION
Kevin noticed MaintainPull was outliving parent workflow for some time,
temporal contexts only detect cancelation with RecordHeartbeat,
in order to reduce shutdown latency implement UnmaintainPull