### PR TITLE
UI: split initial load table into 2

### DIFF
--- a/ui/app/mirrors/[mirrorId]/snapshot.tsx
+++ b/ui/app/mirrors/[mirrorId]/snapshot.tsx
@@ -1,18 +1,7 @@
 'use client';
-import SelectTheme from '@/app/styles/select';
-import TimeLabel from '@/components/TimeComponent';
 import { CloneTableSummary, SnapshotStatus } from '@/grpc_generated/route';
-import { Badge } from '@/lib/Badge/Badge';
-import { Button } from '@/lib/Button';
-import { Icon } from '@/lib/Icon';
-import { Label } from '@/lib/Label';
-import { ProgressBar } from '@/lib/ProgressBar';
-import { SearchField } from '@/lib/SearchField';
-import { Table, TableCell, TableRow } from '@/lib/Table';
 import moment, { Duration, Moment } from 'moment';
-import Link from 'next/link';
-import { useMemo, useState } from 'react';
-import ReactSelect from 'react-select';
+import SnapshotTable from './snapshotTable';
 
 export class TableCloneSummary {
   cloneStartTime: Moment | null = null;
@@ -53,233 +42,34 @@ type SnapshotStatusProps = {
   status: SnapshotStatus;
 };
 
-const ROWS_PER_PAGE = 5;
 export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
-  const [sortField, setSortField] = useState<
-    'cloneStartTime' | 'avgTimePerPartition'
-  >('cloneStartTime');
-  const allRows = status.clones.map(summarizeTableClone);
-  const [currentPage, setCurrentPage] = useState(1);
-  const totalPages = Math.ceil(allRows.length / ROWS_PER_PAGE);
-  const [searchQuery, setSearchQuery] = useState<string>('');
-  const [sortDir, setSortDir] = useState<'asc' | 'dsc'>('dsc');
-  const displayedRows = useMemo(() => {
-    const shownRows = allRows.filter((row: TableCloneSummary) =>
-      row.cloneTableSummary.tableName
-        ?.toLowerCase()
-        .includes(searchQuery.toLowerCase())
-    );
-    shownRows.sort((a, b) => {
-      const aValue = a[sortField];
-      const bValue = b[sortField];
-      if (aValue === null || bValue === null) {
-        return 0;
-      }
+  const allTableLoads = status.clones.map(summarizeTableClone);
+  const completedTableLoads = allTableLoads.filter(
+    (row) => row.cloneTableSummary.consolidateCompleted === true
+  );
+  const inProgressTableLoads = allTableLoads.filter(
+    (row) => !row.cloneTableSummary.consolidateCompleted
+  );
 
-      if (aValue < bValue) {
-        return sortDir === 'dsc' ? 1 : -1;
-      } else if (aValue > bValue) {
-        return sortDir === 'dsc' ? -1 : 1;
-      } else {
-        return 0;
-      }
-    });
-
-    const startRow = (currentPage - 1) * ROWS_PER_PAGE;
-    const endRow = startRow + ROWS_PER_PAGE;
-    return shownRows.length > ROWS_PER_PAGE
-      ? shownRows.slice(startRow, endRow)
-      : shownRows;
-  }, [allRows, currentPage, searchQuery, sortField, sortDir]);
-
-  const handlePrevPage = () => {
-    if (currentPage > 1) {
-      setCurrentPage(currentPage - 1);
-    }
-  };
-
-  const handleNextPage = () => {
-    if (currentPage < totalPages) {
-      setCurrentPage(currentPage + 1);
-    }
-  };
-
-  const getStatus = (clone: CloneTableSummary) => {
-    if (clone.consolidateCompleted) {
-      return (
-        <Badge type='longText' variant='positive'>
-          <Icon name='check' />
-          <div className='font-bold'>Done</div>
-        </Badge>
-      );
-    }
-    if (!clone.fetchCompleted) {
-      return (
-        <Badge type='longText' variant='normal'>
-          <Icon name='download' />
-          <div className='font-bold'>Fetching</div>
-        </Badge>
-      );
-    }
-
-    if (clone.numPartitionsCompleted == clone.numPartitionsTotal) {
-      return (
-        <Badge type='longText' variant='normal'>
-          <Icon name='upload' />
-          <div className='font-bold'>Consolidating</div>
-        </Badge>
-      );
-    }
-
-    return (
-      <Badge type='longText' variant='normal'>
-        <Icon name='upload' />
-        <div className='font-bold'>Syncing</div>
-      </Badge>
-    );
-  };
-
-  const sortOptions = [
-    { value: 'cloneStartTime', label: 'Start Time' },
-    { value: 'avgTimePerPartition', label: 'Time Per Partition' },
-  ];
   return (
     <div
       style={{
         marginTop: '2rem',
         display: 'flex',
         flexDirection: 'column',
-        rowGap: '1rem',
+        rowGap: '3rem',
       }}
     >
-      <Table
-        title={<Label variant='headline'>Initial Copy</Label>}
-        toolbar={{
-          left: (
-            <div style={{ display: 'flex', alignItems: 'center' }}>
-              <Button variant='normalBorderless' onClick={handlePrevPage}>
-                <Icon name='chevron_left' />
-              </Button>
-              <Button variant='normalBorderless' onClick={handleNextPage}>
-                <Icon name='chevron_right' />
-              </Button>
-              <Label>{`${currentPage} of ${totalPages}`}</Label>
-              <Button
-                variant='normalBorderless'
-                onClick={() => window.location.reload()}
-              >
-                <Icon name='refresh' />
-              </Button>
-              <div style={{ minWidth: '10em' }}>
-                <ReactSelect
-                  options={sortOptions}
-                  onChange={(val, _) => {
-                    const sortVal =
-                      (val?.value as
-                        | 'cloneStartTime'
-                        | 'avgTimePerPartition') ?? 'cloneStartTime';
-                    setSortField(sortVal);
-                  }}
-                  value={{
-                    value: sortField,
-                    label: sortOptions.find((opt) => opt.value === sortField)
-                      ?.label,
-                  }}
-                  defaultValue={{
-                    value: 'cloneStartTime',
-                    label: 'Start Time',
-                  }}
-                  theme={SelectTheme}
-                />
-              </div>
-              <button
-                className='IconButton'
-                onClick={() => setSortDir('asc')}
-                aria-label='sort up'
-                style={{ color: sortDir == 'asc' ? 'green' : 'gray' }}
-              >
-                <Icon name='arrow_upward' />
-              </button>
-              <button
-                className='IconButton'
-                onClick={() => setSortDir('dsc')}
-                aria-label='sort down'
-                style={{ color: sortDir == 'dsc' ? 'green' : 'gray' }}
-              >
-                <Icon name='arrow_downward' />
-              </button>
-            </div>
-          ),
-          right: (
-            <SearchField
-              placeholder='Search by table name'
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setSearchQuery(e.target.value)
-              }
-            />
-          ),
-        }}
-        header={
-          <TableRow>
-            <TableCell as='th'>Table Identifier</TableCell>
-            <TableCell as='th'>Status</TableCell>
-            <TableCell as='th'>Sync Start</TableCell>
-            <TableCell as='th'>Progress Partitions</TableCell>
-            <TableCell as='th'>Num Rows Processed</TableCell>
-            <TableCell as='th'>Avg Time Per Partition</TableCell>
-          </TableRow>
-        }
-      >
-        {displayedRows.map((clone, index) => (
-          <TableRow key={index}>
-            <TableCell>
-              <Label>
-                <Link
-                  href={`/mirrors/status/qrep/${clone.cloneTableSummary.flowJobName}`}
-                  className='underline cursor-pointer'
-                >
-                  {clone.cloneTableSummary.tableName}
-                </Link>
-              </Label>
-            </TableCell>
-            <TableCell>{getStatus(clone.cloneTableSummary)}</TableCell>
-            <TableCell>
-              {clone.cloneStartTime ? (
-                <TimeLabel
-                  timeVal={clone.cloneStartTime.format('YYYY-MM-DD HH:mm:ss')}
-                />
-              ) : (
-                'N/A'
-              )}
-            </TableCell>
-            {clone.cloneTableSummary.fetchCompleted ? (
-              <TableCell>
-                <ProgressBar
-                  progress={clone.getPartitionProgressPercentage()}
-                />
-                {clone.cloneTableSummary.numPartitionsCompleted} /{' '}
-                {clone.cloneTableSummary.numPartitionsTotal}
-              </TableCell>
-            ) : (
-              <TableCell>N/A</TableCell>
-            )}
-            <TableCell>
-              {clone.cloneTableSummary.fetchCompleted
-                ? clone.cloneTableSummary.numRowsSynced
-                : 0}
-            </TableCell>
-            {clone.cloneTableSummary.fetchCompleted ? (
-              <TableCell>
-                <Label>
-                  {clone.avgTimePerPartition?.humanize({ ss: 1 }) || 'N/A'}
-                </Label>
-              </TableCell>
-            ) : (
-              <TableCell>N/A</TableCell>
-            )}
-          </TableRow>
-        ))}
-      </Table>
+      {[
+        { data: completedTableLoads, title: 'Completed tables' },
+        { data: inProgressTableLoads, title: 'In progress' },
+      ].map((tableLoads, index) => (
+        <SnapshotTable
+          key={index}
+          tableLoads={tableLoads.data}
+          title={tableLoads.title}
+        />
+      ))}
     </div>
   );
 };

