### PR TITLE
Slot lag graph: don't show 1min/5min/15min options

### DIFF
--- a/ui/app/peers/[peerName]/lagGraph.tsx
+++ b/ui/app/peers/[peerName]/lagGraph.tsx
@@ -98,7 +98,7 @@ function LagGraph({ slotNames }: { slotNames: string[] }) {
         <ReactSelect
           id={timeSince}
           placeholder='Select a timeframe'
-          options={timeOptions}
+          options={timeOptions.filter((x) => !x.value.endsWith('min'))}
           defaultValue={{ label: 'hour', value: 'hour' }}
           onChange={(val, _) => val && setTimeSince(val.value)}
           theme={SelectTheme}


### PR DESCRIPTION
Slot is only sampled every 5 minutes, pointless to view less than an hour