### PR TITLE
UI: Create Eventhub Peer and Eventhub Mirror

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -583,6 +583,13 @@ func (h *FlowRequestHandler) CreatePeer(
 		}
 		psConfig := psConfigObject.PubsubConfig
 		encodedConfig, encodingErr = proto.Marshal(psConfig)
+	case protos.DBType_EVENTHUBS:
+		ehConfigObject, ok := config.(*protos.Peer_EventhubGroupConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		ehConfig := ehConfigObject.EventhubGroupConfig
+		encodedConfig, encodingErr = proto.Marshal(ehConfig)
 	default:
 		return wrongConfigResponse, nil
 	}

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -68,7 +68,7 @@ func (c *EventHubConnector) Close() error {
 	return nil
 }
 
-func (c *EventHubConnector) ConnectionActive(_ context.Context) error {
+func (c *EventHubConnector) ConnectionActive(ctx context.Context) error {
 	return nil
 }
 

--- a/ui/app/api/peers/route.ts
+++ b/ui/app/api/peers/route.ts
@@ -120,7 +120,6 @@ export async function POST(request: Request) {
     }
   } else if (mode === 'create') {
     const req: CreatePeerRequest = { peer };
-    console.log('/peer/create req:', req);
     try {
       const createStatus: CreatePeerResponse = await fetch(
         `${flowServiceAddr}/v1/peers/create`,

--- a/ui/app/dto/PeersDTO.ts
+++ b/ui/app/dto/PeersDTO.ts
@@ -1,6 +1,7 @@
 import {
   BigqueryConfig,
   ClickhouseConfig,
+  EventHubConfig,
   EventHubGroupConfig,
   KafkaConfig,
   PostgresConfig,
@@ -49,6 +50,7 @@ export type PeerConfig =
   | S3Config
   | KafkaConfig
   | PubSubConfig
+  | EventHubConfig
   | EventHubGroupConfig;
 export type CatalogPeer = {
   id: number;

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -60,7 +60,14 @@ export default function CDCConfigForm({
       (label === 'replication slot name' &&
         mirrorConfig.doInitialSnapshot === true) ||
       (label.includes('staging path') &&
-        defaultSyncMode(mirrorConfig.destination?.type) !== 'AVRO')
+        defaultSyncMode(mirrorConfig.destination?.type) !== 'AVRO') ||
+      ((mirrorConfig.destination?.type === DBType.EVENTHUBS ||
+        mirrorConfig.destination?.type === DBType.KAFKA ||
+        mirrorConfig.destination?.type === DBType.PUBSUB) &&
+        (label.includes('initial copy') ||
+          label.includes('initial load') ||
+          label.includes('soft delete') ||
+          label.includes('snapshot')))
     ) {
       return false;
     }
@@ -117,11 +124,13 @@ export default function CDCConfigForm({
         {show &&
           advancedSettings.map((setting, id) => {
             return (
-              <CDCField
-                key={setting.label}
-                handleChange={handleChange}
-                setting={setting}
-              />
+              paramDisplayCondition(setting) && (
+                <CDCField
+                  key={setting.label}
+                  handleChange={handleChange}
+                  setting={setting}
+                />
+              )
             );
           })}
 

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -54,16 +54,19 @@ export default function CDCConfigForm({
   }, [settings]);
 
   const paramDisplayCondition = (setting: MirrorSetting) => {
+    const isQueueDestination =
+      mirrorConfig.destination?.type === DBType.EVENTHUBS ||
+      mirrorConfig.destination?.type === DBType.KAFKA ||
+      mirrorConfig.destination?.type === DBType.PUBSUB;
     const label = setting.label.toLowerCase();
     if (
       (label.includes('snapshot') && mirrorConfig.doInitialSnapshot !== true) ||
       (label === 'replication slot name' &&
-        mirrorConfig.doInitialSnapshot === true) ||
+        mirrorConfig.doInitialSnapshot === true &&
+        !isQueueDestination) ||
       (label.includes('staging path') &&
         defaultSyncMode(mirrorConfig.destination?.type) !== 'AVRO') ||
-      ((mirrorConfig.destination?.type === DBType.EVENTHUBS ||
-        mirrorConfig.destination?.type === DBType.KAFKA ||
-        mirrorConfig.destination?.type === DBType.PUBSUB) &&
+      (isQueueDestination &&
         (label.includes('initial copy') ||
           label.includes('initial load') ||
           label.includes('soft delete') ||

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/lib/Button';
 import { Icon } from '@/lib/Icon';
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { CDCConfig, MirrorSetter, TableMapRow } from '../../../dto/MirrorsDTO';
-import { fetchPublications } from '../handlers';
+import { IsQueuePeer, fetchPublications } from '../handlers';
 import { MirrorSetting } from '../helpers/common';
 import CDCField from './fields';
 import TableMapping from './tablemapping';
@@ -54,19 +54,16 @@ export default function CDCConfigForm({
   }, [settings]);
 
   const paramDisplayCondition = (setting: MirrorSetting) => {
-    const isQueueDestination =
-      mirrorConfig.destination?.type === DBType.EVENTHUBS ||
-      mirrorConfig.destination?.type === DBType.KAFKA ||
-      mirrorConfig.destination?.type === DBType.PUBSUB;
     const label = setting.label.toLowerCase();
+    const isQueue = IsQueuePeer(mirrorConfig.destination?.type);
     if (
       (label.includes('snapshot') && mirrorConfig.doInitialSnapshot !== true) ||
       (label === 'replication slot name' &&
         mirrorConfig.doInitialSnapshot === true &&
-        !isQueueDestination) ||
+        !isQueue) ||
       (label.includes('staging path') &&
         defaultSyncMode(mirrorConfig.destination?.type) !== 'AVRO') ||
-      (isQueueDestination &&
+      (isQueue &&
         (label.includes('initial copy') ||
           label.includes('initial load') ||
           label.includes('soft delete') ||

--- a/ui/app/mirrors/create/cdc/tablemapping.tsx
+++ b/ui/app/mirrors/create/cdc/tablemapping.tsx
@@ -2,6 +2,7 @@
 import { DBType } from '@/grpc_generated/peers';
 import { Label } from '@/lib/Label';
 import { SearchField } from '@/lib/SearchField';
+import { Callout } from '@tremor/react';
 import Link from 'next/link';
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { BarLoader } from 'react-spinners/';
@@ -60,6 +61,22 @@ const TableMapping = ({
         </Link>{' '}
         have been granted for your tables.
       </Label>
+      {peerType === DBType.EVENTHUBS && (
+        <Callout
+          title='Note on Eventhubs targets'
+          color='grey'
+          style={{ fontSize: 14 }}
+        >
+          Eventhubs targets are of the form{' '}
+          <b>namespace.eventhub_name.partition_column.</b>
+          <br></br>
+          Namespaces are specified in the Eventhub peer. PeerDB will create the
+          eventhub if needed with the name you specify in the provided namespace
+          for each source table <br></br>
+          Messages are sent to partitions based on the values of the partition
+          column.
+        </Callout>
+      )}
       <div
         style={{
           display: 'flex',

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -22,6 +22,17 @@ import {
   tableMappingSchema,
 } from './schema';
 
+export const IsQueuePeer = (peerType?: DBType): boolean => {
+  if (!peerType) {
+    return false;
+  }
+  return (
+    peerType === DBType.KAFKA ||
+    peerType === DBType.PUBSUB ||
+    peerType === DBType.EVENTHUBS
+  );
+};
+
 export const handlePeer = (
   peer: Peer | null,
   peerEnd: 'src' | 'dst',
@@ -71,7 +82,7 @@ const CDCCheck = (
     config.replicationSlotName = '';
   }
 
-  if (config.destination?.type == DBType.EVENTHUBS) {
+  if (IsQueuePeer(config.destination?.type)) {
     config.doInitialSnapshot = false;
     config.softDelete = false;
   }

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -71,6 +71,11 @@ const CDCCheck = (
     config.replicationSlotName = '';
   }
 
+  if (config.destination?.type == DBType.EVENTHUBS) {
+    config.doInitialSnapshot = false;
+    config.softDelete = false;
+  }
+
   return '';
 };
 
@@ -261,6 +266,14 @@ const getDefaultDestinationTable = (
   ) {
     return `${schemaName}_${tableName}`;
   }
+
+  if (
+    peerType.toString() == 'EVENTHUBS' ||
+    dBTypeToJSON(peerType) == 'EVENTHUBS'
+  ) {
+    return `<namespace>.${schemaName}_${tableName}.<partition_column>`;
+  }
+
   return `${schemaName}.${tableName}`;
 };
 

--- a/ui/app/peers/create/[peerType]/handlers.ts
+++ b/ui/app/peers/create/[peerType]/handlers.ts
@@ -8,6 +8,7 @@ import { Dispatch, SetStateAction } from 'react';
 import {
   bqSchema,
   chSchema,
+  ehGroupSchema,
   kaSchema,
   peerNameSchema,
   pgSchema,
@@ -66,6 +67,11 @@ const validateFields = (
     case 'PUBSUB':
       const psConfig = psSchema.safeParse(config);
       if (!psConfig.success) validationErr = psConfig.error.issues[0].message;
+      break;
+    case 'EVENTHUBS':
+      const ehGroupConfig = ehGroupSchema.safeParse(config);
+      if (!ehGroupConfig.success)
+        validationErr = ehGroupConfig.error.issues[0].message;
       break;
     default:
       validationErr = 'Unsupported peer type ' + type;

--- a/ui/app/peers/create/[peerType]/helpers/common.ts
+++ b/ui/app/peers/create/[peerType]/helpers/common.ts
@@ -1,6 +1,7 @@
 import { PeerConfig, PeerSetter } from '@/app/dto/PeersDTO';
 import { blankBigquerySetting } from './bq';
 import { blankClickhouseSetting } from './ch';
+import { blankEventHubGroupSetting } from './eh';
 import { blankKafkaSetting } from './ka';
 import { blankPostgresSetting } from './pg';
 import { blankPubSubSetting } from './ps';
@@ -35,6 +36,8 @@ export const getBlankSetting = (dbType: string): PeerConfig => {
       return blankKafkaSetting;
     case 'S3':
       return blankS3Setting;
+    case 'EVENTHUBS':
+      return blankEventHubGroupSetting;
     default:
       return blankPostgresSetting;
   }

--- a/ui/app/peers/create/[peerType]/helpers/eh.ts
+++ b/ui/app/peers/create/[peerType]/helpers/eh.ts
@@ -1,0 +1,77 @@
+import { EventHubConfig, EventHubGroupConfig } from '@/grpc_generated/peers';
+import { PeerSetting } from './common';
+
+export const ehSetting: PeerSetting[] = [
+  {
+    label: 'Namespace',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, namespace: value as string })),
+    tips: 'An Event Hubs namespace is a management container for event hubs (or topics)',
+    helpfulLink:
+      'https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-features#namespace',
+  },
+  {
+    label: 'Subscription ID',
+    type: 'password',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, subscriptionId: value as string })),
+    tips: 'Subscription ID uniquely identify a Microsoft Azure subscription.',
+  },
+  {
+    label: 'Resource Group',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, resourceGroup: value as string })),
+    tips: 'A resource group is a logical collection of Azure resources.',
+    helpfulLink:
+      'https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-create#create-a-resource-group',
+  },
+  {
+    label: 'Location',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, location: value as string })),
+    tips: 'The location of the resource group',
+    helpfulLink:
+      'https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zones',
+  },
+  {
+    label: 'Partition Count',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({
+        ...curr,
+        partitionCount: parseInt(value as string, 10) ?? 1,
+      })),
+    tips: 'Event Hubs organizes sequences of events sent to an event hub into one or more partitions',
+    helpfulLink:
+      'https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-features#partitions',
+    default: 1,
+    type: 'number',
+  },
+  {
+    label: 'Message Retention (Days)',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({
+        ...curr,
+        messageRetentionInDays: parseInt(value as string, 10) ?? 1,
+      })),
+    placeholder: 'Number of days to retain messages',
+    tips: 'The retention period for events in the event hub',
+    helpfulLink:
+      'https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-features#event-retention',
+    default: 1,
+    type: 'number',
+  },
+];
+
+export const blankEventhubSetting: EventHubConfig = {
+  namespace: '',
+  resourceGroup: '',
+  location: '',
+  subscriptionId: '',
+  partitionCount: 1,
+  messageRetentionInDays: 1,
+};
+
+export const blankEventHubGroupSetting: EventHubGroupConfig = {
+  eventhubs: {},
+  unnestColumns: [],
+};

--- a/ui/app/peers/create/[peerType]/page.tsx
+++ b/ui/app/peers/create/[peerType]/page.tsx
@@ -11,6 +11,8 @@ import SnowflakeForm from '@/components/PeerForms/SnowflakeForm';
 
 import { notifyErr } from '@/app/utils/notify';
 import TitleCase from '@/app/utils/titlecase';
+import EventhubsForm from '@/components/PeerForms/Eventhubs/EventhubGroupConfig';
+import { EventHubGroupConfig } from '@/grpc_generated/peers';
 import { Button } from '@/lib/Button';
 import { ButtonGroup } from '@/lib/ButtonGroup';
 import { Label } from '@/lib/Label';
@@ -75,6 +77,13 @@ export default function CreateConfig({
         return <KafkaForm setter={setConfig} />;
       case 'PUBSUB':
         return <PubSubForm setter={setConfig} />;
+      case 'EVENTHUBS':
+        return (
+          <EventhubsForm
+            groupConfig={config as EventHubGroupConfig}
+            setter={setConfig}
+          />
+        );
       default:
         return <></>;
     }
@@ -139,7 +148,7 @@ export default function CreateConfig({
             Back
           </Button>
           <Button
-            style={{ backgroundColor: 'gold' }}
+            style={{ backgroundColor: 'wheat' }}
             onClick={() =>
               handleValidate(getDBType(), config, notifyErr, setLoading, name)
             }
@@ -159,7 +168,7 @@ export default function CreateConfig({
               )
             }
           >
-            Create
+            Create peer
           </Button>
         </ButtonGroup>
         <Panel>

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -1,3 +1,4 @@
+import { ehSchema } from '@/components/PeerForms/Eventhubs/schema';
 import * as z from 'zod';
 
 export const peerNameSchema = z
@@ -419,5 +420,12 @@ export const psSchema = z.object({
       })
       .url({ message: 'Invalid client cert URL' })
       .min(1, { message: 'Client Cert URL must be non-empty' }),
+  }),
+});
+
+export const ehGroupSchema = z.object({
+  // string to ehSchema map
+  eventhubs: z.record(ehSchema).refine((obj) => Object.keys(obj).length > 0, {
+    message: 'At least 1 Event Hub is required',
   }),
 });

--- a/ui/components/PeerComponent.tsx
+++ b/ui/components/PeerComponent.tsx
@@ -37,6 +37,8 @@ export const DBTypeToImageMapping = (peerType: DBType | string) => {
     case DBType.PUBSUB:
     case 'PUBSUB':
       return '/svgs/pubsub.svg';
+    case 'EVENTHUBS':
+      return '/svgs/ms.svg';
     default:
       return '/svgs/pg.svg';
   }

--- a/ui/components/PeerForms/Eventhubs/EventhubConfig.tsx
+++ b/ui/components/PeerForms/Eventhubs/EventhubConfig.tsx
@@ -1,0 +1,188 @@
+'use client';
+import { PeerSetter } from '@/app/dto/PeersDTO';
+import { ehSetting } from '@/app/peers/create/[peerType]/helpers/eh';
+import { notifyErr } from '@/app/utils/notify';
+import { InfoPopover } from '@/components/InfoPopover';
+import { EventHubConfig } from '@/grpc_generated/peers';
+import { Button } from '@/lib/Button';
+import { Icon } from '@/lib/Icon';
+import { Label } from '@/lib/Label';
+import { RowWithTextField } from '@/lib/Layout';
+import { TextField } from '@/lib/TextField';
+import { Tooltip } from '@/lib/Tooltip';
+import { Dispatch, SetStateAction, useState } from 'react';
+import { ehSchema } from './schema';
+
+interface EventhubConfigProps {
+  eventhubConfig: EventHubConfig & {
+    id: number;
+  };
+  updateForms: Dispatch<
+    SetStateAction<
+      (EventHubConfig & {
+        id: number;
+      })[]
+    >
+  >;
+  onDelete: () => void;
+}
+
+const EventhubsConfig = ({
+  eventhubConfig,
+  updateForms,
+  onDelete,
+}: EventhubConfigProps) => {
+  const [ehConfig, setEhConfig] = useState<
+    EventHubConfig & {
+      id: number;
+    }
+  >(eventhubConfig);
+  const [collapsed, setCollapsed] = useState<boolean>(false);
+
+  const handleSave = () => {
+    const ehConfigValidity = ehSchema.safeParse(ehConfig);
+    if (ehConfigValidity.success) {
+      updateForms((prev) =>
+        prev.map((config) => {
+          if (config.id === ehConfig.id) {
+            return ehConfig;
+          }
+          return config;
+        })
+      );
+      setCollapsed(true);
+    } else {
+      notifyErr(ehConfigValidity.error.issues[0].message);
+    }
+  };
+
+  const getFieldValue = (label: string) => {
+    if (label === 'Namespace') {
+      return ehConfig.namespace;
+    }
+    if (label === 'Subscription ID') {
+      return ehConfig.subscriptionId;
+    }
+    if (label === 'Resource Group') {
+      return ehConfig.resourceGroup;
+    }
+    if (label === 'Location') {
+      return ehConfig.location;
+    }
+    if (label === 'Partition Count') {
+      return ehConfig.partitionCount;
+    }
+    if (label === 'Message Retention (Days)') {
+      return ehConfig.messageRetentionInDays;
+    }
+    return '';
+  };
+
+  return (
+    <div
+      style={{
+        padding: !collapsed ? '1rem' : '0.5rem',
+        border: '1px solid rgba(0,0,0,0.1)',
+        borderRadius: '1rem',
+        display: collapsed ? 'flex' : 'block',
+        justifyContent: collapsed ? 'space-between' : 'auto',
+        width: 'fit-content',
+      }}
+    >
+      {collapsed ? (
+        <Label as='label' style={{ fontSize: 14 }}>
+          {ehConfig.namespace || 'Yet to be configured'}
+        </Label>
+      ) : (
+        ehSetting.map((setting, index) => {
+          return (
+            <RowWithTextField
+              key={index}
+              label={
+                <Label as='label' style={{ fontSize: 14 }}>
+                  {setting.label}{' '}
+                  {!setting.optional && (
+                    <Tooltip
+                      style={{ width: '100%' }}
+                      content={'This is a required field.'}
+                    >
+                      <Label colorName='lowContrast' colorSet='destructive'>
+                        *
+                      </Label>
+                    </Tooltip>
+                  )}
+                </Label>
+              }
+              action={
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                  }}
+                >
+                  <TextField
+                    variant='simple'
+                    style={
+                      setting.type === 'file'
+                        ? { border: 'none', height: 'auto' }
+                        : { border: 'auto' }
+                    }
+                    type={setting.type}
+                    value={getFieldValue(setting.label)}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      setting.stateHandler(
+                        e.target.value,
+                        setEhConfig as PeerSetter
+                      )
+                    }
+                  />
+                  {setting.tips && (
+                    <InfoPopover
+                      tips={setting.tips}
+                      link={setting.helpfulLink}
+                    />
+                  )}
+                </div>
+              }
+            />
+          );
+        })
+      )}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: collapsed ? 'flex-end' : 'space-between',
+          marginTop: !collapsed ? '1rem' : 'auto',
+        }}
+      >
+        {!collapsed && (
+          <Button variant='normalSolid' onClick={handleSave}>
+            Save
+          </Button>
+        )}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            columnGap: '0.5rem',
+          }}
+        >
+          <Button
+            variant='normal'
+            aria-label='icon-button'
+            onClick={() => setCollapsed((prev) => !prev)}
+          >
+            <Icon name={collapsed ? 'arrow_drop_down' : 'arrow_drop_up'} />
+          </Button>
+          <Button variant='drop' aria-label='icon-button' onClick={onDelete}>
+            <Icon name='delete' />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EventhubsConfig;

--- a/ui/components/PeerForms/Eventhubs/EventhubGroupConfig.tsx
+++ b/ui/components/PeerForms/Eventhubs/EventhubGroupConfig.tsx
@@ -1,0 +1,84 @@
+'use client';
+import { PeerSetter } from '@/app/dto/PeersDTO';
+import { blankEventhubSetting } from '@/app/peers/create/[peerType]/helpers/eh';
+import { EventHubConfig, EventHubGroupConfig } from '@/grpc_generated/peers';
+import { Button } from '@/lib/Button';
+import { Icon } from '@/lib/Icon';
+import { Label } from '@/lib/Label';
+import { useEffect, useState } from 'react';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import EventhubsConfig from './EventhubConfig';
+interface EventhubsProps {
+  groupConfig: EventHubGroupConfig;
+  setter: PeerSetter;
+}
+
+const EventhubsForm = ({ groupConfig, setter }: EventhubsProps) => {
+  const [currConfigForms, setCurrConfigForms] = useState<
+    (EventHubConfig & { id: number })[]
+  >([]);
+
+  const handleAddNamespace = () => {
+    setCurrConfigForms([
+      ...currConfigForms,
+      { ...blankEventhubSetting, id: currConfigForms.length },
+    ]);
+  };
+  const handleDeleteNamespace = (id: number) => {
+    setCurrConfigForms((prev) => prev.filter((_, index) => index !== id));
+  };
+
+  useEffect(() => {
+    // construct a map of namespace to eventhub config
+    const eventhubs = currConfigForms.reduce((acc, curr) => {
+      return {
+        ...acc,
+        [curr.namespace]: curr,
+      };
+    }, {});
+    setter((prev) => {
+      return {
+        ...prev,
+        eventhubs,
+      };
+    });
+  }, [currConfigForms, setter]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: '1rem',
+        marginBottom: '1rem',
+      }}
+    >
+      <Label>
+        The Eventhubs peer requires namespaces to be specified. <br></br>
+        Below you can add namespaces and their details. Save to persist the
+        changes.
+      </Label>
+      {currConfigForms.map((ehConfig) => {
+        return (
+          <EventhubsConfig
+            key={ehConfig.id}
+            eventhubConfig={ehConfig}
+            updateForms={setCurrConfigForms}
+            onDelete={() => handleDeleteNamespace(ehConfig.id)}
+          />
+        );
+      })}
+      <Button
+        variant='normalSolid'
+        onClick={handleAddNamespace}
+        style={{ width: 'fit-content' }}
+      >
+        <Icon name='add' /> Namespace
+      </Button>
+      <ToastContainer containerId={'for eventhubs'} />
+    </div>
+  );
+};
+
+export default EventhubsForm;