--- a/ui/app/mirrors/[mirrorId]/snapshot.tsx
+++ b/ui/app/mirrors/[mirrorId]/snapshot.tsx
@@ -61,8 +61,8 @@ export const SnapshotStatusTable = ({ status }: SnapshotStatusProps) => {
       }}
     >
       {[
-        { data: completedTableLoads, title: 'Completed tables' },
         { data: inProgressTableLoads, title: 'In progress' },
+        { data: completedTableLoads, title: 'Completed tables' },
       ].map((tableLoads, index) => (
         <SnapshotTable
           key={index}

--- a/ui/app/mirrors/[mirrorId]/snapshotTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/snapshotTable.tsx
@@ -1,0 +1,249 @@
+'use client';
+import SelectTheme from '@/app/styles/select';
+import TimeLabel from '@/components/TimeComponent';
+import { CloneTableSummary } from '@/grpc_generated/route';
+import { Badge } from '@/lib/Badge/Badge';
+import { Button } from '@/lib/Button';
+import { Icon } from '@/lib/Icon';
+import { Label } from '@/lib/Label';
+import { ProgressBar } from '@/lib/ProgressBar';
+import { SearchField } from '@/lib/SearchField';
+import { Table, TableCell, TableRow } from '@/lib/Table';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import ReactSelect from 'react-select';
+import { TableCloneSummary } from './snapshot';
+
+const ROWS_PER_PAGE = 5;
+
+const getStatus = (clone: CloneTableSummary) => {
+  if (clone.consolidateCompleted) {
+    return (
+      <Badge type='longText' variant='positive'>
+        <Icon name='check' />
+        <div className='font-bold'>Done</div>
+      </Badge>
+    );
+  }
+  if (!clone.fetchCompleted) {
+    return (
+      <Badge type='longText' variant='normal'>
+        <Icon name='download' />
+        <div className='font-bold'>Fetching</div>
+      </Badge>
+    );
+  }
+
+  if (clone.numPartitionsCompleted == clone.numPartitionsTotal) {
+    return (
+      <Badge type='longText' variant='normal'>
+        <Icon name='upload' />
+        <div className='font-bold'>Consolidating</div>
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge type='longText' variant='normal'>
+      <Icon name='upload' />
+      <div className='font-bold'>Syncing</div>
+    </Badge>
+  );
+};
+
+const SnapshotTable = ({
+  tableLoads,
+  title,
+}: {
+  tableLoads: TableCloneSummary[];
+  title: string;
+}) => {
+  const [sortField, setSortField] = useState<
+    'cloneStartTime' | 'avgTimePerPartition'
+  >('cloneStartTime');
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const totalPages = Math.ceil(tableLoads.length / ROWS_PER_PAGE);
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [sortDir, setSortDir] = useState<'asc' | 'dsc'>('dsc');
+  const displayedLoads = useMemo(() => {
+    const shownRows = tableLoads.filter((row: TableCloneSummary) =>
+      row.cloneTableSummary.tableName
+        ?.toLowerCase()
+        .includes(searchQuery.toLowerCase())
+    );
+    shownRows.sort((a, b) => {
+      const aValue = a[sortField];
+      const bValue = b[sortField];
+      if (aValue === null || bValue === null) {
+        return 0;
+      }
+
+      if (aValue < bValue) {
+        return sortDir === 'dsc' ? 1 : -1;
+      } else if (aValue > bValue) {
+        return sortDir === 'dsc' ? -1 : 1;
+      } else {
+        return 0;
+      }
+    });
+
+    const startRow = (currentPage - 1) * ROWS_PER_PAGE;
+    const endRow = startRow + ROWS_PER_PAGE;
+    return shownRows.length > ROWS_PER_PAGE
+      ? shownRows.slice(startRow, endRow)
+      : shownRows;
+  }, [tableLoads, currentPage, searchQuery, sortField, sortDir]);
+
+  const handlePrevPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage(currentPage + 1);
+    }
+  };
+
+  const sortOptions = [
+    { value: 'cloneStartTime', label: 'Start Time' },
+    { value: 'avgTimePerPartition', label: 'Time Per Partition' },
+  ];
+  return (
+    <Table
+      title={<Label variant='headline'>{title}</Label>}
+      toolbar={{
+        left: (
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <Button variant='normalBorderless' onClick={handlePrevPage}>
+              <Icon name='chevron_left' />
+            </Button>
+            <Button variant='normalBorderless' onClick={handleNextPage}>
+              <Icon name='chevron_right' />
+            </Button>
+            <Label>{`${currentPage} of ${totalPages}`}</Label>
+            <Button
+              variant='normalBorderless'
+              onClick={() => window.location.reload()}
+            >
+              <Icon name='refresh' />
+            </Button>
+            <div style={{ minWidth: '10em' }}>
+              <ReactSelect
+                options={sortOptions}
+                onChange={(val, _) => {
+                  const sortVal =
+                    (val?.value as 'cloneStartTime' | 'avgTimePerPartition') ??
+                    'cloneStartTime';
+                  setSortField(sortVal);
+                }}
+                value={{
+                  value: sortField,
+                  label: sortOptions.find((opt) => opt.value === sortField)
+                    ?.label,
+                }}
+                defaultValue={{
+                  value: 'cloneStartTime',
+                  label: 'Start Time',
+                }}
+                theme={SelectTheme}
+              />
+            </div>
+            <button
+              className='IconButton'
+              onClick={() => setSortDir('asc')}
+              aria-label='sort up'
+              style={{ color: sortDir == 'asc' ? 'green' : 'gray' }}
+            >
+              <Icon name='arrow_upward' />
+            </button>
+            <button
+              className='IconButton'
+              onClick={() => setSortDir('dsc')}
+              aria-label='sort down'
+              style={{ color: sortDir == 'dsc' ? 'green' : 'gray' }}
+            >
+              <Icon name='arrow_downward' />
+            </button>
+          </div>
+        ),
+        right: (
+          <SearchField
+            placeholder='Search by table name'
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setSearchQuery(e.target.value)
+            }
+          />
+        ),
+      }}
+      header={
+        <TableRow>
+          {[
+            'Table Identifier',
+            'Status',
+            'Sync Start',
+            'Progress Partitions',
+            'Num Rows Processed',
+            'Avg Time Per Partition',
+          ].map((header) => (
+            <TableCell key={header} as='th'>
+              {header}
+            </TableCell>
+          ))}
+        </TableRow>
+      }
+    >
+      {displayedLoads.map((clone, index) => (
+        <TableRow key={index}>
+          <TableCell>
+            <Label>
+              <Link
+                href={`/mirrors/status/qrep/${clone.cloneTableSummary.flowJobName}`}
+                className='underline cursor-pointer'
+              >
+                {clone.cloneTableSummary.tableName}
+              </Link>
+            </Label>
+          </TableCell>
+          <TableCell>{getStatus(clone.cloneTableSummary)}</TableCell>
+          <TableCell>
+            {clone.cloneStartTime ? (
+              <TimeLabel
+                timeVal={clone.cloneStartTime.format('YYYY-MM-DD HH:mm:ss')}
+              />
+            ) : (
+              'N/A'
+            )}
+          </TableCell>
+          {clone.cloneTableSummary.fetchCompleted ? (
+            <TableCell>
+              <ProgressBar progress={clone.getPartitionProgressPercentage()} />
+              {clone.cloneTableSummary.numPartitionsCompleted} /{' '}
+              {clone.cloneTableSummary.numPartitionsTotal}
+            </TableCell>
+          ) : (
+            <TableCell>N/A</TableCell>
+          )}
+          <TableCell>
+            {clone.cloneTableSummary.fetchCompleted
+              ? clone.cloneTableSummary.numRowsSynced
+              : 0}
+          </TableCell>
+          {clone.cloneTableSummary.fetchCompleted ? (
+            <TableCell>
+              <Label>
+                {clone.avgTimePerPartition?.humanize({ ss: 1 }) || 'N/A'}
+              </Label>
+            </TableCell>
+          ) : (
+            <TableCell>N/A</TableCell>
+          )}
+        </TableRow>
+      ))}
+    </Table>
+  );
+};
+
+export default SnapshotTable;


### PR DESCRIPTION
This PR splits the initial load table in the mirror page into two - completed and in progress

<img width="1724" alt="Screenshot 2024-04-11 at 11 36 13 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/f3317374-b7b3-4f61-95c4-b3798de2b0c2">
