### PR TITLE
UI Partitions table: remove extra column

### DIFF
--- a/ui/app/mirrors/status/qrep/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/status/qrep/[mirrorId]/page.tsx
@@ -34,7 +34,6 @@ export default async function QRepMirrorStatus({
       endTime: run.end_time,
       pulledRows: run.rows_in_partition,
       syncedRows: run.rows_synced,
-      status: '',
     };
     return ret;
   });

--- a/ui/app/mirrors/status/qrep/[mirrorId]/qrepStatusTable.tsx
+++ b/ui/app/mirrors/status/qrep/[mirrorId]/qrepStatusTable.tsx
@@ -13,7 +13,6 @@ import ReactSelect from 'react-select';
 
 export type QRepPartitionStatus = {
   partitionId: string;
-  status: string;
   startTime: Date | null;
   endTime: Date | null;
   pulledRows: number | null;
@@ -30,7 +29,6 @@ function TimeOrProgressBar({ time }: { time: Date | null }) {
 
 function RowPerPartition({
   partitionId,
-  status,
   startTime,
   endTime,
   pulledRows: numRows,
@@ -204,7 +202,6 @@ export default function QRepStatusTable({ partitions }: QRepStatusTableProps) {
         <TableRow>
           {[
             'Partition UUID',
-            'Run UUID',
             'Duration',
             'Start Time',
             'End Time',


### PR DESCRIPTION
Bug in one of the qrep tables where run uuid was removed from the fetch but the column was still in the table causing the table headers to be mismatched. This PR fixes this
<img width="1726" alt="Screenshot 2024-04-11 at 7 30 33 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/8c3df5ed-a71c-4881-9ba3-bda9aef3741e">
