### PR TITLE
Snowflake: Addition of dynamic numeric columns

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -217,19 +217,19 @@ func (c *BigQueryConnector) ReplayTableSchemaDeltas(
 
 		for _, addedColumn := range schemaDelta.AddedColumns {
 			dstDatasetTable, _ := c.convertToDatasetTable(schemaDelta.DstTableName)
-			addedColumnBigQueryType := qValueKindToBigQueryTypeString(addedColumn.Column.Type)
+			addedColumnBigQueryType := qValueKindToBigQueryTypeString(addedColumn.Type)
 			query := c.client.Query(fmt.Sprintf(
 				"ALTER TABLE %s ADD COLUMN IF NOT EXISTS `%s` %s",
-				dstDatasetTable.table, addedColumn.Column.Name, addedColumnBigQueryType))
+				dstDatasetTable.table, addedColumn.Name, addedColumnBigQueryType))
 			query.DefaultProjectID = c.projectID
 			query.DefaultDatasetID = dstDatasetTable.dataset
 			_, err := query.Read(ctx)
 			if err != nil {
-				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Column.Name,
+				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Name,
 					schemaDelta.DstTableName, err)
 			}
 			c.logger.Info(fmt.Sprintf("[schema delta replay] added column %s with data type %s to table %s",
-				addedColumn.Column.Name, addedColumn.Column.Type, schemaDelta.DstTableName))
+				addedColumn.Name, addedColumn.Type, schemaDelta.DstTableName))
 		}
 	}
 

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -217,19 +217,19 @@ func (c *BigQueryConnector) ReplayTableSchemaDeltas(
 
 		for _, addedColumn := range schemaDelta.AddedColumns {
 			dstDatasetTable, _ := c.convertToDatasetTable(schemaDelta.DstTableName)
-			addedColumnBigQueryType := qValueKindToBigQueryTypeString(addedColumn.ColumnType)
+			addedColumnBigQueryType := qValueKindToBigQueryTypeString(addedColumn.Column.Type)
 			query := c.client.Query(fmt.Sprintf(
 				"ALTER TABLE %s ADD COLUMN IF NOT EXISTS `%s` %s",
-				dstDatasetTable.table, addedColumn.ColumnName, addedColumnBigQueryType))
+				dstDatasetTable.table, addedColumn.Column.Name, addedColumnBigQueryType))
 			query.DefaultProjectID = c.projectID
 			query.DefaultDatasetID = dstDatasetTable.dataset
 			_, err := query.Read(ctx)
 			if err != nil {
-				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.ColumnName,
+				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Column.Name,
 					schemaDelta.DstTableName, err)
 			}
 			c.logger.Info(fmt.Sprintf("[schema delta replay] added column %s with data type %s to table %s",
-				addedColumn.ColumnName, addedColumn.ColumnType, schemaDelta.DstTableName))
+				addedColumn.Column.Name, addedColumn.Column.Type, schemaDelta.DstTableName))
 		}
 	}
 

--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -8,9 +8,9 @@ import (
 
 	"cloud.google.com/go/bigquery"
 
+	"github.com/PeerDB-io/peer-flow/datatypes"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
-	"github.com/PeerDB-io/peer-flow/model/numeric"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
@@ -75,7 +75,7 @@ func (c *BigQueryConnector) replayTableSchemaDeltasQRep(
 				Column: &protos.FieldDescription{
 					Name:         col.Name,
 					Type:         string(col.Type),
-					TypeModifier: numeric.MakeNumericTypmod(int32(col.Precision), int32(col.Scale)),
+					TypeModifier: datatypes.MakeNumericTypmod(int32(col.Precision), int32(col.Scale)),
 				},
 			})
 		}

--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -71,13 +71,12 @@ func (c *BigQueryConnector) replayTableSchemaDeltasQRep(
 			c.logger.Info(fmt.Sprintf("adding column %s to destination table %s",
 				col.Name, config.DestinationTableIdentifier),
 				slog.String(string(shared.PartitionIDKey), partition.PartitionId))
-			tableSchemaDelta.AddedColumns = append(tableSchemaDelta.AddedColumns, &protos.DeltaAddedColumn{
-				Column: &protos.FieldDescription{
-					Name:         col.Name,
-					Type:         string(col.Type),
-					TypeModifier: datatypes.MakeNumericTypmod(int32(col.Precision), int32(col.Scale)),
-				},
-			})
+			tableSchemaDelta.AddedColumns = append(tableSchemaDelta.AddedColumns, &protos.FieldDescription{
+				Name:         col.Name,
+				Type:         string(col.Type),
+				TypeModifier: datatypes.MakeNumericTypmod(int32(col.Precision), int32(col.Scale)),
+			},
+			)
 		}
 	}
 

