### PR TITLE
UI for queues: remove queue specific setting handling 

### DIFF
--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -82,6 +82,10 @@ const CDCCheck = (
     config.replicationSlotName = '';
   }
 
+  if (IsQueuePeer(config.destination?.type)) {
+    config.softDelete = false;
+  }
+
   return '';
 };
 

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -82,11 +82,6 @@ const CDCCheck = (
     config.replicationSlotName = '';
   }
 
-  if (IsQueuePeer(config.destination?.type)) {
-    config.doInitialSnapshot = false;
-    config.softDelete = false;
-  }
-
   return '';
 };
 


### PR DESCRIPTION
Before we were setting initial load off for queues in handler
With #1675 and #1683, these steps aren't required