### PR TITLE
Add peerdb columns to ui, fix for BQ

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -639,9 +639,10 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 
 	if softDeleteColName != "" {
 		columns = append(columns, &bigquery.FieldSchema{
-			Name:     softDeleteColName,
-			Type:     bigquery.BooleanFieldType,
-			Repeated: false,
+			Name:                   softDeleteColName,
+			Type:                   bigquery.BooleanFieldType,
+			Repeated:               false,
+			DefaultValueExpression: "false",
 		})
 	}
 

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -1231,7 +1231,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Soft_Delete_UD_Same_Batch() {
 		s.bqHelper.Config.DatasetId, dstName)
 	numNewRows, err := s.bqHelper.RunInt64Query(newerSyncedAtQuery)
 	require.NoError(s.t, err)
-	require.Equal(s.t, int64(0), numNewRows)
+	require.Equal(s.t, int64(1), numNewRows)
 }
 
 func (s PeerFlowE2ETestSuiteBQ) Test_Soft_Delete_Insert_After_Delete() {

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -70,7 +70,10 @@ export default function CDCConfigForm({
           label.includes('snapshot'))) ||
       ((mirrorConfig.source?.type !== DBType.POSTGRES ||
         mirrorConfig.destination?.type !== DBType.POSTGRES) &&
-        label.includes('type system'))
+        label.includes('type system')) ||
+      (mirrorConfig.destination?.type !== DBType.BIGQUERY &&
+        mirrorConfig.destination?.type !== DBType.SNOWFLAKE &&
+        label.includes('column name'))
     ) {
       return false;
     }

--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -162,4 +162,24 @@ export const cdcSettings: MirrorSetting[] = [
     tips: 'Decide if PeerDB should use native Postgres types directly',
     advanced: true,
   },
+  {
+    label: 'Synced-At Column Name',
+    stateHandler: (value, setter) =>
+      setter((curr: CDCConfig) => ({
+        ...curr,
+        syncedAtColName: value as string | '',
+      })),
+    tips: 'A field to set the name of PeerDBs synced_at column. If not set, a default name will be set',
+    advanced: true,
+  },
+  {
+    label: 'Soft Delete Column Name',
+    stateHandler: (value, setter) =>
+      setter((curr: CDCConfig) => ({
+        ...curr,
+        softDeleteColName: value as string | '',
+      })),
+    tips: 'A field to set the name of PeerDBs soft delete column.',
+    advanced: true,
+  },
 ];


### PR DESCRIPTION
- Add fields for synced_at and soft delete column names in UI under advanced section. 
- These are visible for BQ and SF destinations for now
- Fix default soft delete false for BQ CDC

<img width="1156" alt="Screenshot 2024-04-29 at 10 01 13 PM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/3e6f6217-20e1-4e66-8534-bd181e366a05">


Functionally tested
