### PR TITLE
Read and dial timeouts of 1 hour for clickhouse

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	_ "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -184,6 +185,8 @@ func connect(ctx context.Context, config *protos.ClickhouseConfig) (*sql.DB, err
 				{Name: "peerdb"},
 			},
 		},
+		DialTimeout: 3600 * time.Second,
+		ReadTimeout: 3600 * time.Second,
 	})
 
 	if err := conn.PingContext(ctx); err != nil {


### PR DESCRIPTION
Clickhouse connections need to stay open for long running queries. The default values of timeouts being low is resulting in our queries to clickhouse in mirrors to fail with I/O timeout errors
This PR sets a safe 1 hour timeout for dialing and reading, which has helped recover mirrors in above cases