### PR TITLE
Snowflake: use sysdate() for peerdb synced at

### DIFF
--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -693,7 +693,7 @@ func generateCreateTableSQLForNormalizedTable(
 	// this is a timestamp column that is used to mark records as synced
 	// default value is the current timestamp (snowflake)
 	if syncedAtColName != "" {
-		createTableSQLArray = append(createTableSQLArray, syncedAtColName+" TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+		createTableSQLArray = append(createTableSQLArray, syncedAtColName+" TIMESTAMP_TZ DEFAULT CURRENT_TIMESTAMP")
 	}
 
 	// add composite primary key to the table

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -693,7 +693,7 @@ func generateCreateTableSQLForNormalizedTable(
 	// this is a timestamp column that is used to mark records as synced
 	// default value is the current timestamp (snowflake)
 	if syncedAtColName != "" {
-		createTableSQLArray = append(createTableSQLArray, syncedAtColName+" TIMESTAMP_TZ DEFAULT CURRENT_TIMESTAMP")
+		createTableSQLArray = append(createTableSQLArray, syncedAtColName+" TIMESTAMP DEFAULT SYSDATE()")
 	}
 
 	// add composite primary key to the table


### PR DESCRIPTION
CURRENT_TIMESTAMP returns timestamp in local timezone which can be misleading when inspecting `peerdb_synced_at` values on Snowflake. SYSDATE() gives it in UTC

https://docs.snowflake.com/en/sql-reference/functions/sysdate