### PR TITLE
fix: duplicate metrics pushed via otel sdk

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -596,10 +596,10 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 				return
 			}
 
-			var slotLagGauge *otel_metrics.Float64Gauge
-			var openConnectionsGauge *otel_metrics.Int64Gauge
+			var slotLagGauge *otel_metrics.Float64SyncGauge
+			var openConnectionsGauge *otel_metrics.Int64SyncGauge
 			if a.OtelManager != nil {
-				slotLagGauge, err = otel_metrics.GetOrInitFloat64Gauge(a.OtelManager.Meter,
+				slotLagGauge, err = otel_metrics.GetOrInitFloat64SyncGauge(a.OtelManager.Meter,
 					a.OtelManager.Float64GaugesCache,
 					"cdc_slot_lag",
 					metric.WithUnit("MB"),
@@ -609,7 +609,7 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 					return
 				}
 
-				openConnectionsGauge, err = otel_metrics.GetOrInitInt64Gauge(a.OtelManager.Meter,
+				openConnectionsGauge, err = otel_metrics.GetOrInitInt64SyncGauge(a.OtelManager.Meter,
 					a.OtelManager.Int64GaugesCache,
 					"open_connections",
 					metric.WithDescription("Current open connections for PeerDB user"))

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -72,9 +72,8 @@ type CDCPullConnectorCore interface {
 	PullFlowCleanup(ctx context.Context, jobName string) error
 
 	// HandleSlotInfo update monitoring info on slot size etc
-	HandleSlotInfo(ctx context.Context, alerter *alerting.Alerter,
-		catalogPool *pgxpool.Pool, slotName string, peerName string,
-		slotLagGauge *otel_metrics.Float64Gauge, openConnectionsGauge *otel_metrics.Int64Gauge) error
+	HandleSlotInfo(ctx context.Context, alerter *alerting.Alerter, catalogPool *pgxpool.Pool, slotName string, peerName string,
+		slotLagGauge *otel_metrics.Float64SyncGauge, openConnectionsGauge *otel_metrics.Int64SyncGauge) error
 
 	// GetSlotInfo returns the WAL (or equivalent) info of a slot for the connector.
 	GetSlotInfo(ctx context.Context, slotName string) ([]*protos.SlotInfo, error)

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -22,7 +22,7 @@ import (
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
-	"github.com/PeerDB-io/peer-flow/otel_metrics"
+	"github.com/PeerDB-io/peer-flow/otel_metrics/peerdb_guages"
 )
 
 type Connector interface {
@@ -72,8 +72,14 @@ type CDCPullConnectorCore interface {
 	PullFlowCleanup(ctx context.Context, jobName string) error
 
 	// HandleSlotInfo update monitoring info on slot size etc
-	HandleSlotInfo(ctx context.Context, alerter *alerting.Alerter, catalogPool *pgxpool.Pool, slotName string, peerName string,
-		slotLagGauge *otel_metrics.Float64SyncGauge, openConnectionsGauge *otel_metrics.Int64SyncGauge) error
+	HandleSlotInfo(
+		ctx context.Context,
+		alerter *alerting.Alerter,
+		catalogPool *pgxpool.Pool,
+		slotName string,
+		peerName string,
+		slotMetricGuages peerdb_guages.SlotMetricGuages,
+	) error
 
 	// GetSlotInfo returns the WAL (or equivalent) info of a slot for the connector.
 	GetSlotInfo(ctx context.Context, slotName string) ([]*protos.SlotInfo, error)

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -72,9 +72,10 @@ const (
 	)
 	%s src_rank WHERE %s AND src_rank._peerdb_rank=1 AND src_rank._peerdb_record_type=2`
 
-	dropTableIfExistsSQL     = "DROP TABLE IF EXISTS %s.%s"
-	deleteJobMetadataSQL     = "DELETE FROM %s.%s WHERE mirror_job_name=$1"
-	getNumConnectionsForUser = "SELECT COUNT(*) FROM pg_stat_activity WHERE usename=$1 AND client_addr IS NOT NULL"
+	dropTableIfExistsSQL         = "DROP TABLE IF EXISTS %s.%s"
+	deleteJobMetadataSQL         = "DELETE FROM %s.%s WHERE mirror_job_name=$1"
+	getNumConnectionsForUser     = "SELECT COUNT(*) FROM pg_stat_activity WHERE usename=$1 AND client_addr IS NOT NULL"
+	getNumReplicationConnections = "select COUNT(*) from pg_stat_replication WHERE usename = $1 AND client_addr IS NOT NULL"
 )
 
 type ReplicaIdentityType rune

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1113,14 +1113,8 @@ func (c *PostgresConnector) SyncFlowCleanup(ctx context.Context, jobName string)
 	return nil
 }
 
-func (c *PostgresConnector) HandleSlotInfo(
-	ctx context.Context,
-	alerter *alerting.Alerter,
-	catalogPool *pgxpool.Pool,
-	slotName string,
-	peerName string,
-	slotLagGauge *otel_metrics.Float64Gauge,
-	openConnectionsGauge *otel_metrics.Int64Gauge,
+func (c *PostgresConnector) HandleSlotInfo(ctx context.Context, alerter *alerting.Alerter, catalogPool *pgxpool.Pool,
+	slotName string, peerName string, slotLagGauge *otel_metrics.Float64SyncGauge, openConnectionsGauge *otel_metrics.Int64SyncGauge,
 ) error {
 	logger := logger.LoggerFromCtx(ctx)
 

--- a/flow/go.mod
+++ b/flow/go.mod
@@ -116,6 +116,7 @@ require (
 	github.com/twmb/franz-go/pkg/kmsg v1.7.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.51.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.51.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.26.0 // indirect
 	go.opentelemetry.io/otel/trace v1.26.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.2.0 // indirect
 	golang.org/x/term v0.20.0 // indirect

--- a/flow/go.sum
+++ b/flow/go.sum
@@ -427,6 +427,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.51.0 h1:Xs2Ncz0
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.51.0/go.mod h1:vy+2G/6NvVMpwGX/NyLqcC41fxepnuKHk16E6IZUcJc=
 go.opentelemetry.io/otel v1.26.0 h1:LQwgL5s/1W7YiiRwxf03QGnWLb2HW4pLiAhaA5cZXBs=
 go.opentelemetry.io/otel v1.26.0/go.mod h1:UmLkJHUAidDval2EICqBMbnAd0/m2vmpf/dAM+fvFs4=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.26.0 h1:+hm+I+KigBy3M24/h1p/NHkUx/evbLH0PNcjpMyCHc4=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.26.0/go.mod h1:NjC8142mLvvNT6biDpaMjyz78kyEHIwAJlSX0N9P5KI=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.26.0 h1:HGZWGmCVRCVyAs2GQaiHQPbDHo+ObFWeUEOd+zDnp64=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.26.0/go.mod h1:SaH+v38LSCHddyk7RGlU9uZyQoRrKao6IBnJw6Kbn+c=
 go.opentelemetry.io/otel/metric v1.26.0 h1:7S39CLuY5Jgg9CrnA9HHiEjGMF/X2VHvoXGgSllRz30=

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -34,8 +34,6 @@ func newOtelResource(otelServiceName string) (*resource.Resource, error) {
 	return r, err
 }
 
-// TODO set either OTEL_EXPORTER_OTLP_COMPRESSION or OTEL_EXPORTER_OTLP_METRICS_COMPRESSION to "gzip" to enable compression
-
 func setupHttpOtelMetricsExporter() (sdkmetric.Exporter, error) {
 	return otlpmetrichttp.New(context.Background())
 }
@@ -66,7 +64,6 @@ func SetupOtelMetricsExporter(otelServiceName string) (*sdkmetric.MeterProvider,
 	}
 
 	meterProvider := sdkmetric.NewMeterProvider(
-		// TODO Set env OTEL_METRIC_EXPORT_INTERVAL (in milliseconds) to change export interval, default is 60 seconds
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter)),
 		sdkmetric.WithResource(otelResource),
 	)

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -3,14 +3,15 @@ package otel_metrics
 import (
 	"context"
 	"fmt"
-	"github.com/PeerDB-io/peer-flow/peerdbenv"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+
+	"github.com/PeerDB-io/peer-flow/peerdbenv"
 )
 
 type OtelManager struct {
@@ -44,7 +45,8 @@ func setupGrpcOtelMetricsExporter() (sdkmetric.Exporter, error) {
 }
 
 func SetupOtelMetricsExporter(otelServiceName string) (*sdkmetric.MeterProvider, error) {
-	otlpMetricProtocol := peerdbenv.GetEnvString("OTEL_EXPORTER_OTLP_PROTOCOL", peerdbenv.GetEnvString("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "http/protobuf"))
+	otlpMetricProtocol := peerdbenv.GetEnvString("OTEL_EXPORTER_OTLP_PROTOCOL",
+		peerdbenv.GetEnvString("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "http/protobuf"))
 	var metricExporter sdkmetric.Exporter
 	var err error
 	switch otlpMetricProtocol {

--- a/flow/otel_metrics/peerdb_guages/attributes.go
+++ b/flow/otel_metrics/peerdb_guages/attributes.go
@@ -1,0 +1,7 @@
+package peerdb_guages
+
+const (
+	PeerNameKey      string = "peerName"
+	SlotNameKey      string = "slotName"
+	DeploymentUidKey string = "deploymentUID"
+)

--- a/flow/otel_metrics/peerdb_guages/guages.go
+++ b/flow/otel_metrics/peerdb_guages/guages.go
@@ -1,0 +1,15 @@
+package peerdb_guages
+
+import "github.com/PeerDB-io/peer-flow/otel_metrics"
+
+const (
+	SlotLagGuageName                    string = "cdc_slot_lag"
+	OpenConnectionsGuageName            string = "open_connections"
+	OpenReplicationConnectionsGuageName string = "open_replication_connections"
+)
+
+type SlotMetricGuages struct {
+	SlotLagGuage                    *otel_metrics.Float64SyncGauge
+	OpenConnectionsGuage            *otel_metrics.Int64SyncGauge
+	OpenReplicationConnectionsGuage *otel_metrics.Int64SyncGauge
+}

--- a/flow/otel_metrics/sync_gauges.go
+++ b/flow/otel_metrics/sync_gauges.go
@@ -11,7 +11,6 @@ import (
 
 type ObservationMapValue[V comparable] struct {
 	Value V
-	// Observed bool
 }
 
 // SyncGauge is a generic synchronous gauge that can be used to observe any type of value

--- a/flow/otel_metrics/sync_gauges.go
+++ b/flow/otel_metrics/sync_gauges.go
@@ -3,89 +3,106 @@ package otel_metrics
 import (
 	"context"
 	"fmt"
-	"math"
-	"sync/atomic"
+	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+
+	"github.com/PeerDB-io/peer-flow/logger"
 )
 
-// synchronous gauges are what we want, so we can control when the value is updated
-// but they are "experimental", so we resort to using the asynchronous gauges
-// but the callback is just a wrapper around the current value, so we can control by calling Set()
-type Int64Gauge struct {
-	observableGauge metric.Int64ObservableGauge
-	observations    map[attribute.Set]*atomic.Int64
+type ObservationMapValue[V comparable] struct {
+	Value V
+	// Observed bool
 }
 
-func NewInt64SyncGauge(meter metric.Meter, gaugeName string, opts ...metric.Int64ObservableGaugeOption) (*Int64Gauge, error) {
-	syncGauge := &Int64Gauge{}
-	observableGauge, err := meter.Int64ObservableGauge(gaugeName, append(opts, metric.WithInt64Callback(syncGauge.callback))...)
+// SyncGauge is a generic synchronous gauge that can be used to observe any type of value
+// Inspired from https://github.com/open-telemetry/opentelemetry-go/issues/3984#issuecomment-1743231837
+type SyncGauge[V comparable, O metric.Observable] struct {
+	observableGauge O
+	observations    sync.Map
+	name            string
+}
+
+func (a *SyncGauge[V, O]) Callback(ctx context.Context, observeFunc func(value V, options ...metric.ObserveOption)) error {
+	logger.LoggerFromCtx(ctx).Info("[MetricsTest]Observing SyncGauge", "gauge", a, "guageName", a.name)
+	var count int
+	a.observations.Range(func(key, value interface{}) bool {
+		attrs := key.(attribute.Set)
+		val := value.(*ObservationMapValue[V])
+		count++
+		observeFunc(val.Value, metric.WithAttributeSet(attrs))
+		// If the pointer is still same we can safely delete, else it means that the value was overwritten in parallel
+		a.observations.CompareAndDelete(attrs, val)
+		return true
+	})
+	logger.LoggerFromCtx(ctx).Info("[MetricsTest]Observed SyncGauge", "gauge", a, "count", count, "guageName", a.name)
+	return nil
+}
+
+func (a *SyncGauge[V, O]) Set(input V, attrs attribute.Set) {
+	if a == nil {
+		return
+	}
+	logger.LoggerFromCtx(context.Background()).Info("[MetricsTest]Setting SyncGauge", "gauge", a, "guageName", a.name)
+	val := ObservationMapValue[V]{Value: input}
+	a.observations.Store(attrs, &val)
+	logger.LoggerFromCtx(context.Background()).Info("[MetricsTest]Set SyncGauge", "gauge", a, "guageName", a.name)
+}
+
+type Int64SyncGauge struct {
+	syncGuage *SyncGauge[int64, metric.Int64Observable]
+}
+
+func (a *Int64SyncGauge) Set(input int64, attrs attribute.Set) {
+	a.syncGuage.Set(input, attrs)
+}
+
+func NewInt64SyncGauge(meter metric.Meter, gaugeName string, opts ...metric.Int64ObservableGaugeOption) (*Int64SyncGauge, error) {
+	syncGauge := &SyncGauge[int64, metric.Int64Observable]{
+		name: gaugeName,
+	}
+	observableGauge, err := meter.Int64ObservableGauge(gaugeName,
+		append(opts, metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
+			return syncGauge.Callback(ctx, func(value int64, options ...metric.ObserveOption) {
+				observer.Observe(value, options...)
+			})
+		}))...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Int64SyncGauge: %w", err)
 	}
 	syncGauge.observableGauge = observableGauge
-	syncGauge.observations = make(map[attribute.Set]*atomic.Int64)
-	return syncGauge, nil
+	return &Int64SyncGauge{syncGuage: syncGauge}, nil
 }
 
-func (g *Int64Gauge) callback(ctx context.Context, o metric.Int64Observer) error {
-	for attrs, val := range g.observations {
-		o.Observe(val.Load(), metric.WithAttributeSet(attrs))
+type Float64SyncGauge struct {
+	syncGuage *SyncGauge[float64, metric.Float64Observable]
+}
+
+func (a *Float64SyncGauge) Set(input float64, attrs attribute.Set) {
+	a.syncGuage.Set(input, attrs)
+}
+
+func NewFloat64SyncGauge(meter metric.Meter, gaugeName string, opts ...metric.Float64ObservableGaugeOption) (*Float64SyncGauge, error) {
+	syncGauge := &SyncGauge[float64, metric.Float64Observable]{
+		name: gaugeName,
 	}
-	return nil
-}
-
-func (g *Int64Gauge) Set(input int64, attrs attribute.Set) {
-	if g == nil {
-		return
-	}
-	val, ok := g.observations[attrs]
-	if !ok {
-		val = &atomic.Int64{}
-		g.observations[attrs] = val
-	}
-	val.Store(input)
-}
-
-type Float64Gauge struct {
-	observableGauge      metric.Float64ObservableGauge
-	observationsAsUint64 map[attribute.Set]*atomic.Uint64
-}
-
-func NewFloat64SyncGauge(meter metric.Meter, gaugeName string, opts ...metric.Float64ObservableGaugeOption) (*Float64Gauge, error) {
-	syncGauge := &Float64Gauge{}
-	observableGauge, err := meter.Float64ObservableGauge(gaugeName, append(opts, metric.WithFloat64Callback(syncGauge.callback))...)
+	observableGauge, err := meter.Float64ObservableGauge(gaugeName,
+		append(opts, metric.WithFloat64Callback(func(ctx context.Context, observer metric.Float64Observer) error {
+			return syncGauge.Callback(ctx, func(value float64, options ...metric.ObserveOption) {
+				observer.Observe(value, options...)
+			})
+		}))...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Int64SyncGauge: %w", err)
+		return nil, fmt.Errorf("failed to create Float64SyncGauge: %w", err)
 	}
 	syncGauge.observableGauge = observableGauge
-	syncGauge.observationsAsUint64 = make(map[attribute.Set]*atomic.Uint64)
-	return syncGauge, nil
+	return &Float64SyncGauge{syncGuage: syncGauge}, nil
 }
 
-func (g *Float64Gauge) callback(ctx context.Context, o metric.Float64Observer) error {
-	for attrs, val := range g.observationsAsUint64 {
-		o.Observe(math.Float64frombits(val.Load()), metric.WithAttributeSet(attrs))
-	}
-	return nil
-}
-
-func (g *Float64Gauge) Set(input float64, attrs attribute.Set) {
-	if g == nil {
-		return
-	}
-	val, ok := g.observationsAsUint64[attrs]
-	if !ok {
-		val = &atomic.Uint64{}
-		g.observationsAsUint64[attrs] = val
-	}
-	val.Store(math.Float64bits(input))
-}
-
-func GetOrInitInt64Gauge(meter metric.Meter, cache map[string]*Int64Gauge,
-	name string, opts ...metric.Int64ObservableGaugeOption,
-) (*Int64Gauge, error) {
+func GetOrInitInt64SyncGauge(meter metric.Meter, cache map[string]*Int64SyncGauge, name string,
+	opts ...metric.Int64ObservableGaugeOption,
+) (*Int64SyncGauge, error) {
 	gauge, ok := cache[name]
 	if !ok {
 		var err error
@@ -98,9 +115,9 @@ func GetOrInitInt64Gauge(meter metric.Meter, cache map[string]*Int64Gauge,
 	return gauge, nil
 }
 
-func GetOrInitFloat64Gauge(meter metric.Meter, cache map[string]*Float64Gauge,
+func GetOrInitFloat64SyncGauge(meter metric.Meter, cache map[string]*Float64SyncGauge,
 	name string, opts ...metric.Float64ObservableGaugeOption,
-) (*Float64Gauge, error) {
+) (*Float64SyncGauge, error) {
 	gauge, ok := cache[name]
 	if !ok {
 		var err error

--- a/flow/workflows/scheduled_flows.go
+++ b/flow/workflows/scheduled_flows.go
@@ -62,7 +62,8 @@ func GlobalScheduleManagerWorkflow(ctx workflow.Context) error {
 
 	slotSizeCtx := withCronOptions(ctx,
 		"record-slot-size-"+info.OriginalRunID,
-		"*/5 * * * *")
+		// TODO revert this back to 5 minutes?
+		"*/1 * * * *")
 	workflow.ExecuteChildWorkflow(slotSizeCtx, RecordSlotSizeWorkflow)
 
 	ctx.Done().Receive(ctx, nil)

--- a/flow/workflows/scheduled_flows.go
+++ b/flow/workflows/scheduled_flows.go
@@ -62,8 +62,7 @@ func GlobalScheduleManagerWorkflow(ctx workflow.Context) error {
 
 	slotSizeCtx := withCronOptions(ctx,
 		"record-slot-size-"+info.OriginalRunID,
-		// TODO revert this back to 5 minutes?
-		"*/1 * * * *")
+		"*/5 * * * *")
 	workflow.ExecuteChildWorkflow(slotSizeCtx, RecordSlotSizeWorkflow)
 
 	ctx.Done().Receive(ctx, nil)

--- a/stacks/flow.Dockerfile
+++ b/stacks/flow.Dockerfile
@@ -41,6 +41,11 @@ ENTRYPOINT [\
   ]
 
 FROM flow-base AS flow-worker
+
+# Sane defaults for OpenTelemetry
+ENV OTEL_METRIC_EXPORT_INTERVAL=10000
+ENV OTEL_EXPORTER_OTLP_COMPRESSION=gzip
+
 ENTRYPOINT [\
   "./peer-flow",\
   "worker"\


### PR DESCRIPTION
This is accomplished by clearing out the metric from the MetricsMap once Observed/Collected.


Use a query like:
```
max(peerdb_cdc_slot_lag_MB{}) without(k8s_pod_name, k8s_pod_uid, k8s_pod_ip, k8s_pod_start_time, k8s_node_name)
```
to deduplicate metrics across pods, they are only pushed once in 1 cycle in a pod



TODO:
- [x] Enable GRPC exporter
- [x] Update dockerfile env vars:
  - [x] Set a default export interval (?? in the docker file ??)
  - [x] Set default compression
- [x] Revert cron back to 5 minutes
- [x] Open replication connections