### PR TITLE
fixed some context usages in PG connector

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -495,7 +495,7 @@ func (c *PostgresConnector) SyncRecords(ctx context.Context, req *model.SyncReco
 		return nil, fmt.Errorf("error starting transaction for syncing records: %w", err)
 	}
 	defer func() {
-		deferErr := syncRecordsTx.Rollback(ctx)
+		deferErr := syncRecordsTx.Rollback(context.Background())
 		if deferErr != pgx.ErrTxClosed && deferErr != nil {
 			c.logger.Error("error rolling back transaction for syncing records", slog.Any("error", err))
 		}
@@ -591,7 +591,7 @@ func (c *PostgresConnector) NormalizeRecords(ctx context.Context, req *model.Nor
 		return nil, fmt.Errorf("error starting transaction for normalizing records: %w", err)
 	}
 	defer func() {
-		deferErr := normalizeRecordsTx.Rollback(ctx)
+		deferErr := normalizeRecordsTx.Rollback(context.Background())
 		if deferErr != pgx.ErrTxClosed && deferErr != nil {
 			c.logger.Error("error rolling back transaction for normalizing records", slog.Any("error", err))
 		}
@@ -664,7 +664,7 @@ func (c *PostgresConnector) CreateRawTable(ctx context.Context, req *protos.Crea
 		return nil, fmt.Errorf("error starting transaction for creating raw table: %w", err)
 	}
 	defer func() {
-		deferErr := createRawTableTx.Rollback(ctx)
+		deferErr := createRawTableTx.Rollback(context.Background())
 		if deferErr != pgx.ErrTxClosed && deferErr != nil {
 			c.logger.Error("error rolling back transaction for creating raw table.", slog.Any("error", err))
 		}
@@ -846,7 +846,7 @@ func (c *PostgresConnector) ReplayTableSchemaDeltas(
 			err)
 	}
 	defer func() {
-		deferErr := tableSchemaModifyTx.Rollback(ctx)
+		deferErr := tableSchemaModifyTx.Rollback(context.Background())
 		if deferErr != pgx.ErrTxClosed && deferErr != nil {
 			c.logger.Error("error rolling back transaction for table schema modification", slog.Any("error", err))
 		}
@@ -1053,7 +1053,7 @@ func (c *PostgresConnector) SyncFlowCleanup(ctx context.Context, jobName string)
 		return fmt.Errorf("unable to begin transaction for sync flow cleanup: %w", err)
 	}
 	defer func() {
-		deferErr := syncFlowCleanupTx.Rollback(ctx)
+		deferErr := syncFlowCleanupTx.Rollback(context.Background())
 		if deferErr != pgx.ErrTxClosed && deferErr != nil {
 			c.logger.Error("error while rolling back transaction for flow cleanup", slog.Any("error", deferErr))
 		}

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -47,7 +47,7 @@ func (c *PostgresConnector) GetQRepPartitions(
 		return nil, fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() {
-		deferErr := tx.Rollback(ctx)
+		deferErr := tx.Rollback(context.Background())
 		if deferErr != pgx.ErrTxClosed && deferErr != nil {
 			c.logger.Error("error rolling back transaction for get partitions", slog.Any("error", deferErr))
 		}
@@ -289,7 +289,7 @@ func (c *PostgresConnector) CheckForUpdatedMaxValue(
 		return false, fmt.Errorf("unable to begin transaction for getting max value: %w", err)
 	}
 	defer func() {
-		deferErr := tx.Rollback(ctx)
+		deferErr := tx.Rollback(context.Background())
 		if deferErr != pgx.ErrTxClosed && deferErr != nil {
 			c.logger.Error("error rolling back transaction for getting max value", "error", err)
 		}

--- a/flow/connectors/postgres/qrep_query_executor.go
+++ b/flow/connectors/postgres/qrep_query_executor.go
@@ -319,12 +319,7 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQueryStreamWithTx(
 ) (int, error) {
 	var err error
 
-	defer func() {
-		err := tx.Rollback(context.Background())
-		if err != nil && err != pgx.ErrTxClosed {
-			qe.logger.Error("[pg_query_executor] failed to rollback transaction", slog.Any("error", err))
-		}
-	}()
+	defer shared.RollbackTx(tx, qe.logger)
 
 	if qe.snapshot != "" {
 		_, err = tx.Exec(ctx, "SET TRANSACTION SNAPSHOT "+QuoteLiteral(qe.snapshot))

--- a/flow/connectors/postgres/qrep_query_executor.go
+++ b/flow/connectors/postgres/qrep_query_executor.go
@@ -320,7 +320,7 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQueryStreamWithTx(
 	var err error
 
 	defer func() {
-		err := tx.Rollback(ctx)
+		err := tx.Rollback(context.Background())
 		if err != nil && err != pgx.ErrTxClosed {
 			qe.logger.Error("[pg_query_executor] failed to rollback transaction", slog.Any("error", err))
 		}

--- a/flow/connectors/postgres/qrep_sql_sync.go
+++ b/flow/connectors/postgres/qrep_sql_sync.go
@@ -97,7 +97,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 
 		// Perform the COPY FROM operation
 		numRowsSynced, err = tx.CopyFrom(
-			context.Background(),
+			ctx,
 			pgx.Identifier{dstTableName.Schema, dstTableName.Table},
 			schema.GetColumnNames(),
 			copySource,
@@ -113,7 +113,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 				QuoteIdentifier(syncedAtCol),
 				QuoteIdentifier(syncedAtCol),
 			)
-			_, err = tx.Exec(context.Background(), updateSyncedAtStmt)
+			_, err = tx.Exec(ctx, updateSyncedAtStmt)
 			if err != nil {
 				return -1, fmt.Errorf("failed to update synced_at column: %w", err)
 			}
@@ -132,14 +132,14 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 
 		s.connector.logger.Info(fmt.Sprintf("Creating staging table %s - '%s'",
 			stagingTableName, createStagingTableStmt), syncLog)
-		_, err = tx.Exec(context.Background(), createStagingTableStmt)
+		_, err = tx.Exec(ctx, createStagingTableStmt)
 		if err != nil {
 			return -1, fmt.Errorf("failed to create staging table: %w", err)
 		}
 
 		// Step 2.2: Insert records into the staging table
 		numRowsSynced, err = tx.CopyFrom(
-			context.Background(),
+			ctx,
 			stagingTableIdentifier,
 			schema.GetColumnNames(),
 			copySource,
@@ -182,7 +182,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 			setClause,
 		)
 		s.connector.logger.Info("Performing upsert operation", slog.String("upsertStmt", upsertStmt), syncLog)
-		res, err := tx.Exec(context.Background(), upsertStmt)
+		res, err := tx.Exec(ctx, upsertStmt)
 		if err != nil {
 			return -1, fmt.Errorf("failed to perform upsert operation: %w", err)
 		}
@@ -195,7 +195,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 			stagingTableIdentifier.Sanitize(),
 		)
 		s.connector.logger.Info("Dropping staging table", slog.String("stagingTable", stagingTableName), syncLog)
-		_, err = tx.Exec(context.Background(), dropStagingTableStmt)
+		_, err = tx.Exec(ctx, dropStagingTableStmt)
 		if err != nil {
 			return -1, fmt.Errorf("failed to drop staging table: %w", err)
 		}
@@ -216,7 +216,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 	)
 	s.connector.logger.Info("Executing transaction inside QRep sync", syncLog)
 	_, err = tx.Exec(
-		context.Background(),
+		ctx,
 		insertMetadataStmt,
 		flowJobName,
 		partitionID,
@@ -228,7 +228,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 		return -1, fmt.Errorf("failed to execute statements in a transaction: %w", err)
 	}
 
-	err = tx.Commit(context.Background())
+	err = tx.Commit(ctx)
 	if err != nil {
 		return -1, fmt.Errorf("failed to commit transaction: %w", err)
 	}

--- a/flow/connectors/utils/monitoring/monitoring.go
+++ b/flow/connectors/utils/monitoring/monitoring.go
@@ -114,7 +114,7 @@ func AddCDCBatchTablesForFlow(ctx context.Context, pool *pgxpool.Pool, flowJobNa
 		return fmt.Errorf("error while beginning transaction for inserting statistics into cdc_batch_table: %w", err)
 	}
 	defer func() {
-		err = insertBatchTablesTx.Rollback(ctx)
+		err = insertBatchTablesTx.Rollback(context.Background())
 		if err != pgx.ErrTxClosed && err != nil {
 			logger.LoggerFromCtx(ctx).Error("error during transaction rollback",
 				slog.Any("error", err),


### PR DESCRIPTION
1. `context.Background()` was being used in PG qrep destination in some places instead of the dedicated context
2. defer functions should not use context passed in, as the defer could have run due to context cancellation and so the defer will be useless. Primarily for pg tx rollbacks