### PR TITLE
Fix PG-PG QRep Overwrite

### DIFF
--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -429,15 +429,6 @@ func (c *PostgresConnector) SetupQRepMetadataTables(ctx context.Context, config 
 	}
 	c.logger.Info("Setup metadata table.")
 
-	if config.WriteMode != nil &&
-		config.WriteMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE {
-		_, err = c.conn.Exec(ctx,
-			"TRUNCATE TABLE "+config.DestinationTableIdentifier)
-		if err != nil {
-			return fmt.Errorf("failed to TRUNCATE table before query replication: %w", err)
-		}
-	}
-
 	return nil
 }
 

--- a/flow/connectors/postgres/qrep_sql_sync.go
+++ b/flow/connectors/postgres/qrep_sql_sync.go
@@ -88,6 +88,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 
 		if writeMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE {
 			// Truncate the destination table before copying records
+			s.connector.logger.Info(fmt.Sprintf("Truncating table %s for overwrite mode", dstTableName), syncLog)
 			_, err = tx.Exec(ctx,
 				"TRUNCATE TABLE "+dstTableName.String())
 			if err != nil {

--- a/flow/connectors/postgres/qrep_sql_sync.go
+++ b/flow/connectors/postgres/qrep_sql_sync.go
@@ -85,7 +85,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 	if writeMode == nil ||
 		writeMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_APPEND ||
 		writeMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE {
-		if writeMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE {
+		if writeMode != nil && writeMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE {
 			// Truncate the destination table before copying records
 			s.connector.logger.Info(fmt.Sprintf("Truncating table %s for overwrite mode", dstTableName), syncLog)
 			_, err = tx.Exec(ctx,

--- a/flow/connectors/postgres/qrep_sql_sync.go
+++ b/flow/connectors/postgres/qrep_sql_sync.go
@@ -85,7 +85,6 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 	if writeMode == nil ||
 		writeMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_APPEND ||
 		writeMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE {
-
 		if writeMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE {
 			// Truncate the destination table before copying records
 			s.connector.logger.Info(fmt.Sprintf("Truncating table %s for overwrite mode", dstTableName), syncLog)

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -32,6 +32,12 @@ func (s PeerFlowE2ETestSuitePG) setupSourceTable(tableName string, rowCount int)
 	}
 }
 
+func (s PeerFlowE2ETestSuitePG) populateSourceTable(tableName string, rowCount int) {
+	if rowCount > 0 {
+		require.NoError(s.t, e2e.PopulateSourceTable(s.Conn(), s.suffix, tableName, rowCount))
+	}
+}
+
 func (s PeerFlowE2ETestSuitePG) comparePGTables(srcSchemaQualified, dstSchemaQualified, selector string) error {
 	// Execute the two EXCEPT queries
 	return errors.Join(
@@ -89,6 +95,20 @@ func (s PeerFlowE2ETestSuitePG) compareQuery(srcSchemaQualified, dstSchemaQualif
 	if len(errors) > 0 {
 		return fmt.Errorf("comparison failed: rows are not equal\n%s", strings.Join(errors, "\n---\n"))
 	}
+	return nil
+}
+
+func (s PeerFlowE2ETestSuitePG) compareCounts(dstSchemaQualified string, expectedCount int64) error {
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", dstSchemaQualified)
+	count, err := s.RunInt64Query(query)
+	if err != nil {
+		return err
+	}
+
+	if count != expectedCount {
+		return fmt.Errorf("expected %d rows, got %d", expectedCount, count)
+	}
+
 	return nil
 }
 
@@ -234,6 +254,56 @@ func (s PeerFlowE2ETestSuitePG) Test_PeerDB_Columns_QRep_PG() {
 
 	err = s.checkSyncedAt(dstSchemaQualified)
 	require.NoError(s.t, err)
+}
+
+func (s PeerFlowE2ETestSuitePG) Test_Overwrite_PG() {
+	numRows := 10
+
+	srcTable := "test_overwrite_pg_1"
+	s.setupSourceTable(srcTable, numRows)
+
+	dstTable := "test_overwrite_pg_2"
+
+	srcSchemaQualified := fmt.Sprintf("%s_%s.%s", "e2e_test", s.suffix, srcTable)
+	dstSchemaQualified := fmt.Sprintf("%s_%s.%s", "e2e_test", s.suffix, dstTable)
+
+	query := fmt.Sprintf("SELECT * FROM e2e_test_%s.%s WHERE updated_at BETWEEN {{.start}} AND {{.end}}",
+		s.suffix, srcTable)
+
+	postgresPeer := e2e.GeneratePostgresPeer()
+
+	qrepConfig, err := e2e.CreateQRepWorkflowConfig(
+		"test_overwrite_pg",
+		srcSchemaQualified,
+		dstSchemaQualified,
+		query,
+		postgresPeer,
+		"",
+		true,
+		"_PEERDB_SYNCED_AT",
+	)
+	require.NoError(s.t, err)
+	qrepConfig.WriteMode = &protos.QRepWriteMode{
+		WriteType: protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE,
+	}
+	qrepConfig.InitialCopyOnly = false
+
+	tc := e2e.NewTemporalClient(s.t)
+	env := e2e.RunQRepFlowWorkflow(tc, qrepConfig)
+	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "waiting for first sync to complete", func() bool {
+		err = s.compareCounts(dstSchemaQualified, int64(numRows))
+		return err == nil
+	})
+
+	newRowCount := 5
+	s.populateSourceTable(srcTable, newRowCount)
+
+	e2e.EnvWaitFor(s.t, env, 2*time.Minute, "waiting for overwrite sync to complete", func() bool {
+		err = s.compareCounts(dstSchemaQualified, int64(newRowCount))
+		return err == nil
+	})
+
+	require.NoError(s.t, env.Error())
 }
 
 func (s PeerFlowE2ETestSuitePG) Test_No_Rows_QRep_PG() {

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -99,7 +99,7 @@ func (s PeerFlowE2ETestSuitePG) compareQuery(srcSchemaQualified, dstSchemaQualif
 }
 
 func (s PeerFlowE2ETestSuitePG) compareCounts(dstSchemaQualified string, expectedCount int64) error {
-	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", dstSchemaQualified)
+	query := "SELECT COUNT(*) FROM " + dstSchemaQualified
 	count, err := s.RunInt64Query(query)
 	if err != nil {
 		return err


### PR DESCRIPTION
Overwrite mode was using the sync records branch for Upsert, which expects unique key columns. It failed there.
This PR fixes this by making it use the append branch. It also moves the truncate step to this branch from setup flow, since after the first sync, qrep flow continues as new, enters setup flow again where it would truncate what it just synced even though no new rows were ingested necessarily

Automated test added
Functionally tested