### PR TITLE
QRep: Adjust start value for TID watermark column

### DIFF
--- a/flow/connectors/utils/partition/partition.go
+++ b/flow/connectors/utils/partition/partition.go
@@ -51,6 +51,15 @@ func adjustStartValue(prevEnd interface{}, start interface{}) interface{} {
 	case time.Time:
 		// postgres timestamp has microsecond precision
 		return prevEnd.(time.Time).Add(1 * time.Microsecond)
+	case pgtype.TID:
+		pe := prevEnd.(pgtype.TID)
+		if pe.OffsetNumber < 0xFFFF {
+			pe.OffsetNumber++
+		} else {
+			pe.BlockNumber++
+			pe.OffsetNumber = 0
+		}
+		return pe
 	default:
 		return start
 	}

--- a/flow/connectors/utils/partition/partition.go
+++ b/flow/connectors/utils/partition/partition.go
@@ -60,6 +60,8 @@ func adjustStartValue(prevEnd interface{}, start interface{}) interface{} {
 			pe.OffsetNumber = 0
 		}
 		return pe
+	case uint32:
+		return prevEnd.(uint32) + 1
 	default:
 		return start
 	}


### PR DESCRIPTION
This issue was noticed with tables where CTIDs are _not_ unique ex: partitioned tables
We adjust(increment) the start values of partitions after the first partition. This is to avoid overlapping partitions.

This was not done for TID columns because the assumption was that they would always be unique.
As a result, this could lead to duplication of rows for initial load and XMIN where CTIDs are the watermark column.