### PR TITLE
feat(cdc): enhance schema box with schema settings and target schema

### DIFF
--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { TableMapRow } from '@/app/dto/MirrorsDTO';
 import { DBType } from '@/grpc_generated/peers';
 import { Checkbox } from '@/lib/Checkbox';
@@ -12,12 +13,14 @@ import {
   Dispatch,
   SetStateAction,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
 import { BarLoader } from 'react-spinners/';
 import { fetchColumns, fetchTables } from '../handlers';
 import ColumnBox from './columnbox';
+import { SchemaSettings } from './schemasettings';
 import {
   expandableStyle,
   schemaBoxStyle,
@@ -37,6 +40,7 @@ interface SchemaBoxProps {
   peerType?: DBType;
   omitAdditionalTables: string[] | undefined;
 }
+
 const SchemaBox = ({
   sourcePeer,
   peerType,
@@ -51,6 +55,8 @@ const SchemaBox = ({
   const [columnsLoading, setColumnsLoading] = useState(false);
   const [expandedSchemas, setExpandedSchemas] = useState<string[]>([]);
   const [tableQuery, setTableQuery] = useState<string>('');
+  const [defaultTargetSchema, setDefaultTargetSchema] =
+    useState<string>(schema);
 
   const searchedTables = useMemo(() => {
     const tableQueryLower = tableQuery.toLowerCase();
@@ -61,7 +67,7 @@ const SchemaBox = ({
           row.source.toLowerCase().includes(tableQueryLower)
       )
       .sort((a, b) => a.source.localeCompare(b.source));
-  }, [schema, rows, tableQuery]);
+  }, [rows, tableQuery]);
 
   const schemaIsExpanded = useCallback(
     (schema: string) => {
@@ -146,19 +152,7 @@ const SchemaBox = ({
       setExpandedSchemas((curr) => [...curr, schemaName]);
 
       if (rowsDoNotHaveSchemaTables(schemaName)) {
-        setTablesLoading(true);
-        fetchTables(sourcePeer, schemaName, peerType).then((newRows) => {
-          for (const row of newRows) {
-            if (omitAdditionalTables?.includes(row.source)) {
-              row.canMirror = false;
-            }
-          }
-          setRows((oldRows) => [
-            ...oldRows.filter((oldRow) => oldRow.schema !== schema),
-            ...newRows,
-          ]);
-          setTablesLoading(false);
-        });
+        fetchTablesForSchema(schemaName);
       }
     } else {
       setExpandedSchemas((curr) =>
@@ -166,6 +160,31 @@ const SchemaBox = ({
       );
     }
   };
+
+  const fetchTablesForSchema = (schemaName: string) => {
+    setTablesLoading(true);
+    fetchTables(sourcePeer, schemaName, defaultTargetSchema, peerType).then(
+      (newRows) => {
+        for (const row of newRows) {
+          if (omitAdditionalTables?.includes(row.source)) {
+            row.canMirror = false;
+          }
+        }
+        setRows((oldRows) => {
+          const filteredRows = oldRows.filter(
+            (oldRow) => oldRow.schema !== schemaName
+          );
+          const updatedRows = [...filteredRows, ...newRows];
+          return updatedRows;
+        });
+        setTablesLoading(false);
+      }
+    );
+  };
+
+  useEffect(() => {
+    fetchTablesForSchema(schema);
+  }, [defaultTargetSchema]);
 
   return (
     <div style={schemaBoxStyle}>
@@ -200,6 +219,12 @@ const SchemaBox = ({
                 setTableQuery(e.target.value)
               }
             />
+            <div style={{ alignSelf: 'center', cursor: 'pointer' }}>
+              <SchemaSettings
+                schema={defaultTargetSchema}
+                setTargetSchemaOverride={setDefaultTargetSchema}
+              />
+            </div>
           </div>
         </div>
         {/* TABLE BOX */}
@@ -273,7 +298,7 @@ const SchemaBox = ({
                           }}
                           variant='simple'
                           placeholder={'Enter target table'}
-                          defaultValue={row.destination}
+                          value={row.destination}
                           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                             updateDestination(row.source, e.target.value)
                           }

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -67,7 +67,7 @@ const SchemaBox = ({
           row.source.toLowerCase().includes(tableQueryLower)
       )
       .sort((a, b) => a.source.localeCompare(b.source));
-  }, [rows, tableQuery]);
+  }, [schema, rows, tableQuery]);
 
   const schemaIsExpanded = useCallback(
     (schema: string) => {
@@ -161,30 +161,33 @@ const SchemaBox = ({
     }
   };
 
-  const fetchTablesForSchema = (schemaName: string) => {
-    setTablesLoading(true);
-    fetchTables(sourcePeer, schemaName, defaultTargetSchema, peerType).then(
-      (newRows) => {
-        for (const row of newRows) {
-          if (omitAdditionalTables?.includes(row.source)) {
-            row.canMirror = false;
+  const fetchTablesForSchema = useCallback(
+    (schemaName: string) => {
+      setTablesLoading(true);
+      fetchTables(sourcePeer, schemaName, defaultTargetSchema, peerType).then(
+        (newRows) => {
+          for (const row of newRows) {
+            if (omitAdditionalTables?.includes(row.source)) {
+              row.canMirror = false;
+            }
           }
+          setRows((oldRows) => {
+            const filteredRows = oldRows.filter(
+              (oldRow) => oldRow.schema !== schemaName
+            );
+            const updatedRows = [...filteredRows, ...newRows];
+            return updatedRows;
+          });
+          setTablesLoading(false);
         }
-        setRows((oldRows) => {
-          const filteredRows = oldRows.filter(
-            (oldRow) => oldRow.schema !== schemaName
-          );
-          const updatedRows = [...filteredRows, ...newRows];
-          return updatedRows;
-        });
-        setTablesLoading(false);
-      }
-    );
-  };
+      );
+    },
+    [setRows, sourcePeer, defaultTargetSchema, peerType, omitAdditionalTables]
+  );
 
   useEffect(() => {
     fetchTablesForSchema(schema);
-  }, [defaultTargetSchema]);
+  }, [schema, fetchTablesForSchema]);
 
   return (
     <div style={schemaBoxStyle}>

--- a/ui/app/mirrors/create/cdc/schemasettings.tsx
+++ b/ui/app/mirrors/create/cdc/schemasettings.tsx
@@ -1,0 +1,85 @@
+import { Icon } from '@/lib/Icon';
+import * as Popover from '@radix-ui/react-popover';
+import { useState } from 'react';
+
+export const SchemaSettings = ({
+  schema,
+  setTargetSchemaOverride,
+}: {
+  schema: string;
+  setTargetSchemaOverride: (schema: string) => void;
+}) => {
+  const [inputValue, setInputValue] = useState(schema);
+  const [savedIndicator, setSavedIndicator] = useState(false);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  const handleSave = () => {
+    setTargetSchemaOverride(inputValue);
+    setSavedIndicator(true);
+    setTimeout(() => setSavedIndicator(false), 3000);
+  };
+
+  return (
+    <Popover.Root modal={true}>
+      <Popover.Trigger asChild>
+        <div style={{ alignSelf: 'center', cursor: 'pointer' }}>
+          <Icon name='settings' />
+        </div>
+      </Popover.Trigger>
+
+      <Popover.Portal>
+        <Popover.Content
+          style={{ backgroundColor: '#fff' }}
+          className='PopoverContent'
+          sideOffset={5}
+        >
+          <div
+            style={{
+              border: '1px solid #d9d7d7',
+              boxShadow: '0 0 10px #d9d7d7',
+              padding: '0.5rem',
+              borderRadius: '0.5rem',
+              minWidth: '15rem',
+            }}
+          >
+            <h3 style={{ fontSize: 14 }}>Schema On Target</h3>
+            <input
+              type='text'
+              value={inputValue}
+              onChange={handleInputChange}
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                marginBottom: '0.5rem',
+                borderRadius: '0.25rem',
+                border: '1px solid #d9d7d7',
+              }}
+            />
+            <button
+              onClick={handleSave}
+              style={{
+                padding: '0.25rem 0.5rem',
+                backgroundColor: '#30A46C',
+                color: '#fff',
+                border: 'none',
+                borderRadius: '0.25rem',
+                cursor: 'pointer',
+                fontSize: 14,
+              }}
+            >
+              Save
+            </button>
+            {savedIndicator && (
+              <span style={{ marginLeft: '0.5rem', color: 'green' }}>
+                success
+              </span>
+            )}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+};

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -332,6 +332,10 @@ const getDefaultDestinationTable = (
     return `<namespace>.${schemaName}_${tableName}.<partition_column>`;
   }
 
+  if (schemaName.length === 0) {
+    return tableName;
+  }
+
   return `${schemaName}.${tableName}`;
 };
 

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -309,12 +309,19 @@ const getDefaultDestinationTable = (
     peerType.toString() == 'BIGQUERY' ||
     dBTypeToJSON(peerType) == 'BIGQUERY'
   ) {
-    return tableName;
+    if (schemaName.length === 0) {
+      return tableName;
+    }
+    return `${schemaName}_${tableName}`;
   }
+
   if (
     peerType.toString() == 'CLICKHOUSE' ||
     dBTypeToJSON(peerType) == 'CLICKHOUSE'
   ) {
+    if (schemaName.length === 0) {
+      return tableName;
+    }
     return `${schemaName}_${tableName}`;
   }
 
@@ -331,6 +338,7 @@ const getDefaultDestinationTable = (
 export const fetchTables = async (
   peerName: string,
   schemaName: string,
+  targetSchemaName: string,
   peerType?: DBType
 ) => {
   if (schemaName.length === 0) return [];
@@ -351,7 +359,7 @@ export const fetchTables = async (
       // for bigquery, tables are not schema-qualified
       const dstName = getDefaultDestinationTable(
         peerType!,
-        schemaName,
+        targetSchemaName,
         tableObject.tableName
       );
       tables.push({


### PR DESCRIPTION
The rationale here is that editing the schema individually is not an ideal experience.

<img width="1248" alt="Screenshot 2024-06-05 at 4 46 24 PM" src="https://github.com/PeerDB-io/peerdb/assets/1006071/0908b7d3-8270-4121-969a-2805d9ec8162">


- Added `SchemaSettings` component for modifying target schema.
- Introduced `defaultTargetSchema` state to manage target schema.
- Implemented `fetchTablesForSchema` function to handle table fetching with the target schema.
- Modified `fetchTables` function to accept `targetSchemaName` parameter.
- Updated table row handling to use `value` instead of `defaultValue` for destination inputs.
- Improved schema box initialization with `useEffect` to fetch tables based on `defaultTargetSchema`.