--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
+	"github.com/PeerDB-io/peer-flow/model/numeric"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
@@ -71,8 +72,11 @@ func (c *BigQueryConnector) replayTableSchemaDeltasQRep(
 				col.Name, config.DestinationTableIdentifier),
 				slog.String(string(shared.PartitionIDKey), partition.PartitionId))
 			tableSchemaDelta.AddedColumns = append(tableSchemaDelta.AddedColumns, &protos.DeltaAddedColumn{
-				ColumnName: col.Name,
-				ColumnType: string(col.Type),
+				Column: &protos.FieldDescription{
+					Name:         col.Name,
+					Type:         string(col.Type),
+					TypeModifier: numeric.MakeNumericTypmod(int32(col.Precision), int32(col.Scale)),
+				},
 			})
 		}
 	}

--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -152,20 +152,20 @@ func (c *ClickhouseConnector) ReplayTableSchemaDeltas(ctx context.Context, flowJ
 		}
 
 		for _, addedColumn := range schemaDelta.AddedColumns {
-			clickhouseColType, err := qvalue.QValueKind(addedColumn.ColumnType).ToDWHColumnType(protos.DBType_CLICKHOUSE)
+			clickhouseColType, err := qvalue.QValueKind(addedColumn.Column.Type).ToDWHColumnType(protos.DBType_CLICKHOUSE)
 			if err != nil {
 				return fmt.Errorf("failed to convert column type %s to clickhouse type: %w",
-					addedColumn.ColumnType, err)
+					addedColumn.Column.Type, err)
 			}
 			_, err = tableSchemaModifyTx.ExecContext(ctx,
 				fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS \"%s\" %s",
-					schemaDelta.DstTableName, addedColumn.ColumnName, clickhouseColType))
+					schemaDelta.DstTableName, addedColumn.Column.Name, clickhouseColType))
 			if err != nil {
-				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.ColumnName,
+				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Column.Name,
 					schemaDelta.DstTableName, err)
 			}
-			c.logger.Info(fmt.Sprintf("[schema delta replay] added column %s with data type %s", addedColumn.ColumnName,
-				addedColumn.ColumnType),
+			c.logger.Info(fmt.Sprintf("[schema delta replay] added column %s with data type %s", addedColumn.Column.Name,
+				addedColumn.Column.Type),
 				"destination table name", schemaDelta.DstTableName,
 				"source table name", schemaDelta.SrcTableName)
 		}

--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -152,20 +152,20 @@ func (c *ClickhouseConnector) ReplayTableSchemaDeltas(ctx context.Context, flowJ
 		}
 
 		for _, addedColumn := range schemaDelta.AddedColumns {
-			clickhouseColType, err := qvalue.QValueKind(addedColumn.Column.Type).ToDWHColumnType(protos.DBType_CLICKHOUSE)
+			clickhouseColType, err := qvalue.QValueKind(addedColumn.Type).ToDWHColumnType(protos.DBType_CLICKHOUSE)
 			if err != nil {
 				return fmt.Errorf("failed to convert column type %s to clickhouse type: %w",
-					addedColumn.Column.Type, err)
+					addedColumn.Type, err)
 			}
 			_, err = tableSchemaModifyTx.ExecContext(ctx,
 				fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS \"%s\" %s",
-					schemaDelta.DstTableName, addedColumn.Column.Name, clickhouseColType))
+					schemaDelta.DstTableName, addedColumn.Name, clickhouseColType))
 			if err != nil {
-				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Column.Name,
+				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Name,
 					schemaDelta.DstTableName, err)
 			}
