### PR TITLE
Add heartbeat for gettableschema

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/temporal"
 
@@ -723,6 +724,7 @@ func (c *PostgresConnector) GetTableSchema(
 ) (*protos.GetTableSchemaBatchOutput, error) {
 	res := make(map[string]*protos.TableSchema)
 	for _, tableName := range req.TableIdentifiers {
+		activity.RecordHeartbeat(ctx, fmt.Sprintf("fetching schema for table %s", tableName))
 		tableSchema, err := c.getTableSchemaForTable(ctx, tableName, req.System)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
GetTableSchema of SetupFlow can take a long time for a large number of tables, leading to activity heartbeat timeouts. This PR adds a heartbeat after fetching schema for each table