### PR TITLE
Add error log for fetch table schema

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -740,6 +740,7 @@ func (c *PostgresConnector) GetTableSchema(
 		}
 		tableSchema, err := c.getTableSchemaForTable(ctx, tableName, req.System)
 		if err != nil {
+			c.logger.Info("error fetching schema for table "+tableName, slog.Any("error", err))
 			return nil, err
 		}
 		res[tableName] = tableSchema


### PR DESCRIPTION
For a large number of tables in the mirror, when schema fetching for one of the tables fails, the top level caller of `getTableSchema` logs the error which can be too big to log, yielding a temporal message:
```
Complete result exceeds size limit
```

This PR adds a log so that we know which table schema fetch failed