### PR TITLE
Better sync flow cleanup

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -687,8 +687,13 @@ func (c *BigQueryConnector) SyncFlowCleanup(ctx context.Context, jobName string)
 	}
 
 	dataset := c.client.DatasetInProject(c.projectID, c.datasetID)
-	// deleting PeerDB specific tables
-	err = dataset.Table(c.getRawTableName(jobName)).Delete(ctx)
+	rawTableHandle := dataset.Table(c.getRawTableName(jobName))
+	// check if exists, then delete
+	_, err = rawTableHandle.Metadata(ctx)
+	if err == nil {
+		err = rawTableHandle.Delete(ctx)
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to delete raw table: %w", err)
 	}

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -691,11 +691,10 @@ func (c *BigQueryConnector) SyncFlowCleanup(ctx context.Context, jobName string)
 	// check if exists, then delete
 	_, err = rawTableHandle.Metadata(ctx)
 	if err == nil {
-		err = rawTableHandle.Delete(ctx)
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to delete raw table: %w", err)
+		deleteErr := rawTableHandle.Delete(ctx)
+		if deleteErr != nil {
+			return fmt.Errorf("failed to delete raw table: %w", deleteErr)
+		}
 	}
 
 	return nil

--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -19,9 +19,8 @@ import (
 )
 
 const (
-	checkIfTableExistsSQL     = `SELECT exists(SELECT 1 FROM system.tables WHERE database = ? AND name = ?) AS table_exists;`
-	dropTableIfExistsSQL      = `DROP TABLE IF EXISTS %s;`
-	mirrorJobsTableIdentifier = "PEERDB_MIRROR_JOBS"
+	checkIfTableExistsSQL = `SELECT exists(SELECT 1 FROM system.tables WHERE database = ? AND name = ?) AS table_exists;`
+	dropTableIfExistsSQL  = `DROP TABLE IF EXISTS %s;`
 )
 
 // getRawTableName returns the raw table name for the given table identifier.
@@ -43,13 +42,6 @@ func (c *ClickhouseConnector) checkIfTableExists(ctx context.Context, databaseNa
 	}
 
 	return result.Int32 == 1, nil
-}
-
-type MirrorJobRow struct {
-	MirrorJobName    string
-	Offset           int
-	SyncBatchID      int
-	NormalizeBatchID int
 }
 
 func (c *ClickhouseConnector) CreateRawTable(ctx context.Context, req *protos.CreateRawTableInput) (*protos.CreateRawTableOutput, error) {


### PR DESCRIPTION
This PR:
- Deletes (if not exists) raw table for snowflake
- Adds sync flow cleanup method for clickhouse (same as above)
- Deletes (if not exists) raw table for bigquery thereby fixing drop mirror for Qrep BQ mirrors