### PR TITLE
Fix depiction of defaults and organise them

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/temporal"
@@ -21,6 +21,7 @@ import (
 	"github.com/PeerDB-io/peer-flow/connectors"
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/connectors/utils/monitoring"
+	peerdb_mirror_defaults "github.com/PeerDB-io/peer-flow/defaultparameters"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
@@ -106,7 +107,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 
 	batchSize := options.BatchSize
 	if batchSize == 0 {
-		batchSize = 1_000_000
+		batchSize = peerdb_mirror_defaults.DefaultPullBatchSize
 	}
 
 	lastOffset, err := dstConn.GetLastOffset(ctx, config.FlowJobName)

--- a/flow/defaultparameters/mirror_parameters.go
+++ b/flow/defaultparameters/mirror_parameters.go
@@ -1,0 +1,11 @@
+package peerdb_mirror_defaults
+
+const (
+	// --- INITIAL LOAD ---
+	DefaultSnapshotNumTablesInParallel = 1
+	DefaultSnapshotParallelWorkers     = 4
+	DefaultSnapshotNumRowsPerPartition = 1000000
+
+	// --- CDC ---
+	DefaultPullBatchSize = 1000000
+)

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -15,6 +15,7 @@ import (
 	"github.com/PeerDB-io/peer-flow/concurrency"
 	connpostgres "github.com/PeerDB-io/peer-flow/connectors/postgres"
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
+	peerdb_mirror_defaults "github.com/PeerDB-io/peer-flow/defaultparameters"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
 	"github.com/PeerDB-io/peer-flow/shared"
@@ -161,12 +162,12 @@ func (s *SnapshotFlowExecution) cloneTable(
 			from, parsedSrcTable.String(), mapping.PartitionKey)
 	}
 
-	numWorkers := uint32(8)
+	numWorkers := uint32(peerdb_mirror_defaults.DefaultSnapshotParallelWorkers)
 	if s.config.SnapshotMaxParallelWorkers > 0 {
 		numWorkers = s.config.SnapshotMaxParallelWorkers
 	}
 
-	numRowsPerPartition := uint32(500000)
+	numRowsPerPartition := uint32(peerdb_mirror_defaults.DefaultSnapshotNumRowsPerPartition)
 	if s.config.SnapshotNumRowsPerPartition > 0 {
 		numRowsPerPartition = s.config.SnapshotNumRowsPerPartition
 	}
@@ -296,7 +297,8 @@ func SnapshotFlowWorkflow(
 			slog.String(string(shared.FlowNameKey), config.FlowJobName)),
 	}
 
