### PR TITLE
UI for opting into PG type system

### DIFF
--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -67,7 +67,10 @@ export default function CDCConfigForm({
         (label.includes('initial copy') ||
           label.includes('initial load') ||
           label.includes('soft delete') ||
-          label.includes('snapshot')))
+          label.includes('snapshot'))) ||
+      ((mirrorConfig.source?.type !== DBType.POSTGRES ||
+        mirrorConfig.destination?.type !== DBType.POSTGRES) &&
+        label.includes('type system'))
     ) {
       return false;
     }
@@ -97,7 +100,7 @@ export default function CDCConfigForm({
                     ? publications
                     : undefined
                 }
-                publicationsLoading={pubLoading}
+                optionsLoading={pubLoading}
               />
             )
           );

--- a/ui/app/mirrors/create/cdc/fields.tsx
+++ b/ui/app/mirrors/create/cdc/fields.tsx
@@ -20,7 +20,7 @@ const CDCField = ({
   setting,
   handleChange,
   options,
-  optionsLoading: publicationsLoading,
+  optionsLoading,
 }: FieldProps) => {
   return setting.type === 'switch' ? (
     <RowWithSwitch
@@ -77,7 +77,7 @@ const CDCField = ({
               getOptionLabel={(option) => option.label}
               getOptionValue={(option) => option.option}
               theme={SelectTheme}
-              isLoading={publicationsLoading}
+              isLoading={optionsLoading}
             />
           </div>
           {setting.tips && (

--- a/ui/app/mirrors/create/cdc/fields.tsx
+++ b/ui/app/mirrors/create/cdc/fields.tsx
@@ -13,14 +13,14 @@ interface FieldProps {
   setting: MirrorSetting;
   handleChange: (val: string | boolean, setting: MirrorSetting) => void;
   options?: string[];
-  publicationsLoading?: boolean;
+  optionsLoading?: boolean;
 }
 
 const CDCField = ({
   setting,
   handleChange,
   options,
-  publicationsLoading,
+  optionsLoading: publicationsLoading,
 }: FieldProps) => {
   return setting.type === 'switch' ? (
     <RowWithSwitch
@@ -70,7 +70,6 @@ const CDCField = ({
         >
           <div style={{ width: '100%' }}>
             <ReactSelect
-              placeholder={`Select a publication`}
               onChange={(val, action) =>
                 val && handleChange(val.option, setting)
               }

--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -1,3 +1,4 @@
+import { TypeSystem } from '@/grpc_generated/flow';
 import { CDCConfig } from '../../../dto/MirrorsDTO';
 import { MirrorSetting } from './common';
 export const cdcSettings: MirrorSetting[] = [
@@ -147,6 +148,18 @@ export const cdcSettings: MirrorSetting[] = [
         script: (value as string) || '',
       })),
     tips: 'Associate PeerDB script with this mirror.',
+    advanced: true,
+  },
+  {
+    label: 'Use Postgres type system',
+    stateHandler: (value, setter) =>
+      setter((curr: CDCConfig) => ({
+        ...curr,
+        system: value === true ? TypeSystem.PG : TypeSystem.Q,
+      })),
+    type: 'switch',
+    default: false,
+    tips: 'Decide if PeerDB should use native Postgres types directly',
     advanced: true,
   },
 ];

--- a/ui/app/mirrors/create/helpers/common.ts
+++ b/ui/app/mirrors/create/helpers/common.ts
@@ -1,16 +1,8 @@
-import {
-  FlowConnectionConfigs,
-  QRepWriteType,
-  TypeSystem,
-} from '@/grpc_generated/flow';
-import { Peer } from '@/grpc_generated/peers';
+import { FlowConnectionConfigs, TypeSystem } from '@/grpc_generated/flow';
 
 export interface MirrorSetting {
   label: string;
-  stateHandler: (
-    value: string | string[] | Peer | boolean | QRepWriteType,
-    setter: any
-  ) => void;
+  stateHandler: (value: any, setter: any) => void;
   type?: string;
   required?: boolean;
   tips?: string;


### PR DESCRIPTION
Adds a switch field in create CDC UI  for opting for pg type system - for source and destination set to Postgres peers.
Functionally tested

<img width="1380" alt="Screenshot 2024-04-19 at 9 29 08 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/b0c29573-c687-4b6d-a303-a966a259c01c">
