### PR TITLE
UI: Fix replication slot field for queues

### DIFF
--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -79,8 +79,7 @@ export default function CDCConfigForm({
     if (
       (label.includes('snapshot') && mirrorConfig.doInitialSnapshot !== true) ||
       (label === 'replication slot name' &&
-        mirrorConfig.doInitialSnapshot === true &&
-        !isQueue) ||
+        mirrorConfig.doInitialSnapshot === true) ||
       (label.includes('staging path') &&
         defaultSyncMode(mirrorConfig.destination?.type) !== 'AVRO') ||
       (isQueue && label.includes('soft delete')) ||


### PR DESCRIPTION
This PR fixes a bug where replication slot name field was not respected for PG to queues. Functionally tested