### PR TITLE
Fix mirror actions dropdown

### DIFF
--- a/ui/app/mirrors/[mirrorId]/configValues.ts
+++ b/ui/app/mirrors/[mirrorId]/configValues.ts
@@ -23,14 +23,6 @@ const MirrorValues = (mirrorConfig: FlowConnectionConfigs | undefined) => {
       label: 'Soft Delete',
     },
     {
-      value: mirrorConfig?.cdcStagingPath || 'Local',
-      label: 'CDC Staging Path',
-    },
-    {
-      value: mirrorConfig?.snapshotStagingPath || 'Local',
-      label: 'Snapshot Staging Path',
-    },
-    {
       value: mirrorConfig?.script,
       label: 'Script',
     },

--- a/ui/components/EditButton.tsx
+++ b/ui/components/EditButton.tsx
@@ -2,7 +2,6 @@
 import { Button } from '@/lib/Button';
 import { Label } from '@/lib/Label';
 import { ProgressCircle } from '@/lib/ProgressCircle';
-import { Tooltip } from '@/lib/Tooltip';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -21,32 +20,21 @@ const EditButton = ({
     router.push(toLink);
   };
   return (
-    <Tooltip
+    <Button
+      onClick={handleEdit}
+      variant='normalBorderless'
       style={{
-        display: disabled ? 'flex' : 'none',
-        backgroundColor: 'white',
-        color: 'black',
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'left',
+        columnGap: '0.3rem',
         width: '100%',
       }}
-      content='Pause the mirror to enable editing'
+      disabled={disabled}
     >
-      <Button
-        className='IconButton'
-        onClick={handleEdit}
-        aria-label='sort up'
-        variant='normalBorderless'
-        style={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          columnGap: '0.3rem',
-          width: '100%',
-        }}
-        disabled={disabled}
-      >
-        <Label>Edit mirror</Label>
-        {loading && <ProgressCircle variant='determinate_progress_circle' />}
-      </Button>
-    </Tooltip>
+      <Label>Edit {disabled ? '(pause first)' : 'mirror'}</Label>
+      {loading && <ProgressCircle variant='determinate_progress_circle' />}
+    </Button>
   );
 };
 

--- a/ui/components/MirrorActionsDropdown.tsx
+++ b/ui/components/MirrorActionsDropdown.tsx
@@ -4,7 +4,7 @@ import EditButton from '@/components/EditButton';
 import { ResyncDialog } from '@/components/ResyncDialog';
 import { FlowConnectionConfigs, FlowStatus } from '@/grpc_generated/flow';
 import { MirrorStatusResponse } from '@/grpc_generated/route';
-import { Select, SelectItem } from '@tremor/react';
+import { Select } from '@tremor/react';
 import { useEffect, useState } from 'react';
 import PauseOrResumeButton from './PauseOrResumeButton';
 
@@ -36,31 +36,17 @@ const MirrorActions = ({
   if (mounted)
     return (
       <div>
-        <Select
-          placeholder='Actions'
-          value='Actions'
-          style={{ width: 'fit-content' }}
-        >
-          <SelectItem value='1' style={{ padding: 0 }}>
-            {mirrorStatus && (
-              <PauseOrResumeButton
-                mirrorConfig={mirrorConfig}
-                mirrorStatus={mirrorStatus}
-              />
-            )}
-          </SelectItem>
-          <SelectItem value='2' style={{ padding: 0 }}>
-            <EditButton toLink={editLink} disabled={isNotPaused} />
-          </SelectItem>
-
-          <SelectItem value='3' style={{ padding: 0 }}>
-            {canResync && (
-              <ResyncDialog
-                mirrorConfig={mirrorConfig}
-                workflowId={workflowId}
-              />
-            )}
-          </SelectItem>
+        <Select placeholder='Actions' value='Actions'>
+          {mirrorStatus && (
+            <PauseOrResumeButton
+              mirrorConfig={mirrorConfig}
+              mirrorStatus={mirrorStatus}
+            />
+          )}
+          <EditButton toLink={editLink} disabled={isNotPaused} />
+          {canResync && (
+            <ResyncDialog mirrorConfig={mirrorConfig} workflowId={workflowId} />
+          )}
         </Select>
       </div>
     );

--- a/ui/components/PauseOrResumeButton.tsx
+++ b/ui/components/PauseOrResumeButton.tsx
@@ -14,9 +14,8 @@ function PauseOrResumeButton({
   if (mirrorStatus.toString() === FlowStatus[FlowStatus.STATUS_RUNNING]) {
     return (
       <Button
-        className='IconButton'
-        aria-label='Pause'
         variant='normalBorderless'
+        style={{ width: '100%', justifyContent: 'left' }}
         onClick={() => changeFlowState(mirrorConfig, FlowStatus.STATUS_PAUSED)}
       >
         <Label>Pause mirror</Label>
@@ -25,8 +24,7 @@ function PauseOrResumeButton({
   } else if (mirrorStatus.toString() === FlowStatus[FlowStatus.STATUS_PAUSED]) {
     return (
       <Button
-        className='IconButton'
-        aria-label='Play'
+        style={{ width: '100%', justifyContent: 'left' }}
         onClick={() => changeFlowState(mirrorConfig, FlowStatus.STATUS_RUNNING)}
       >
         <Label>Resume mirror</Label>

--- a/ui/components/ResyncDialog.tsx
+++ b/ui/components/ResyncDialog.tsx
@@ -62,7 +62,10 @@ export const ResyncDialog = ({
       noInteract={true}
       size='xLarge'
       triggerButton={
-        <Button variant='normalBorderless' style={{ width: '100%' }}>
+        <Button
+          variant='normalBorderless'
+          style={{ width: '100%', justifyContent: 'left' }}
+        >
           <Label as='label'>Resync mirror</Label>
         </Button>
       }


### PR DESCRIPTION
Resync dialog box was instantly disappearing. 
Simplified the mirror actions dropdown component to fix this
Remove tooltip for edit button as it was causing issues with width. Indicate pause neccessity with text instead

<img width="749" alt="Screenshot 2024-04-27 at 7 52 01 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/7928b0cd-4483-49c7-bff5-eb1d2a511144">


also remove staging path info in View More modal