### PR TITLE
Fix Clickhouse QRep Append

### DIFF
--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -128,6 +128,7 @@ func (s *ClickhouseAvroSyncMethod) SyncQRepRecords(
 	for _, col := range dstTableSchema {
 		colName := col.Name()
 		if strings.EqualFold(colName, config.SoftDeleteColName) ||
+			strings.EqualFold(colName, signColName) ||
 			strings.EqualFold(colName, config.SyncedAtColName) ||
 			strings.EqualFold(colName, versionColName) {
 			continue


### PR DESCRIPTION
Gets CH QRep append working by skipping the sign column for the final insert into select