### PR TITLE
BigQuery: add flag-gated time partitioning

### DIFF
--- a/flow/dynamicconf/dynamicconf.go
+++ b/flow/dynamicconf/dynamicconf.go
@@ -52,6 +52,34 @@ func dynamicConfUint32(ctx context.Context, key string, defaultValue uint32) uin
 	return uint32(result)
 }
 
+func dynamicConfBool(ctx context.Context, key string, defaultValue bool) bool {
+	conn, err := peerdbenv.GetCatalogConnectionPoolFromEnv(ctx)
+	if err != nil {
+		logger.LoggerFromCtx(ctx).Error("Failed to get catalog connection pool: %v", err)
+		return defaultValue
+	}
+
+	if !dynamicConfKeyExists(ctx, conn, key) {
+		return defaultValue
+	}
+
+	var value pgtype.Text
+	query := "SELECT config_value FROM alerting_settings WHERE config_name = $1"
+	err = conn.QueryRow(ctx, query, key).Scan(&value)
+	if err != nil {
+		logger.LoggerFromCtx(ctx).Error("Failed to get key: %v", err)
+		return defaultValue
+	}
+
+	result, err := strconv.ParseBool(value.String)
+	if err != nil {
+		logger.LoggerFromCtx(ctx).Error("Failed to parse bool: %v", err)
+		return defaultValue
+	}
+
+	return result
+}
+
 // PEERDB_SLOT_LAG_MB_ALERT_THRESHOLD, 0 disables slot lag alerting entirely
 func PeerDBSlotLagMBAlertThreshold(ctx context.Context) uint32 {
 	return dynamicConfUint32(ctx, "PEERDB_SLOT_LAG_MB_ALERT_THRESHOLD", 5000)
@@ -66,4 +94,12 @@ func PeerDBAlertingGapMinutesAsDuration(ctx context.Context) time.Duration {
 // PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD, 0 disables open connections alerting entirely
 func PeerDBOpenConnectionsAlertThreshold(ctx context.Context) uint32 {
 	return dynamicConfUint32(ctx, "PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD", 5)
+}
+
+// PEERDB_ENABLE_SYNCED_AT_PARTITIONING, for creating target tables with
+// partitioning by _PEERDB_SYNCED_AT column
+// If true, the target tables will be partitioned by _PEERDB_SYNCED_AT column
+// If false, the target tables will not be partitioned
+func PeerDBBigQueryEnableSyncedAtPartitioning(ctx context.Context) bool {
+	return dynamicConfBool(ctx, "PEERDB_ENABLE_SYNCED_AT_PARTITIONING", false)
 }

--- a/flow/dynamicconf/dynamicconf.go
+++ b/flow/dynamicconf/dynamicconf.go
@@ -96,10 +96,10 @@ func PeerDBOpenConnectionsAlertThreshold(ctx context.Context) uint32 {
 	return dynamicConfUint32(ctx, "PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD", 5)
 }
 
-// PEERDB_ENABLE_SYNCED_AT_PARTITIONING, for creating target tables with
+// PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING, for creating target tables with
 // partitioning by _PEERDB_SYNCED_AT column
 // If true, the target tables will be partitioned by _PEERDB_SYNCED_AT column
 // If false, the target tables will not be partitioned
 func PeerDBBigQueryEnableSyncedAtPartitioning(ctx context.Context) bool {
-	return dynamicConfBool(ctx, "PEERDB_ENABLE_SYNCED_AT_PARTITIONING", false)
+	return dynamicConfBool(ctx, "PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING", false)
 }

--- a/flow/dynamicconf/dynamicconf.go
+++ b/flow/dynamicconf/dynamicconf.go
@@ -96,10 +96,10 @@ func PeerDBOpenConnectionsAlertThreshold(ctx context.Context) uint32 {
 	return dynamicConfUint32(ctx, "PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD", 5)
 }
 
-// PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING, for creating target tables with
+// PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS, for creating target tables with
 // partitioning by _PEERDB_SYNCED_AT column
 // If true, the target tables will be partitioned by _PEERDB_SYNCED_AT column
 // If false, the target tables will not be partitioned
 func PeerDBBigQueryEnableSyncedAtPartitioning(ctx context.Context) bool {
-	return dynamicConfBool(ctx, "PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING", false)
+	return dynamicConfBool(ctx, "PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS", false)
 }


### PR DESCRIPTION
This PR adds support for partitioning the target tables we create in BigQuery mirrors by the `_PEERDB_SYNCED_AT` column, by **days**

This feature is gated by a dynamic configured env variable - `PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS`