### PR TITLE
UI: check for start and end existence for qrep

### DIFF
--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -212,6 +212,7 @@ export const handleCreateQRep = async (
   }
 
   if (
+    !xmin &&
     config.writeMode?.writeType != QRepWriteType.QREP_WRITE_MODE_OVERWRITE &&
     !(query.includes('{{.start}}') && query.includes('{{.end}}'))
   ) {

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -211,6 +211,16 @@ export const handleCreateQRep = async (
     return;
   }
 
+  if (
+    config.writeMode?.writeType != QRepWriteType.QREP_WRITE_MODE_OVERWRITE &&
+    !(query.includes('{{.start}}') && query.includes('{{.end}}'))
+  ) {
+    notifyErr(
+      'Please include placeholders {{.start}} and {{.end}} in the query'
+    );
+    return;
+  }
+
   if (xmin == true) {
     config.watermarkColumn = 'xmin';
     config.query = `SELECT * FROM ${quotedWatermarkTable(

--- a/ui/app/mirrors/create/page.tsx
+++ b/ui/app/mirrors/create/page.tsx
@@ -191,6 +191,11 @@ export default function CreateMirrors() {
                 Write a query whose results will be replicated to a target
                 table.
                 <br></br>
+                For append and upsert modes, make sure the query{' '}
+                <b>includes the start and end placeholders</b> in the query.
+                PeerDB uses these placeholders for partitioning query results
+                for performance.
+                <br></br>
                 In most cases, you will require a watermark table and a
                 watermark column in that table.
                 <br></br>


### PR DESCRIPTION
For append and upsert modes in qrep, we need start and end placeholders for partitioning. this PR adds validation and explanation text for this
<img width="1364" alt="Screenshot 2024-04-29 at 4 32 30 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/fb930449-07b8-4d06-b12a-b93faebccb3b">
