### PR TITLE
UI: do not disable tables if initial copy only

### DIFF
--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -190,6 +190,7 @@ const EditMirror = ({ params: { mirrorId } }: EditMirrorProps) => {
         rows={rows}
         setRows={setRows}
         omitAdditionalTablesMapping={omitAdditionalTablesMapping}
+        allowNoCDCTables={false}
       />
 
       {isNotPaused && (

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -140,6 +140,7 @@ export default function CDCConfigForm({
           setRows={setRows}
           peerType={mirrorConfig.destination?.type}
           omitAdditionalTablesMapping={new Map<string, string[]>()}
+          allowNoCDCTables={mirrorConfig.initialSnapshotOnly}
         />
       </>
     );

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -149,7 +149,7 @@ const SchemaBox = ({
 
       if (rowsDoNotHaveSchemaTables(schemaName)) {
         setTablesLoading(true);
-        fetchTables(sourcePeer, schemaName, peerType, allowNoCDCTables).then(
+        fetchTables(sourcePeer, schemaName, allowNoCDCTables, peerType).then(
           (newRows) => {
             for (const row of newRows) {
               if (omitAdditionalTables?.includes(row.source)) {

--- a/ui/app/mirrors/create/cdc/tablemapping.tsx
+++ b/ui/app/mirrors/create/cdc/tablemapping.tsx
@@ -18,6 +18,8 @@ interface TableMappingProps {
   peerType?: DBType;
   // schema -> omitted source table mapping
   omitAdditionalTablesMapping: Map<string, string[]>;
+  // for initial copy only
+  allowNoCDCTables: boolean;
 }
 
 const TableMapping = ({
@@ -26,6 +28,7 @@ const TableMapping = ({
   setRows,
   peerType,
   omitAdditionalTablesMapping,
+  allowNoCDCTables,
 }: TableMappingProps) => {
   const [allSchemas, setAllSchemas] = useState<string[]>();
   const [schemaQuery, setSchemaQuery] = useState('');
@@ -109,6 +112,7 @@ const TableMapping = ({
               setTableColumns={setTableColumns}
               peerType={peerType}
               omitAdditionalTables={omitAdditionalTablesMapping.get(schema)}
+              allowNoCDCTables={allowNoCDCTables}
             />
           ))
         ) : (

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -318,8 +318,8 @@ const getDefaultDestinationTable = (
 export const fetchTables = async (
   peerName: string,
   schemaName: string,
-  peerType?: DBType,
-  allowNoCDCTables?: boolean
+  allowNoCDCTables: boolean,
+  peerType?: DBType
 ) => {
   if (schemaName.length === 0) return [];
   const tablesRes: UTablesResponse = await fetch('/api/peers/tables', {
@@ -349,7 +349,7 @@ export const fetchTables = async (
         partitionKey: '',
         exclude: new Set(),
         selected: false,
-        canMirror: tableObject.canMirror || !allowNoCDCTables,
+        canMirror: tableObject.canMirror || allowNoCDCTables,
         tableSize: tableObject.tableSize,
       });
     }

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -318,7 +318,8 @@ const getDefaultDestinationTable = (
 export const fetchTables = async (
   peerName: string,
   schemaName: string,
-  peerType?: DBType
+  peerType?: DBType,
+  allowNoCDCTables?: boolean
 ) => {
   if (schemaName.length === 0) return [];
   const tablesRes: UTablesResponse = await fetch('/api/peers/tables', {
@@ -348,7 +349,7 @@ export const fetchTables = async (
         partitionKey: '',
         exclude: new Set(),
         selected: false,
-        canMirror: tableObject.canMirror,
+        canMirror: tableObject.canMirror || !allowNoCDCTables,
         tableSize: tableObject.tableSize,
       });
     }


### PR DESCRIPTION
Allow no primary key/replica identity full tables to be mirrored in UI via CDC if initial copy only is set to true
Fixes #1628 