### PR TITLE
feat(cdc): reload peers on flow resume

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -801,3 +801,95 @@ func (a *FlowableActivity) AddTablesToPublication(ctx context.Context, cfg *prot
 	}
 	return err
 }
+
+func (a *FlowableActivity) LoadPeer(ctx context.Context, peerName string) (*protos.Peer, error) {
+	row := a.CatalogPool.QueryRow(ctx, `
+		SELECT name, type, options
+		FROM peers
+		WHERE name = $1`, peerName)
+
+	var peer protos.Peer
+	var peerOptions []byte
+	if err := row.Scan(&peer.Name, &peer.Type, &peerOptions); err != nil {
+		return nil, fmt.Errorf("failed to load peer: %w", err)
+	}
+
+	switch peer.Type {
+	case protos.DBType_BIGQUERY:
+		var config protos.BigqueryConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal BigQuery config: %w", err)
+		}
+		peer.Config = &protos.Peer_BigqueryConfig{BigqueryConfig: &config}
+	case protos.DBType_SNOWFLAKE:
+		var config protos.SnowflakeConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal Snowflake config: %w", err)
+		}
+		peer.Config = &protos.Peer_SnowflakeConfig{SnowflakeConfig: &config}
+	case protos.DBType_MONGO:
+		var config protos.MongoConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal MongoDB config: %w", err)
+		}
+		peer.Config = &protos.Peer_MongoConfig{MongoConfig: &config}
+	case protos.DBType_POSTGRES:
+		var config protos.PostgresConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal Postgres config: %w", err)
+		}
+		peer.Config = &protos.Peer_PostgresConfig{PostgresConfig: &config}
+	case protos.DBType_S3:
+		var config protos.S3Config
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal S3 config: %w", err)
+		}
+		peer.Config = &protos.Peer_S3Config{S3Config: &config}
+	case protos.DBType_SQLSERVER:
+		var config protos.SqlServerConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal SQL Server config: %w", err)
+		}
+		peer.Config = &protos.Peer_SqlserverConfig{SqlserverConfig: &config}
+	case protos.DBType_MYSQL:
+		var config protos.MySqlConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal MySQL config: %w", err)
+		}
+		peer.Config = &protos.Peer_MysqlConfig{MysqlConfig: &config}
+	case protos.DBType_CLICKHOUSE:
+		var config protos.ClickhouseConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal ClickHouse config: %w", err)
+		}
+		peer.Config = &protos.Peer_ClickhouseConfig{ClickhouseConfig: &config}
+	case protos.DBType_KAFKA:
+		var config protos.KafkaConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal Kafka config: %w", err)
+		}
+		peer.Config = &protos.Peer_KafkaConfig{KafkaConfig: &config}
+	case protos.DBType_PUBSUB:
+		var config protos.PubSubConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal Pub/Sub config: %w", err)
+		}
+		peer.Config = &protos.Peer_PubsubConfig{PubsubConfig: &config}
+	case protos.DBType_EVENTHUBS:
+		var config protos.EventHubGroupConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal Event Hubs config: %w", err)
+		}
+		peer.Config = &protos.Peer_EventhubGroupConfig{EventhubGroupConfig: &config}
+	case protos.DBType_ELASTICSEARCH:
+		var config protos.ElasticsearchConfig
+		if err := proto.Unmarshal(peerOptions, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal Elasticsearch config: %w", err)
+		}
+		peer.Config = &protos.Peer_ElasticsearchConfig{ElasticsearchConfig: &config}
+	default:
+		return nil, fmt.Errorf("unsupported peer type: %s", peer.Type)
+	}
+
+	return &peer, nil
+}

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/PeerDB-io/peer-flow/alerting"
+	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
 	"github.com/PeerDB-io/peer-flow/shared"
@@ -516,110 +517,7 @@ func (h *FlowRequestHandler) CreatePeer(
 		}, nil
 	}
 
