### PR TITLE
S3: add endpoint field to UI

### DIFF
--- a/flow/connectors/utils/aws.go
+++ b/flow/connectors/utils/aws.go
@@ -176,7 +176,7 @@ func GetAWSCredentialsProvider(ctx context.Context, connectorName string, peerCr
 			AWS:         peerCredentials.Credentials,
 			EndpointUrl: peerCredentials.EndpointUrl,
 		}, peerCredentials.Region)
-		if peerCredentials.RoleArn == nil {
+		if peerCredentials.RoleArn == nil || *peerCredentials.RoleArn == "" {
 			logger.LoggerFromCtx(ctx).Info("Received AWS credentials from peer for connector: " + connectorName)
 			return staticProvider, nil
 		}

--- a/flow/connectors/utils/aws.go
+++ b/flow/connectors/utils/aws.go
@@ -170,7 +170,7 @@ func LoadPeerDBAWSEnvConfigProvider(connectorName string) AWSCredentialsProvider
 
 func GetAWSCredentialsProvider(ctx context.Context, connectorName string, peerCredentials PeerAWSCredentials) (AWSCredentialsProvider, error) {
 	if !(peerCredentials.Credentials.AccessKeyID == "" && peerCredentials.Credentials.SecretAccessKey == "" &&
-		peerCredentials.Region == "" && peerCredentials.RoleArn == nil &&
+		peerCredentials.Region == "" && (peerCredentials.RoleArn == nil || *peerCredentials.RoleArn == "") &&
 		(peerCredentials.EndpointUrl == nil || *peerCredentials.EndpointUrl == "")) {
 		staticProvider := NewStaticAWSCredentialsProvider(AWSCredentials{
 			AWS:         peerCredentials.Credentials,

--- a/ui/app/peers/create/[peerType]/helpers/s3.ts
+++ b/ui/app/peers/create/[peerType]/helpers/s3.ts
@@ -34,6 +34,12 @@ export const s3Setting: PeerSetting[] = [
     tips: 'The region where your bucket is located. For example, us-east-1. In case of GCS, this will be set to auto, which detects where your bucket it.',
   },
   {
+    label: 'Endpoint',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, endpoint: value as string })),
+    tips: 'The endpoint of your S3 bucket. This is optional.',
+  },
+  {
     label: 'Role ARN',
     stateHandler: (value, setter) =>
       setter((curr) => ({ ...curr, roleArn: value as string })),

--- a/ui/app/peers/create/[peerType]/helpers/s3.ts
+++ b/ui/app/peers/create/[peerType]/helpers/s3.ts
@@ -38,6 +38,7 @@ export const s3Setting: PeerSetting[] = [
     stateHandler: (value, setter) =>
       setter((curr) => ({ ...curr, endpoint: value as string })),
     tips: 'The endpoint of your S3 bucket. This is optional.',
+    optional: true,
   },
   {
     label: 'Role ARN',

--- a/ui/app/utils/gcsEndpoint.ts
+++ b/ui/app/utils/gcsEndpoint.ts
@@ -1,0 +1,1 @@
+const GCS_ENDPOINT = 'https://storage.googleapis.com';

--- a/ui/app/utils/gcsEndpoint.ts
+++ b/ui/app/utils/gcsEndpoint.ts
@@ -1,1 +1,1 @@
-const GCS_ENDPOINT = 'https://storage.googleapis.com';
+export const GCS_ENDPOINT = 'https://storage.googleapis.com';

--- a/ui/components/PeerForms/S3Form.tsx
+++ b/ui/components/PeerForms/S3Form.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { PeerSetter } from '@/app/dto/PeersDTO';
 import { s3Setting } from '@/app/peers/create/[peerType]/helpers/s3';
+import { GCS_ENDPOINT } from '@/app/utils/gcsEndpoint';
 import { Label } from '@/lib/Label';
 import { RowWithRadiobutton, RowWithTextField } from '@/lib/Layout';
 import { RadioButton, RadioButtonGroup } from '@/lib/RadioButtonGroup';

--- a/ui/components/PeerForms/S3Form.tsx
+++ b/ui/components/PeerForms/S3Form.tsx
@@ -16,26 +16,18 @@ const S3Form = ({ setter }: S3Props) => {
   const [storageType, setStorageType] = useState<'S3' | 'GCS'>('S3');
   const displayCondition = (label: string) => {
     return !(
-      (label === 'Region' || label === 'Role ARN') &&
+      (label === 'Region' || label === 'Role ARN' || label === 'Endpoint') &&
       storageType === 'GCS'
     );
   };
 
   useEffect(() => {
-    const endpoint =
-      storageType === 'S3' ? '' : 'https://storage.googleapis.com';
-    setter((prev) => {
-      return {
-        ...prev,
-        endpoint,
-      };
-    });
-
     if (storageType === 'GCS') {
       setter((prev) => {
         return {
           ...prev,
           region: 'auto',
+          endpoint: GCS_ENDPOINT,
         };
       });
     }


### PR DESCRIPTION
Environment variable for the Endpoint field for the S3 peer would not be used if access key id etc were set from UI. Thus we need a field for Endpoint in UI
Also adds empty string checks for roleArn