### PR TITLE
Numeric: fix scale check for bqnumeric

### DIFF
--- a/flow/datatypes/numeric.go
+++ b/flow/datatypes/numeric.go
@@ -69,7 +69,7 @@ func (BigQueryNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
 }
 
 func (BigQueryNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
-	return precision > 0 && precision <= 38 && scale <= 20
+	return precision > 0 && precision <= 38 && scale <= 20 && scale < precision
 }
 
 type DefaultNumericCompatibility struct{}

--- a/flow/datatypes/numeric.go
+++ b/flow/datatypes/numeric.go
@@ -61,7 +61,7 @@ func (BigQueryNumericCompatibility) MaxPrecision() int16 {
 }
 
 func (BigQueryNumericCompatibility) MaxScale() int16 {
-	return 37
+	return 20
 }
 
 func (BigQueryNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
@@ -69,7 +69,7 @@ func (BigQueryNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
 }
 
 func (BigQueryNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
-	return precision > 0 && precision <= 38 && scale < precision
+	return precision > 0 && precision <= 38 && scale <= 20
 }
 
 type DefaultNumericCompatibility struct{}


### PR DESCRIPTION
For bigquery we were checking for numeric scale being < precision, also need to make sure it is less than 20 as that is the scale we set for bignumeric in bq