### PR TITLE
Eventhub peer refactor

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -397,7 +397,7 @@ func (a *FlowableActivity) SyncFlow(
 	var res *model.SyncResponse
 	errGroup.Go(func() error {
 		syncBatchID, err := dstConn.GetLastSyncBatchID(errCtx, flowName)
-		if err != nil && config.Destination.Type != protos.DBType_EVENTHUB {
+		if err != nil && config.Destination.Type != protos.DBType_EVENTHUBS {
 			return err
 		}
 		syncBatchID += 1

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -50,6 +50,7 @@ func NewEventHubConnector(
 		config:           config,
 		creds:            defaultAzureCreds,
 		hubManager:       hubManager,
+		logger:           logger,
 	}, nil
 }
 
@@ -135,7 +136,7 @@ func (c *EventHubConnector) processBatch(
 				return 0, err
 			}
 
-			ehConfig, ok := c.hubManager.peerConfig.Get(destination.PeerName)
+			ehConfig, ok := c.hubManager.namespaceToEventhubMap.Get(destination.NamespaceName)
 			if !ok {
 				c.logger.Error("failed to get eventhub config", slog.Any("error", err))
 				return 0, err

--- a/flow/connectors/eventhub/hubmanager.go
+++ b/flow/connectors/eventhub/hubmanager.go
@@ -23,7 +23,7 @@ import (
 type EventHubManager struct {
 	creds *azidentity.DefaultAzureCredential
 	// eventhub peer name -> config
-	peerConfig cmap.ConcurrentMap[string, *protos.EventHubConfig]
+	namespaceToEventhubMap cmap.ConcurrentMap[string, *protos.EventHubConfig]
 	// eventhub name -> client
 	hubs sync.Map
 }
@@ -32,22 +32,22 @@ func NewEventHubManager(
 	creds *azidentity.DefaultAzureCredential,
 	groupConfig *protos.EventHubGroupConfig,
 ) *EventHubManager {
-	peerConfig := cmap.New[*protos.EventHubConfig]()
+	namespaceToEventhubMap := cmap.New[*protos.EventHubConfig]()
 
 	for name, config := range groupConfig.Eventhubs {
-		peerConfig.Set(name, config)
+		namespaceToEventhubMap.Set(name, config)
 	}
 
 	return &EventHubManager{
-		creds:      creds,
-		peerConfig: peerConfig,
+		creds:                  creds,
+		namespaceToEventhubMap: namespaceToEventhubMap,
 	}
 }
 
 func (m *EventHubManager) GetOrCreateHubClient(ctx context.Context, name ScopedEventhub) (
 	*azeventhubs.ProducerClient, error,
 ) {
-	ehConfig, ok := m.peerConfig.Get(name.PeerName)
+	ehConfig, ok := m.namespaceToEventhubMap.Get(name.NamespaceName)
 	if !ok {
 		return nil, fmt.Errorf("eventhub '%s' not configured", name.Eventhub)
 	}
@@ -152,9 +152,9 @@ func (m *EventHubManager) CreateEventDataBatch(ctx context.Context, destination 
 
 // EnsureEventHubExists ensures that the eventhub exists.
 func (m *EventHubManager) EnsureEventHubExists(ctx context.Context, name ScopedEventhub) error {
-	cfg, ok := m.peerConfig.Get(name.PeerName)
+	cfg, ok := m.namespaceToEventhubMap.Get(name.NamespaceName)
 	if !ok {
-		return fmt.Errorf("eventhub peer '%s' not configured", name.PeerName)
+		return fmt.Errorf("eventhub namespace '%s' not registered", name.NamespaceName)
 	}
 
 	hubClient, err := m.getEventHubMgmtClient(cfg.SubscriptionId)

--- a/flow/connectors/eventhub/hubmanager.go
+++ b/flow/connectors/eventhub/hubmanager.go
@@ -22,7 +22,7 @@ import (
 
 type EventHubManager struct {
 	creds *azidentity.DefaultAzureCredential
-	// eventhub peer name -> config
+	// eventhub namespace name -> config
 	namespaceToEventhubMap cmap.ConcurrentMap[string, *protos.EventHubConfig]
 	// eventhub name -> client
 	hubs sync.Map

--- a/flow/connectors/eventhub/scoped_eventhub.go
+++ b/flow/connectors/eventhub/scoped_eventhub.go
@@ -5,18 +5,18 @@ import (
 	"strings"
 )
 
-// Scoped eventhub is of the form peer_name.eventhub_name.partition_column.partition_key_value
+// Scoped eventhub is of the form namespace.eventhub_name.partition_column.partition_key_value
 // partition_column is the column in the table that is used to determine
 // the partition key for the eventhub. Partition value is one such value of that column.
 type ScopedEventhub struct {
-	PeerName           string
+	NamespaceName      string
 	Eventhub           string
 	PartitionKeyColumn string
 	PartitionKeyValue  string
 }
 
 func NewScopedEventhub(dstTableName string) (ScopedEventhub, error) {
-	// split by dot, the model is peername.eventhub.partition_key_column
+	// split by dot, the model is namespace.eventhub.partition_key_column
 	parts := strings.Split(dstTableName, ".")
 
 	if len(parts) != 3 {
@@ -27,7 +27,7 @@ func NewScopedEventhub(dstTableName string) (ScopedEventhub, error) {
 	eventhubPart := strings.Trim(parts[1], `"`)
 	partitionPart := strings.Trim(parts[2], `"`)
 	return ScopedEventhub{
-		PeerName:           parts[0],
+		NamespaceName:      parts[0],
 		Eventhub:           eventhubPart,
 		PartitionKeyColumn: partitionPart,
 	}, nil
@@ -38,7 +38,7 @@ func (s *ScopedEventhub) SetPartitionValue(value string) {
 }
 
 func (s ScopedEventhub) Equals(other ScopedEventhub) bool {
-	return s.PeerName == other.PeerName &&
+	return s.NamespaceName == other.NamespaceName &&
 		s.Eventhub == other.Eventhub &&
 		s.PartitionKeyColumn == other.PartitionKeyColumn &&
 		s.PartitionKeyValue == other.PartitionKeyValue
@@ -46,5 +46,5 @@ func (s ScopedEventhub) Equals(other ScopedEventhub) bool {
 
 // ToString returns the string representation of the ScopedEventhub
 func (s ScopedEventhub) ToString() string {
-	return fmt.Sprintf("%s.%s.%s.%s", s.PeerName, s.Eventhub, s.PartitionKeyColumn, s.PartitionKeyValue)
+	return fmt.Sprintf("%s.%s.%s.%s", s.NamespaceName, s.Eventhub, s.PartitionKeyColumn, s.PartitionKeyValue)
 }

--- a/nexus/Cargo.lock
+++ b/nexus/Cargo.lock
@@ -2935,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.41.0"
-source = "git+https://github.com/peerdb-io/sqlparser-rs.git#9fbfb423db7fc0949dea2b1400cb5ef848426409"
+source = "git+https://github.com/peerdb-io/sqlparser-rs.git#178a84c3c48123a2818298d87748033581886eae"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.2.1"
-source = "git+https://github.com/peerdb-io/sqlparser-rs.git#9fbfb423db7fc0949dea2b1400cb5ef848426409"
+source = "git+https://github.com/peerdb-io/sqlparser-rs.git#178a84c3c48123a2818298d87748033581886eae"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -89,13 +89,8 @@ impl<'a> StatementAnalyzer for PeerExistanceAnalyzer<'a> {
 /// PeerDDLAnalyzer is a statement analyzer that checks if the given
 /// statement is a PeerDB DDL statement. If it is, it returns the type of
 /// DDL statement.
+#[derive(Default)]
 pub struct PeerDDLAnalyzer;
-
-impl Default for PeerDDLAnalyzer {
-    fn default() -> Self {
-        Self
-    }
-}
 
 #[derive(Debug, Clone)]
 pub enum PeerDDL {
@@ -493,10 +488,7 @@ impl StatementAnalyzer for PeerCursorAnalyzer {
     }
 }
 
-fn parse_db_options(
-    db_type: DbType,
-    with_options: &[SqlOption],
-) -> anyhow::Result<Option<Config>> {
+fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Result<Option<Config>> {
     let mut opts: HashMap<&str, &str> = HashMap::with_capacity(with_options.len());
     for opt in with_options {
         let val = match opt.value {

--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -278,11 +278,6 @@ impl Catalog {
                         pt::peerdb_peers::MongoConfig::decode(options).with_context(err)?;
                     Config::MongoConfig(mongo_config)
                 }
-                DbType::Eventhub => {
-                    let eventhub_config =
-                        pt::peerdb_peers::EventHubConfig::decode(options).with_context(err)?;
-                    Config::EventhubConfig(eventhub_config)
-                }
                 DbType::Postgres => {
                     let postgres_config =
                         pt::peerdb_peers::PostgresConfig::decode(options).with_context(err)?;
@@ -297,11 +292,6 @@ impl Catalog {
                     let sqlserver_config =
                         pt::peerdb_peers::SqlServerConfig::decode(options).with_context(err)?;
                     Config::SqlserverConfig(sqlserver_config)
-                }
-                DbType::EventhubGroup => {
-                    let eventhub_group_config =
-                        pt::peerdb_peers::EventHubGroupConfig::decode(options).with_context(err)?;
-                    Config::EventhubGroupConfig(eventhub_group_config)
                 }
                 DbType::Eventhubs => {
                     let eventhub_group_config =

--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -303,6 +303,11 @@ impl Catalog {
                         pt::peerdb_peers::EventHubGroupConfig::decode(options).with_context(err)?;
                     Config::EventhubGroupConfig(eventhub_group_config)
                 }
+                DbType::Eventhubs => {
+                    let eventhub_group_config =
+                        pt::peerdb_peers::EventHubGroupConfig::decode(options).with_context(err)?;
+                    Config::EventhubGroupConfig(eventhub_group_config)
+                }
                 DbType::Clickhouse => {
                     let clickhouse_config =
                         pt::peerdb_peers::ClickhouseConfig::decode(options).with_context(err)?;

--- a/nexus/flow-rs/src/grpc.rs
+++ b/nexus/flow-rs/src/grpc.rs
@@ -2,8 +2,7 @@ use catalog::WorkflowDetails;
 use pt::{
     flow_model::{FlowJob, QRepFlowJob},
     peerdb_flow::{QRepWriteMode, QRepWriteType},
-    peerdb_route,
-    tonic,
+    peerdb_route, tonic,
 };
 use serde_json::Value;
 use tonic_health::pb::health_client;

--- a/nexus/parser/src/lib.rs
+++ b/nexus/parser/src/lib.rs
@@ -42,7 +42,7 @@ impl NexusStatement {
         stmt: &Statement,
     ) -> PgWireResult<Self> {
         let ddl = {
-            let pdl: PeerDDLAnalyzer = PeerDDLAnalyzer::new(&peers);
+            let pdl: PeerDDLAnalyzer = PeerDDLAnalyzer;
             pdl.analyze(stmt).map_err(|e| {
                 PgWireError::UserError(Box::new(ErrorInfo::new(
                     "ERROR".to_owned(),

--- a/nexus/pt/src/lib.rs
+++ b/nexus/pt/src/lib.rs
@@ -24,11 +24,10 @@ impl From<PeerType> for DbType {
             PeerType::Mongo => DbType::Mongo,
             PeerType::Snowflake => DbType::Snowflake,
             PeerType::Postgres => DbType::Postgres,
-            PeerType::EventHub => DbType::Eventhub,
             PeerType::S3 => DbType::S3,
             PeerType::SQLServer => DbType::Sqlserver,
-            PeerType::EventHubGroup => DbType::EventhubGroup,
             PeerType::Kafka => DbType::Kafka,
+            PeerType::Eventhubs => DbType::Eventhubs,
         }
     }
 }

--- a/nexus/server/src/main.rs
+++ b/nexus/server/src/main.rs
@@ -147,8 +147,9 @@ impl NexusBackend {
 
     fn is_peer_validity_supported(peer_type: i32) -> bool {
         let unsupported_peer_types = [
-            4, // EVENTHUB
-            7, // EVENTHUB_GROUP
+            4,  // EVENTHUB
+            7,  // EVENTHUB_GROUP
+            11, // EVENTHUBS
         ];
         !unsupported_peer_types.contains(&peer_type)
     }

--- a/nexus/server/src/main.rs
+++ b/nexus/server/src/main.rs
@@ -147,8 +147,6 @@ impl NexusBackend {
 
     fn is_peer_validity_supported(peer_type: i32) -> bool {
         let unsupported_peer_types = [
-            4,  // EVENTHUB
-            7,  // EVENTHUB_GROUP
             11, // EVENTHUBS
         ];
         !unsupported_peer_types.contains(&peer_type)

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -90,7 +90,7 @@ message EventHubConfig {
 }
 
 message EventHubGroupConfig {
-  // event hub peer name to event hub config
+  // event hub namespace name to event hub config
   map<string, EventHubConfig> eventhubs = 1;
   repeated string unnest_columns = 3;
 }
@@ -146,6 +146,7 @@ enum DBType {
   CLICKHOUSE = 8;
   KAFKA = 9;
   PUBSUB = 10;
+  EVENTHUBS = 11;
 }
 
 message Peer {

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -139,10 +139,8 @@ enum DBType {
   SNOWFLAKE = 1;
   MONGO = 2;
   POSTGRES = 3;
-  EVENTHUB = 4;
   S3 = 5;
   SQLSERVER = 6;
-  EVENTHUB_GROUP = 7;
   CLICKHOUSE = 8;
   KAFKA = 9;
   PUBSUB = 10;

--- a/ui/app/api/peers/getTruePeer.ts
+++ b/ui/app/api/peers/getTruePeer.ts
@@ -71,6 +71,10 @@ export const getTruePeer = (peer: CatalogPeer) => {
       config = PubSubConfig.decode(options);
       newPeer.pubsubConfig = config;
       break;
+    case 11:
+      config = EventHubGroupConfig.decode(options);
+      newPeer.eventhubGroupConfig = config;
+      break;
     default:
       return newPeer;
   }

--- a/ui/app/api/peers/info/[peerName]/route.ts
+++ b/ui/app/api/peers/info/[peerName]/route.ts
@@ -19,7 +19,7 @@ export async function GET(
   const bqConfig = peerConfig.bigqueryConfig;
   const s3Config = peerConfig.s3Config;
   const sfConfig = peerConfig.snowflakeConfig;
-  const ehConfig = peerConfig.eventhubConfig;
+  const ehConfig = peerConfig.eventhubGroupConfig;
   const chConfig = peerConfig.clickhouseConfig;
   const kaConfig = peerConfig.kafkaConfig;
   const psConfig = peerConfig.pubsubConfig;
@@ -39,8 +39,11 @@ export async function GET(
     sfConfig.password = '********';
   }
   if (ehConfig) {
-    ehConfig.subscriptionId = '********';
+    for (const key in ehConfig.eventhubs) {
+      ehConfig.eventhubs[key].subscriptionId = '********';
+    }
   }
+
   if (chConfig) {
     chConfig.password = '********';
     chConfig.secretAccessKey = '********';

--- a/ui/app/api/peers/route.ts
+++ b/ui/app/api/peers/route.ts
@@ -10,6 +10,7 @@ import {
   BigqueryConfig,
   ClickhouseConfig,
   DBType,
+  EventHubGroupConfig,
   KafkaConfig,
   Peer,
   PostgresConfig,
@@ -76,6 +77,12 @@ const constructPeer = (
         name,
         type: DBType.PUBSUB,
         pubsubConfig: config as PubSubConfig,
+      };
+    case 'EVENTHUBS':
+      return {
+        name,
+        type: DBType.EVENTHUBS,
+        eventhubGroupConfig: config as EventHubGroupConfig,
       };
     default:
       return;

--- a/ui/app/dto/PeersDTO.ts
+++ b/ui/app/dto/PeersDTO.ts
@@ -1,6 +1,7 @@
 import {
   BigqueryConfig,
   ClickhouseConfig,
+  EventHubGroupConfig,
   KafkaConfig,
   PostgresConfig,
   PubSubConfig,
@@ -47,7 +48,8 @@ export type PeerConfig =
   | ClickhouseConfig
   | S3Config
   | KafkaConfig
-  | PubSubConfig;
+  | PubSubConfig
+  | EventHubGroupConfig;
 export type CatalogPeer = {
   id: number;
   name: string;

--- a/ui/components/DropDialog.tsx
+++ b/ui/components/DropDialog.tsx
@@ -127,12 +127,16 @@ export const DropDialog = ({
     switch (mode) {
       case 'MIRROR':
         objectSpecificDeleteText = `mirror ${(dropArgs as dropMirrorArgs).flowJobName}`;
+        break;
       case 'PEER':
         objectSpecificDeleteText = `peer ${(dropArgs as dropPeerArgs).peerName}`;
+        break;
       case 'ALERT':
         objectSpecificDeleteText = 'this alert';
+        break;
       case 'SCRIPT':
         objectSpecificDeleteText = 'this script';
+        break;
     }
     return (
       deletePart + objectSpecificDeleteText + '? This action cannot be reverted'
@@ -143,12 +147,16 @@ export const DropDialog = ({
     switch (mode) {
       case 'MIRROR':
         handleDropMirror(dropArgs as dropMirrorArgs, setLoading, setMsg);
+        break;
       case 'PEER':
         handleDropPeer(dropArgs as dropPeerArgs);
+        break;
       case 'ALERT':
         handleDeleteAlert(dropArgs as deleteAlertArgs);
+        break;
       case 'SCRIPT':
         handleDeleteScript(dropArgs as deleteScriptArgs);
+        break;
     }
   };
 

--- a/ui/components/PeerComponent.tsx
+++ b/ui/components/PeerComponent.tsx
@@ -29,8 +29,7 @@ export const DBTypeToImageMapping = (peerType: DBType | string) => {
     case 'CLICKHOUSE':
     case DBType.CLICKHOUSE:
       return '/svgs/ch.svg';
-    case DBType.EVENTHUB_GROUP:
-    case DBType.EVENTHUB:
+    case DBType.EVENTHUBS:
       return '/svgs/ms.svg';
     case DBType.KAFKA:
     case 'KAFKA':

--- a/ui/components/PeerTypeComponent.tsx
+++ b/ui/components/PeerTypeComponent.tsx
@@ -10,7 +10,7 @@ export const DBTypeToGoodText = (ptype: DBType) => {
       return 'PostgreSQL';
     case DBType.SNOWFLAKE:
       return 'Snowflake';
-    case DBType.EVENTHUB:
+    case (DBType.EVENTHUB, DBType.EVENTHUBS):
       return 'Event Hubs';
     case DBType.EVENTHUB_GROUP:
       return 'Event Hubs (Group)';
@@ -28,7 +28,7 @@ export const DBTypeToGoodText = (ptype: DBType) => {
       return 'Kafka';
     case DBType.PUBSUB:
       return 'PubSub';
-    case DBType.UNRECOGNIZED:
+    default:
       return 'Unrecognised';
   }
 };

--- a/ui/components/PeerTypeComponent.tsx
+++ b/ui/components/PeerTypeComponent.tsx
@@ -10,10 +10,8 @@ export const DBTypeToGoodText = (ptype: DBType) => {
       return 'PostgreSQL';
     case DBType.SNOWFLAKE:
       return 'Snowflake';
-    case (DBType.EVENTHUB, DBType.EVENTHUBS):
+    case DBType.EVENTHUBS:
       return 'Event Hubs';
-    case DBType.EVENTHUB_GROUP:
-      return 'Event Hubs (Group)';
     case DBType.BIGQUERY:
       return 'BigQuery';
     case DBType.S3:


### PR DESCRIPTION
## BREAKING CHANGE FOR EVENTHUBS ❗❗
### Eventhub Peer Redesign
This PR performs a redesign of our Eventhubs peer architecture on the core engine side. Create Peer UI is going to be a follow up PR to this.

`Eventhub` and `Eventhub Group` peers are **removed.** However `EventhubConfig` and `EventhubGroupConfig` are still in use.
A new peer - `Eventhubs` is the only peer related to this queue.
#### Current structure of Eventhubs peer
The `Eventhubs` peer is an extension of the earlier `EventhubGroup` peer, with it now having a list of `EventhubConfig`s.

You can create an `Eventhubs` peer via the SQL Layer as follows:
```sql
CREATE PEER eventhubs_peer_x FROM EVENTHUBS WITH (
eventhubs = '[{"subscription_id":"my-sub-id",
"resource_group":"myresource",
"namespace":"mynamespace-1",
"location":"eastus",
"partition_count":5,
"message_retention_in_days":2
},
{"subscription_id":"my-sub-id",
"resource_group":"myresource",
"namespace":"mynamespace-2",
"location":"eastus",
"partition_count":3,
"message_retention_in_days":1
}
]',
unnest_columns = [] -- can omit this field too
);
```

The UI has had changes made to it to reflect the above redesign, with no displays showing the earlier two peers.

<img width="1185" alt="Screenshot 2024-04-02 at 6 59 14 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/36d9dbfc-b271-4340-87c0-3a31a03abccf">

#### Functional testing of this PR
- Create peer command for `Eventhubs` tested via SQL Layer
- Create mirror with the redesigned peer tested via UI
