### PR TITLE
Remove QRecordOrError

### DIFF
--- a/flow/connectors/postgres/qrep_query_executor.go
+++ b/flow/connectors/postgres/qrep_query_executor.go
@@ -148,16 +148,11 @@ func (qe *QRepQueryExecutor) processRowsStream(
 		record, err := qe.mapRowToQRecord(rows, fieldDescriptions)
 		if err != nil {
 			qe.logger.Error("[pg_query_executor] failed to map row to QRecord", slog.Any("error", err))
-			stream.Records <- model.QRecordOrError{
-				Err: fmt.Errorf("failed to map row to QRecord: %w", err),
-			}
+			stream.Close(fmt.Errorf("failed to map row to QRecord: %w", err))
 			return 0, fmt.Errorf("failed to map row to QRecord: %w", err)
 		}
 
-		stream.Records <- model.QRecordOrError{
-			Record: record,
-			Err:    nil,
-		}
+		stream.Records <- record
 
 		if numRows%heartBeatNumRows == 0 {
 			qe.logger.Info("processing row stream", slog.String("cursor", cursorName), slog.Int("records", numRows))
@@ -180,9 +175,7 @@ func (qe *QRepQueryExecutor) processFetchedRows(
 ) (int, error) {
 	rows, err := qe.executeQueryInTx(ctx, tx, cursorName, fetchSize)
 	if err != nil {
-		stream.Records <- model.QRecordOrError{
-			Err: err,
-		}
+		stream.Close(err)
 		qe.logger.Error("[pg_query_executor] failed to execute query in tx",
 			slog.Any("error", err), slog.String("query", query))
 		return 0, fmt.Errorf("[pg_query_executor] failed to execute query in tx: %w", err)
@@ -201,10 +194,8 @@ func (qe *QRepQueryExecutor) processFetchedRows(
 		return 0, fmt.Errorf("failed to process rows: %w", err)
 	}
 
-	if rows.Err() != nil {
-		stream.Records <- model.QRecordOrError{
-			Err: rows.Err(),
-		}
+	if err := rows.Err(); err != nil {
+		stream.Close(err)
 		qe.logger.Error("[pg_query_executor] row iteration failed",
 			slog.String("query", query), slog.Any("error", rows.Err()))
 		return 0, fmt.Errorf("[pg_query_executor] row iteration failed '%s': %w", query, rows.Err())
@@ -241,14 +232,14 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQuery(
 			Records: make([][]qvalue.QValue, 0),
 		}
 		for record := range stream.Records {
-			if record.Err == nil {
-				batch.Records = append(batch.Records, record.Record)
-			} else {
-				<-errors
-				return nil, fmt.Errorf("[pg] failed to get record from stream: %w", record.Err)
-			}
+			batch.Records = append(batch.Records, record)
 		}
-		<-errors
+		if err := <-errors; err != nil {
+			return nil, err
+		}
+		if err := stream.Err(); err != nil {
+			return nil, fmt.Errorf("[pg] failed to get record from stream: %w", err)
+		}
 		return batch, nil
 	}
 }
@@ -260,7 +251,7 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQueryStream(
 	args ...interface{},
 ) (int, error) {
 	qe.logger.Info("Executing and processing query stream", slog.String("query", query))
-	defer close(stream.Records)
+	defer stream.Close(nil)
 
 	tx, err := qe.conn.BeginTx(ctx, pgx.TxOptions{
 		AccessMode: pgx.ReadOnly,
@@ -271,8 +262,7 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQueryStream(
 		return 0, fmt.Errorf("[pg_query_executor] failed to begin transaction: %w", err)
 	}
 
-	totalRecordsFetched, err := qe.ExecuteAndProcessQueryStreamWithTx(ctx, tx, stream, query, args...)
-	return totalRecordsFetched, err
+	return qe.ExecuteAndProcessQueryStreamWithTx(ctx, tx, stream, query, args...)
 }
 
 func (qe *QRepQueryExecutor) ExecuteAndProcessQueryStreamGettingCurrentSnapshotXmin(
@@ -283,7 +273,7 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQueryStreamGettingCurrentSnapshotX
 ) (int, int64, error) {
 	var currentSnapshotXmin pgtype.Int8
 	qe.logger.Info("Executing and processing query stream", slog.String("query", query))
-	defer close(stream.Records)
+	defer stream.Close(nil)
 
 	tx, err := qe.conn.BeginTx(ctx, pgx.TxOptions{
 		AccessMode: pgx.ReadOnly,
@@ -323,22 +313,20 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQueryStreamWithTx(
 	if qe.snapshot != "" {
 		_, err = tx.Exec(ctx, "SET TRANSACTION SNAPSHOT "+QuoteLiteral(qe.snapshot))
 		if err != nil {
-			stream.Records <- model.QRecordOrError{
-				Err: fmt.Errorf("failed to set snapshot: %w", err),
-			}
 			qe.logger.Error("[pg_query_executor] failed to set snapshot",
 				slog.Any("error", err), slog.String("query", query))
-			return 0, fmt.Errorf("[pg_query_executor] failed to set snapshot: %w", err)
+			err := fmt.Errorf("[pg_query_executor] failed to set snapshot: %w", err)
+			stream.Close(err)
+			return 0, err
 		}
 	}
 
 	randomUint, err := shared.RandomUInt64()
 	if err != nil {
 		qe.logger.Error("[pg_query_executor] failed to generate random uint", slog.Any("error", err))
-		stream.Records <- model.QRecordOrError{
-			Err: fmt.Errorf("failed to generate random uint: %w", err),
-		}
-		return 0, fmt.Errorf("[pg_query_executor] failed to generate random uint: %w", err)
+		err = fmt.Errorf("[pg_query_executor] failed to generate random uint: %w", err)
+		stream.Close(err)
+		return 0, err
 	}
 
 	cursorName := fmt.Sprintf("peerdb_cursor_%d", randomUint)
@@ -347,12 +335,11 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQueryStreamWithTx(
 	qe.logger.Info(fmt.Sprintf("[pg_query_executor] executing cursor declaration for %v with args %v", cursorQuery, args))
 	_, err = tx.Exec(ctx, cursorQuery, args...)
 	if err != nil {
-		stream.Records <- model.QRecordOrError{
-			Err: fmt.Errorf("failed to declare cursor: %w", err),
-		}
 		qe.logger.Info("[pg_query_executor] failed to declare cursor",
 			slog.String("cursorQuery", cursorQuery), slog.Any("error", err))
-		return 0, fmt.Errorf("[pg_query_executor] failed to declare cursor: %w", err)
+		err = fmt.Errorf("[pg_query_executor] failed to declare cursor: %w", err)
+		stream.Close(err)
+		return 0, err
 	}
 
 	qe.logger.Info(fmt.Sprintf("[pg_query_executor] declared cursor '%s' for query '%s'", cursorName, query))
@@ -377,10 +364,9 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQueryStreamWithTx(
 	err = tx.Commit(ctx)
 	if err != nil {
 		qe.logger.Error("[pg_query_executor] failed to commit transaction", slog.Any("error", err))
-		stream.Records <- model.QRecordOrError{
-			Err: fmt.Errorf("failed to commit transaction: %w", err),
-		}
-		return 0, fmt.Errorf("[pg_query_executor] failed to commit transaction: %w", err)
+		err = fmt.Errorf("[pg_query_executor] failed to commit transaction: %w", err)
+		stream.Close(err)
+		return 0, err
 	}
 
 	qe.logger.Info(fmt.Sprintf("[pg_query_executor] committed transaction for query '%s', rows = %d",

--- a/flow/connectors/utils/avro/avro_writer.go
+++ b/flow/connectors/utils/avro/avro_writer.go
@@ -130,13 +130,8 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(ctx context.Context, ocfWriter
 	)
 
 	numRows := 0
-	for qRecordOrErr := range p.stream.Records {
-		if qRecordOrErr.Err != nil {
-			logger.Error("[avro] failed to get record from stream", slog.Any("error", qRecordOrErr.Err))
-			return 0, fmt.Errorf("[avro] failed to get record from stream: %w", qRecordOrErr.Err)
-		}
-
-		avroMap, err := avroConverter.Convert(qRecordOrErr.Record)
+	for qrecord := range p.stream.Records {
+		avroMap, err := avroConverter.Convert(qrecord)
 		if err != nil {
 			logger.Error("failed to convert QRecord to Avro compatible map: ", slog.Any("error", err))
 			return 0, fmt.Errorf("failed to convert QRecord to Avro compatible map: %w", err)
@@ -149,6 +144,10 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(ctx context.Context, ocfWriter
 		}
 
 		numRows += 1
+	}
+	if err := p.stream.Err(); err != nil {
+		logger.Error("[avro] failed to get record from stream", slog.Any("error", err))
+		return 0, fmt.Errorf("[avro] failed to get record from stream: %w", err)
 	}
 
 	return numRows, nil

--- a/flow/model/qrecord_stream.go
+++ b/flow/model/qrecord_stream.go
@@ -75,6 +75,9 @@ func (s *QRecordStream) Err() error {
 	return s.err
 }
 
+// Set error & close stream. Calling with multiple errors only tracks first error & does not panic.
+// Close(nil) after an error won't panic, but Close after Close(nil) will panic,
+// this is enough to be able to safely `defer stream.Close(nil)`.
 func (s *QRecordStream) Close(err error) {
 	if s.err == nil {
 		s.err = err

--- a/flow/model/qrecord_stream.go
+++ b/flow/model/qrecord_stream.go
@@ -10,18 +10,10 @@ type RecordTypeCounts struct {
 	DeleteCount int
 }
 
-type QRecordOrError struct {
-	Err    error
-	Record []qvalue.QValue
-}
-
-type QRecordSchemaOrError struct {
-	Schema *qvalue.QRecordSchema
-}
-
 type QRecordStream struct {
 	schemaLatch chan struct{}
-	Records     chan QRecordOrError
+	Records     chan []qvalue.QValue
+	err         error
 	schema      qvalue.QRecordSchema
 	schemaSet   bool
 }
@@ -51,8 +43,9 @@ func (r *RecordsToStreamRequest[T]) GetRecords() <-chan Record[T] {
 func NewQRecordStream(buffer int) *QRecordStream {
 	return &QRecordStream{
 		schemaLatch: make(chan struct{}),
-		Records:     make(chan QRecordOrError, buffer),
+		Records:     make(chan []qvalue.QValue, buffer),
 		schema:      qvalue.QRecordSchema{},
+		err:         nil,
 		schemaSet:   false,
 	}
 }
@@ -76,4 +69,15 @@ func (s *QRecordStream) IsSchemaSet() bool {
 
 func (s *QRecordStream) SchemaChan() <-chan struct{} {
 	return s.schemaLatch
+}
+
+func (s *QRecordStream) Err() error {
+	return s.err
+}
+
+func (s *QRecordStream) Close(err error) {
+	if s.err == nil {
+		s.err = err
+		close(s.Records)
+	}
 }


### PR DESCRIPTION
Errors are non recoverable, indicating end of stream
Match existing APIs which have an Err method which should be checked after iteration