--- a/ui/components/PeerForms/Eventhubs/schema.ts
+++ b/ui/components/PeerForms/Eventhubs/schema.ts
@@ -1,0 +1,50 @@
+import * as z from 'zod';
+
+export const ehSchema = z.object({
+  namespace: z
+    .string({
+      required_error: 'Namespace is required',
+      invalid_type_error: 'Namespace must be a string',
+    })
+    .min(1, { message: 'Namespace cannot be empty' })
+    .max(255, { message: 'Namespace cannot be longer than 255 characters' }),
+  subscriptionId: z
+    .string({
+      required_error: 'Subscription ID is required',
+      invalid_type_error: 'Subscription ID must be a string',
+    })
+    .min(1, { message: 'Subscription ID cannot be empty' })
+    .max(255, {
+      message: 'Subscription ID cannot be longer than 255 characters',
+    }),
+  resourceGroup: z
+    .string({
+      required_error: 'Resource Group is required',
+      invalid_type_error: 'Resource Group must be a string',
+    })
+    .min(1, { message: 'Resource Group cannot be empty' })
+    .max(255, {
+      message: 'Resource Group cannot be longer than 255 characters',
+    }),
+  location: z
+    .string({
+      required_error: 'Location is required',
+      invalid_type_error: 'Location must be a string',
+    })
+    .min(1, { message: 'Location cannot be empty' })
+    .max(255, { message: 'Location cannot be longer than 255 characters' }),
+  partitionCount: z
+    .number({
+      required_error: 'Partition Count is required',
+      invalid_type_error: 'Partition Count must be a number',
+    })
+    .int({ message: 'Partition Count must be an integer' })
+    .min(1, { message: 'Partition count must be at least 1' }),
+  messageRetentionInDays: z
+    .number({
+      required_error: 'Message Retention (Days) is required',
+      invalid_type_error: 'Message Retention (Days) must be a number',
+    })
+    .int({ message: 'Message Retention (Days) must be an integer' })
+    .min(1, { message: 'Message retention (days) must be at least 1' }),
+});

