### PR TITLE
CdcStore: use /memory/classes/heap/objects:bytes

### DIFF
--- a/flow/connectors/utils/cdc_store.go
+++ b/flow/connectors/utils/cdc_store.go
@@ -60,7 +60,7 @@ func NewCDCStore[Items model.Items](flowJobName string) *cdcStore[Items] {
 			return 0
 		}(),
 		thresholdReason: "",
-		memStats:        []metrics.Sample{{Name: "/gc/heap/allocs:bytes"}},
+		memStats:        []metrics.Sample{{Name: "/memory/classes/heap/objects:bytes"}},
 	}
 }
 


### PR DESCRIPTION
Turns out cumulative in /gc/heap/allocs:bytes description means monotonic over lifetime of program