### PR TITLE
UI Row display formatter: use en-US

### DIFF
--- a/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
@@ -12,6 +12,7 @@ import { Label } from '@/lib/Label';
 import moment from 'moment';
 import Link from 'next/link';
 import MirrorValues from './configValues';
+import { RowDataFormatter } from './rowsDisplay';
 import TablePairs from './tablePairs';
 
 type props = {
@@ -128,7 +129,7 @@ function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
               </Label>
             </div>
             <div>
-              <Label variant='body'>{numberWithCommas(rowsSynced)}</Label>
+              <Label variant='body'>{RowDataFormatter(rowsSynced)}</Label>
             </div>
           </div>
 
@@ -141,10 +142,6 @@ function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
       <TablePairs tables={tablesSynced} />
     </>
   );
-}
-
-export function numberWithCommas(x: any): string {
-  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
 function statusChangeHandle(

--- a/ui/app/mirrors/[mirrorId]/rowsDisplay.tsx
+++ b/ui/app/mirrors/[mirrorId]/rowsDisplay.tsx
@@ -4,7 +4,7 @@ import { Icon } from '@/lib/Icon';
 import { BarList } from '@tremor/react';
 import { useState } from 'react';
 export const RowDataFormatter = (number: number) =>
-  `${Intl.NumberFormat('us').format(number).toString()}`;
+  `${Intl.NumberFormat('en-US').format(number).toString()}`;
 
 const RowsDisplay = ({
   totalRowsData,

--- a/ui/app/mirrors/[mirrorId]/syncStatus.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatus.tsx
@@ -64,7 +64,7 @@ export default async function SyncStatus({
     0
   );
   const totalRowsData = {
-    total: inserts + updates + deletes,
+    total: rowsSynced,
     inserts,
     updates,
     deletes,


### PR DESCRIPTION
Seems like 'us' is not a valid locale string for `Intl.NumberFormat()`. Noticing different results across systems for the same number.
Changing to `en-US` which is a more well documented choice.

Also switches another instance of number formatting to use `Intl` APIs instead of regex
Also use total rows as sum of rows in batch instead of inserts/updates/deletes