### PR TITLE
SF RenameTables: fix for mixed case

### DIFF
--- a/flow/connectors/snowflake/client.go
+++ b/flow/connectors/snowflake/client.go
@@ -99,20 +99,3 @@ func snowflakeSchemaTableNormalize(schemaTable *utils.SchemaTable) string {
 	return fmt.Sprintf(`%s.%s`, SnowflakeIdentifierNormalize(schemaTable.Schema),
 		SnowflakeIdentifierNormalize(schemaTable.Table))
 }
-
-func normalizeSrcAndDst(source, destination string) (string, string, error) {
-	srcTable, err := utils.ParseSchemaTable(source)
-	if err != nil {
-		return "", "", fmt.Errorf("unable to parse source %s: %w", source, err)
-	}
-
-	dstTable, err := utils.ParseSchemaTable(destination)
-	if err != nil {
-		return "", "", fmt.Errorf("unable to parse destination %s: %w", destination, err)
-	}
-
-	src := snowflakeSchemaTableNormalize(srcTable)
-	dst := snowflakeSchemaTableNormalize(dstTable)
-
-	return src, dst, nil
-}

--- a/flow/connectors/snowflake/client.go
+++ b/flow/connectors/snowflake/client.go
@@ -99,3 +99,20 @@ func snowflakeSchemaTableNormalize(schemaTable *utils.SchemaTable) string {
 	return fmt.Sprintf(`%s.%s`, SnowflakeIdentifierNormalize(schemaTable.Schema),
 		SnowflakeIdentifierNormalize(schemaTable.Table))
 }
+
+func normalizeSrcAndDst(source, destination string) (string, string, error) {
+	srcTable, err := utils.ParseSchemaTable(source)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to parse source %s: %w", source, err)
+	}
+
+	dstTable, err := utils.ParseSchemaTable(destination)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to parse destination %s: %w", destination, err)
+	}
+
+	src := snowflakeSchemaTableNormalize(srcTable)
+	dst := snowflakeSchemaTableNormalize(dstTable)
+
+	return src, dst, nil
+}

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -740,6 +740,10 @@ func (c *SnowflakeConnector) RenameTables(ctx context.Context, req *protos.Renam
 	if req.SyncedAtColName != nil {
 		for _, renameRequest := range req.RenameTableOptions {
 			resyncTblName := renameRequest.CurrentName
+			schema, table, foundDot := strings.Cut(renameRequest.CurrentName, ".")
+			if foundDot {
+				resyncTblName = SnowflakeIdentifierNormalize(schema) + "." + SnowflakeIdentifierNormalize(table)
+			}
 
 			c.logger.Info(fmt.Sprintf("setting synced at column for table '%s'...", resyncTblName))
 

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -757,10 +757,10 @@ func (c *SnowflakeConnector) RenameTables(ctx context.Context, req *protos.Renam
 
 	if req.SoftDeleteColName != nil {
 		for _, renameRequest := range req.RenameTableOptions {
-			srcTable, err := utils.ParseSchemaTable(renameRequest.CurrentName)
-			dstTable, err := utils.ParseSchemaTable(renameRequest.NewName)
-			src := snowflakeSchemaTableNormalize(srcTable)
-			dst := snowflakeSchemaTableNormalize(dstTable)
+			src, dst, err := normalizeSrcAndDst(renameRequest.CurrentName, renameRequest.NewName)
+			if err != nil {
+				return nil, err
+			}
 
 			columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
 			for _, col := range renameRequest.TableSchema.Columns {
@@ -789,10 +789,10 @@ func (c *SnowflakeConnector) RenameTables(ctx context.Context, req *protos.Renam
 
 	// renaming and dropping such that the _resync table is the new destination
 	for _, renameRequest := range req.RenameTableOptions {
-		srcTable, err := utils.ParseSchemaTable(renameRequest.CurrentName)
-		dstTable, err := utils.ParseSchemaTable(renameRequest.NewName)
-		src := snowflakeSchemaTableNormalize(srcTable)
-		dst := snowflakeSchemaTableNormalize(dstTable)
+		src, dst, err := normalizeSrcAndDst(renameRequest.CurrentName, renameRequest.NewName)
+		if err != nil {
+			return nil, err
+		}
 
 		c.logger.Info(fmt.Sprintf("renaming table '%s' to '%s'...", src, dst))
 


### PR DESCRIPTION
This PR accounts for mixed case table name in Snowflake's RenameTables()