### PR TITLE
feat(alerting): enhance telemetry logging

### DIFF
--- a/flow/alerting/alerting.go
+++ b/flow/alerting/alerting.go
@@ -266,6 +266,27 @@ func (a *Alerter) sendTelemetryMessage(ctx context.Context, flowName string, mor
 	}
 }
 
+// Wrapper for different telemetry levels for non-flow events
+func (a *Alerter) LogNonFlowInfo(ctx context.Context, eventType telemetry.EventType, key string, message string) {
+	a.LogNonFlowEvent(ctx, eventType, key, message, telemetry.INFO)
+}
+
+func (a *Alerter) LogNonFlowWarning(ctx context.Context, eventType telemetry.EventType, key string, message string) {
+	a.LogNonFlowEvent(ctx, eventType, key, message, telemetry.WARN)
+}
+
+func (a *Alerter) LogNonFlowError(ctx context.Context, eventType telemetry.EventType, key string, message string) {
+	a.LogNonFlowEvent(ctx, eventType, key, message, telemetry.ERROR)
+}
+
+func (a *Alerter) LogNonFlowCritical(ctx context.Context, eventType telemetry.EventType, key string, message string) {
+	a.LogNonFlowEvent(ctx, eventType, key, message, telemetry.CRITICAL)
+}
+
+func (a *Alerter) LogNonFlowEvent(ctx context.Context, eventType telemetry.EventType, key string, message string, level telemetry.Level) {
+	a.sendTelemetryMessage(ctx, string(eventType)+":"+key, message, level)
+}
+
 func (a *Alerter) LogFlowError(ctx context.Context, flowName string, err error) {
 	logger := logger.LoggerFromCtx(ctx)
 	errorWithStack := fmt.Sprintf("%+v", err)

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/PeerDB-io/peer-flow/alerting"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"go.temporal.io/sdk/client"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/PeerDB-io/peer-flow/alerting"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/shared"
@@ -26,8 +26,8 @@ type FlowRequestHandler struct {
 	protos.UnimplementedFlowServiceServer
 	temporalClient      client.Client
 	pool                *pgxpool.Pool
-	peerflowTaskQueueID string
 	alerter             *alerting.Alerter
+	peerflowTaskQueueID string
 }
 
 func NewFlowRequestHandler(temporalClient client.Client, pool *pgxpool.Pool, taskQueue string) *FlowRequestHandler {

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/PeerDB-io/peer-flow/alerting"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -26,6 +27,7 @@ type FlowRequestHandler struct {
 	temporalClient      client.Client
 	pool                *pgxpool.Pool
 	peerflowTaskQueueID string
+	alerter             *alerting.Alerter
 }
 
 func NewFlowRequestHandler(temporalClient client.Client, pool *pgxpool.Pool, taskQueue string) *FlowRequestHandler {
@@ -33,6 +35,7 @@ func NewFlowRequestHandler(temporalClient client.Client, pool *pgxpool.Pool, tas
 		temporalClient:      temporalClient,
 		pool:                pool,
 		peerflowTaskQueueID: taskQueue,
+		alerter:             alerting.NewAlerter(context.Background(), pool),
 	}
 }
 

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/PeerDB-io/peer-flow/shared/telemetry"
 	"log/slog"
 
 	connpostgres "github.com/PeerDB-io/peer-flow/connectors/postgres"
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/shared/telemetry"
 )
 
 func (h *FlowRequestHandler) ValidateCDCMirror(
@@ -29,7 +29,9 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 
 	pgPeer, err := connpostgres.NewPostgresConnector(ctx, sourcePeerConfig)
 	if err != nil {
-		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, fmt.Sprintf("failed to create postgres connector: %v", err))
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
+			fmt.Sprintf("failed to create postgres connector: %v", err),
+		)
 		return &protos.ValidateCDCMirrorResponse{
 			Ok: false,
 		}, fmt.Errorf("failed to create postgres connector: %v", err)
@@ -39,7 +41,9 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 	// Check replication connectivity
 	err = pgPeer.CheckReplicationConnectivity(ctx)
 	if err != nil {
-		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, fmt.Sprintf("unable to establish replication connectivity: %v", err))
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
+			fmt.Sprintf("unable to establish replication connectivity: %v", err),
+		)
 		return &protos.ValidateCDCMirrorResponse{
 			Ok: false,
 		}, fmt.Errorf("unable to establish replication connectivity: %v", err)
