### PR TITLE
PG upsert create table fix

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -10,7 +10,7 @@ jobs:
   flow_test:
     strategy:
       matrix:
-        runner: [ubicloud-standard-16-ubuntu-2204-arm]
+        runner: [ubicloud-standard-16-ubuntu-2204-arm, ubuntu-latest]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     services:

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -10,7 +10,7 @@ jobs:
   flow_test:
     strategy:
       matrix:
-        runner: [ubicloud-standard-16-ubuntu-2204-arm, ubuntu-latest]
+        runner: [ubicloud-standard-16-ubuntu-2204-arm]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     services:

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -514,11 +514,16 @@ func syncQRepRecords(
 	} else {
 		// Step 2.1: Create a temp staging table
 		stagingTableName := "_peerdb_staging_" + shared.RandomString(8)
-		stagingTableIdentifier := pgx.Identifier{c.metadataSchema, stagingTableName}
+		stagingTableIdentifier := pgx.Identifier{stagingTableName}
 		dstTableIdentifier := pgx.Identifier{dstTable.Schema, dstTable.Table}
 
+		_, err = tx.Exec(ctx, "SET temp_buffers = '4GB';")
+		if err != nil {
+			return -1, fmt.Errorf("failed to set temp_buffers: %w", err)
+		}
+
 		createStagingTableStmt := fmt.Sprintf(
-			"CREATE TEMP UNLOGGED TABLE %s (LIKE %s);",
+			"CREATE TEMP TABLE %s (LIKE %s);",
 			stagingTableIdentifier.Sanitize(),
 			dstTableIdentifier.Sanitize(),
 		)

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -517,6 +517,8 @@ func syncQRepRecords(
 		stagingTableIdentifier := pgx.Identifier{stagingTableName}
 		dstTableIdentifier := pgx.Identifier{dstTable.Schema, dstTable.Table}
 
+		// From PG docs: The cost of setting a large value in sessions that do not actually need many
+		// temporary buffers is only a buffer descriptor, or about 64 bytes, per increment in temp_buffers.
 		_, err = tx.Exec(ctx, "SET temp_buffers = '4GB';")
 		if err != nil {
 			return -1, fmt.Errorf("failed to set temp_buffers: %w", err)


### PR DESCRIPTION
You can't have tables be `TEMP` and `UNLOGGED` apparently, both lead to no WAL being written.
Removed schema as temporary tables go to a temporary schema as well.