### PR TITLE
SetupNormalize for Kafka

### DIFF
--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -351,6 +351,7 @@ var (
 	_ NormalizedTablesConnector = &connbigquery.BigQueryConnector{}
 	_ NormalizedTablesConnector = &connsnowflake.SnowflakeConnector{}
 	_ NormalizedTablesConnector = &connclickhouse.ClickhouseConnector{}
+	_ NormalizedTablesConnector = &connkafka.KafkaConnector{}
 
 	_ QRepPullConnector = &connpostgres.PostgresConnector{}
 	_ QRepPullConnector = &connsqlserver.SQLServerConnector{}

--- a/flow/connectors/kafka/kafka.go
+++ b/flow/connectors/kafka/kafka.go
@@ -43,7 +43,6 @@ func NewKafkaConnector(
 		kgo.SeedBrokers(config.Servers...),
 		kgo.AllowAutoTopicCreation(),
 		kgo.WithLogger(kslog.New(slog.Default())), // TODO use logger.LoggerFromCtx
-		//kgo.SoftwareNameAndVersion("peerdb", peerdbenv.PeerDBVersionShaShort()),
 	)
 	if !config.DisableTls {
 		optionalOpts = append(optionalOpts, kgo.DialTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12}))

--- a/flow/connectors/kafka/kafka.go
+++ b/flow/connectors/kafka/kafka.go
@@ -80,6 +80,9 @@ func NewKafkaConnector(
 	}
 
 	adminClient, err := kadm.NewOptClient(optionalOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kafka admin client: %w", err)
+	}
 
 	pgMetadata, err := metadataStore.NewPostgresMetadata(ctx)
 	if err != nil {

--- a/flow/connectors/kafka/kafka.go
+++ b/flow/connectors/kafka/kafka.go
@@ -27,8 +27,9 @@ import (
 
 type KafkaConnector struct {
 	*metadataStore.PostgresMetadata
-	client *kgo.Client
-	logger log.Logger
+	client     *kgo.Client
+	logger     log.Logger
+	partitions int32
 }
 
 func NewKafkaConnector(
@@ -40,7 +41,7 @@ func NewKafkaConnector(
 		kgo.SeedBrokers(config.Servers...),
 		kgo.AllowAutoTopicCreation(),
 		kgo.WithLogger(kslog.New(slog.Default())), // TODO use logger.LoggerFromCtx
-		kgo.SoftwareNameAndVersion("peerdb", peerdbenv.PeerDBVersionShaShort()),
+		//kgo.SoftwareNameAndVersion("peerdb", peerdbenv.PeerDBVersionShaShort()),
 	)
 	if !config.DisableTls {
 		optionalOpts = append(optionalOpts, kgo.DialTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12}))
@@ -86,6 +87,7 @@ func NewKafkaConnector(
 		PostgresMetadata: pgMetadata,
 		client:           client,
 		logger:           logger.LoggerFromCtx(ctx),
+		partitions:       config.Partitions,
 	}, nil
 }
 

--- a/flow/connectors/kafka/kafka.go
+++ b/flow/connectors/kafka/kafka.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
@@ -27,9 +28,10 @@ import (
 
 type KafkaConnector struct {
 	*metadataStore.PostgresMetadata
-	client     *kgo.Client
-	logger     log.Logger
-	partitions int32
+	client      *kgo.Client
+	adminClient *kadm.Client
+	logger      log.Logger
+	partitions  int32
 }
 
 func NewKafkaConnector(
@@ -78,6 +80,8 @@ func NewKafkaConnector(
 		return nil, fmt.Errorf("failed to create kafka client: %w", err)
 	}
 
+	adminClient, err := kadm.NewOptClient(optionalOpts...)
+
 	pgMetadata, err := metadataStore.NewPostgresMetadata(ctx)
 	if err != nil {
 		return nil, err
@@ -86,6 +90,7 @@ func NewKafkaConnector(
 	return &KafkaConnector{
 		PostgresMetadata: pgMetadata,
 		client:           client,
+		adminClient:      adminClient,
 		logger:           logger.LoggerFromCtx(ctx),
 		partitions:       config.Partitions,
 	}, nil

--- a/flow/connectors/kafka/normalize.go
+++ b/flow/connectors/kafka/normalize.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/PeerDB-io/peer-flow/generated/protos"
-	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 )
 
@@ -28,18 +27,17 @@ func (c *KafkaConnector) SetupNormalizedTable(
 	softDeleteColName string,
 	syncedAtColName string,
 ) (bool, error) {
-	kafkaAdminClient := kadm.NewClient(c.client)
-	_, err := kafkaAdminClient.DescribeTopicConfigs(ctx, tableIdentifier)
+	_, err := c.adminClient.DescribeTopicConfigs(ctx, tableIdentifier)
 	if err != nil && err != kerr.UnknownTopicOrPartition {
 		return false, fmt.Errorf("failed to check topic existence: %w", err)
 	}
 
-	res, err := kafkaAdminClient.CreateTopic(ctx, c.partitions, 1, nil, tableIdentifier)
+	res, err := c.adminClient.CreateTopics(ctx, c.partitions, 1, nil, tableIdentifier)
 	if err != nil {
 		return false, fmt.Errorf("failed to create topic: %w", err)
 	}
-	if res.Err != nil {
-		return false, fmt.Errorf("create topic response has error: %w", res.Err)
+	if res.Error() != nil {
+		return false, fmt.Errorf("failed to create topic: %w", res.Error())
 	}
 
 	return false, nil

--- a/flow/connectors/kafka/normalize.go
+++ b/flow/connectors/kafka/normalize.go
@@ -1,0 +1,46 @@
+package connkafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+)
+
+func (c *KafkaConnector) StartSetupNormalizedTables(_ context.Context) (interface{}, error) {
+	return nil, nil
+}
+
+func (c *KafkaConnector) FinishSetupNormalizedTables(_ context.Context, _ interface{}) error {
+	return nil
+}
+
+func (c *KafkaConnector) CleanupSetupNormalizedTables(_ context.Context, _ interface{}) {
+}
+
+func (c *KafkaConnector) SetupNormalizedTable(
+	ctx context.Context,
+	tx interface{},
+	tableIdentifier string,
+	tableSchema *protos.TableSchema,
+	softDeleteColName string,
+	syncedAtColName string,
+) (bool, error) {
+	kafkaAdminClient := kadm.NewClient(c.client)
+	_, err := kafkaAdminClient.DescribeTopicConfigs(ctx, tableIdentifier)
+	if err != nil && err != kerr.UnknownTopicOrPartition {
+		return false, fmt.Errorf("failed to check topic existence: %w", err)
+	}
+
+	res, err := kafkaAdminClient.CreateTopic(ctx, c.partitions, 1, nil, tableIdentifier)
+	if err != nil {
+		return false, fmt.Errorf("failed to create topic: %w", err)
+	}
+	if res.Err != nil {
+		return false, fmt.Errorf("create topic response has error: %w", res.Err)
+	}
+
+	return false, nil
+}

--- a/flow/go.mod
+++ b/flow/go.mod
@@ -171,6 +171,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/twmb/franz-go/pkg/kadm v1.12.0
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/flow/go.sum
+++ b/flow/go.sum
@@ -389,6 +389,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/twmb/franz-go v1.17.0 h1:hawgCx5ejDHkLe6IwAtFWwxi3OU4OztSTl7ZV5rwkYk=
 github.com/twmb/franz-go v1.17.0/go.mod h1:NreRdJ2F7dziDY/m6VyspWd6sNxHKXdMZI42UfQ3GXM=
+github.com/twmb/franz-go/pkg/kadm v1.12.0 h1:I8P/gpXFzhl73QcAYmJu+1fOXvrynyH/MAotr2udEg4=
+github.com/twmb/franz-go/pkg/kadm v1.12.0/go.mod h1:VMvpfjz/szpH9WB+vGM+rteTzVv0djyHFimci9qm2C0=
 github.com/twmb/franz-go/pkg/kmsg v1.8.0 h1:lAQB9Z3aMrIP9qF9288XcFf/ccaSxEitNA1CDTEIeTA=
 github.com/twmb/franz-go/pkg/kmsg v1.8.0/go.mod h1:HzYEb8G3uu5XevZbtU0dVbkphaKTHk0X68N5ka4q6mU=
 github.com/twmb/franz-go/plugin/kslog v1.0.0 h1:I64oEmF+0PDvmyLgwrlOtg4mfpSE9GwlcLxM4af2t60=

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -798,6 +798,10 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .get("disable_tls")
                     .and_then(|s| s.parse::<bool>().ok())
                     .unwrap_or_default(),
+                partitions: opts
+                    .get("partitions")
+                    .and_then(|s| s.parse::<i32>().ok())
+                    .unwrap_or_default(),
             };
             Config::KafkaConfig(kafka_config)
         }

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -144,6 +144,7 @@ message KafkaConfig {
   string sasl = 4;
   bool disable_tls = 5;
   string partitioner = 6;
+  int32 partitions = 7;
 }
 
 enum ElasticsearchAuthType {

--- a/ui/app/peers/create/[peerType]/helpers/ka.ts
+++ b/ui/app/peers/create/[peerType]/helpers/ka.ts
@@ -66,7 +66,7 @@ export const kaSetting: PeerSetting[] = [
     stateHandler: (value, setter) =>
       setter((curr) => ({ ...curr, partitions: parseInt(value as string) })),
     type: 'number',
-    default:'5',
+    default: '5',
     optional: true,
   },
 ];

--- a/ui/app/peers/create/[peerType]/helpers/ka.ts
+++ b/ui/app/peers/create/[peerType]/helpers/ka.ts
@@ -61,6 +61,14 @@ export const kaSetting: PeerSetting[] = [
     tips: 'If you are using a non-TLS connection for Kafka server, check this box.',
     optional: true,
   },
+  {
+    label: 'Partitions',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, partitions: parseInt(value as string) })),
+    type: 'number',
+    default:'5',
+    optional: true,
+  },
 ];
 
 export const blankKafkaSetting: KafkaConfig = {
@@ -70,4 +78,5 @@ export const blankKafkaSetting: KafkaConfig = {
   sasl: 'PLAIN',
   partitioner: '',
   disableTls: false,
+  partitions: 5,
 };

--- a/ui/app/peers/create/[peerType]/page.tsx
+++ b/ui/app/peers/create/[peerType]/page.tsx
@@ -63,7 +63,6 @@ export default function CreateConfig({
   const [loading, setLoading] = useState<boolean>(false);
   const peerLabel = peerType.toUpperCase().replaceAll('%20', ' ');
 
-
   const configComponentMap = (peerType: string) => {
     switch (getDBType()) {
       case 'POSTGRES':

--- a/ui/app/peers/create/[peerType]/page.tsx
+++ b/ui/app/peers/create/[peerType]/page.tsx
@@ -46,11 +46,7 @@ export default function CreateConfig({
   const router = useRouter();
   const searchParams = useSearchParams();
   const peerName = searchParams.get('update');
-  const blankSetting = getBlankSetting(peerType);
-  const [name, setName] = useState<string>(peerName ?? '');
-  const [config, setConfig] = useState<PeerConfig>(blankSetting);
-  const [loading, setLoading] = useState<boolean>(false);
-  const peerLabel = peerType.toUpperCase().replaceAll('%20', ' ');
+
   const getDBType = () => {
     if (peerType.includes('POSTGRES') || peerType.includes('TEMBO')) {
       return 'POSTGRES';
@@ -60,6 +56,13 @@ export default function CreateConfig({
     }
     return peerType;
   };
+
+  const blankSetting = getBlankSetting(getDBType());
+  const [name, setName] = useState<string>(peerName ?? '');
+  const [config, setConfig] = useState<PeerConfig>(blankSetting);
+  const [loading, setLoading] = useState<boolean>(false);
+  const peerLabel = peerType.toUpperCase().replaceAll('%20', ' ');
+
 
   const configComponentMap = (peerType: string) => {
     switch (getDBType()) {


### PR DESCRIPTION
Implements SetupNormalize for Kafka connector, mainly needed for environments where auto topic creation is not an option, such as Confluent.
Need to figure out how to gate/flag this feature 
For confluent to work, the following things need to be in place:
- We cannot set the software version: apiVersion fetch fails 
- We need to set the number of partitions (5 default for now)
- Replication factor has to be 3

Functionally tested (Initial load + CDC) with Confluent