### PR TITLE
qrep: if the last sync is nil, check the table if there are new rows.

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -615,7 +615,7 @@ func (a *FlowableActivity) QRepHasNewRows(ctx context.Context,
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
 	logger := log.With(activity.GetLogger(ctx), slog.String(string(shared.FlowNameKey), config.FlowJobName))
 
-	if config.SourcePeer.Type != protos.DBType_POSTGRES || last.Range == nil {
+	if config.SourcePeer.Type != protos.DBType_POSTGRES {
 		return QRepWaitUntilNewRowsResult{Found: true}, nil
 	}
 

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -287,6 +287,10 @@ func (c *PostgresConnector) CheckForUpdatedMaxValue(
 		return false, fmt.Errorf("error while getting min and max values: %w", err)
 	}
 
+	if last == nil || last.Range == nil {
+		return maxValue != nil, nil
+	}
+
 	switch x := last.Range.Range.(type) {
 	case *protos.PartitionRange_IntRange:
 		if maxValue.(int64) > x.IntRange.End {


### PR DESCRIPTION
this bug can prevent tables which are empty to be synced once they get data.

in general one has to be very careful here with nil pointer exceptions, I tried to navigate them to the best of my ability but this code path makes lots of assumptions about the state of the world.