### PR TITLE
error workflow in specific ES error

### DIFF
--- a/flow/connectors/connelasticsearch/elasticsearch.go
+++ b/flow/connectors/connelasticsearch/elasticsearch.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -176,8 +175,7 @@ func (esc *ElasticsearchConnector) SyncQRepRecords(ctx context.Context, config *
 					cbErr := fmt.Errorf("id:%s type:%s reason:%s %s", item.DocumentID, res.Error.Type,
 						res.Error.Reason, causeString)
 					bulkIndexErrors = append(bulkIndexErrors, cbErr)
-					if res.Error.Type == "illegal_argument_exception" &&
-						strings.Contains(res.Error.Reason, "Number of documents in the index can't exceed") {
+					if res.Error.Type == "illegal_argument_exception" {
 						bulkIndexFatalError = cbErr
 					}
 				}

--- a/flow/connectors/connelasticsearch/elasticsearch.go
+++ b/flow/connectors/connelasticsearch/elasticsearch.go
@@ -183,9 +183,12 @@ func (esc *ElasticsearchConnector) SyncQRepRecords(ctx context.Context, config *
 				}
 			},
 		})
-		if err != nil || bulkIndexHasFatalError {
+		if err != nil {
 			esc.logger.Error("[es] failed to add record to bulk indexer", slog.Any("error", err))
 			return 0, fmt.Errorf("[es] failed to add record to bulk indexer: %w", err)
+		}
+		if bulkIndexHasFatalError {
+			break
 		}
 
 		// update here instead of OnSuccess, if we close successfully it should match


### PR DESCRIPTION
Currently for the error type `illegal_argument_exception` that contains the error when a index has "too many documents" which is an underlying Lucene limitation. Limit is 2b per Lucene shard.

Needs to be addressed better for ES in the future.