### PR TITLE
ClickHouse Enhancement: Faster replication slot flush

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -31,6 +31,7 @@ type ClickhouseConnector struct {
 	logger             log.Logger
 	config             *protos.ClickhouseConfig
 	credsProvider      *utils.ClickHouseS3Credentials
+	s3Stage            *ClickHouseS3Stage
 }
 
 func ValidateS3(ctx context.Context, creds *utils.ClickHouseS3Credentials) error {
@@ -160,6 +161,7 @@ func NewClickhouseConnector(
 		config:             config,
 		logger:             logger,
 		credsProvider:      &clickHouseS3CredentialsNew,
+		s3Stage:            NewClickHouseS3Stage(),
 	}, nil
 }
 

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -294,7 +294,6 @@ func (c *ClickhouseConnector) copyAvroStageToDestination(ctx context.Context, fl
 	if err != nil {
 		return fmt.Errorf("failed to get avro stage: %w", err)
 	}
-
 	defer avroFile.Cleanup()
 
 	err = avroSynvMethod.CopyStageToDestination(ctx, avroFile)

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -136,6 +136,11 @@ func (c *ClickhouseConnector) NormalizeRecords(ctx context.Context, req *model.N
 		}, nil
 	}
 
+	err = c.copyAvroStagesToDestination(ctx, req.FlowJobName, normBatchID, req.SyncBatchID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy avro stages to destination: %w", err)
+	}
+
 	destinationTableNames, err := c.getDistinctTableNamesInBatch(
 		ctx,
 		req.FlowJobName,
@@ -281,4 +286,32 @@ func (c *ClickhouseConnector) getDistinctTableNamesInBatch(
 	}
 
 	return tableNames, nil
+}
+
+func (c *ClickhouseConnector) copyAvroStageToDestination(ctx context.Context, flowJobName string, syncBatchID int64) error {
+	avroSynvMethod := c.avroSyncMethod(flowJobName)
+	avroFile, err := c.s3Stage.GetAvroStage(ctx, flowJobName, syncBatchID)
+	if err != nil {
+		return fmt.Errorf("failed to get avro stage: %w", err)
+	}
+
+	defer avroFile.Cleanup()
+
+	err = avroSynvMethod.CopyStageToDestination(ctx, avroFile)
+	if err != nil {
+		return fmt.Errorf("failed to copy stage to destination: %w", err)
+	}
+	return nil
+}
+
+func (c *ClickhouseConnector) copyAvroStagesToDestination(
+	ctx context.Context, flowJobName string, normBatchID, syncBatchID int64,
+) error {
+	for s := normBatchID + 1; s <= syncBatchID; s++ {
+		err := c.copyAvroStageToDestination(ctx, flowJobName, s)
+		if err != nil {
+			return fmt.Errorf("failed to copy avro stage to destination: %w", err)
+		}
+	}
+	return nil
 }

--- a/flow/connectors/clickhouse/s3_stage.go
+++ b/flow/connectors/clickhouse/s3_stage.go
@@ -1,0 +1,83 @@
+package connclickhouse
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	utils "github.com/PeerDB-io/peer-flow/connectors/utils/avro"
+	"github.com/PeerDB-io/peer-flow/peerdbenv"
+)
+
+type ClickHouseS3Stage struct{}
+
+func NewClickHouseS3Stage() *ClickHouseS3Stage {
+	return &ClickHouseS3Stage{}
+}
+
+func (c *ClickHouseS3Stage) SetAvroStage(
+	ctx context.Context,
+	flowJobName string,
+	syncBatchID int64,
+	avroFile *utils.AvroFile,
+) error {
+	avroFileJSON, err := json.Marshal(avroFile)
+	if err != nil {
+		return fmt.Errorf("failed to marshal avro file: %w", err)
+	}
+
+	conn, err := c.getConn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get connection: %w", err)
+	}
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO ch_s3_stage (flow_job_name, sync_batch_id, avro_file)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (flow_job_name, sync_batch_id)
+		DO UPDATE SET avro_file = $3, created_at = CURRENT_TIMESTAMP
+	`, flowJobName, syncBatchID, avroFileJSON)
+	if err != nil {
+		return fmt.Errorf("failed to set avro stage: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ClickHouseS3Stage) GetAvroStage(ctx context.Context, flowJobName string, syncBatchID int64) (*utils.AvroFile, error) {
+	conn, err := c.getConn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connection: %w", err)
+	}
+
+	var avroFileJSON []byte
+	err = conn.QueryRow(ctx, `
+		SELECT avro_file FROM ch_s3_stage
+		WHERE flow_job_name = $1 AND sync_batch_id = $2
+	`, flowJobName, syncBatchID).Scan(&avroFileJSON)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, fmt.Errorf("no avro stage found for flow job %s and sync batch %d", flowJobName, syncBatchID)
+		}
+		return nil, fmt.Errorf("failed to get avro stage: %w", err)
+	}
+
+	var avroFile utils.AvroFile
+	if err := json.Unmarshal(avroFileJSON, &avroFile); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal avro file: %w", err)
+	}
+
+	return &avroFile, nil
+}
+
+func (c *ClickHouseS3Stage) getConn(ctx context.Context) (*pgxpool.Pool, error) {
+	conn, err := peerdbenv.GetCatalogConnectionPoolFromEnv(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create catalog connection pool: %w", err)
+	}
+
+	return conn, nil
+}

--- a/flow/connectors/utils/avro/avro_writer.go
+++ b/flow/connectors/utils/avro/avro_writer.go
@@ -51,9 +51,9 @@ type peerDBOCFWriter struct {
 }
 
 type AvroFile struct {
-	FilePath        string
-	StorageLocation AvroStorageLocation
-	NumRecords      int
+	FilePath        string              `json:"filePath"`
+	StorageLocation AvroStorageLocation `json:"storageLocation"`
+	NumRecords      int                 `json:"numRecords"`
 }
 
 func (l *AvroFile) Cleanup() {

--- a/nexus/catalog/migrations/V27__ch_s3_stage.sql
+++ b/nexus/catalog/migrations/V27__ch_s3_stage.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS ch_s3_stage(
+    id SERIAL PRIMARY KEY,
+    flow_job_name TEXT NOT NULL,
+    sync_batch_id BIGINT NOT NULL,
+    avro_file JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS ch_s3_stage_flow_job_name_idx ON ch_s3_stage (flow_job_name);
+
+CREATE INDEX IF NOT EXISTS ch_s3_stage_sync_batch_id_idx ON ch_s3_stage (sync_batch_id);

--- a/nexus/catalog/migrations/V28__ch_s3_stage_unique_constraint.sql
+++ b/nexus/catalog/migrations/V28__ch_s3_stage_unique_constraint.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ch_s3_stage ADD CONSTRAINT 
+ch_s3_stage_flow_job_name_sync_batch_id_key 
+UNIQUE (flow_job_name, sync_batch_id);


### PR DESCRIPTION
Move bulk of the operations to normalize, `syncRecords` will just push to S3, and free up PostgreSQL replication slot faster.