@@ -48,7 +52,9 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 	// Check permissions of postgres peer
 	err = pgPeer.CheckReplicationPermissions(ctx, sourcePeerConfig.User)
 	if err != nil {
-		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, fmt.Sprintf("failed to check replication permissions: %v", err))
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
+			fmt.Sprintf("failed to check replication permissions: %v", err),
+		)
 		return &protos.ValidateCDCMirrorResponse{
 			Ok: false,
 		}, fmt.Errorf("failed to check replication permissions: %v", err)
@@ -59,7 +65,9 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 	for _, tableMapping := range req.ConnectionConfigs.TableMappings {
 		parsedTable, parseErr := utils.ParseSchemaTable(tableMapping.SourceTableIdentifier)
 		if parseErr != nil {
-			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, fmt.Sprintf("invalid source table identifier: %s", tableMapping.SourceTableIdentifier))
+			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
+				"invalid source table identifier: "+tableMapping.SourceTableIdentifier,
+			)
 			return &protos.ValidateCDCMirrorResponse{
 				Ok: false,
 			}, fmt.Errorf("invalid source table identifier: %s", tableMapping.SourceTableIdentifier)
@@ -72,7 +80,9 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 	if pubName != "" {
 		err = pgPeer.CheckSourceTables(ctx, sourceTables, pubName)
 		if err != nil {
-			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, fmt.Sprintf("provided source tables invalidated: %v", err))
+			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
+				fmt.Sprintf("provided source tables invalidated: %v", err),
+			)
 			return &protos.ValidateCDCMirrorResponse{
 				Ok: false,
 			}, fmt.Errorf("provided source tables invalidated: %v", err)

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -32,10 +32,11 @@ func (h *FlowRequestHandler) ValidatePeer(
 
 	conn, err := connectors.GetConnector(ctx, req.Peer)
 	if err != nil {
+		displayErr := fmt.Sprintf("%s peer %s was invalidated: %v", req.Peer.Type, req.Peer.Name, err)
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreatePeer, req.Peer.Name, displayErr)
 		return &protos.ValidatePeerResponse{
-			Status: protos.ValidatePeerStatus_INVALID,
-			Message: fmt.Sprintf("%s peer %s was invalidated: %s",
-				req.Peer.Type, req.Peer.Name, err),
+			Status:  protos.ValidatePeerStatus_INVALID,
+			Message: displayErr,
 		}, nil
 	}
 

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/PeerDB-io/peer-flow/shared/telemetry"
 	"log/slog"
 
 	"github.com/PeerDB-io/peer-flow/connectors"
