### PR TITLE
Numeric: refactoring and truncate for BigQuery

### DIFF
--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -14,7 +14,6 @@ import (
 	"go.temporal.io/sdk/activity"
 
 	avro "github.com/PeerDB-io/peer-flow/connectors/utils/avro"
-	numeric "github.com/PeerDB-io/peer-flow/datatypes"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
@@ -281,12 +280,8 @@ func DefineAvroSchema(dstTableName string,
 }
 
 func GetAvroType(bqField *bigquery.FieldSchema) (interface{}, error) {
-	avroNumericPrecision := int16(bqField.Precision)
-	avroNumericScale := int16(bqField.Scale)
-	bqNumeric := numeric.BigQueryNumericCompatibility{}
-	if !bqNumeric.IsValidPrevisionAndScale(avroNumericPrecision, avroNumericScale) {
-		avroNumericPrecision, avroNumericScale = bqNumeric.DefaultPrecisionAndScale()
-	}
+	avroNumericPrecision, avroNumericScale := qvalue.DetermineNumericSettingForDWH(
+		int16(bqField.Precision), int16(bqField.Scale), protos.DBType_BIGQUERY)
 
 	considerRepeated := func(typ string, repeated bool) interface{} {
 		if repeated {

--- a/flow/datatypes/bigint.go
+++ b/flow/datatypes/bigint.go
@@ -1,41 +1,12 @@
 package datatypes
 
 import (
-	"math"
 	"math/big"
 )
 
-var tenInt = big.NewInt(10)
-
 func CountDigits(bi *big.Int) int {
-	tenInt := big.NewInt(10)
-	if bi.IsUint64() {
-		u64 := bi.Uint64()
-		if u64 < (1 << 53) { // Check if it is less than 2^53
-			if u64 == 0 {
-				return 1 // 0 has one digit
-			}
-			return int(math.Log10(float64(u64))) + 1
-		}
-	} else if bi.IsInt64() {
-		i64 := bi.Int64()
-		if i64 > -(1 << 53) { // Check if it is greater than -2^53
-			if i64 == 0 {
-				return 1 // 0 has one digit
-			}
-			return int(math.Log10(float64(-i64))) + 1
-		}
+	if bi.Sign() < 0 {
+		return len(bi.String()) - 1
 	}
-
-	// For larger numbers, use the bit length and logarithms
-	abs := new(big.Int).Abs(bi)
-	lg10 := int(float64(abs.BitLen()) / math.Log2(10))
-
-	// Verify and adjust lg10 if necessary
-	check := new(big.Int).Exp(tenInt, big.NewInt(int64(lg10)), nil)
-	if abs.Cmp(check) >= 0 {
-		lg10++
-	}
-
-	return lg10
+	return len(bi.String())
 }

--- a/flow/datatypes/bigint.go
+++ b/flow/datatypes/bigint.go
@@ -1,0 +1,41 @@
+package datatypes
+
+import (
+	"math"
+	"math/big"
+)
+
+var tenInt = big.NewInt(10)
+
+func CountDigits(bi *big.Int) int {
+	tenInt := big.NewInt(10)
+	if bi.IsUint64() {
+		u64 := bi.Uint64()
+		if u64 < (1 << 53) { // Check if it is less than 2^53
+			if u64 == 0 {
+				return 1 // 0 has one digit
+			}
+			return int(math.Log10(float64(u64))) + 1
+		}
+	} else if bi.IsInt64() {
+		i64 := bi.Int64()
+		if i64 > -(1 << 53) { // Check if it is greater than -2^53
+			if i64 == 0 {
+				return 1 // 0 has one digit
+			}
+			return int(math.Log10(float64(-i64))) + 1
+		}
+	}
+
+	// For larger numbers, use the bit length and logarithms
+	abs := new(big.Int).Abs(bi)
+	lg10 := int(float64(abs.BitLen()) / math.Log2(10))
+
+	// Verify and adjust lg10 if necessary
+	check := new(big.Int).Exp(tenInt, big.NewInt(int64(lg10)), nil)
+	if abs.Cmp(check) >= 0 {
+		lg10++
+	}
+
+	return lg10
+}

--- a/flow/datatypes/bigint.go
+++ b/flow/datatypes/bigint.go
@@ -1,12 +1,33 @@
 package datatypes
 
 import (
+	"math"
 	"math/big"
 )
 
+var tenInt = big.NewInt(10)
+
 func CountDigits(bi *big.Int) int {
-	if bi.Sign() < 0 {
-		return len(bi.String()) - 1
+	if bi.IsInt64() {
+		i64 := bi.Int64()
+		// restrict fast path to integers with exact conversion to float64
+		if i64 <= (1<<53) && i64 >= -(1<<53) {
+			if i64 == 0 {
+				return 1
+			}
+			return int(math.Log10(math.Abs(float64(i64)))) + 1
+		}
 	}
-	return len(bi.String())
+
+	estimatedNumDigits := int(float64(bi.BitLen()) / math.Log2(10))
+
+	// estimatedNumDigits (lg10) may be off by 1, need to verify
+	digitsBigInt := big.NewInt(int64(estimatedNumDigits))
+	errorCorrectionUnit := digitsBigInt.Exp(tenInt, digitsBigInt, nil)
+
+	if bi.CmpAbs(errorCorrectionUnit) >= 0 {
+		return estimatedNumDigits + 1
+	}
+
+	return estimatedNumDigits
 }

--- a/flow/datatypes/bigint_test.go
+++ b/flow/datatypes/bigint_test.go
@@ -1,0 +1,38 @@
+package datatypes
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestCountDigits(t *testing.T) {
+	bi := big.NewInt(1234567890)
+	expected := 10
+	result := CountDigits(bi)
+	if result != expected {
+		t.Errorf("Unexpected result. Expected: %v, but got: %v", expected, result)
+	}
+
+	bi = big.NewInt(-1234567890)
+	expected = 10
+	result = CountDigits(bi)
+	if result != expected {
+		t.Errorf("Unexpected result. Expected: %v, but got: %v", expected, result)
+	}
+
+	// 18 nines
+	bi = big.NewInt(999999999999999999)
+	result = CountDigits(bi)
+	expected = 18
+	if result != expected {
+		t.Errorf("Unexpected result. Expected: %v, but got: %v", expected, result)
+	}
+
+	// 18 nines
+	bi = big.NewInt(-999999999999999999)
+	result = CountDigits(bi)
+	expected = 18
+	if result != expected {
+		t.Errorf("Unexpected result. Expected: %v, but got: %v", expected, result)
+	}
+}

--- a/flow/datatypes/bigint_test.go
+++ b/flow/datatypes/bigint_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 func TestCountDigits(t *testing.T) {
-	bi := big.NewInt(1234567890)
-	expected := 10
+	bi := big.NewInt(-0)
+	expected := 1
 	result := CountDigits(bi)
 	if result != expected {
 		t.Errorf("Unexpected result. Expected: %v, but got: %v", expected, result)
 	}
 
-	bi = big.NewInt(-1234567890)
-	expected = 10
+	bi = big.NewInt(0)
+	expected = 1
 	result = CountDigits(bi)
 	if result != expected {
 		t.Errorf("Unexpected result. Expected: %v, but got: %v", expected, result)

--- a/flow/datatypes/numeric.go
+++ b/flow/datatypes/numeric.go
@@ -8,6 +8,8 @@ const (
 	PeerDBSnowflakeScale      = 20
 	PeerDBClickhousePrecision = 76
 	PeerDBClickhouseScale     = 38
+	BigQueryNumericUpperBound = 999999999999999999.99999999999999999999
+	BigQueryNumericLowerBound = -999999999999999999.99999999999999999999
 	VARHDRSZ                  = 4
 )
 
@@ -69,7 +71,8 @@ func (BigQueryNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
 }
 
 func (BigQueryNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
-	return precision > 0 && precision <= 38 && scale <= 20 && scale < precision
+	return precision > 0 && precision <= PeerDBBigQueryPrecision &&
+		scale <= PeerDBBigQueryScale && scale < precision
 }
 
 type DefaultNumericCompatibility struct{}

--- a/flow/datatypes/numeric.go
+++ b/flow/datatypes/numeric.go
@@ -8,8 +8,6 @@ const (
 	PeerDBSnowflakeScale      = 20
 	PeerDBClickhousePrecision = 76
 	PeerDBClickhouseScale     = 38
-	BigQueryNumericUpperBound = 999999999999999999.99999999999999999999
-	BigQueryNumericLowerBound = -999999999999999999.99999999999999999999
 	VARHDRSZ                  = 4
 )
 

--- a/flow/datatypes/numeric.go
+++ b/flow/datatypes/numeric.go
@@ -15,7 +15,7 @@ type WarehouseNumericCompatibility interface {
 	MaxPrecision() int16
 	MaxScale() int16
 	DefaultPrecisionAndScale() (int16, int16)
-	IsValidPrevisionAndScale(precision, scale int16) bool
+	IsValidPrecisionAndScale(precision, scale int16) bool
 }
 
 type ClickHouseNumericCompatibility struct{}
@@ -32,7 +32,7 @@ func (ClickHouseNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) 
 	return PeerDBClickhousePrecision, PeerDBClickhouseScale
 }
 
-func (ClickHouseNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
+func (ClickHouseNumericCompatibility) IsValidPrecisionAndScale(precision, scale int16) bool {
 	return precision > 0 && precision <= PeerDBClickhousePrecision && scale < precision
 }
 
@@ -50,7 +50,7 @@ func (SnowflakeNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
 	return PeerDBSnowflakePrecision, PeerDBSnowflakeScale
 }
 
-func (SnowflakeNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
+func (SnowflakeNumericCompatibility) IsValidPrecisionAndScale(precision, scale int16) bool {
 	return precision > 0 && precision <= 38 && scale < precision
 }
 
@@ -68,7 +68,7 @@ func (BigQueryNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
 	return PeerDBBigQueryPrecision, PeerDBBigQueryScale
 }
 
-func (BigQueryNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
+func (BigQueryNumericCompatibility) IsValidPrecisionAndScale(precision, scale int16) bool {
 	return precision > 0 && precision <= PeerDBBigQueryPrecision &&
 		scale <= PeerDBBigQueryScale && scale < precision
 }
@@ -87,7 +87,7 @@ func (DefaultNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
 	return 38, 20
 }
 
-func (DefaultNumericCompatibility) IsValidPrevisionAndScale(precision, scale int16) bool {
+func (DefaultNumericCompatibility) IsValidPrecisionAndScale(precision, scale int16) bool {
 	return true
 }
 
@@ -113,7 +113,7 @@ func GetNumericTypeForWarehouse(typmod int32, warehouseNumeric WarehouseNumericC
 	}
 
 	precision, scale := ParseNumericTypmod(typmod)
-	if !warehouseNumeric.IsValidPrevisionAndScale(precision, scale) {
+	if !warehouseNumeric.IsValidPrecisionAndScale(precision, scale) {
 		return warehouseNumeric.DefaultPrecisionAndScale()
 	}
 

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -61,7 +61,7 @@ func TruncateOrLogNumeric(num decimal.Decimal, precision int16, scale int16, tar
 			return num, errors.New("invalid numeric")
 		} else if num.Exponent() < -int32(avroScale) {
 			num = num.Truncate(int32(avroScale))
-			slog.Info("Truncated NUMERIC value", slog.Any("number", num))
+			slog.Warn("Truncated NUMERIC value", slog.Any("number", num))
 		}
 	}
 	return num, nil

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
-	"math/big"
 	"time"
 
 	"github.com/google/uuid"
@@ -443,33 +441,6 @@ func (c *QValueAvroConverter) processNullableUnion(
 		return goavro.Union(avroType, value), nil
 	}
 	return value, nil
-}
-
-var tenInt = big.NewInt(10)
-
-func countDigits(bi *big.Int) int {
-	if bi.IsInt64() {
-		i64 := bi.Int64()
-		// restrict fast path to integers with exact conversion to float64
-		if i64 <= (1<<53) && i64 >= -(1<<53) {
-			if i64 == 0 {
-				return 1
-			}
-			return int(math.Log10(math.Abs(float64(i64)))) + 1
-		}
-	}
-
-	estimatedNumDigits := int(float64(bi.BitLen()) / math.Log2(10))
-
-	// estimatedNumDigits (lg10) may be off by 1, need to verify
-	digitsBigInt := big.NewInt(int64(estimatedNumDigits))
-	errorCorrectionUnit := digitsBigInt.Exp(tenInt, digitsBigInt, nil)
-
-	if bi.CmpAbs(errorCorrectionUnit) >= 0 {
-		return estimatedNumDigits + 1
-	}
-
-	return estimatedNumDigits
 }
 
 func (c *QValueAvroConverter) processNumeric(num decimal.Decimal) interface{} {

--- a/flow/model/qvalue/dwh.go
+++ b/flow/model/qvalue/dwh.go
@@ -22,7 +22,7 @@ func DetermineNumericSettingForDWH(precision int16, scale int16, dwh protos.DBTy
 		warehouseNumeric = numeric.DefaultNumericCompatibility{}
 	}
 
-	if !warehouseNumeric.IsValidPrevisionAndScale(precision, scale) {
+	if !warehouseNumeric.IsValidPrecisionAndScale(precision, scale) {
 		precision, scale = warehouseNumeric.DefaultPrecisionAndScale()
 	}
 


### PR DESCRIPTION
Some fixes related to numerics.
- `.Round()` can turn a value like `999999....dot 99999...` to `1000...`. Changed this to `.Truncate`
- Included bigquery too for the snowflake specific steps in `processNumeric`
- Moved code snippets to functions

Functionally tested for BigQuery initial load