### PR TITLE
Add missing flow name keys to some logs

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -734,6 +734,7 @@ func (a *FlowableActivity) replicateQRepPartition(ctx context.Context,
 func (a *FlowableActivity) ConsolidateQRepPartitions(ctx context.Context, config *protos.QRepConfig,
 	runUUID string,
 ) error {
+	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
 	dstConn, err := connectors.GetQRepConsolidateConnector(ctx, config.DestinationPeer)
 	if errors.Is(err, connectors.ErrUnsupportedFunctionality) {
 		return monitoring.UpdateEndTimeForQRepRun(ctx, a.CatalogPool, runUUID)
@@ -757,6 +758,7 @@ func (a *FlowableActivity) ConsolidateQRepPartitions(ctx context.Context, config
 }
 
 func (a *FlowableActivity) CleanupQRepFlow(ctx context.Context, config *protos.QRepConfig) error {
+	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
 	dst, err := connectors.GetQRepConsolidateConnector(ctx, config.DestinationPeer)
 	if errors.Is(err, connectors.ErrUnsupportedFunctionality) {
 		return nil
@@ -780,6 +782,7 @@ func (a *FlowableActivity) DropFlowSource(ctx context.Context, config *protos.Sh
 }
 
 func (a *FlowableActivity) DropFlowDestination(ctx context.Context, config *protos.ShutdownRequest) error {
+	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
 	dstConn, err := connectors.GetCDCSyncConnector(ctx, config.DestinationPeer)
 	if err != nil {
 		return fmt.Errorf("failed to get destination connector: %w", err)

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -135,17 +135,17 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 		if cdcRecordsStorage.IsEmpty() {
 			records.SignalAsEmpty()
 		}
-		p.logger.Info(fmt.Sprintf("[finished] PullRecords streamed %d records", cdcRecordsStorage.Len()))
+		p.PostgresConnector.logger.Info(fmt.Sprintf("[finished] PullRecords streamed %d records", cdcRecordsStorage.Len()))
 		err := cdcRecordsStorage.Close()
 		if err != nil {
-			p.logger.Warn("failed to clean up records storage", slog.Any("error", err))
+			p.PostgresConnector.logger.Warn("failed to clean up records storage", slog.Any("error", err))
 		}
 	}()
 
 	shutdown := utils.HeartbeatRoutine(ctx, func() string {
 		currRecords := cdcRecordsStorage.Len()
 		msg := fmt.Sprintf("pulling records, currently have %d records", currRecords)
-		p.logger.Info(msg)
+		p.PostgresConnector.logger.Info(msg)
 		return msg
 	})
 	defer shutdown()
@@ -164,7 +164,7 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 		if cdcRecordsStorage.Len() == 1 {
 			records.SignalAsNotEmpty()
 			nextStandbyMessageDeadline = time.Now().Add(standbyMessageTimeout)
-			p.logger.Info(fmt.Sprintf("pushing the standby deadline to %s", nextStandbyMessageDeadline))
+			p.PostgresConnector.logger.Info(fmt.Sprintf("pushing the standby deadline to %s", nextStandbyMessageDeadline))
 		}
 		return nil
 	}
@@ -183,7 +183,7 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 
 			if time.Since(standByLastLogged) > 10*time.Second {
 				numRowsProcessedMessage := fmt.Sprintf("processed %d rows", cdcRecordsStorage.Len())
-				p.logger.Info("Sent Standby status message. " + numRowsProcessedMessage)
+				p.PostgresConnector.logger.Info("Sent Standby status message. " + numRowsProcessedMessage)
 				standByLastLogged = time.Now()
 			}
 		}
@@ -195,7 +195,7 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 			}
 
 			if waitingForCommit {
-				p.logger.Info(fmt.Sprintf(
+				p.PostgresConnector.logger.Info(fmt.Sprintf(
 					"[%s] commit received, returning currently accumulated records - %d",
 					p.flowJobName,
 					cdcRecordsStorage.Len()),
@@ -207,20 +207,20 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 		// if we are past the next standby deadline (?)
 		if time.Now().After(nextStandbyMessageDeadline) {
 			if !cdcRecordsStorage.IsEmpty() {
-				p.logger.Info(fmt.Sprintf("standby deadline reached, have %d records", cdcRecordsStorage.Len()))
+				p.PostgresConnector.logger.Info(fmt.Sprintf("standby deadline reached, have %d records", cdcRecordsStorage.Len()))
 
 				if p.commitLock == nil {
-					p.logger.Info(
+					p.PostgresConnector.logger.Info(
 						fmt.Sprintf("no commit lock, returning currently accumulated records - %d",
 							cdcRecordsStorage.Len()))
 					return nil
 				} else {
-					p.logger.Info(fmt.Sprintf("commit lock, waiting for commit to return records - %d",
+					p.PostgresConnector.logger.Info(fmt.Sprintf("commit lock, waiting for commit to return records - %d",
 						cdcRecordsStorage.Len()))
 					waitingForCommit = true
 				}
 			} else {
-				p.logger.Info(fmt.Sprintf("[%s] standby deadline reached, no records accumulated, continuing to wait",
+				p.PostgresConnector.logger.Info(fmt.Sprintf("[%s] standby deadline reached, no records accumulated, continuing to wait",
 					p.flowJobName),
 				)
 			}
@@ -244,7 +244,7 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 
 		if err != nil && p.commitLock == nil {
 			if pgconn.Timeout(err) {
-				p.logger.Info(fmt.Sprintf("Stand-by deadline reached, returning currently accumulated records - %d",
+				p.PostgresConnector.logger.Info(fmt.Sprintf("Stand-by deadline reached, returning currently accumulated records - %d",
 					cdcRecordsStorage.Len()))
 				return nil
 			} else {
@@ -253,7 +253,7 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 		}
 
 		if errMsg, ok := rawMsg.(*pgproto3.ErrorResponse); ok {
-			p.logger.Error(fmt.Sprintf("received Postgres WAL error: %+v", errMsg))
+			p.PostgresConnector.logger.Error(fmt.Sprintf("received Postgres WAL error: %+v", errMsg))
 			return fmt.Errorf("received Postgres WAL error: %+v", errMsg)
 		}
 
@@ -269,7 +269,7 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 				return fmt.Errorf("ParsePrimaryKeepaliveMessage failed: %w", err)
 			}
 
-			p.logger.Debug(
+			p.PostgresConnector.logger.Debug(
 				fmt.Sprintf("Primary Keepalive Message => ServerWALEnd: %s ServerTime: %s ReplyRequested: %t",
 					pkm.ServerWALEnd, pkm.ServerTime, pkm.ReplyRequested))
 
@@ -287,7 +287,7 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 				return fmt.Errorf("ParseXLogData failed: %w", err)
 			}
 
-			p.logger.Debug(fmt.Sprintf("XLogData => WALStart %s ServerWALEnd %s ServerTime %s\n",
+			p.PostgresConnector.logger.Debug(fmt.Sprintf("XLogData => WALStart %s ServerWALEnd %s ServerTime %s\n",
 				xld.WALStart, xld.ServerWALEnd, xld.ServerTime))
 			rec, err := p.processMessage(ctx, records, xld, clientXLogPos)
 			if err != nil {
@@ -395,7 +395,7 @@ func (p *PostgresCDCSource) PullRecords(ctx context.Context, req *model.PullReco
 				case *model.RelationRecord:
 					tableSchemaDelta := r.TableSchemaDelta
 					if len(tableSchemaDelta.AddedColumns) > 0 {
-						p.logger.Info(fmt.Sprintf("Detected schema change for table %s, addedColumns: %v",
+						p.PostgresConnector.logger.Info(fmt.Sprintf("Detected schema change for table %s, addedColumns: %v",
 							tableSchemaDelta.SrcTableName, tableSchemaDelta.AddedColumns))
 						records.AddSchemaDelta(req.TableNameMapping, tableSchemaDelta)
 					}
@@ -433,8 +433,8 @@ func (p *PostgresCDCSource) processMessage(
 
 	switch msg := logicalMsg.(type) {
 	case *pglogrepl.BeginMessage:
-		p.logger.Debug(fmt.Sprintf("BeginMessage => FinalLSN: %v, XID: %v", msg.FinalLSN, msg.Xid))
-		p.logger.Debug("Locking PullRecords at BeginMessage, awaiting CommitMessage")
+		p.PostgresConnector.logger.Debug(fmt.Sprintf("BeginMessage => FinalLSN: %v, XID: %v", msg.FinalLSN, msg.Xid))
+		p.PostgresConnector.logger.Debug("Locking PullRecords at BeginMessage, awaiting CommitMessage")
 		p.commitLock = msg
 	case *pglogrepl.InsertMessage:
 		return p.processInsertMessage(xld.WALStart, msg)
@@ -444,7 +444,7 @@ func (p *PostgresCDCSource) processMessage(
 		return p.processDeleteMessage(xld.WALStart, msg)
 	case *pglogrepl.CommitMessage:
 		// for a commit message, update the last checkpoint id for the record batch.
-		p.logger.Debug(fmt.Sprintf("CommitMessage => CommitLSN: %v, TransactionEndLSN: %v",
+		p.PostgresConnector.logger.Debug(fmt.Sprintf("CommitMessage => CommitLSN: %v, TransactionEndLSN: %v",
 			msg.CommitLSN, msg.TransactionEndLSN))
 		batch.UpdateLatestCheckpoint(int64(msg.CommitLSN))
 		p.commitLock = nil
@@ -456,13 +456,13 @@ func (p *PostgresCDCSource) processMessage(
 			return nil, nil
 		}
 
-		p.logger.Debug(fmt.Sprintf("RelationMessage => RelationID: %d, Namespace: %s, RelationName: %s, Columns: %v",
+		p.PostgresConnector.logger.Debug(fmt.Sprintf("RelationMessage => RelationID: %d, Namespace: %s, RelationName: %s, Columns: %v",
 			msg.RelationID, msg.Namespace, msg.RelationName, msg.Columns))
 
 		return p.processRelationMessage(ctx, currentClientXlogPos, msg)
 
 	case *pglogrepl.TruncateMessage:
-		p.logger.Warn("TruncateMessage not supported")
+		p.PostgresConnector.logger.Warn("TruncateMessage not supported")
 	}
 
 	return nil, nil
@@ -480,7 +480,7 @@ func (p *PostgresCDCSource) processInsertMessage(
 	}
 
 	// log lsn and relation id for debugging
-	p.logger.Debug(fmt.Sprintf("InsertMessage => LSN: %d, RelationID: %d, Relation Name: %s",
+	p.PostgresConnector.logger.Debug(fmt.Sprintf("InsertMessage => LSN: %d, RelationID: %d, Relation Name: %s",
 		lsn, relID, tableName))
 
 	rel, ok := p.relationMessageMapping[relID]
@@ -515,7 +515,7 @@ func (p *PostgresCDCSource) processUpdateMessage(
 	}
 
 	// log lsn and relation id for debugging
-	p.logger.Debug(fmt.Sprintf("UpdateMessage => LSN: %d, RelationID: %d, Relation Name: %s",
+	p.PostgresConnector.logger.Debug(fmt.Sprintf("UpdateMessage => LSN: %d, RelationID: %d, Relation Name: %s",
 		lsn, relID, tableName))
 
 	rel, ok := p.relationMessageMapping[relID]
@@ -558,7 +558,7 @@ func (p *PostgresCDCSource) processDeleteMessage(
 	}
 
 	// log lsn and relation id for debugging
-	p.logger.Debug(fmt.Sprintf("DeleteMessage => LSN: %d, RelationID: %d, Relation Name: %s",
+	p.PostgresConnector.logger.Debug(fmt.Sprintf("DeleteMessage => LSN: %d, RelationID: %d, Relation Name: %s",
 		lsn, relID, tableName))
 
 	rel, ok := p.relationMessageMapping[relID]
@@ -648,7 +648,7 @@ func (p *PostgresCDCSource) decodeColumnData(data []byte, dataType uint32, forma
 				// indicates year is more than 4 digits or something similar,
 				// which you can insert into postgres,
 				// but not representable by time.Time
-				p.logger.Warn(fmt.Sprintf("Invalidated and hence nulled %s data: %s",
+				p.PostgresConnector.logger.Warn(fmt.Sprintf("Invalidated and hence nulled %s data: %s",
 					dt.Name, string(data)))
 				switch dt.Name {
 				case "time":
@@ -725,7 +725,7 @@ func (p *PostgresCDCSource) processRelationMessage(
 ) (model.Record, error) {
 	// not present in tables to sync, return immediately
 	if _, ok := p.srcTableIDNameMapping[currRel.RelationID]; !ok {
-		p.logger.Info("relid not present in srcTableIDNameMapping, skipping relation message",
+		p.PostgresConnector.logger.Info("relid not present in srcTableIDNameMapping, skipping relation message",
 			slog.Uint64("relId", uint64(currRel.RelationID)))
 		return nil, nil
 	}
@@ -768,14 +768,14 @@ func (p *PostgresCDCSource) processRelationMessage(
 			// present in previous and current relation messages, but data types have changed.
 			// so we add it to AddedColumns and DroppedColumns, knowing that we process DroppedColumns first.
 		} else if prevRelMap[column.Name] != currRelMap[column.Name] {
-			p.logger.Warn(fmt.Sprintf("Detected column %s with type changed from %s to %s in table %s, but not propagating",
+			p.PostgresConnector.logger.Warn(fmt.Sprintf("Detected column %s with type changed from %s to %s in table %s, but not propagating",
 				column.Name, prevRelMap[column.Name], currRelMap[column.Name], schemaDelta.SrcTableName))
 		}
 	}
 	for _, column := range prevSchema.Columns {
 		// present in previous relation message, but not in current one, so dropped.
 		if _, ok := currRelMap[column.Name]; !ok {
-			p.logger.Warn(fmt.Sprintf("Detected dropped column %s in table %s, but not propagating", column,
+			p.PostgresConnector.logger.Warn(fmt.Sprintf("Detected dropped column %s in table %s, but not propagating", column,
 				schemaDelta.SrcTableName))
 		}
 	}

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -160,8 +160,6 @@ func (c *SnowflakeConnector) createExternalStage(stageName string, config *proto
 }
 
 func (c *SnowflakeConnector) ConsolidateQRepPartitions(ctx context.Context, config *protos.QRepConfig) error {
-	c.logger.Info("Consolidating partitions")
-
 	destTable := config.DestinationTableIdentifier
 	stageName := c.getStageNameForJob(config.FlowJobName)
 

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -288,8 +288,6 @@ func (q *QRepFlowExecution) processPartitions(
 // For some targets we need to consolidate all the partitions from stages before
 // we proceed to next batch.
 func (q *QRepFlowExecution) consolidatePartitions(ctx workflow.Context) error {
-	q.logger.Info("consolidating partitions")
-
 	// only an operation for Snowflake currently.
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 24 * time.Hour,


### PR DESCRIPTION
Logs in PullRecords and ConsolidatePartitions were missing the flow name key.
Added values to context in activity for the latter
For PullRecords, `p.logger` (and p.PostgresConnector.logger) for some reason does not print flow name even though it takes from loggerfromctx where ctx should have the flowName key. Using loggerfromctx in the pullrecords function explicitly instead, does print it