@@ -59,6 +60,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 	validationConn, ok := conn.(connectors.ValidationConnector)
 	if ok {
 		validErr := validationConn.ValidateCheck(ctx)
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreatePeer, req.Peer.Name, fmt.Sprintf("Failed to validate peer %s: %v", req.Peer.Name, validErr))
 		if validErr != nil {
 			return &protos.ValidatePeerResponse{
 				Status: protos.ValidatePeerStatus_INVALID,
@@ -70,6 +72,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 
 	connErr := conn.ConnectionActive(ctx)
 	if connErr != nil {
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreatePeer, req.Peer.Name, fmt.Sprintf("Failed to establish peer connection %s: %v", req.Peer.Name, connErr))
 		return &protos.ValidatePeerResponse{
 			Status: protos.ValidatePeerStatus_INVALID,
 			Message: fmt.Sprintf("failed to establish active connection to %s peer %s: %v",

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/PeerDB-io/peer-flow/shared/telemetry"
 	"log/slog"
 
 	"github.com/PeerDB-io/peer-flow/connectors"
 	connpostgres "github.com/PeerDB-io/peer-flow/connectors/postgres"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/shared"
+	"github.com/PeerDB-io/peer-flow/shared/telemetry"
 )
 
 func (h *FlowRequestHandler) ValidatePeer(
@@ -60,7 +60,9 @@ func (h *FlowRequestHandler) ValidatePeer(
 	validationConn, ok := conn.(connectors.ValidationConnector)
 	if ok {
 		validErr := validationConn.ValidateCheck(ctx)
-		h.alerter.LogNonFlowWarning(ctx, telemetry.CreatePeer, req.Peer.Name, fmt.Sprintf("Failed to validate peer %s: %v", req.Peer.Name, validErr))
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreatePeer, req.Peer.Name,
+			fmt.Sprintf("Failed to validate peer %s: %v", req.Peer.Name, validErr),
+		)
 		if validErr != nil {
 			return &protos.ValidatePeerResponse{
 				Status: protos.ValidatePeerStatus_INVALID,
@@ -72,7 +74,9 @@ func (h *FlowRequestHandler) ValidatePeer(
 
 	connErr := conn.ConnectionActive(ctx)
 	if connErr != nil {
-		h.alerter.LogNonFlowWarning(ctx, telemetry.CreatePeer, req.Peer.Name, fmt.Sprintf("Failed to establish peer connection %s: %v", req.Peer.Name, connErr))
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreatePeer, req.Peer.Name,
+			fmt.Sprintf("Failed to establish peer connection %s: %v", req.Peer.Name, connErr),
+		)
 		return &protos.ValidatePeerResponse{
 			Status: protos.ValidatePeerStatus_INVALID,
 			Message: fmt.Sprintf("failed to establish active connection to %s peer %s: %v",

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -60,27 +60,27 @@ func (h *FlowRequestHandler) ValidatePeer(
 	validationConn, ok := conn.(connectors.ValidationConnector)
 	if ok {
 		validErr := validationConn.ValidateCheck(ctx)
+		displayErr := fmt.Sprintf("failed to validate peer %s: %v", req.Peer.Name, validErr)
 		h.alerter.LogNonFlowWarning(ctx, telemetry.CreatePeer, req.Peer.Name,
-			fmt.Sprintf("Failed to validate peer %s: %v", req.Peer.Name, validErr),
+			displayErr,
 		)
 		if validErr != nil {
 			return &protos.ValidatePeerResponse{
-				Status: protos.ValidatePeerStatus_INVALID,
-				Message: fmt.Sprintf("failed to validate %s peer %s: %v",
-					req.Peer.Type, req.Peer.Name, validErr),
+				Status:  protos.ValidatePeerStatus_INVALID,
+				Message: displayErr,
 			}, nil
 		}
 	}
 
 	connErr := conn.ConnectionActive(ctx)
 	if connErr != nil {
+		displayErr := fmt.Sprintf("failed to establish active connection to %s peer %s: %v", req.Peer.Type, req.Peer.Name, connErr)
 		h.alerter.LogNonFlowWarning(ctx, telemetry.CreatePeer, req.Peer.Name,
-			fmt.Sprintf("Failed to establish peer connection %s: %v", req.Peer.Name, connErr),
+			displayErr,
 		)
 		return &protos.ValidatePeerResponse{
-			Status: protos.ValidatePeerStatus_INVALID,
-			Message: fmt.Sprintf("failed to establish active connection to %s peer %s: %v",
-				req.Peer.Type, req.Peer.Name, connErr),
+			Status:  protos.ValidatePeerStatus_INVALID,
+			Message: displayErr,
 		}, nil
 	}
 

--- a/flow/shared/telemetry/event_types.go
+++ b/flow/shared/telemetry/event_types.go
@@ -1,0 +1,9 @@
+package telemetry
+
+type EventType string
+
+const (
+	CreatePeer   EventType = "CreatePeer"
+	CreateMirror EventType = "CreateMirror"
+	Other        EventType = "Other"
+)

--- a/flow/shared/telemetry/sns_message_sender.go
+++ b/flow/shared/telemetry/sns_message_sender.go
@@ -29,7 +29,10 @@ type SNSMessageSenderConfig struct {
 }
 
 func (s *SNSMessageSenderImpl) SendMessage(ctx context.Context, subject string, body string, attributes Attributes) (*string, error) {
-	activityInfo := activity.GetInfo(ctx)
+	activityInfo := activity.Info{}
+	if activity.IsActivity(ctx) {
+		activityInfo = activity.GetInfo(ctx)
+	}
 	deduplicationString := strings.Join([]string{
 		"deployID", attributes.DeploymentUID,
 		"subject", subject,


### PR DESCRIPTION
- Add new methods in `alerting.go` for different telemetry levels for non-flow events
- Integrate these methods in `handler.go`, `validate_mirror.go` and `validate_peer.go` to log warnings during validate_peer and validate_mirror
- Add new event types in `event_types.go` for telemetry

TODOs:
- [x] Test during
  - [x] create peer
  - [x] create mirror