-	numTablesInParallel := int(max(config.SnapshotNumTablesInParallel, 1))
+	numTablesInParallel := int(max(config.SnapshotNumTablesInParallel,
+		peerdb_mirror_defaults.DefaultSnapshotNumTablesInParallel))
 
 	if !config.DoInitialSnapshot {
 		_, err := se.setupReplication(ctx)

--- a/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { SyncStatusRow } from '@/app/dto/MirrorsDTO';
+import { DefaultSyncInterval } from '@/app/utils/defaultMirrorSettings';
 import MirrorInfo from '@/components/MirrorInfo';
 import PeerButton from '@/components/PeerComponent';
 import TimeLabel from '@/components/TimeComponent';
@@ -21,7 +22,7 @@ type props = {
   mirrorStatus: FlowStatus;
 };
 function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
-  const [syncInterval, setSyncInterval] = useState<number>();
+  const [syncInterval, setSyncInterval] = useState<number>(DefaultSyncInterval);
 
   let rowsSynced = syncs.reduce((acc, sync) => {
     if (sync.endTime !== null) {
@@ -33,9 +34,9 @@ function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
   const tablesSynced = mirrorConfig.tableMappings;
   useEffect(() => {
     getCurrentIdleTimeout(mirrorConfig.flowJobName).then((res) => {
-      setSyncInterval(res);
+      if (res > 0) setSyncInterval(res);
     });
-  }, [mirrorConfig.flowJobName]);
+  }, [mirrorConfig.flowJobName, setSyncInterval]);
   return (
     <>
       <div className='mt-10'>

--- a/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
@@ -21,7 +21,7 @@ type props = {
   mirrorStatus: FlowStatus;
 };
 function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
-  const [syncInterval, getSyncInterval] = useState<number>();
+  const [syncInterval, setSyncInterval] = useState<number>();
 
   let rowsSynced = syncs.reduce((acc, sync) => {
     if (sync.endTime !== null) {
@@ -33,7 +33,7 @@ function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
   const tablesSynced = mirrorConfig.tableMappings;
   useEffect(() => {
     getCurrentIdleTimeout(mirrorConfig.flowJobName).then((res) => {
-      getSyncInterval(res);
+      setSyncInterval(res);
     });
   }, [mirrorConfig.flowJobName]);
   return (

--- a/ui/app/mirrors/[mirrorId]/configValues.ts
+++ b/ui/app/mirrors/[mirrorId]/configValues.ts
@@ -1,6 +1,8 @@
 import {
   DefaultPullBatchSize,
+  DefaultSnapshotMaxParallelWorkers,
   DefaultSnapshotNumRowsPerPartition,
+  DefaultSnapshotNumTablesInParallel,
 } from '@/app/utils/defaultMirrorSettings';
 import { FlowConnectionConfigs } from '@/grpc_generated/flow';
 
@@ -15,11 +17,11 @@ const MirrorValues = (mirrorConfig: FlowConnectionConfigs | undefined) => {
       label: 'Snapshot Rows Per Partition',
     },
     {
-      value: `${mirrorConfig?.snapshotNumTablesInParallel} table(s)`,
+      value: `${mirrorConfig?.snapshotNumTablesInParallel || DefaultSnapshotNumTablesInParallel} table(s)`,
       label: 'Snapshot Tables In Parallel',
     },
     {
-      value: `${mirrorConfig?.snapshotMaxParallelWorkers} worker(s)`,
+      value: `${mirrorConfig?.snapshotMaxParallelWorkers || DefaultSnapshotMaxParallelWorkers} worker(s)`,
       label: 'Snapshot Parallel Workers',
     },
     {

--- a/ui/app/mirrors/[mirrorId]/configValues.ts
+++ b/ui/app/mirrors/[mirrorId]/configValues.ts
@@ -1,13 +1,17 @@
+import {
+  DefaultPullBatchSize,
+  DefaultSnapshotNumRowsPerPartition,
+} from '@/app/utils/defaultMirrorSettings';
 import { FlowConnectionConfigs } from '@/grpc_generated/flow';
 
 const MirrorValues = (mirrorConfig: FlowConnectionConfigs | undefined) => {
   return [
     {
-      value: `${mirrorConfig?.maxBatchSize} rows`,
+      value: `${mirrorConfig?.maxBatchSize || DefaultPullBatchSize} rows`,
       label: 'Pull Batch Size',
     },
     {
-      value: `${mirrorConfig?.snapshotNumRowsPerPartition} rows`,
+      value: `${mirrorConfig?.snapshotNumRowsPerPartition || DefaultSnapshotNumRowsPerPartition} rows`,
       label: 'Snapshot Rows Per Partition',
     },
     {
@@ -16,15 +20,17 @@ const MirrorValues = (mirrorConfig: FlowConnectionConfigs | undefined) => {
     },
     {
       value: `${mirrorConfig?.snapshotMaxParallelWorkers} worker(s)`,
-      label: 'Snapshot Parallel Tables',
+      label: 'Snapshot Parallel Workers',
     },
     {
       value: `${mirrorConfig?.softDelete}`,
       label: 'Soft Delete',
     },
     {
-      value: mirrorConfig?.script,
-      label: 'Script',
+      value:
+        mirrorConfig?.publicationName ||
+        'peerflow_pub_' + mirrorConfig?.flowJobName.toLowerCase(),
+      label: 'Publication Name',
     },
   ];
 };

--- a/ui/app/mirrors/[mirrorId]/handlers.ts
+++ b/ui/app/mirrors/[mirrorId]/handlers.ts
@@ -1,3 +1,4 @@
+import { DefaultSyncInterval } from '@/app/utils/defaultMirrorSettings';
 import { FlowConnectionConfigs, FlowStatus } from '@/grpc_generated/flow';
 import {
   FlowStateChangeRequest,
@@ -15,7 +16,10 @@ export const getMirrorState = async (mirrorId: string) => {
 
 export const getCurrentIdleTimeout = async (mirrorId: string) => {
   return await getMirrorState(mirrorId).then((res) => {
-    return (res as MirrorStatusResponse).cdcStatus?.config?.idleTimeoutSeconds;
+    return (
+      (res as MirrorStatusResponse).cdcStatus?.config?.idleTimeoutSeconds ||
+      DefaultSyncInterval
+    );
   });
 };
 

--- a/ui/app/mirrors/[mirrorId]/handlers.ts
+++ b/ui/app/mirrors/[mirrorId]/handlers.ts
@@ -1,4 +1,3 @@
-import { DefaultSyncInterval } from '@/app/utils/defaultMirrorSettings';
 import { FlowConnectionConfigs, FlowStatus } from '@/grpc_generated/flow';
 import {
   FlowStateChangeRequest,
@@ -15,12 +14,10 @@ export const getMirrorState = async (mirrorId: string) => {
 };
 
 export const getCurrentIdleTimeout = async (mirrorId: string) => {
-  return await getMirrorState(mirrorId).then((res) => {
-    return (
-      (res as MirrorStatusResponse).cdcStatus?.config?.idleTimeoutSeconds ||
-      DefaultSyncInterval
-    );
-  });
+  return await getMirrorState(mirrorId).then(
+    (res) =>
+      (res as MirrorStatusResponse).cdcStatus?.config?.idleTimeoutSeconds || 0
+  );
 };
 
 export const changeFlowState = async (

--- a/ui/app/mirrors/create/helpers/common.ts
+++ b/ui/app/mirrors/create/helpers/common.ts
@@ -1,3 +1,10 @@
+import {
+  DefaultPullBatchSize,
+  DefaultSnapshotMaxParallelWorkers,
+  DefaultSnapshotNumRowsPerPartition,
+  DefaultSnapshotNumTablesInParallel,
+  DefaultSyncInterval,
+} from '@/app/utils/defaultMirrorSettings';
 import { FlowConnectionConfigs, TypeSystem } from '@/grpc_generated/flow';
 
 export enum AdvancedSettingType {
@@ -23,12 +30,12 @@ export const blankCDCSetting: FlowConnectionConfigs = {
   destination: undefined,
   flowJobName: '',
   tableMappings: [],
-  maxBatchSize: 1000000,
+  maxBatchSize: DefaultPullBatchSize,
   doInitialSnapshot: true,
   publicationName: '',
-  snapshotNumRowsPerPartition: 1000000,
-  snapshotMaxParallelWorkers: 4,
-  snapshotNumTablesInParallel: 1,
+  snapshotNumRowsPerPartition: DefaultSnapshotNumRowsPerPartition,
+  snapshotMaxParallelWorkers: DefaultSnapshotMaxParallelWorkers,
+  snapshotNumTablesInParallel: DefaultSnapshotNumTablesInParallel,
   snapshotStagingPath: '',
   cdcStagingPath: '',
   softDelete: true,
@@ -37,7 +44,7 @@ export const blankCDCSetting: FlowConnectionConfigs = {
   softDeleteColName: '',
   syncedAtColName: '',
   initialSnapshotOnly: false,
-  idleTimeoutSeconds: 60,
+  idleTimeoutSeconds: DefaultSyncInterval,
   script: '',
   system: TypeSystem.Q,
 };

--- a/ui/app/utils/defaultMirrorSettings.ts
+++ b/ui/app/utils/defaultMirrorSettings.ts
@@ -1,0 +1,15 @@
+// These are the backend defaults if the user creates a new mirror
+// via SQL layer without specifying these settings.
+const DefaultSyncInterval = 60;
+const DefaultSnapshotNumRowsPerPartition = 1000000;
+const DefaultPullBatchSize = 1000000;
+const DefaultSnapshotNumTablesInParallel = 1;
+const DefaultSnapshotMaxParallelWorkers = 4;
+
+export {
+  DefaultPullBatchSize,
+  DefaultSnapshotMaxParallelWorkers,
+  DefaultSnapshotNumRowsPerPartition,
+  DefaultSnapshotNumTablesInParallel,
+  DefaultSyncInterval,
+};

--- a/ui/components/MirrorInfo.tsx
+++ b/ui/components/MirrorInfo.tsx
@@ -15,7 +15,7 @@ const MirrorInfo = ({ configs }: InfoPopoverProps) => {
   return (
     <Dialog
       noInteract={false}
-      size='large'
+      size='xLarge'
       triggerButton={
         <Button style={{ backgroundColor: 'white', border: '1px solid gray' }}>
           <Label variant='body'>View More</Label>


### PR DESCRIPTION
![Screenshot 2024-05-25 at 12 36 59 AM](https://github.com/PeerDB-io/peerdb/assets/65964360/db170c00-db51-4dbf-ab56-c84f918c15ae)


Fixes issues where some params in overview page would show '0' but they would actually have a default value

Organise default values of :
Snapshot number of tables in parallel
Snapshot number of workers
Snapshot number of rows per partition
Pull batch Size
Sync interval

to constant files in Go and UI

Show these defaults when not set in UI (happens when mirror is created via query layer)
Also show publication name in UI

Functionally tested with creating a mirror from UI and Query Layer