### PR TITLE
Add intervalstyle to replconfig map

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -86,6 +86,7 @@ func NewPostgresConnector(ctx context.Context, pgConfig *protos.PostgresConfig) 
 	// ensure that replication is set to database
 	replConfig.Config.RuntimeParams["replication"] = "database"
 	replConfig.Config.RuntimeParams["bytea_output"] = "hex"
+	replConfig.Config.RuntimeParams["intervalstyle"] = "postgres"
 
 	customTypeMap, err := shared.GetCustomDataTypes(ctx, conn)
 	if err != nil {


### PR DESCRIPTION
Ensure we get nice interval values when reading rows in cdc
functionally tested by switching to iso_8601 and back during cdc