-	config := req.Peer.Config
-	wrongConfigResponse := &protos.CreatePeerResponse{
-		Status: protos.CreatePeerStatus_FAILED,
-		Message: fmt.Sprintf("invalid config for %s peer %s",
-			req.Peer.Type, req.Peer.Name),
-	}
-	var encodedConfig []byte
-	var encodingErr error
-	peerType := req.Peer.Type
-	switch peerType {
-	case protos.DBType_POSTGRES:
-		pgConfigObject, ok := config.(*protos.Peer_PostgresConfig)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		pgConfig := pgConfigObject.PostgresConfig
-		encodedConfig, encodingErr = proto.Marshal(pgConfig)
-	case protos.DBType_SNOWFLAKE:
-		sfConfigObject, ok := config.(*protos.Peer_SnowflakeConfig)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		sfConfig := sfConfigObject.SnowflakeConfig
-		encodedConfig, encodingErr = proto.Marshal(sfConfig)
-	case protos.DBType_BIGQUERY:
-		bqConfigObject, ok := config.(*protos.Peer_BigqueryConfig)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		bqConfig := bqConfigObject.BigqueryConfig
-		encodedConfig, encodingErr = proto.Marshal(bqConfig)
-	case protos.DBType_SQLSERVER:
-		sqlServerConfigObject, ok := config.(*protos.Peer_SqlserverConfig)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		sqlServerConfig := sqlServerConfigObject.SqlserverConfig
-		encodedConfig, encodingErr = proto.Marshal(sqlServerConfig)
-	case protos.DBType_S3:
-		s3ConfigObject, ok := config.(*protos.Peer_S3Config)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		s3Config := s3ConfigObject.S3Config
-		encodedConfig, encodingErr = proto.Marshal(s3Config)
-	case protos.DBType_CLICKHOUSE:
-		chConfigObject, ok := config.(*protos.Peer_ClickhouseConfig)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		chConfig := chConfigObject.ClickhouseConfig
-		encodedConfig, encodingErr = proto.Marshal(chConfig)
-	case protos.DBType_KAFKA:
-		kaConfigObject, ok := config.(*protos.Peer_KafkaConfig)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		kaConfig := kaConfigObject.KafkaConfig
-		encodedConfig, encodingErr = proto.Marshal(kaConfig)
-	case protos.DBType_PUBSUB:
-		psConfigObject, ok := config.(*protos.Peer_PubsubConfig)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		psConfig := psConfigObject.PubsubConfig
-		encodedConfig, encodingErr = proto.Marshal(psConfig)
-	case protos.DBType_EVENTHUBS:
-		ehConfigObject, ok := config.(*protos.Peer_EventhubGroupConfig)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		ehConfig := ehConfigObject.EventhubGroupConfig
-		encodedConfig, encodingErr = proto.Marshal(ehConfig)
-	case protos.DBType_ELASTICSEARCH:
-		esConfigObject, ok := config.(*protos.Peer_ElasticsearchConfig)
-		if !ok {
-			return wrongConfigResponse, nil
-		}
-		esConfig := esConfigObject.ElasticsearchConfig
-		encodedConfig, encodingErr = proto.Marshal(esConfig)
-	default:
-		return wrongConfigResponse, nil
-	}
-	if encodingErr != nil {
-		slog.Error(fmt.Sprintf("failed to encode peer configuration for %s peer %s : %v",
-			req.Peer.Type, req.Peer.Name, encodingErr))
-		return nil, encodingErr
-	}
-
-	_, err := h.pool.Exec(ctx, "INSERT INTO peers (name, type, options) VALUES ($1, $2, $3)",
-		req.Peer.Name, peerType, encodedConfig,
-	)
-	if err != nil {
-		return &protos.CreatePeerResponse{
-			Status: protos.CreatePeerStatus_FAILED,
-			Message: fmt.Sprintf("failed to insert into peers table for %s peer %s: %s",
-				req.Peer.Type, req.Peer.Name, err.Error()),
-		}, nil
-	}
-
-	return &protos.CreatePeerResponse{
-		Status:  protos.CreatePeerStatus_CREATED,
-		Message: "",
-	}, nil
+	return utils.CreatePeerNoValidate(ctx, h.pool, req.Peer)
 }
 
 func (h *FlowRequestHandler) DropPeer(

--- a/flow/connectors/utils/peers.go
+++ b/flow/connectors/utils/peers.go
@@ -1,0 +1,122 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"google.golang.org/protobuf/proto"
+)
+
+func CreatePeerNoValidate(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	peer *protos.Peer,
+) (*protos.CreatePeerResponse, error) {
+	config := peer.Config
+	wrongConfigResponse := &protos.CreatePeerResponse{
+		Status: protos.CreatePeerStatus_FAILED,
+		Message: fmt.Sprintf("invalid config for %s peer %s",
+			peer.Type, peer.Name),
+	}
+	var encodedConfig []byte
+	var encodingErr error
+	peerType := peer.Type
+	switch peerType {
+	case protos.DBType_POSTGRES:
+		pgConfigObject, ok := config.(*protos.Peer_PostgresConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		pgConfig := pgConfigObject.PostgresConfig
+		encodedConfig, encodingErr = proto.Marshal(pgConfig)
+	case protos.DBType_SNOWFLAKE:
+		sfConfigObject, ok := config.(*protos.Peer_SnowflakeConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		sfConfig := sfConfigObject.SnowflakeConfig
+		encodedConfig, encodingErr = proto.Marshal(sfConfig)
+	case protos.DBType_BIGQUERY:
+		bqConfigObject, ok := config.(*protos.Peer_BigqueryConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		bqConfig := bqConfigObject.BigqueryConfig
+		encodedConfig, encodingErr = proto.Marshal(bqConfig)
+	case protos.DBType_SQLSERVER:
+		sqlServerConfigObject, ok := config.(*protos.Peer_SqlserverConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		sqlServerConfig := sqlServerConfigObject.SqlserverConfig
+		encodedConfig, encodingErr = proto.Marshal(sqlServerConfig)
+	case protos.DBType_S3:
+		s3ConfigObject, ok := config.(*protos.Peer_S3Config)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		s3Config := s3ConfigObject.S3Config
+		encodedConfig, encodingErr = proto.Marshal(s3Config)
+	case protos.DBType_CLICKHOUSE:
+		chConfigObject, ok := config.(*protos.Peer_ClickhouseConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		chConfig := chConfigObject.ClickhouseConfig
+		encodedConfig, encodingErr = proto.Marshal(chConfig)
+	case protos.DBType_KAFKA:
+		kaConfigObject, ok := config.(*protos.Peer_KafkaConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		kaConfig := kaConfigObject.KafkaConfig
+		encodedConfig, encodingErr = proto.Marshal(kaConfig)
+	case protos.DBType_PUBSUB:
+		psConfigObject, ok := config.(*protos.Peer_PubsubConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		psConfig := psConfigObject.PubsubConfig
+		encodedConfig, encodingErr = proto.Marshal(psConfig)
+	case protos.DBType_EVENTHUBS:
+		ehConfigObject, ok := config.(*protos.Peer_EventhubGroupConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		ehConfig := ehConfigObject.EventhubGroupConfig
+		encodedConfig, encodingErr = proto.Marshal(ehConfig)
+	case protos.DBType_ELASTICSEARCH:
+		esConfigObject, ok := config.(*protos.Peer_ElasticsearchConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		esConfig := esConfigObject.ElasticsearchConfig
+		encodedConfig, encodingErr = proto.Marshal(esConfig)
+	default:
+		return wrongConfigResponse, nil
+	}
+	if encodingErr != nil {
+		slog.Error(fmt.Sprintf("failed to encode peer configuration for %s peer %s : %v",
+			peer.Type, peer.Name, encodingErr))
+		return nil, encodingErr
+	}
+
+	_, err := pool.Exec(ctx, "INSERT INTO peers (name, type, options) VALUES ($1, $2, $3)",
+		peer.Name, peerType, encodedConfig,
+	)
+	if err != nil {
+		return &protos.CreatePeerResponse{
+			Status: protos.CreatePeerStatus_FAILED,
+			Message: fmt.Sprintf("failed to insert into peers table for %s peer %s: %s",
+				peer.Type, peer.Name, err.Error()),
+		}, nil
+	}
+
+	return &protos.CreatePeerResponse{
+		Status:  protos.CreatePeerStatus_CREATED,
+		Message: "",
+	}, nil
+}

--- a/flow/connectors/utils/peers.go
+++ b/flow/connectors/utils/peers.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/PeerDB-io/peer-flow/generated/protos"
 )
 
 func CreatePeerNoValidate(

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/e2e"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
+	"github.com/PeerDB-io/peer-flow/peerdbenv"
 	"github.com/PeerDB-io/peer-flow/shared"
 	peerflow "github.com/PeerDB-io/peer-flow/workflows"
 )
@@ -905,6 +907,17 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 		FlowJobName: s.attachSuffix("test_dynconfig"),
 	}
 
+	sourcePeer := e2e.GeneratePostgresPeer()
+
+	conn, err := peerdbenv.GetCatalogConnectionPoolFromEnv(context.Background())
+	require.NoError(s.t, err)
+
+	_, err = utils.CreatePeerNoValidate(context.Background(), conn, sourcePeer)
+	require.NoError(s.t, err)
+
+	_, err = utils.CreatePeerNoValidate(context.Background(), conn, s.peer)
+	require.NoError(s.t, err)
+
 	config := &protos.FlowConnectionConfigs{
 		FlowJobName: connectionGen.FlowJobName,
 		Destination: s.peer,
@@ -914,7 +927,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 				DestinationTableIdentifier: dstTable1Name,
 			},
 		},
-		Source:                      e2e.GeneratePostgresPeer(),
+		Source:                      sourcePeer,
 		CdcStagingPath:              connectionGen.CdcStagingPath,
 		MaxBatchSize:                6,
 		IdleTimeoutSeconds:          7,

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -187,23 +187,23 @@ func reloadPeers(ctx workflow.Context, logger log.Logger, cfg *protos.FlowConnec
 		StartToCloseTimeout: 5 * time.Minute,
 	})
 
-	logger.Info(fmt.Sprintf("reloading source peer %s", cfg.Source.Name))
+	logger.Info("reloading source peer " + cfg.Source.Name)
 	srcFuture := workflow.ExecuteActivity(reloadPeersCtx, flowable.LoadPeer, cfg.Source.Name)
 	var srcPeer *protos.Peer
 	if err := srcFuture.Get(reloadPeersCtx, &srcPeer); err != nil {
 		logger.Error("failed to load source peer", slog.Any("error", err))
 		return fmt.Errorf("failed to load source peer: %w", err)
 	}
-	logger.Info(fmt.Sprintf("reloaded peer %s", cfg.Source.Name))
+	logger.Info("reloaded peer " + cfg.Source.Name)
 
-	logger.Info(fmt.Sprintf("reloading destination peer %s", cfg.Destination.Name))
+	logger.Info("reloading destination peer " + cfg.Destination.Name)
 	dstFuture := workflow.ExecuteActivity(reloadPeersCtx, flowable.LoadPeer, cfg.Destination.Name)
 	var dstPeer *protos.Peer
 	if err := dstFuture.Get(reloadPeersCtx, &dstPeer); err != nil {
 		logger.Error("failed to load destination peer", slog.Any("error", err))
 		return fmt.Errorf("failed to load destination peer: %w", err)
 	}
-	logger.Info(fmt.Sprintf("reloaded peer %s", cfg.Destination.Name))
+	logger.Info("reloaded peer " + cfg.Destination.Name)
 
 	cfg.Source = srcPeer
 	cfg.Destination = dstPeer
@@ -271,7 +271,7 @@ func CDCFlowWorkflow(
 				return state, err
 			}
 
-			// reload peers this is to support EDIT PEER functionality.
+			// reload peers in case of EDIT PEER
 			err := reloadPeers(ctx, logger, cfg)
 			if err != nil {
 				logger.Error("failed to reload peers", slog.Any("error", err))

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -187,23 +187,23 @@ func reloadPeers(ctx workflow.Context, logger log.Logger, cfg *protos.FlowConnec
 		StartToCloseTimeout: 5 * time.Minute,
 	})
 
-	logger.Info("reloading source peer " + cfg.Source.Name)
+	logger.Info("reloading source peer", slog.String("peerName", cfg.Source.Name))
 	srcFuture := workflow.ExecuteActivity(reloadPeersCtx, flowable.LoadPeer, cfg.Source.Name)
 	var srcPeer *protos.Peer
 	if err := srcFuture.Get(reloadPeersCtx, &srcPeer); err != nil {
 		logger.Error("failed to load source peer", slog.Any("error", err))
 		return fmt.Errorf("failed to load source peer: %w", err)
 	}
-	logger.Info("reloaded peer " + cfg.Source.Name)
+	logger.Info("reloaded peer", slog.String("peerName", cfg.Source.Name))
 
-	logger.Info("reloading destination peer " + cfg.Destination.Name)
+	logger.Info("reloading destination peer", slog.String("peerName", cfg.Destination.Name))
 	dstFuture := workflow.ExecuteActivity(reloadPeersCtx, flowable.LoadPeer, cfg.Destination.Name)
 	var dstPeer *protos.Peer
 	if err := dstFuture.Get(reloadPeersCtx, &dstPeer); err != nil {
 		logger.Error("failed to load destination peer", slog.Any("error", err))
 		return fmt.Errorf("failed to load destination peer: %w", err)
 	}
-	logger.Info("reloaded peer " + cfg.Destination.Name)
+	logger.Info("reloaded peer", slog.String("peerName", cfg.Destination.Name))
 
 	cfg.Source = srcPeer
 	cfg.Destination = dstPeer


### PR DESCRIPTION
Implement the reloadPeers function to support the edit peer functionality. When a flow is paused and resumed, reload the latest peer details for both the source and destination peers. This ensures that any changes made to the peer configuration during the pause are picked up when the flow resumes execution.