-			c.logger.Info(fmt.Sprintf("[schema delta replay] added column %s with data type %s", addedColumn.Column.Name,
-				addedColumn.Column.Type),
+			c.logger.Info(fmt.Sprintf("[schema delta replay] added column %s with data type %s", addedColumn.Name,
+				addedColumn.Type),
 				"destination table name", schemaDelta.DstTableName,
 				"source table name", schemaDelta.SrcTableName)
 		}

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -835,7 +835,7 @@ func processRelationMessage[Items model.Items](
 			if _, ok := p.tableNameMapping[p.srcTableIDNameMapping[currRel.RelationID]].Exclude[column.Name]; !ok {
 				schemaDelta.AddedColumns = append(schemaDelta.AddedColumns, &protos.FieldDescription{
 					Name:         column.Name,
-					Type:         string(currRelMap[column.Name]),
+					Type:         currRelMap[column.Name],
 					TypeModifier: column.TypeModifier,
 				},
 				)

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -834,8 +834,11 @@ func processRelationMessage[Items model.Items](
 			// only add to delta if not excluded
 			if _, ok := p.tableNameMapping[p.srcTableIDNameMapping[currRel.RelationID]].Exclude[column.Name]; !ok {
 				schemaDelta.AddedColumns = append(schemaDelta.AddedColumns, &protos.DeltaAddedColumn{
-					ColumnName: column.Name,
-					ColumnType: currRelMap[column.Name],
+					Column: &protos.FieldDescription{
+						Name:         column.Name,
+						Type:         string(currRelMap[column.Name]),
+						TypeModifier: column.TypeModifier,
+					},
 				})
 			}
 			// present in previous and current relation messages, but data types have changed.

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -825,7 +825,7 @@ func processRelationMessage[Items model.Items](
 	schemaDelta := &protos.TableSchemaDelta{
 		SrcTableName: p.srcTableIDNameMapping[currRel.RelationID],
 		DstTableName: p.tableNameMapping[p.srcTableIDNameMapping[currRel.RelationID]].Name,
-		AddedColumns: make([]*protos.DeltaAddedColumn, 0),
+		AddedColumns: make([]*protos.FieldDescription, 0),
 		System:       prevSchema.System,
 	}
 	for _, column := range currRel.Columns {
@@ -833,13 +833,12 @@ func processRelationMessage[Items model.Items](
 		if _, ok := prevRelMap[column.Name]; !ok {
 			// only add to delta if not excluded
 			if _, ok := p.tableNameMapping[p.srcTableIDNameMapping[currRel.RelationID]].Exclude[column.Name]; !ok {
-				schemaDelta.AddedColumns = append(schemaDelta.AddedColumns, &protos.DeltaAddedColumn{
-					Column: &protos.FieldDescription{
-						Name:         column.Name,
-						Type:         string(currRelMap[column.Name]),
-						TypeModifier: column.TypeModifier,
-					},
-				})
+				schemaDelta.AddedColumns = append(schemaDelta.AddedColumns, &protos.FieldDescription{
+					Name:         column.Name,
+					Type:         string(currRelMap[column.Name]),
+					TypeModifier: column.TypeModifier,
+				},
+				)
 			}
 			// present in previous and current relation messages, but data types have changed.
 			// so we add it to AddedColumns and DroppedColumns, knowing that we process DroppedColumns first.

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -891,7 +891,7 @@ func (c *PostgresConnector) ReplayTableSchemaDeltas(
 			_, err = tableSchemaModifyTx.Exec(ctx, fmt.Sprintf(
 				"ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s",
 				schemaDelta.DstTableName, QuoteIdentifier(addedColumn.Name),
-				addedColumn.Type))
+				columnType))
 			if err != nil {
 				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Name,
 					schemaDelta.DstTableName, err)

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -891,7 +891,7 @@ func (c *PostgresConnector) ReplayTableSchemaDeltas(
 			_, err = tableSchemaModifyTx.Exec(ctx, fmt.Sprintf(
 				"ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s",
 				schemaDelta.DstTableName, QuoteIdentifier(addedColumn.Name),
-				qValueKindToPostgresType(addedColumn.Type)))
+				addedColumn.Type))
 			if err != nil {
 				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Name,
 					schemaDelta.DstTableName, err)

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -884,20 +884,20 @@ func (c *PostgresConnector) ReplayTableSchemaDeltas(
 		}
 
 		for _, addedColumn := range schemaDelta.AddedColumns {
-			columnType := addedColumn.ColumnType
+			columnType := addedColumn.Type
 			if schemaDelta.System == protos.TypeSystem_Q {
 				columnType = qValueKindToPostgresType(columnType)
 			}
 			_, err = tableSchemaModifyTx.Exec(ctx, fmt.Sprintf(
 				"ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s",
-				schemaDelta.DstTableName, QuoteIdentifier(addedColumn.Column.Name),
-				qValueKindToPostgresType(addedColumn.Column.Type)))
+				schemaDelta.DstTableName, QuoteIdentifier(addedColumn.Name),
+				qValueKindToPostgresType(addedColumn.Type)))
 			if err != nil {
-				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Column.Name,
+				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Name,
 					schemaDelta.DstTableName, err)
 			}
 			c.logger.Info(fmt.Sprintf("[schema delta replay] added column %s with data type %s",
-				addedColumn.Column.Name, addedColumn.Column.Type),
+				addedColumn.Name, addedColumn.Type),
 				slog.String("srcTableName", schemaDelta.SrcTableName),
 				slog.String("dstTableName", schemaDelta.DstTableName),
 			)

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -890,8 +890,7 @@ func (c *PostgresConnector) ReplayTableSchemaDeltas(
 			}
 			_, err = tableSchemaModifyTx.Exec(ctx, fmt.Sprintf(
 				"ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s",
-				schemaDelta.DstTableName, QuoteIdentifier(addedColumn.Name),
-				columnType))
+				schemaDelta.DstTableName, QuoteIdentifier(addedColumn.Name), columnType))
 			if err != nil {
 				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Name,
 					schemaDelta.DstTableName, err)

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -890,14 +890,14 @@ func (c *PostgresConnector) ReplayTableSchemaDeltas(
 			}
 			_, err = tableSchemaModifyTx.Exec(ctx, fmt.Sprintf(
 				"ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s",
-				schemaDelta.DstTableName, QuoteIdentifier(addedColumn.ColumnName), columnType,
-			))
+				schemaDelta.DstTableName, QuoteIdentifier(addedColumn.Column.Name),
+				qValueKindToPostgresType(addedColumn.Column.Type)))
 			if err != nil {
-				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.ColumnName,
+				return fmt.Errorf("failed to add column %s for table %s: %w", addedColumn.Column.Name,
 					schemaDelta.DstTableName, err)
 			}
 			c.logger.Info(fmt.Sprintf("[schema delta replay] added column %s with data type %s",
-				addedColumn.ColumnName, addedColumn.ColumnType),
+				addedColumn.Column.Name, addedColumn.Column.Type),
 				slog.String("srcTableName", schemaDelta.SrcTableName),
 				slog.String("dstTableName", schemaDelta.DstTableName),
 			)

