### PR TITLE
Remove QRecordSchemaOrError

### DIFF
--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -22,10 +22,8 @@ func (c *BigQueryConnector) SyncQRepRecords(
 ) (int, error) {
 	// Ensure the destination table is available.
 	destTable := config.DestinationTableIdentifier
-	srcSchema, err := stream.Schema()
-	if err != nil {
-		return 0, fmt.Errorf("failed to get schema of source table %s: %w", config.WatermarkTable, err)
-	}
+	srcSchema := stream.Schema()
+
 	tblMetadata, err := c.replayTableSchemaDeltasQRep(ctx, config, partition, srcSchema)
 	if err != nil {
 		return 0, err
@@ -44,7 +42,7 @@ func (c *BigQueryConnector) replayTableSchemaDeltasQRep(
 	ctx context.Context,
 	config *protos.QRepConfig,
 	partition *protos.QRepPartition,
-	srcSchema *qvalue.QRecordSchema,
+	srcSchema qvalue.QRecordSchema,
 ) (*bigquery.TableMetadata, error) {
 	destDatasetTable, _ := c.convertToDatasetTable(config.DestinationTableIdentifier)
 	bqTable := c.client.DatasetInProject(c.projectID, destDatasetTable.dataset).Table(destDatasetTable.table)

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -62,11 +62,7 @@ func (s *ClickhouseAvroSyncMethod) SyncRecords(
 	tableLog := slog.String("destinationTable", s.config.DestinationTableIdentifier)
 	dstTableName := s.config.DestinationTableIdentifier
 
-	schema, err := stream.Schema()
-	if err != nil {
-		return -1, fmt.Errorf("failed to get schema from stream: %w", err)
-	}
-
+	schema := stream.Schema()
 	s.connector.logger.Info("sync function called and schema acquired", tableLog)
 
 	avroSchema, err := s.getAvroSchema(dstTableName, schema)
@@ -99,11 +95,8 @@ func (s *ClickhouseAvroSyncMethod) SyncQRepRecords(
 	startTime := time.Now()
 	dstTableName := config.DestinationTableIdentifier
 	stagingPath := s.connector.creds.BucketPath
-	schema, err := stream.Schema()
-	if err != nil {
-		return -1, fmt.Errorf("failed to get schema from stream: %w", err)
-	}
-	avroSchema, err := s.getAvroSchema(dstTableName, schema)
+
+	avroSchema, err := s.getAvroSchema(dstTableName, stream.Schema())
 	if err != nil {
 		return 0, err
 	}
@@ -155,7 +148,7 @@ func (s *ClickhouseAvroSyncMethod) SyncQRepRecords(
 
 func (s *ClickhouseAvroSyncMethod) getAvroSchema(
 	dstTableName string,
-	schema *qvalue.QRecordSchema,
+	schema qvalue.QRecordSchema,
 ) (*model.QRecordAvroSchemaDefinition, error) {
 	avroSchema, err := model.GetAvroSchemaDefinition(dstTableName, schema, protos.DBType_CLICKHOUSE)
 	if err != nil {

--- a/flow/connectors/postgres/qrep_sql_sync.go
+++ b/flow/connectors/postgres/qrep_sql_sync.go
@@ -46,11 +46,7 @@ func (s *QRepStagingTableSync) SyncQRepRecords(
 	)
 	partitionID := partition.PartitionId
 	startTime := time.Now()
-	schema, err := stream.Schema()
-	if err != nil {
-		logger.LoggerFromCtx(ctx).Error("failed to get schema from stream", slog.Any("error", err), syncLog)
-		return 0, fmt.Errorf("failed to get schema from stream: %w", err)
-	}
+	schema := stream.Schema()
 
 	txConfig := s.connector.conn.Config()
 	txConn, err := pgx.ConnectConfig(ctx, txConfig)

--- a/flow/connectors/s3/qrep.go
+++ b/flow/connectors/s3/qrep.go
@@ -3,14 +3,12 @@ package conns3
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	avro "github.com/PeerDB-io/peer-flow/connectors/utils/avro"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
-	"github.com/PeerDB-io/peer-flow/shared"
 )
 
 func (c *S3Connector) SyncQRepRecords(
@@ -19,13 +17,7 @@ func (c *S3Connector) SyncQRepRecords(
 	partition *protos.QRepPartition,
 	stream *model.QRecordStream,
 ) (int, error) {
-	schema, err := stream.Schema()
-	if err != nil {
-		c.logger.Error("failed to get schema from stream",
-			slog.Any("error", err),
-			slog.String(string(shared.PartitionIDKey), partition.PartitionId))
-		return 0, fmt.Errorf("failed to get schema from stream: %w", err)
-	}
+	schema := stream.Schema()
 
 	dstTableName := config.DestinationTableIdentifier
 	avroSchema, err := getAvroSchema(dstTableName, schema)
@@ -43,7 +35,7 @@ func (c *S3Connector) SyncQRepRecords(
 
 func getAvroSchema(
 	dstTableName string,
-	schema *qvalue.QRecordSchema,
+	schema qvalue.QRecordSchema,
 ) (*model.QRecordAvroSchemaDefinition, error) {
 	avroSchema, err := model.GetAvroSchemaDefinition(dstTableName, schema, protos.DBType_S3)
 	if err != nil {

--- a/flow/connectors/snowflake/avro_file_writer_test.go
+++ b/flow/connectors/snowflake/avro_file_writer_test.go
@@ -74,7 +74,7 @@ func generateRecords(
 	nullable bool,
 	numRows uint32,
 	allnulls bool,
-) (*model.QRecordStream, *qvalue.QRecordSchema) {
+) (*model.QRecordStream, qvalue.QRecordSchema) {
 	t.Helper()
 
 	allQValueKinds := []qvalue.QValueKind{
@@ -102,22 +102,21 @@ func generateRecords(
 
 	numKinds := len(allQValueKinds)
 
-	schema := &qvalue.QRecordSchema{
+	schema := qvalue.QRecordSchema{
 		Fields: make([]qvalue.QField, numKinds),
 	}
-
-	// Create sample records
-	records := &model.QRecordBatch{
-		Records: make([][]qvalue.QValue, numRows),
-		Schema:  schema,
-	}
-
 	for i, kind := range allQValueKinds {
 		schema.Fields[i] = qvalue.QField{
 			Name:     string(kind),
 			Type:     kind,
 			Nullable: nullable,
 		}
+	}
+
+	// Create sample records
+	records := &model.QRecordBatch{
+		Schema:  schema,
+		Records: make([][]qvalue.QValue, numRows),
 	}
 
 	for row := range numRows {

--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -44,10 +44,7 @@ func (s *SnowflakeAvroSyncHandler) SyncRecords(
 	tableLog := slog.String("destinationTable", s.config.DestinationTableIdentifier)
 	dstTableName := s.config.DestinationTableIdentifier
 
-	schema, err := stream.Schema()
-	if err != nil {
-		return -1, fmt.Errorf("failed to get schema from stream: %w", err)
-	}
+	schema := stream.Schema()
 
 	s.connector.logger.Info("sync function called and schema acquired", tableLog)
 
@@ -99,13 +96,10 @@ func (s *SnowflakeAvroSyncHandler) SyncQRepRecords(
 	startTime := time.Now()
 	dstTableName := config.DestinationTableIdentifier
 
-	schema, err := stream.Schema()
-	if err != nil {
-		return -1, fmt.Errorf("failed to get schema from stream: %w", err)
-	}
+	schema := stream.Schema()
 	s.connector.logger.Info("sync function called and schema acquired", partitionLog)
 
-	err = s.addMissingColumns(ctx, schema, dstTableSchema, dstTableName, partition)
+	err := s.addMissingColumns(ctx, schema, dstTableSchema, dstTableName, partition)
 	if err != nil {
 		return 0, err
 	}
@@ -141,7 +135,7 @@ func (s *SnowflakeAvroSyncHandler) SyncQRepRecords(
 
 func (s *SnowflakeAvroSyncHandler) addMissingColumns(
 	ctx context.Context,
-	schema *qvalue.QRecordSchema,
+	schema qvalue.QRecordSchema,
 	dstTableSchema []*sql.ColumnType,
 	dstTableName string,
 	partition *protos.QRepPartition,
@@ -205,7 +199,7 @@ func (s *SnowflakeAvroSyncHandler) addMissingColumns(
 
 func (s *SnowflakeAvroSyncHandler) getAvroSchema(
 	dstTableName string,
-	schema *qvalue.QRecordSchema,
+	schema qvalue.QRecordSchema,
 ) (*model.QRecordAvroSchemaDefinition, error) {
 	avroSchema, err := model.GetAvroSchemaDefinition(dstTableName, schema, protos.DBType_SNOWFLAKE)
 	if err != nil {

--- a/flow/connectors/sql/query_executor.go
+++ b/flow/connectors/sql/query_executor.go
@@ -262,8 +262,8 @@ func (g *GenericSQLQueryExecutor) processRows(ctx context.Context, rows *sqlx.Ro
 	}
 
 	return &model.QRecordBatch{
-		Records: records,
 		Schema:  qvalue.NewQRecordSchema(qfields),
+		Records: records,
 	}, nil
 }
 

--- a/flow/connectors/utils/avro/avro_writer.go
+++ b/flow/connectors/utils/avro/avro_writer.go
@@ -120,13 +120,7 @@ func (p *peerDBOCFWriter) createOCFWriter(w io.Writer) (*goavro.OCFWriter, error
 
 func (p *peerDBOCFWriter) writeRecordsToOCFWriter(ctx context.Context, ocfWriter *goavro.OCFWriter) (int, error) {
 	logger := logger.LoggerFromCtx(ctx)
-	schema, err := p.stream.Schema()
-	if err != nil {
-		logger.Error("failed to get schema from stream", slog.Any("error", err))
-		return 0, fmt.Errorf("failed to get schema from stream: %w", err)
-	}
-
-	numRows := 0
+	schema := p.stream.Schema()
 
 	avroConverter := model.NewQRecordAvroConverter(
 		p.avroSchema,
@@ -135,6 +129,7 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(ctx context.Context, ocfWriter
 		logger,
 	)
 
+	numRows := 0
 	for qRecordOrErr := range p.stream.Records {
 		if qRecordOrErr.Err != nil {
 			logger.Error("[avro] failed to get record from stream", slog.Any("error", qRecordOrErr.Err))

--- a/flow/connectors/utils/stream.go
+++ b/flow/connectors/utils/stream.go
@@ -13,7 +13,7 @@ import (
 
 func RecordsToRawTableStream[Items model.Items](req *model.RecordsToStreamRequest[Items]) (*model.QRecordStream, error) {
 	recordStream := model.NewQRecordStream(1 << 17)
-	err := recordStream.SetSchema(&qvalue.QRecordSchema{
+	recordStream.SetSchema(qvalue.QRecordSchema{
 		Fields: []qvalue.QField{
 			{
 				Name:     "_peerdb_uid",
@@ -57,9 +57,6 @@ func RecordsToRawTableStream[Items model.Items](req *model.RecordsToStreamReques
 			},
 		},
 	})
-	if err != nil {
-		return nil, err
-	}
 
 	go func() {
 		for record := range req.GetRecords() {

--- a/flow/e2e/bigquery/bigquery_helper.go
+++ b/flow/e2e/bigquery/bigquery_helper.go
@@ -305,12 +305,12 @@ func toQValue(bqValue bigquery.Value) (qvalue.QValue, error) {
 }
 
 // bqSchemaToQRecordSchema converts a bigquery schema to a QRecordSchema.
-func bqSchemaToQRecordSchema(schema bigquery.Schema) *qvalue.QRecordSchema {
+func bqSchemaToQRecordSchema(schema bigquery.Schema) qvalue.QRecordSchema {
 	fields := make([]qvalue.QField, 0, len(schema))
 	for _, fieldSchema := range schema {
 		fields = append(fields, peer_bq.BigQueryFieldToQField(fieldSchema))
 	}
-	return &qvalue.QRecordSchema{Fields: fields}
+	return qvalue.QRecordSchema{Fields: fields}
 }
 
 func (b *BigQueryTestHelper) ExecuteAndProcessQuery(query string) (*model.QRecordBatch, error) {
@@ -349,8 +349,8 @@ func (b *BigQueryTestHelper) ExecuteAndProcessQuery(query string) (*model.QRecor
 	schema := bqSchemaToQRecordSchema(it.Schema)
 
 	return &model.QRecordBatch{
-		Records: records,
 		Schema:  schema,
+		Records: records,
 	}, nil
 }
 

--- a/flow/model/conversion_avro.go
+++ b/flow/model/conversion_avro.go
@@ -69,7 +69,7 @@ type QRecordAvroSchemaDefinition struct {
 
 func GetAvroSchemaDefinition(
 	dstTableName string,
-	qRecordSchema *qvalue.QRecordSchema,
+	qRecordSchema qvalue.QRecordSchema,
 	targetDWH protos.DBType,
 ) (*QRecordAvroSchemaDefinition, error) {
 	avroFields := make([]QRecordAvroField, 0, len(qRecordSchema.Fields))

--- a/flow/model/qrecord_batch.go
+++ b/flow/model/qrecord_batch.go
@@ -3,7 +3,6 @@ package model
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -16,7 +15,7 @@ import (
 
 // QRecordBatch holds a batch of []QValue slices
 type QRecordBatch struct {
-	Schema  *qvalue.QRecordSchema
+	Schema  qvalue.QRecordSchema
 	Records [][]qvalue.QValue
 }
 
@@ -27,10 +26,7 @@ func (q *QRecordBatch) ToQRecordStream(buffer int) *QRecordStream {
 }
 
 func (q *QRecordBatch) FeedToQRecordStream(stream *QRecordStream) {
-	err := stream.SetSchema(q.Schema)
-	if err != nil {
-		slog.Warn(err.Error())
-	}
+	stream.SetSchema(q.Schema)
 
 	for _, record := range q.Records {
 		stream.Records <- QRecordOrError{Record: record}

--- a/flow/model/qvalue/qschema.go
+++ b/flow/model/qvalue/qschema.go
@@ -17,16 +17,12 @@ type QRecordSchema struct {
 }
 
 // NewQRecordSchema creates a new QRecordSchema.
-func NewQRecordSchema(fields []QField) *QRecordSchema {
-	return &QRecordSchema{Fields: fields}
+func NewQRecordSchema(fields []QField) QRecordSchema {
+	return QRecordSchema{Fields: fields}
 }
 
 // EqualNames returns true if the field names are equal.
-func (q *QRecordSchema) EqualNames(other *QRecordSchema) bool {
-	if other == nil {
-		return q == nil
-	}
-
+func (q QRecordSchema) EqualNames(other QRecordSchema) bool {
 	if len(q.Fields) != len(other.Fields) {
 		return false
 	}
@@ -44,7 +40,7 @@ func (q *QRecordSchema) EqualNames(other *QRecordSchema) bool {
 }
 
 // GetColumnNames returns a slice of column names.
-func (q *QRecordSchema) GetColumnNames() []string {
+func (q QRecordSchema) GetColumnNames() []string {
 	names := make([]string, 0, len(q.Fields))
 	for _, field := range q.Fields {
 		names = append(names, field.Name)


### PR DESCRIPTION
There was no fallible case

SchemaChan pulling the schema was incompatible with calling Schema,
take a page from context.Context `chan struct{}`

With this schemaSet can be relied on, allowing schema to be non nullable