### PR TITLE
dynamic config from catalog: groundwork

### DIFF
--- a/flow/alerting/alerting.go
+++ b/flow/alerting/alerting.go
@@ -123,7 +123,11 @@ func (a *Alerter) AlertIfSlotLag(ctx context.Context, peerName string, slotInfo 
 		deploymentUIDPrefix = fmt.Sprintf("[%s] ", peerdbenv.PeerDBDeploymentUID())
 	}
 
-	defaultSlotLagMBAlertThreshold := dynamicconf.PeerDBSlotLagMBAlertThreshold(ctx)
+	defaultSlotLagMBAlertThreshold, err := dynamicconf.PeerDBSlotLagMBAlertThreshold(ctx)
+	if err != nil {
+		logger.LoggerFromCtx(ctx).Warn("failed to get slot lag alert threshold from catalog", slog.Any("error", err))
+		return
+	}
 	// catalog cannot use default threshold to space alerts properly, use the lowest set threshold instead
 	lowestSlotLagMBAlertThreshold := defaultSlotLagMBAlertThreshold
 	for _, alertSender := range alertSenderConfigs {
@@ -171,7 +175,11 @@ func (a *Alerter) AlertIfOpenConnections(ctx context.Context, peerName string,
 	}
 
 	// same as with slot lag, use lowest threshold for catalog
-	defaultOpenConnectionsThreshold := dynamicconf.PeerDBOpenConnectionsAlertThreshold(ctx)
+	defaultOpenConnectionsThreshold, err := dynamicconf.PeerDBOpenConnectionsAlertThreshold(ctx)
+	if err != nil {
+		logger.LoggerFromCtx(ctx).Warn("failed to get open connections alert threshold from catalog", slog.Any("error", err))
+		return
+	}
 	lowestOpenConnectionsThreshold := defaultOpenConnectionsThreshold
 	for _, alertSender := range alertSenderConfigs {
 		if alertSender.Sender.getOpenConnectionsAlertThreshold() > 0 {
@@ -216,7 +224,11 @@ func (a *Alerter) alertToProvider(ctx context.Context, alertSenderConfig AlertSe
 // in the past X minutes, where X is configurable and defaults to 15 minutes
 // returns true if alert added to catalog, so proceed with processing alerts to slack
 func (a *Alerter) checkAndAddAlertToCatalog(ctx context.Context, alertConfigId int64, alertKey string, alertMessage string) bool {
-	dur := dynamicconf.PeerDBAlertingGapMinutesAsDuration(ctx)
+	dur, err := dynamicconf.PeerDBAlertingGapMinutesAsDuration(ctx)
+	if err != nil {
+		logger.LoggerFromCtx(ctx).Warn("failed to get alerting gap duration from catalog", slog.Any("error", err))
+		return false
+	}
 	if dur == 0 {
 		logger.LoggerFromCtx(ctx).Warn("Alerting disabled via environment variable, returning")
 		return false
@@ -227,7 +239,7 @@ func (a *Alerter) checkAndAddAlertToCatalog(ctx context.Context, alertConfigId i
 		 ORDER BY created_timestamp DESC LIMIT 1`,
 		alertKey, alertConfigId)
 	var createdTimestamp time.Time
-	err := row.Scan(&createdTimestamp)
+	err = row.Scan(&createdTimestamp)
 	if err != nil && err != pgx.ErrNoRows {
 		logger.LoggerFromCtx(ctx).Warn("failed to send alert: ", slog.String("err", err.Error()))
 		return false

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -681,7 +681,10 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 		}
 	}
 
-	timePartitionEnabled := dynamicconf.PeerDBBigQueryEnableSyncedAtPartitioning(ctx)
+	timePartitionEnabled, err := dynamicconf.PeerDBBigQueryEnableSyncedAtPartitioning(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get dynamic setting for BigQuery time partitioning: %w", err)
+	}
 	var timePartitioning *bigquery.TimePartitioning
 	if timePartitionEnabled && syncedAtColName != "" {
 		timePartitioning = &bigquery.TimePartitioning{

--- a/flow/dynamicconf/dynamicconf.go
+++ b/flow/dynamicconf/dynamicconf.go
@@ -2,104 +2,112 @@ package dynamicconf
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/exp/constraints"
 
 	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
 )
 
-func dynamicConfKeyExists(ctx context.Context, conn *pgxpool.Pool, key string) bool {
-	var exists pgtype.Bool
-	query := "SELECT EXISTS(SELECT 1 FROM alerting_settings WHERE config_name = $1)"
-	err := conn.QueryRow(ctx, query, key).Scan(&exists)
-	if err != nil {
-		logger.LoggerFromCtx(ctx).Error("Failed to check if key exists: %v", err)
-		return false
-	}
-
-	return exists.Bool
-}
-
-func dynamicConfUint32(ctx context.Context, key string, defaultValue uint32) uint32 {
+func dynamicConfSigned[T constraints.Signed](ctx context.Context, key string) (T, error) {
 	conn, err := peerdbenv.GetCatalogConnectionPoolFromEnv(ctx)
 	if err != nil {
 		logger.LoggerFromCtx(ctx).Error("Failed to get catalog connection pool: %v", err)
-		return defaultValue
-	}
-
-	if !dynamicConfKeyExists(ctx, conn, key) {
-		return defaultValue
+		return 0, fmt.Errorf("failed to get catalog connection pool: %w", err)
 	}
 
 	var value pgtype.Text
-	query := "SELECT config_value FROM alerting_settings WHERE config_name = $1"
+	query := "SELECT coalesce(config_value,config_default_value) FROM dynamic_settings WHERE config_name=$1"
 	err = conn.QueryRow(ctx, query, key).Scan(&value)
 	if err != nil {
 		logger.LoggerFromCtx(ctx).Error("Failed to get key: %v", err)
-		return defaultValue
+		return 0, fmt.Errorf("failed to get key: %w", err)
 	}
 
-	result, err := strconv.ParseUint(value.String, 10, 32)
+	result, err := strconv.ParseInt(value.String, 10, 64)
 	if err != nil {
-		logger.LoggerFromCtx(ctx).Error("Failed to parse uint32: %v", err)
-		return defaultValue
+		logger.LoggerFromCtx(ctx).Error("Failed to parse as int64: %v", err)
+		return 0, fmt.Errorf("failed to parse as int64: %w", err)
 	}
 
-	return uint32(result)
+	return T(result), nil
 }
 
-func dynamicConfBool(ctx context.Context, key string, defaultValue bool) bool {
+func dynamicConfUnsigned[T constraints.Unsigned](ctx context.Context, key string) (T, error) {
 	conn, err := peerdbenv.GetCatalogConnectionPoolFromEnv(ctx)
 	if err != nil {
 		logger.LoggerFromCtx(ctx).Error("Failed to get catalog connection pool: %v", err)
-		return defaultValue
-	}
-
-	if !dynamicConfKeyExists(ctx, conn, key) {
-		return defaultValue
+		return 0, fmt.Errorf("failed to get catalog connection pool: %w", err)
 	}
 
 	var value pgtype.Text
-	query := "SELECT config_value FROM alerting_settings WHERE config_name = $1"
+	query := "SELECT coalesce(config_value,config_default_value) FROM dynamic_settings WHERE config_name=$1"
 	err = conn.QueryRow(ctx, query, key).Scan(&value)
 	if err != nil {
 		logger.LoggerFromCtx(ctx).Error("Failed to get key: %v", err)
-		return defaultValue
+		return 0, fmt.Errorf("failed to get key: %w", err)
+	}
+
+	result, err := strconv.ParseUint(value.String, 10, 64)
+	if err != nil {
+		logger.LoggerFromCtx(ctx).Error("Failed to parse as int64: %v", err)
+		return 0, fmt.Errorf("failed to parse as int64: %w", err)
+	}
+
+	return T(result), nil
+}
+
+func dynamicConfBool(ctx context.Context, key string) (bool, error) {
+	conn, err := peerdbenv.GetCatalogConnectionPoolFromEnv(ctx)
+	if err != nil {
+		logger.LoggerFromCtx(ctx).Error("Failed to get catalog connection pool: %v", err)
+		return false, fmt.Errorf("failed to get catalog connection pool: %w", err)
+	}
+
+	var value pgtype.Text
+	query := "SELECT coalesce(config_value,config_default_value) FROM dynamic_settings WHERE config_name = $1"
+	err = conn.QueryRow(ctx, query, key).Scan(&value)
+	if err != nil {
+		logger.LoggerFromCtx(ctx).Error("Failed to get key: %v", err)
+		return false, fmt.Errorf("failed to get key: %w", err)
 	}
 
 	result, err := strconv.ParseBool(value.String)
 	if err != nil {
 		logger.LoggerFromCtx(ctx).Error("Failed to parse bool: %v", err)
-		return defaultValue
+		return false, fmt.Errorf("failed to parse bool: %w", err)
 	}
 
-	return result
+	return result, nil
 }
 
 // PEERDB_SLOT_LAG_MB_ALERT_THRESHOLD, 0 disables slot lag alerting entirely
-func PeerDBSlotLagMBAlertThreshold(ctx context.Context) uint32 {
-	return dynamicConfUint32(ctx, "PEERDB_SLOT_LAG_MB_ALERT_THRESHOLD", 5000)
+func PeerDBSlotLagMBAlertThreshold(ctx context.Context) (uint32, error) {
+	return dynamicConfUnsigned[uint32](ctx, "PEERDB_SLOT_LAG_MB_ALERT_THRESHOLD")
 }
 
 // PEERDB_ALERTING_GAP_MINUTES, 0 disables all alerting entirely
-func PeerDBAlertingGapMinutesAsDuration(ctx context.Context) time.Duration {
-	why := int64(dynamicConfUint32(ctx, "PEERDB_ALERTING_GAP_MINUTES", 15))
-	return time.Duration(why) * time.Minute
+func PeerDBAlertingGapMinutesAsDuration(ctx context.Context) (time.Duration, error) {
+	why, err := dynamicConfUnsigned[uint32](ctx, "PEERDB_ALERTING_GAP_MINUTES")
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(int64(why)) * time.Minute, nil
 }
 
 // PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD, 0 disables open connections alerting entirely
-func PeerDBOpenConnectionsAlertThreshold(ctx context.Context) uint32 {
-	return dynamicConfUint32(ctx, "PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD", 5)
+func PeerDBOpenConnectionsAlertThreshold(ctx context.Context) (uint32, error) {
+	return dynamicConfUnsigned[uint32](ctx, "PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD")
 }
 
 // PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS, for creating target tables with
 // partitioning by _PEERDB_SYNCED_AT column
 // If true, the target tables will be partitioned by _PEERDB_SYNCED_AT column
 // If false, the target tables will not be partitioned
-func PeerDBBigQueryEnableSyncedAtPartitioning(ctx context.Context) bool {
-	return dynamicConfBool(ctx, "PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS", false)
+func PeerDBBigQueryEnableSyncedAtPartitioning(ctx context.Context) (bool, error) {
+	return dynamicConfBool(ctx, "PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS")
 }

--- a/nexus/catalog/migrations/V27__dynconf_table.sql
+++ b/nexus/catalog/migrations/V27__dynconf_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE alerting_settings RENAME TO dynamic_settings;
+ALTER TABLE dynamic_settings ADD COLUMN config_value_type INT, ADD COLUMN config_description TEXT, ADD COLUMN config_apply_mode INT, ADD COLUMN config_default_value TEXT;

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -404,3 +404,18 @@ message ExportTxSnapshotOutput {
   bool supports_tid_scans = 2;
 }
 
+enum DynconfValueType {
+  UNKNOWN = 0;
+  STRING = 1;
+  INT = 2;
+  UINT = 3;
+  BOOL = 4;
+}
+
+enum DynconfApplyMode {
+  APPLY_MODE_UNKNOWN = 0;
+  APPLY_MODE_IMMEDIATE = 1;
+  APPLY_MODE_AFTER_RESUME = 2;
+  APPLY_MODE_RESTART = 3;
+}
+


### PR DESCRIPTION
1. Renames `alerting_settings` table and adds columns to make it more useful for dynamic configuration.
2. Some code cleanup and genericization

Default values should only be set from catalog, a migration will be added for existing settings and new settings to be added to this table.

UI to be added in a future PR.