--- a/flow/connectors/postgres/postgres_schema_delta_test.go
+++ b/flow/connectors/postgres/postgres_schema_delta_test.go
@@ -62,7 +62,7 @@ func (s PostgresSchemaDeltaTestSuite) TestSimpleAddColumn() {
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: []*protos.FieldDescription{
-			&protos.FieldDescription{
+			{
 				Name:         "hi",
 				Type:         string(qvalue.QValueKindInt64),
 				TypeModifier: -1,

--- a/flow/connectors/postgres/postgres_schema_delta_test.go
+++ b/flow/connectors/postgres/postgres_schema_delta_test.go
@@ -61,13 +61,13 @@ func (s PostgresSchemaDeltaTestSuite) TestSimpleAddColumn() {
 	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
-		AddedColumns: []*protos.DeltaAddedColumn{{
-			Column: &protos.FieldDescription{
+		AddedColumns: []*protos.FieldDescription{
+			&protos.FieldDescription{
 				Name:         "hi",
 				Type:         string(qvalue.QValueKindInt64),
 				TypeModifier: -1,
 			},
-		}},
+		},
 	}})
 	require.NoError(s.t, err)
 
@@ -107,16 +107,15 @@ func (s PostgresSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 		Columns:           AddAllColumnTypesFields,
 		System:            protos.TypeSystem_Q,
 	}
-	addedColumns := make([]*protos.DeltaAddedColumn, 0)
+	addedColumns := make([]*protos.FieldDescription, 0)
 	for _, column := range expectedTableSchema.Columns {
 		if column.Name != "id" {
-			addedColumns = append(addedColumns, &protos.DeltaAddedColumn{
-				Column: &protos.FieldDescription{
-					Name:         column.Name,
-					Type:         column.Type,
-					TypeModifier: -1,
-				},
-			})
+			addedColumns = append(addedColumns, &protos.FieldDescription{
+				Name:         column.Name,
+				Type:         column.Type,
+				TypeModifier: -1,
+			},
+			)
 		}
 	}
 
@@ -147,16 +146,15 @@ func (s PostgresSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
 		Columns:           TrickyFields,
 		System:            protos.TypeSystem_Q,
 	}
-	addedColumns := make([]*protos.DeltaAddedColumn, 0)
+	addedColumns := make([]*protos.FieldDescription, 0)
 	for _, column := range expectedTableSchema.Columns {
 		if column.Name != "id" {
-			addedColumns = append(addedColumns, &protos.DeltaAddedColumn{
-				Column: &protos.FieldDescription{
-					Name:         column.Name,
-					Type:         column.Type,
-					TypeModifier: -1,
-				},
-			})
+			addedColumns = append(addedColumns, &protos.FieldDescription{
+				Name:         column.Name,
+				Type:         column.Type,
+				TypeModifier: -1,
+			},
+			)
 		}
 	}
 
@@ -187,16 +185,15 @@ func (s PostgresSchemaDeltaTestSuite) TestAddDropWhitespaceColumnNames() {
 		Columns:           WhitespaceFields,
 		System:            protos.TypeSystem_Q,
 	}
-	addedColumns := make([]*protos.DeltaAddedColumn, 0)
+	addedColumns := make([]*protos.FieldDescription, 0)
 	for _, column := range expectedTableSchema.Columns {
 		if column.Name != " " {
-			addedColumns = append(addedColumns, &protos.DeltaAddedColumn{
-				Column: &protos.FieldDescription{
-					Name:         column.Name,
-					Type:         column.Type,
-					TypeModifier: -1,
-				},
-			})
+			addedColumns = append(addedColumns, &protos.FieldDescription{
+				Name:         column.Name,
+				Type:         column.Type,
+				TypeModifier: -1,
+			},
+			)
 		}
 	}
 

--- a/flow/connectors/postgres/postgres_schema_delta_test.go
+++ b/flow/connectors/postgres/postgres_schema_delta_test.go
@@ -62,8 +62,11 @@ func (s PostgresSchemaDeltaTestSuite) TestSimpleAddColumn() {
 		SrcTableName: tableName,
 		DstTableName: tableName,
 		AddedColumns: []*protos.DeltaAddedColumn{{
-			ColumnName: "hi",
-			ColumnType: string(qvalue.QValueKindInt64),
+			Column: &protos.FieldDescription{
+				Name:         "hi",
+				Type:         string(qvalue.QValueKindInt64),
+				TypeModifier: -1,
+			},
 		}},
 	}})
 	require.NoError(s.t, err)
@@ -108,8 +111,11 @@ func (s PostgresSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 	for _, column := range expectedTableSchema.Columns {
 		if column.Name != "id" {
 			addedColumns = append(addedColumns, &protos.DeltaAddedColumn{
-				ColumnName: column.Name,
-				ColumnType: column.Type,
+				Column: &protos.FieldDescription{
+					Name:         column.Name,
+					Type:         column.Type,
+					TypeModifier: -1,
+				},
 			})
 		}
 	}
@@ -145,8 +151,11 @@ func (s PostgresSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
 	for _, column := range expectedTableSchema.Columns {
 		if column.Name != "id" {
 			addedColumns = append(addedColumns, &protos.DeltaAddedColumn{
-				ColumnName: column.Name,
-				ColumnType: column.Type,
+				Column: &protos.FieldDescription{
+					Name:         column.Name,
+					Type:         column.Type,
+					TypeModifier: -1,
+				},
 			})
 		}
 	}
@@ -182,8 +191,11 @@ func (s PostgresSchemaDeltaTestSuite) TestAddDropWhitespaceColumnNames() {
 	for _, column := range expectedTableSchema.Columns {
 		if column.Name != " " {
 			addedColumns = append(addedColumns, &protos.DeltaAddedColumn{
-				ColumnName: column.Name,
-				ColumnType: column.Type,
+				Column: &protos.FieldDescription{
+					Name:         column.Name,
+					Type:         column.Type,
+					TypeModifier: -1,
+				},
 			})
 		}
 	}

--- a/flow/connectors/snowflake/get_schema_for_tests.go
+++ b/flow/connectors/snowflake/get_schema_for_tests.go
@@ -3,28 +3,29 @@ package connsnowflake
 import (
 	"context"
 
+	"github.com/PeerDB-io/peer-flow/datatypes"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 )
 
 func (c *SnowflakeConnector) getTableSchemaForTable(ctx context.Context, tableName string) (*protos.TableSchema, error) {
-	colNames, colTypes, err := c.getColsFromTable(ctx, tableName)
+	columns, err := c.getColsFromTable(ctx, tableName)
 	if err != nil {
 		return nil, err
 	}
 
-	colFields := make([]*protos.FieldDescription, 0, len(colNames))
-	for i, sfType := range colTypes {
-		genericColType, err := snowflakeTypeToQValueKind(sfType)
+	colFields := make([]*protos.FieldDescription, 0, len(columns))
+	for i, sfColumn := range columns {
+		genericColType, err := snowflakeTypeToQValueKind(sfColumn.ColumnType)
 		if err != nil {
 			// we use string for invalid types
 			genericColType = qvalue.QValueKindString
 		}
-		colTypes[i] = string(genericColType)
+
 		colFields = append(colFields, &protos.FieldDescription{
-			Name:         colNames[i],
-			Type:         colTypes[i],
-			TypeModifier: -1,
+			Name:         columns[i].ColumnName,
+			Type:         string(genericColType),
+			TypeModifier: datatypes.MakeNumericTypmod(sfColumn.NumericPrecision, sfColumn.NumericScale),
 		})
 	}
 

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -17,6 +17,13 @@ import (
 	"github.com/PeerDB-io/peer-flow/shared"
 )
 
+type SnowflakeTableColumn struct {
+	ColumnName       string
+	ColumnType       string
+	NumericPrecision int32
+	NumericScale     int32
+}
+
 func (c *SnowflakeConnector) SyncQRepRecords(
 	ctx context.Context,
 	config *protos.QRepConfig,
@@ -179,11 +186,11 @@ func (c *SnowflakeConnector) CleanupQRepFlow(ctx context.Context, config *protos
 	return c.dropStage(ctx, config.StagingPath, config.FlowJobName)
 }
 
-func (c *SnowflakeConnector) getColsFromTable(ctx context.Context, tableName string) ([]string, []string, error) {
+func (c *SnowflakeConnector) getColsFromTable(ctx context.Context, tableName string) ([]SnowflakeTableColumn, error) {
 	// parse the table name to get the schema and table name
 	schemaTable, err := utils.ParseSchemaTable(tableName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse table name: %w", err)
+		return nil, fmt.Errorf("failed to parse table name: %w", err)
 	}
 
 	rows, err := c.database.QueryContext(
@@ -193,31 +200,35 @@ func (c *SnowflakeConnector) getColsFromTable(ctx context.Context, tableName str
 		strings.ToUpper(schemaTable.Table),
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to execute query: %w", err)
+		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 	defer rows.Close()
 
 	var colName, colType pgtype.Text
-	colNames := make([]string, 0, 8)
-	colTypes := make([]string, 0, 8)
+	var numericPrecision, numericScale pgtype.Int4
+	var cols []SnowflakeTableColumn
 	for rows.Next() {
-		if err := rows.Scan(&colName, &colType); err != nil {
-			return nil, nil, fmt.Errorf("failed to scan row: %w", err)
+		if err := rows.Scan(&colName, &colType, &numericPrecision, &numericScale); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
-		colNames = append(colNames, colName.String)
-		colTypes = append(colTypes, colType.String)
+		cols = append(cols, SnowflakeTableColumn{
+			ColumnName:       colName.String,
+			ColumnType:       colType.String,
+			NumericPrecision: numericPrecision.Int32,
+			NumericScale:     numericScale.Int32,
+		})
 	}
 
 	err = rows.Err()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read rows: %w", err)
+		return nil, fmt.Errorf("failed to read rows: %w", err)
 	}
 
-	if len(colNames) == 0 {
-		return nil, nil, fmt.Errorf("cannot load schema: table %s.%s does not exist", schemaTable.Schema, schemaTable.Table)
+	if len(cols) == 0 {
+		return nil, fmt.Errorf("cannot load schema: table %s.%s does not exist", schemaTable.Schema, schemaTable.Table)
 	}
 
-	return colNames, colTypes, nil
+	return cols, nil
 }
 
 // dropStage drops the stage for the given job.

--- a/flow/connectors/snowflake/qrep_avro_consolidate.go
+++ b/flow/connectors/snowflake/qrep_avro_consolidate.go
@@ -39,9 +39,16 @@ func NewSnowflakeAvroConsolidateHandler(
 func (s *SnowflakeAvroConsolidateHandler) CopyStageToDestination(ctx context.Context) error {
 	s.connector.logger.Info("Copying stage to destination " + s.dstTableName)
 
-	colNames, colTypes, colsErr := s.connector.getColsFromTable(ctx, s.dstTableName)
+	columns, colsErr := s.connector.getColsFromTable(ctx, s.dstTableName)
 	if colsErr != nil {
 		return fmt.Errorf("failed to get columns from destination table: %w", colsErr)
+	}
+
+	colNames := make([]string, 0, len(columns))
+	colTypes := make([]string, 0, len(columns))
+	for _, col := range columns {
+		colNames = append(colNames, col.ColumnName)
+		colTypes = append(colTypes, col.ColumnType)
 	}
 	s.allColNames = colNames
 	s.allColTypes = colTypes

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -538,8 +538,7 @@ func (c *SnowflakeConnector) mergeTablesForBatch(
 		peerdbCols:               peerdbCols,
 	}
 
-	for _, table := range destinationTableNames {
-		tableName := table
+	for _, tableName := range destinationTableNames {
 		if gCtx.Err() != nil {
 			break
 		}

--- a/flow/datatypes/numeric.go
+++ b/flow/datatypes/numeric.go
@@ -8,86 +8,8 @@ const (
 	PeerDBSnowflakeScale      = 20
 	PeerDBClickhousePrecision = 76
 	PeerDBClickhouseScale     = 38
+	VARHDRSZ                  = 4
 )
-
-type WarehouseNumericCompatibility interface {
-	MaxPrecision() int16
-	MaxScale() int16
-	DefaultPrecisionAndScale() (int16, int16)
-	IsValidPrevisionAndScale(precision, scale int16) bool
-}
-
-type ClickHouseNumericCompatibility struct{}
-
-func (ClickHouseNumericCompatibility) MaxPrecision() int16 {
-	return 76
-}
-
-func (ClickHouseNumericCompatibility) MaxScale() int16 {
-	return 38
-}
-
-func (ClickHouseNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
-	return PeerDBClickhousePrecision, PeerDBClickhouseScale
-}
-
-func (ClickHouseNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
-	return precision > 0 && precision <= PeerDBClickhousePrecision && scale < precision
-}
-
-type SnowflakeNumericCompatibility struct{}
-
-func (SnowflakeNumericCompatibility) MaxPrecision() int16 {
-	return 38
-}
-
-func (SnowflakeNumericCompatibility) MaxScale() int16 {
-	return 37
-}
-
-func (SnowflakeNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
-	return PeerDBSnowflakePrecision, PeerDBSnowflakeScale
-}
-
-func (SnowflakeNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
-	return precision > 0 && precision <= 38 && scale < precision
-}
-
-type BigQueryNumericCompatibility struct{}
-
-func (BigQueryNumericCompatibility) MaxPrecision() int16 {
-	return 38
-}
-
-func (BigQueryNumericCompatibility) MaxScale() int16 {
-	return 37
-}
-
-func (BigQueryNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
-	return PeerDBBigQueryPrecision, PeerDBBigQueryScale
-}
-
-func (BigQueryNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
-	return precision > 0 && precision <= 38 && scale < precision
-}
-
-type DefaultNumericCompatibility struct{}
-
-func (DefaultNumericCompatibility) MaxPrecision() int16 {
-	return 38
-}
-
-func (DefaultNumericCompatibility) MaxScale() int16 {
-	return 37
-}
-
-func (DefaultNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
-	return 38, 20
-}
-
-func (DefaultNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
-	return true
-}
 
 // This is to reverse what make_numeric_typmod of Postgres does:
 // https://github.com/postgres/postgres/blob/21912e3c0262e2cfe64856e028799d6927862563/src/backend/utils/adt/numeric.c#L897

--- a/flow/datatypes/numeric.go
+++ b/flow/datatypes/numeric.go
@@ -11,10 +11,96 @@ const (
 	VARHDRSZ                  = 4
 )
 
+type WarehouseNumericCompatibility interface {
+	MaxPrecision() int16
+	MaxScale() int16
+	DefaultPrecisionAndScale() (int16, int16)
+	IsValidPrevisionAndScale(precision, scale int16) bool
+}
+
+type ClickHouseNumericCompatibility struct{}
+
+func (ClickHouseNumericCompatibility) MaxPrecision() int16 {
+	return 76
+}
+
+func (ClickHouseNumericCompatibility) MaxScale() int16 {
+	return 38
+}
+
+func (ClickHouseNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
+	return PeerDBClickhousePrecision, PeerDBClickhouseScale
+}
+
+func (ClickHouseNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
+	return precision > 0 && precision <= PeerDBClickhousePrecision && scale < precision
+}
+
+type SnowflakeNumericCompatibility struct{}
+
+func (SnowflakeNumericCompatibility) MaxPrecision() int16 {
+	return 38
+}
+
+func (SnowflakeNumericCompatibility) MaxScale() int16 {
+	return 37
+}
+
+func (SnowflakeNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
+	return PeerDBSnowflakePrecision, PeerDBSnowflakeScale
+}
+
+func (SnowflakeNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
+	return precision > 0 && precision <= 38 && scale < precision
+}
+
+type BigQueryNumericCompatibility struct{}
+
+func (BigQueryNumericCompatibility) MaxPrecision() int16 {
+	return 38
+}
+
+func (BigQueryNumericCompatibility) MaxScale() int16 {
+	return 37
+}
+
+func (BigQueryNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
+	return PeerDBBigQueryPrecision, PeerDBBigQueryScale
+}
+
+func (BigQueryNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
+	return precision > 0 && precision <= 38 && scale < precision
+}
+
+type DefaultNumericCompatibility struct{}
+
+func (DefaultNumericCompatibility) MaxPrecision() int16 {
+	return 38
+}
+
+func (DefaultNumericCompatibility) MaxScale() int16 {
+	return 37
+}
+
+func (DefaultNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
+	return 38, 20
+}
+
+func (DefaultNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
+	return true
+}
+
+func MakeNumericTypmod(precision int32, scale int32) int32 {
+	if precision == 0 && scale == 0 {
+		return -1
+	}
+	return (precision << 16) | (scale & 0x7ff) + VARHDRSZ
+}
+
 // This is to reverse what make_numeric_typmod of Postgres does:
 // https://github.com/postgres/postgres/blob/21912e3c0262e2cfe64856e028799d6927862563/src/backend/utils/adt/numeric.c#L897
 func ParseNumericTypmod(typmod int32) (int16, int16) {
-	offsetMod := typmod - 4
+	offsetMod := typmod - VARHDRSZ
 	precision := int16((offsetMod >> 16) & 0x7FFF)
 	scale := int16(offsetMod & 0x7FFF)
 	return precision, scale

--- a/flow/e2e/snowflake/snowflake_schema_delta_test.go
+++ b/flow/e2e/snowflake/snowflake_schema_delta_test.go
@@ -56,13 +56,13 @@ func (s SnowflakeSchemaDeltaTestSuite) TestSimpleAddColumn() {
 	err = s.connector.ReplayTableSchemaDeltas(context.Background(), "schema_delta_flow", []*protos.TableSchemaDelta{{
 		SrcTableName: tableName,
 		DstTableName: tableName,
-		AddedColumns: []*protos.DeltaAddedColumn{{
-			Column: &protos.FieldDescription{
+		AddedColumns: []*protos.FieldDescription{
+			{
 				Name:         "HI",
 				Type:         string(qvalue.QValueKindJSON),
 				TypeModifier: -1,
 			},
-		}},
+		},
 	}})
 	require.NoError(s.t, err)
 
@@ -152,7 +152,7 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 			},
 		},
 	}
-	addedColumns := make([]*protos.DeltaAddedColumn, 0)
+	addedColumns := make([]*protos.FieldDescription, 0)
 	for _, column := range expectedTableSchema.Columns {
 		if column.Name != "ID" {
 			var typeModifierOfAddedCol int32
@@ -160,13 +160,12 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 			if column.Type == string(qvalue.QValueKindNumeric) {
 				typeModifierOfAddedCol = numericAddedColumnTypeModifier
 			}
-			addedColumns = append(addedColumns, &protos.DeltaAddedColumn{
-				Column: &protos.FieldDescription{
-					Name:         column.Name,
-					Type:         column.Type,
-					TypeModifier: typeModifierOfAddedCol,
-				},
-			})
+			addedColumns = append(addedColumns, &protos.FieldDescription{
+				Name:         column.Name,
+				Type:         column.Type,
+				TypeModifier: typeModifierOfAddedCol,
+			},
+			)
 		}
 	}
 
@@ -239,16 +238,15 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
 			},
 		},
 	}
-	addedColumns := make([]*protos.DeltaAddedColumn, 0)
+	addedColumns := make([]*protos.FieldDescription, 0)
 	for _, column := range expectedTableSchema.Columns {
 		if column.Name != "ID" {
-			addedColumns = append(addedColumns, &protos.DeltaAddedColumn{
-				Column: &protos.FieldDescription{
-					Name:         column.Name,
-					Type:         column.Type,
-					TypeModifier: -1,
-				},
-			})
+			addedColumns = append(addedColumns, &protos.FieldDescription{
+				Name:         column.Name,
+				Type:         column.Type,
+				TypeModifier: -1,
+			},
+			)
 		}
 	}
 
@@ -297,16 +295,15 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddWhitespaceColumnNames() {
 		},
 	}
 
-	addedColumns := make([]*protos.DeltaAddedColumn, 0)
+	addedColumns := make([]*protos.FieldDescription, 0)
 	for _, column := range expectedTableSchema.Columns {
 		if column.Name != " " {
-			addedColumns = append(addedColumns, &protos.DeltaAddedColumn{
-				Column: &protos.FieldDescription{
-					Name:         column.Name,
-					Type:         column.Type,
-					TypeModifier: -1,
-				},
-			})
+			addedColumns = append(addedColumns, &protos.FieldDescription{
+				Name:         column.Name,
+				Type:         column.Type,
+				TypeModifier: -1,
+			},
+			)
 		}
 	}
 

--- a/flow/e2e/snowflake/snowflake_schema_delta_test.go
+++ b/flow/e2e/snowflake/snowflake_schema_delta_test.go
@@ -126,9 +126,8 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 				TypeModifier: -1,
 			},
 			{
-				Name: "C6",
-				Type: string(qvalue.QValueKindNumeric),
-
+				Name:         "C6",
+				Type:         string(qvalue.QValueKindNumeric),
 				TypeModifier: numericAddedColumnTypeModifier, // Numeric(16,7)
 			},
 			{

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -318,14 +318,10 @@ message DropFlowInput {
   string flow_name = 1;
 }
 
-message DeltaAddedColumn {
-  FieldDescription column = 1;
-}
-
 message TableSchemaDelta {
   string src_table_name = 1;
   string dst_table_name = 2;
-  repeated DeltaAddedColumn added_columns = 3;
+  repeated FieldDescription added_columns = 3;
   TypeSystem system = 4;
 }
 

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -319,8 +319,7 @@ message DropFlowInput {
 }
 
 message DeltaAddedColumn {
-  string column_name = 1;
-  string column_type = 2;
+  FieldDescription column = 1;
 }
 
 message TableSchemaDelta {


### PR DESCRIPTION
This PR alters the DeltaAddedColumn proto file to now have one field - `Columns` of type FieldDescription, so that we now possess type modifier information.
This is then used to achieve creation of numerics with specified precision and scale in `ReplayTableSchemaDeltas` for Snowflake, like we do in `SetupNormalizedTable`
Test has been adapted for Snowflake