### PR TITLE
CI: skip nexus tests unless nexus/protos updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, release/*]
   pull_request:
     branches: [main, release/*]
+    paths: [nexus/**, protos/**]
 
 jobs:
   build:

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths: [ui/**]
+    paths: [ui/**, protos/**]
 
 jobs:
   build-test:


### PR DESCRIPTION
Originally kept mandatory because this CI item was required