### PR TITLE
kafka/pubsub: PEERDB_QUEUE_FLUSH_TIMEOUT_SECONDS

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -334,7 +334,7 @@ func (a *FlowableActivity) SyncFlow(
 	defer shutdown()
 
 	batchSize := options.BatchSize
-	if batchSize <= 0 {
+	if batchSize == 0 {
 		batchSize = 1_000_000
 	}
 

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -47,8 +47,8 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 	tableNameRowsMapping map[string]*model.RecordTypeCounts,
 ) (*model.SyncResponse, error) {
 	s.connector.logger.Info(
-		fmt.Sprintf("Flow job %s: Obtaining Avro schema for destination table %s and sync batch ID %d",
-			req.FlowJobName, rawTableName, syncBatchID))
+		fmt.Sprintf("Obtaining Avro schema for destination table %s and sync batch ID %d",
+			rawTableName, syncBatchID))
 	// You will need to define your Avro schema as a string
 	avroSchema, err := DefineAvroSchema(rawTableName, dstTableMetadata, "", "")
 	if err != nil {

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -13,7 +13,6 @@ import (
 	"cloud.google.com/go/bigquery"
 	"go.temporal.io/sdk/activity"
 
-	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	avro "github.com/PeerDB-io/peer-flow/connectors/utils/avro"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
@@ -412,12 +411,6 @@ func (s *QRepAvroSyncMethod) writeToStage(
 	stream *model.QRecordStream,
 	flowName string,
 ) (int, error) {
-	shutdown := utils.HeartbeatRoutine(ctx, func() string {
-		return fmt.Sprintf("writing to avro stage for objectFolder %s and staging table %s",
-			objectFolder, stagingTable)
-	})
-	defer shutdown()
-
 	var avroFile *avro.AvroFile
 	ocfWriter := avro.NewPeerDBOCFWriter(stream, avroSchema, avro.CompressNone, protos.DBType_BIGQUERY)
 	idLog := slog.Group("write-metadata",

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -46,11 +46,9 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 	stream *model.QRecordStream,
 	tableNameRowsMapping map[string]*model.RecordTypeCounts,
 ) (*model.SyncResponse, error) {
-	activity.RecordHeartbeat(ctx,
-		fmt.Sprintf("Flow job %s: Obtaining Avro schema"+
-			" for destination table %s and sync batch ID %d",
-			req.FlowJobName, rawTableName, syncBatchID),
-	)
+	s.connector.logger.Info(
+		fmt.Sprintf("Flow job %s: Obtaining Avro schema for destination table %s and sync batch ID %d",
+			req.FlowJobName, rawTableName, syncBatchID))
 	// You will need to define your Avro schema as a string
 	avroSchema, err := DefineAvroSchema(rawTableName, dstTableMetadata, "", "")
 	if err != nil {

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -190,7 +190,7 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 
 		if p.commitLock == nil {
 			cdclen := cdcRecordsStorage.Len()
-			if cdclen > 0 && uint32(cdclen) >= req.MaxBatchSize {
+			if cdclen >= 0 && uint32(cdclen) >= req.MaxBatchSize {
 				return nil
 			}
 

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -189,7 +189,8 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 		}
 
 		if p.commitLock == nil {
-			if cdcRecordsStorage.Len() >= int(req.MaxBatchSize) {
+			cdclen := cdcRecordsStorage.Len()
+			if cdclen > 0 && uint32(cdclen) >= req.MaxBatchSize {
 				return nil
 			}
 

--- a/flow/connectors/pubsub/pubsub.go
+++ b/flow/connectors/pubsub/pubsub.go
@@ -3,8 +3,11 @@ package connpubsub
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"cloud.google.com/go/pubsub"
 	lua "github.com/yuin/gopher-lua"
@@ -15,6 +18,7 @@ import (
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
+	"github.com/PeerDB-io/peer-flow/peerdbenv"
 	"github.com/PeerDB-io/peer-flow/pua"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
@@ -109,6 +113,55 @@ func lvalueToPubSubMessage(ls *lua.LState, value lua.LValue) (string, *pubsub.Me
 	return topic, msg, nil
 }
 
+type topicCache struct {
+	cache map[string]*pubsub.Topic
+	lock  sync.RWMutex
+}
+
+func (tc *topicCache) forEach(ctx context.Context, f func(topic *pubsub.Topic)) {
+	tc.lock.RLock()
+	defer tc.lock.RUnlock()
+	for _, topicClient := range tc.cache {
+		if ctx.Err() != nil {
+			return
+		}
+		f(topicClient)
+	}
+}
+
+func (tc *topicCache) Flush(ctx context.Context) {
+	tc.forEach(ctx, func(topic *pubsub.Topic) {
+		topic.Flush()
+	})
+}
+
+func (tc *topicCache) Stop(ctx context.Context) {
+	tc.forEach(ctx, func(topic *pubsub.Topic) {
+		topic.Stop()
+	})
+}
+
+func (tc *topicCache) GetOrSet(topic string, f func() (*pubsub.Topic, error)) (*pubsub.Topic, error) {
+	tc.lock.RLock()
+	client, ok := tc.cache[topic]
+	tc.lock.RUnlock()
+	if ok {
+		return client, nil
+	}
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
+	// check cache again, in case of write race
+	if client, ok := tc.cache[topic]; ok {
+		return client, nil
+	}
+	client, err := f()
+	if err != nil {
+		return nil, err
+	}
+	tc.cache[topic] = client
+	return client, nil
+}
+
 func (c *PubSubConnector) SyncRecords(ctx context.Context, req *model.SyncRecordsRequest) (*model.SyncResponse, error) {
 	numRecords := int64(0)
 	tableNameRowsMapping := utils.InitialiseTableRowsMap(req.TableMappings)
@@ -160,60 +213,100 @@ func (c *PubSubConnector) SyncRecords(ctx context.Context, req *model.SyncRecord
 		}
 	}()
 
-	topiccache := make(map[string]*pubsub.Topic)
-	for record := range req.Records.GetRecords() {
-		if err := ctx.Err(); err != nil {
-			return nil, err
+	topiccache := topicCache{cache: make(map[string]*pubsub.Topic)}
+	lastSeenLSN := atomic.Int64{}
+	flushLoopDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(peerdbenv.PeerDBQueueFlushTimeoutSeconds())
+		defer ticker.Stop()
+
+		lastUpdatedOffset := int64(0)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-flushLoopDone:
+				return
+			// flush loop doesn't block processing new messages
+			case <-ticker.C:
+				lastSeen := lastSeenLSN.Load()
+				func() {
+				}()
+				if err := ctx.Err(); err != nil {
+					return
+				}
+				if lastSeen > lastUpdatedOffset {
+					if err := c.SetLastOffset(ctx, req.FlowJobName, lastSeen); err != nil {
+						c.logger.Warn("[kafka] SetLastOffset error", slog.Any("error", err))
+					} else {
+						lastUpdatedOffset = lastSeen
+						c.logger.Info("processBatch", slog.Int64("updated last offset", lastSeen))
+					}
+				}
+			}
 		}
-		ls.Push(fn)
-		ls.Push(pua.LuaRecord.New(ls, record))
-		err := ls.PCall(1, -1, nil)
-		if err != nil {
-			return nil, fmt.Errorf("script failed: %w", err)
-		}
-		args := ls.GetTop()
-		for i := range args {
-			topic, msg, err := lvalueToPubSubMessage(ls, ls.Get(i-args))
+	}()
+
+Loop:
+	for {
+		select {
+		case record, ok := <-req.Records.GetRecords():
+			if !ok {
+				c.logger.Info("flushing batches because no more records")
+				break Loop
+			}
+			ls.Push(fn)
+			ls.Push(pua.LuaRecord.New(ls, record))
+			err := ls.PCall(1, -1, nil)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("script failed: %w", err)
 			}
-			if msg != nil {
-				if topic == "" {
-					topic = record.GetDestinationTableName()
+			args := ls.GetTop()
+			for i := range args {
+				topic, msg, err := lvalueToPubSubMessage(ls, ls.Get(i-args))
+				if err != nil {
+					return nil, err
 				}
-				topicClient, ok := topiccache[topic]
-				if !ok {
-					topicClient = c.client.Topic(topic)
-					exists, err := topicClient.Exists(ctx)
-					if err != nil {
-						return nil, fmt.Errorf("error checking if topic exists: %w", err)
+				if msg != nil {
+					if topic == "" {
+						topic = record.GetDestinationTableName()
 					}
-					if !exists {
-						topicClient, err = c.client.CreateTopic(ctx, topic)
+					topicClient, err := topiccache.GetOrSet(topic, func() (*pubsub.Topic, error) {
+						topicClient := c.client.Topic(topic)
+						exists, err := topicClient.Exists(wgCtx)
 						if err != nil {
-							return nil, fmt.Errorf("error creating topic: %w", err)
+							return nil, fmt.Errorf("error checking if topic exists: %w", err)
 						}
+						if !exists {
+							topicClient, err = c.client.CreateTopic(wgCtx, topic)
+							if err != nil {
+								return nil, fmt.Errorf("error creating topic: %w", err)
+							}
+						}
+						return topicClient, nil
+					})
+					if err != nil {
+						return nil, err
 					}
-					topiccache[topic] = topicClient
+
+					pubresult := topicClient.Publish(ctx, msg)
+					wg.Add(1)
+					publish <- pubresult
+					record.PopulateCountMap(tableNameRowsMapping)
 				}
-
-				pubresult := topicClient.Publish(ctx, msg)
-				wg.Add(1)
-				publish <- pubresult
-				record.PopulateCountMap(tableNameRowsMapping)
 			}
+			ls.SetTop(0)
+			numRecords += 1
+			shared.AtomicInt64Max(&lastSeenLSN, record.GetCheckpointID())
+
+		case <-wgCtx.Done():
+			return nil, wgCtx.Err()
 		}
-		numRecords += 1
-		ls.SetTop(0)
 	}
 
+	close(flushLoopDone)
 	close(publish)
-	for _, topicClient := range topiccache {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		topicClient.Stop()
-	}
+	topiccache.Stop(wgCtx)
 	waitChan := make(chan struct{})
 	go func() {
 		wg.Wait()

--- a/flow/connectors/pubsub/pubsub.go
+++ b/flow/connectors/pubsub/pubsub.go
@@ -232,7 +232,7 @@ func (c *PubSubConnector) SyncRecords(ctx context.Context, req *model.SyncRecord
 				lastSeen := lastSeenLSN.Load()
 				if lastSeen > lastUpdatedOffset {
 					if err := c.SetLastOffset(ctx, req.FlowJobName, lastSeen); err != nil {
-						c.logger.Warn("[kafka] SetLastOffset error", slog.Any("error", err))
+						c.logger.Warn("[pubsub] SetLastOffset error", slog.Any("error", err))
 					} else {
 						lastUpdatedOffset = lastSeen
 						c.logger.Info("processBatch", slog.Int64("updated last offset", lastUpdatedOffset))

--- a/flow/connectors/pubsub/pubsub.go
+++ b/flow/connectors/pubsub/pubsub.go
@@ -230,17 +230,12 @@ func (c *PubSubConnector) SyncRecords(ctx context.Context, req *model.SyncRecord
 			// flush loop doesn't block processing new messages
 			case <-ticker.C:
 				lastSeen := lastSeenLSN.Load()
-				func() {
-				}()
-				if err := ctx.Err(); err != nil {
-					return
-				}
 				if lastSeen > lastUpdatedOffset {
 					if err := c.SetLastOffset(ctx, req.FlowJobName, lastSeen); err != nil {
 						c.logger.Warn("[kafka] SetLastOffset error", slog.Any("error", err))
 					} else {
 						lastUpdatedOffset = lastSeen
-						c.logger.Info("processBatch", slog.Int64("updated last offset", lastSeen))
+						c.logger.Info("processBatch", slog.Int64("updated last offset", lastUpdatedOffset))
 					}
 				}
 			}

--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -266,7 +266,6 @@ func (s *SnowflakeAvroSyncHandler) putFileToStage(ctx context.Context, avroFile 
 		return nil
 	}
 
-	activity.RecordHeartbeat(ctx, "putting file to stage")
 	putCmd := fmt.Sprintf("PUT file://%s @%s", avroFile.FilePath, stage)
 
 	if _, err := s.connector.database.ExecContext(ctx, putCmd); err != nil {

--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -269,11 +269,6 @@ func (s *SnowflakeAvroSyncHandler) putFileToStage(ctx context.Context, avroFile 
 	activity.RecordHeartbeat(ctx, "putting file to stage")
 	putCmd := fmt.Sprintf("PUT file://%s @%s", avroFile.FilePath, stage)
 
-	shutdown := utils.HeartbeatRoutine(ctx, func() string {
-		return "putting file to stage " + stage
-	})
-	defer shutdown()
-
 	if _, err := s.connector.database.ExecContext(ctx, putCmd); err != nil {
 		return fmt.Errorf("failed to put file to stage: %w", err)
 	}

--- a/flow/model/cdc_record_stream.go
+++ b/flow/model/cdc_record_stream.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
+	"github.com/PeerDB-io/peer-flow/shared"
 )
 
 type CDCRecordStream struct {
@@ -32,12 +33,7 @@ func NewCDCRecordStream() *CDCRecordStream {
 }
 
 func (r *CDCRecordStream) UpdateLatestCheckpoint(val int64) {
-	// TODO update with https://github.com/golang/go/issues/63999 once implemented
-	// r.lastCheckpointID.Max(val)
-	oldLast := r.lastCheckpointID.Load()
-	for oldLast < val && !r.lastCheckpointID.CompareAndSwap(oldLast, val) {
-		oldLast = r.lastCheckpointID.Load()
-	}
+	shared.AtomicInt64Max(&r.lastCheckpointID, val)
 }
 
 func (r *CDCRecordStream) GetLastCheckpoint() int64 {

--- a/flow/peerdbenv/config.go
+++ b/flow/peerdbenv/config.go
@@ -34,9 +34,9 @@ func PeerDBCDCChannelBufferSize() int {
 	return getEnvInt("PEERDB_CDC_CHANNEL_BUFFER_SIZE", 1<<18)
 }
 
-// PEERDB_EVENTHUB_FLUSH_TIMEOUT_SECONDS
-func PeerDBEventhubFlushTimeoutSeconds() time.Duration {
-	x := getEnvInt("PEERDB_EVENTHUB_FLUSH_TIMEOUT_SECONDS", 10)
+// PEERDB_QUEUE_FLUSH_TIMEOUT_SECONDS
+func PeerDBQueueFlushTimeoutSeconds() time.Duration {
+	x := getEnvInt("PEERDB_QUEUE_FLUSH_TIMEOUT_SECONDS", 10)
 	return time.Duration(x) * time.Second
 }
 

--- a/flow/shared/atomic.go
+++ b/flow/shared/atomic.go
@@ -1,0 +1,11 @@
+package shared
+
+import "sync/atomic"
+
+// TODO remove after https://github.com/golang/go/issues/63999
+func AtomicInt64Max(a *atomic.Int64, v int64) {
+	oldLast := a.Load()
+	for oldLast < v && !a.CompareAndSwap(oldLast, v) {
+		oldLast = a.Load()
+	}
+}


### PR DESCRIPTION
Renamed from PEERDB_EVENTHUB_FLUSH_TIMEOUT_SECONDS

Efforts made in kafka/pubsub to prevent flush blocking processing more records

Removed unnecessary calls to HeartbeatRoutine, these calls really only belong in flowable.go

Adjusted max batch size logic so that setting max batch size above math.MaxInt32 prevents batches ever finishing

A follow up improvement could be that when `MaxBatchSize == math.MaxUint32` flush will insert a new sync batch record, but normalization will be disabled. But need to consider better how we want to integrate queues in UI when sync batches don't really make sense