### PR TITLE
Add scripting to eventhubs

### DIFF
--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	azeventhubs "github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
+	"github.com/yuin/gopher-lua"
 	"go.temporal.io/sdk/log"
 
 	metadataStore "github.com/PeerDB-io/peer-flow/connectors/external_metadata"
@@ -16,6 +19,8 @@ import (
 	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
+	"github.com/PeerDB-io/peer-flow/pua"
+	"github.com/PeerDB-io/peer-flow/shared"
 )
 
 type EventHubConnector struct {
@@ -80,11 +85,104 @@ func (c *EventHubConnector) SetupMetadataTables(_ context.Context) error {
 	return nil
 }
 
+func lvalueToEventData(ls *lua.LState, value lua.LValue) (ScopedEventhubData, error) {
+	var scoped ScopedEventhubData
+	switch v := value.(type) {
+	case lua.LString:
+		scoped.Data = &azeventhubs.EventData{
+			Body: shared.UnsafeFastStringToReadOnlyBytes(string(v)),
+		}
+	case *lua.LTable:
+		value, err := utils.LVAsReadOnlyBytes(ls, ls.GetField(v, "value"))
+		if err != nil {
+			return scoped, fmt.Errorf("invalid value, %w", err)
+		}
+		destination, err := utils.LVAsStringOrNil(ls, ls.GetField(v, "destination"))
+		if err != nil {
+			return scoped, fmt.Errorf("invalid destination, %w", err)
+		}
+		if destination != "" {
+			scoped.Hub, err = NewScopedEventhub(destination)
+			if err != nil {
+				return scoped, fmt.Errorf("invalid topic, %w", err)
+			}
+		}
+		namespace, err := utils.LVAsStringOrNil(ls, ls.GetField(v, "namespace"))
+		if err != nil {
+			return scoped, fmt.Errorf("invalid namespace, %w", err)
+		}
+		if namespace != "" {
+			scoped.Hub.NamespaceName = namespace
+		}
+		partCol, err := utils.LVAsStringOrNil(ls, ls.GetField(v, "partitionColumn"))
+		if err != nil {
+			return scoped, fmt.Errorf("invalid partitionColumn, %w", err)
+		}
+		if partCol != "" {
+			scoped.Hub.PartitionKeyColumn = partCol
+		}
+		key, err := utils.LVAsStringOrNil(ls, ls.GetField(v, "key"))
+		if err != nil {
+			return scoped, fmt.Errorf("invalid key, %w", err)
+		}
+		if key != "" {
+			scoped.Hub.PartitionKeyValue = key
+		}
+		hub, err := utils.LVAsStringOrNil(ls, ls.GetField(v, "hub"))
+		if err != nil {
+			return scoped, fmt.Errorf("invalid hub, %w", err)
+		}
+		if hub != "" {
+			scoped.Hub.Eventhub = hub
+		}
+		contentType, err := utils.LVAsStringOrNil(ls, ls.GetField(v, "contentType"))
+		if err != nil {
+			return scoped, fmt.Errorf("invalid contentType, %w", err)
+		}
+		contentTypePtr := &contentType
+		if contentType == "" {
+			contentTypePtr = nil
+		}
+		messageId, err := utils.LVAsStringOrNil(ls, ls.GetField(v, "messageId"))
+		if err != nil {
+			return scoped, fmt.Errorf("invalid messageId, %w", err)
+		}
+		messageIdPtr := &messageId
+		if messageId == "" {
+			messageIdPtr = nil
+		}
+		scoped.Data = &azeventhubs.EventData{
+			Body:        value,
+			ContentType: contentTypePtr,
+			MessageID:   messageIdPtr,
+		}
+		lheaders := ls.GetField(v, "headers")
+		if headers, ok := lheaders.(*lua.LTable); ok {
+			scoped.Data.Properties = make(map[string]any)
+			headers.ForEach(func(k, v lua.LValue) {
+				scoped.Data.Properties[k.String()] = v
+			})
+		} else if lua.LVAsBool(lheaders) {
+			return scoped, fmt.Errorf("invalid headers, must be nil or table: %s", lheaders)
+		}
+	case *lua.LNilType:
+	default:
+		return scoped, fmt.Errorf("script returned invalid value: %s", value)
+	}
+	return scoped, nil
+}
+
+type ScopedEventhubData struct {
+	Data *azeventhubs.EventData
+	Hub  ScopedEventhub
+}
+
 // returns the number of records synced
 func (c *EventHubConnector) processBatch(
 	ctx context.Context,
 	flowJobName string,
 	batch *model.CDCRecordStream,
+	script string,
 ) (uint32, error) {
 	batchPerTopic := NewHubBatches(c.hubManager)
 	toJSONOpts := model.NewToJSONOptions(c.config.UnnestColumns, false)
@@ -96,6 +194,34 @@ func (c *EventHubConnector) processBatch(
 	lastUpdatedOffset := int64(0)
 
 	numRecords := atomic.Uint32{}
+
+	var ls *lua.LState
+	var fn *lua.LFunction
+	if script != "" {
+		ls, err := utils.LoadScript(ctx, script, func(ls *lua.LState) int {
+			top := ls.GetTop()
+			ss := make([]string, top)
+			for i := range top {
+				ss[i] = ls.ToStringMeta(ls.Get(i + 1)).String()
+			}
+			_ = c.LogFlowInfo(ctx, flowJobName, strings.Join(ss, "\t"))
+			return 0
+		})
+		if err != nil {
+			return 0, err
+		}
+		defer ls.Close()
+		if script == "" {
+			ls.Env.RawSetString("onRecord", ls.NewFunction(utils.DefaultOnRecord))
+		}
+
+		lfn := ls.Env.RawGetString("onRecord")
+		var ok bool
+		fn, ok = lfn.(*lua.LFunction)
+		if !ok {
+			return 0, fmt.Errorf("script should define `onRecord` as function, not %s", lfn)
+		}
+	}
 
 	for {
 		select {
@@ -113,51 +239,82 @@ func (c *EventHubConnector) processBatch(
 				return currNumRecords, nil
 			}
 
-			numRecords.Add(1)
-
 			recordLSN := record.GetCheckpointID()
 			if recordLSN > lastSeenLSN {
 				lastSeenLSN = recordLSN
 			}
 
-			json, err := record.GetItems().ToJSONWithOptions(toJSONOpts)
-			if err != nil {
-				c.logger.Info("failed to convert record to json", slog.Any("error", err))
-				return 0, err
+			var events []ScopedEventhubData
+			destinationString := record.GetDestinationTableName()
+			if fn != nil {
+				ls.Push(fn)
+				ls.Push(pua.LuaRecord.New(ls, record))
+				err := ls.PCall(1, -1, nil)
+				if err != nil {
+					return 0, fmt.Errorf("script failed: %w", err)
+				}
+				args := ls.GetTop()
+				for i := range args {
+					scoped, err := lvalueToEventData(ls, ls.Get(i-args))
+					if err != nil {
+						return 0, err
+					}
+					if scoped.Data != nil {
+						if scoped.Hub.NamespaceName == "" {
+							scoped.Hub, err = NewScopedEventhub(destinationString)
+							if err != nil {
+								c.logger.Error("failed to get topic name", slog.Any("error", err))
+								return 0, err
+							}
+						}
+						events = append(events, scoped)
+					}
+				}
+				ls.SetTop(0)
+			} else {
+				json, err := record.GetItems().ToJSONWithOptions(toJSONOpts)
+				if err != nil {
+					c.logger.Info("failed to convert record to json", slog.Any("error", err))
+					return 0, err
+				}
+				scopedHub, err := NewScopedEventhub(destinationString)
+				if err != nil {
+					c.logger.Error("failed to get topic name", slog.Any("error", err))
+					return 0, err
+				}
+				events = []ScopedEventhubData{{Hub: scopedHub, Data: &azeventhubs.EventData{Body: []byte(json)}}}
 			}
 
-			destination, err := NewScopedEventhub(record.GetDestinationTableName())
-			if err != nil {
-				c.logger.Error("failed to get topic name", slog.Any("error", err))
-				return 0, err
+			for _, event := range events {
+				ehConfig, ok := c.hubManager.namespaceToEventhubMap.Get(event.Hub.NamespaceName)
+				if !ok {
+					c.logger.Error("failed to get eventhub config", slog.String("namespace", event.Hub.NamespaceName))
+					return 0, fmt.Errorf("failed to get eventhub config %s", event.Hub.NamespaceName)
+				}
+
+				// Scoped eventhub is of the form peer_name.eventhub_name.partition_column
+				// partition_column is the column in the table that is used to determine
+				// the partition key for the eventhub.
+				partitionKey := event.Hub.PartitionKeyValue
+				if partitionKey == "" {
+					partitionColumn := event.Hub.PartitionKeyColumn
+					partitionValue := record.GetItems().GetColumnValue(partitionColumn).Value()
+					if partitionValue != nil {
+						partitionKey = fmt.Sprint(partitionValue)
+					}
+
+					partitionKey = utils.HashedPartitionKey(partitionKey, ehConfig.PartitionCount)
+					event.Hub.PartitionKeyValue = partitionKey
+				}
+				err := batchPerTopic.AddEvent(ctx, event.Hub, event.Data, false)
+				if err != nil {
+					c.logger.Error("failed to add event to batch", slog.Any("error", err))
+					return 0, err
+				}
 			}
 
-			ehConfig, ok := c.hubManager.namespaceToEventhubMap.Get(destination.NamespaceName)
-			if !ok {
-				c.logger.Error("failed to get eventhub config", slog.Any("error", err))
-				return 0, err
-			}
-
-			numPartitions := ehConfig.PartitionCount
-			// Scoped eventhub is of the form peer_name.eventhub_name.partition_column
-			// partition_column is the column in the table that is used to determine
-			// the partition key for the eventhub.
-			partitionColumn := destination.PartitionKeyColumn
-			partitionValue := record.GetItems().GetColumnValue(partitionColumn).Value()
-			var partitionKey string
-			if partitionValue != nil {
-				partitionKey = fmt.Sprint(partitionValue)
-			}
-			partitionKey = utils.HashedPartitionKey(partitionKey, numPartitions)
-			destination.SetPartitionValue(partitionKey)
-			err = batchPerTopic.AddEvent(ctx, destination, json, false)
-			if err != nil {
-				c.logger.Error("failed to add event to batch", slog.Any("error", err))
-				return 0, err
-			}
-
-			curNumRecords := numRecords.Load()
-			if curNumRecords&1023 == 0 {
+			curNumRecords := numRecords.Add(1)
+			if curNumRecords%10000 == 0 {
 				c.logger.Info("processBatch", slog.Int("number of records processed for sending", int(curNumRecords)))
 			}
 
@@ -183,7 +340,7 @@ func (c *EventHubConnector) processBatch(
 }
 
 func (c *EventHubConnector) SyncRecords(ctx context.Context, req *model.SyncRecordsRequest) (*model.SyncResponse, error) {
-	numRecords, err := c.processBatch(ctx, req.FlowJobName, req.Records)
+	numRecords, err := c.processBatch(ctx, req.FlowJobName, req.Records, req.Script)
 	if err != nil {
 		c.logger.Error("failed to process batch", slog.Any("error", err))
 		return nil, err

--- a/flow/connectors/eventhub/hub_batches.go
+++ b/flow/connectors/eventhub/hub_batches.go
@@ -30,7 +30,7 @@ func NewHubBatches(manager *EventHubManager) *HubBatches {
 func (h *HubBatches) AddEvent(
 	ctx context.Context,
 	destination ScopedEventhub,
-	event string,
+	event *azeventhubs.EventData,
 	// this is true when we are retrying to send the event after the batch size exceeded
 	// this should initially be false, and then true when we are retrying.
 	retryForBatchSizeExceed bool,
@@ -45,7 +45,7 @@ func (h *HubBatches) AddEvent(
 		h.batch[destination] = batch
 	}
 
-	err := tryAddEventToBatch(event, batch)
+	err := batch.AddEventData(event, nil)
 	if err == nil {
 		// we successfully added the event to the batch, so we're done.
 		return nil
@@ -156,17 +156,5 @@ func (h *HubBatches) flushAllBatches(
 
 // Clear removes all batches from the HubBatches
 func (h *HubBatches) Clear() {
-	h.batch = make(map[ScopedEventhub]*azeventhubs.EventDataBatch)
-}
-
-func tryAddEventToBatch(event string, batch *azeventhubs.EventDataBatch) error {
-	eventData := eventDataFromString(event)
-	opts := &azeventhubs.AddEventDataOptions{}
-	return batch.AddEventData(eventData, opts)
-}
-
-func eventDataFromString(s string) *azeventhubs.EventData {
-	return &azeventhubs.EventData{
-		Body: []byte(s),
-	}
+	clear(h.batch)
 }

--- a/flow/connectors/eventhub/scoped_eventhub.go
+++ b/flow/connectors/eventhub/scoped_eventhub.go
@@ -33,10 +33,6 @@ func NewScopedEventhub(dstTableName string) (ScopedEventhub, error) {
 	}, nil
 }
 
-func (s *ScopedEventhub) SetPartitionValue(value string) {
-	s.PartitionKeyValue = value
-}
-
 func (s ScopedEventhub) Equals(other ScopedEventhub) bool {
 	return s.NamespaceName == other.NamespaceName &&
 		s.Eventhub == other.Eventhub &&

--- a/flow/connectors/utils/partition_hash.go
+++ b/flow/connectors/utils/partition_hash.go
@@ -3,11 +3,13 @@ package utils
 import (
 	"hash/fnv"
 	"strconv"
+
+	"github.com/PeerDB-io/peer-flow/shared"
 )
 
 func hashString(s string) uint32 {
 	h := fnv.New32a()
-	h.Write([]byte(s))
+	h.Write(shared.UnsafeFastStringToReadOnlyBytes(s))
 	return h.Sum32()
 }
 

--- a/flow/go.mod
+++ b/flow/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/PeerDB-io/gluabit32 v1.0.2
 	github.com/PeerDB-io/gluaflatbuffers v1.0.1
 	github.com/PeerDB-io/gluajson v1.0.2
-	github.com/PeerDB-io/gluamsgpack v1.0.1
+	github.com/PeerDB-io/gluamsgpack v1.0.2
 	github.com/PeerDB-io/gluautf8 v1.0.0
 	github.com/aws/aws-sdk-go-v2 v1.26.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.9

--- a/flow/go.sum
+++ b/flow/go.sum
@@ -66,8 +66,8 @@ github.com/PeerDB-io/gluaflatbuffers v1.0.1 h1:Oxlv0VlMYoQ05Q5n/k4hXAsvtDnuVNC99
 github.com/PeerDB-io/gluaflatbuffers v1.0.1/go.mod h1:unZOM4Mm2Sn+aAFuVjoJDZ2Dji7jlDWrt4Hvq79as2g=
 github.com/PeerDB-io/gluajson v1.0.2 h1:Kv5Qabj2Md6gxRZsX5QVUOQDf5WMOQEF8lIkKXguajM=
 github.com/PeerDB-io/gluajson v1.0.2/go.mod h1:arRzpblxlLiWfBAluxP9Xibf6J8UkUIfoY4FPHTsz4Q=
-github.com/PeerDB-io/gluamsgpack v1.0.1 h1:BvZ4+BQdg+wd+/uZn/grmM15QxIS+xWycHCmA78Nwgc=
-github.com/PeerDB-io/gluamsgpack v1.0.1/go.mod h1:1ufs5NK2DczzQS78Nhy0AkCA0dOVyt/KVEk39lbWzyU=
+github.com/PeerDB-io/gluamsgpack v1.0.2 h1:J5VhMSfJdWfCMJ1wszDNC2BVD4F+ATgXwGVs1lNft9g=
+github.com/PeerDB-io/gluamsgpack v1.0.2/go.mod h1:1ufs5NK2DczzQS78Nhy0AkCA0dOVyt/KVEk39lbWzyU=
 github.com/PeerDB-io/gluautf8 v1.0.0 h1:Ubhy6FVnrED5jrosdUOxzAkf3YdcgebYJzX2YBdGedE=
 github.com/PeerDB-io/gluautf8 v1.0.0/go.mod h1:+4RQlCVFCMikYFmiKUA9ADZftgGAZseMmdErxfE1EZQ=
 github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=


### PR DESCRIPTION
When script is empty stick to existing eventhubs behavior

Script can return quite a bit as a table:
1. value: EventData Body
2. contentType: EventData ContentType
3. messageId: EventData MessageID
4. headers: EventData Properties

Destination can also be overriden:
1. destination: overrides mirror's destination table value. Following values will overwrite values from this string
2. namespace: can pick other namespaces, but pick from hub configs
3. partitionColumn: setting without `key` will use existing partition-by-column logic
4. key: sets partition key value, bypassing hashing & everything
5. hub: sets eventhub name

By having destination apply first, users can
```lua
return { destination = r.target, key = "override" }
```
causing behavior to adapt existing behavior set by their destination table string