--- a/ui/components/PeerForms/PubSubConfig.tsx
+++ b/ui/components/PeerForms/PubSubConfig.tsx
@@ -52,16 +52,17 @@ export default function PubSubForm(props: PSProps) {
   return (
     <>
       <Label>
-        A service account JSON file in PubSub is a file that contains
-        information which allows PeerDB to securely access PubSub resources.
+        A service account JSON file allows PeerDB to securely access PubSub
+        resources.
       </Label>
-      <Link
-        style={{ color: 'teal', textDecoration: 'underline' }}
+      <Label
+        as={Link}
+        style={{ color: 'teal', textDecoration: 'underline', display: 'block' }}
         href='https://cloud.google.com/bigquery/docs/authentication/service-account-file'
         target='_blank'
       >
         Creating a service account file
-      </Link>
+      </Label>
       <RowWithTextField
         label={
           <Label>

--- a/ui/components/SelectSource.tsx
+++ b/ui/components/SelectSource.tsx
@@ -36,6 +36,7 @@ export default function SelectSource({
           value === 'S3' ||
           value === 'CLICKHOUSE' ||
           value === 'KAFKA' ||
+          value === 'EVENTHUBS' ||
           value === 'PUBSUB')
     )
     .map((value) => ({ label: value, value }));


### PR DESCRIPTION
This PR adds Eventhubs as a peer in UI.
- Includes form validation
- Helper text
<img width="844" alt="Screenshot 2024-04-04 at 2 14 13 AM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/2f71db3b-6577-40f6-be50-ec18c480affb">



It also adapts the CDC create mirror page for Eventhubs.
- Info on target table semantics for Eventhub
- Automatically turns off and does not display initial load related and soft delete settings
<img width="1266" alt="Screenshot 2024-04-04 at 2 27 27 AM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/7a35e1ea-eae4-4f81-99cc-ac316014fe80">

