### PR TITLE
BigQuery rename tables: account for json column in replica identity full table

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -673,12 +673,12 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 
 	// cluster by the primary key if < 4 columns.
 	var clustering *bigquery.Clustering
-	// numPkeyCols := len(tableSchema.PrimaryKeyColumns)
-	// if numPkeyCols > 0 && numPkeyCols < 4 {
-	// 	clustering = &bigquery.Clustering{
-	// 		Fields: tableSchema.PrimaryKeyColumns,
-	// 	}
-	// }
+	numPkeyCols := len(tableSchema.PrimaryKeyColumns)
+	if numPkeyCols > 0 && numPkeyCols < 4 {
+		clustering = &bigquery.Clustering{
+			Fields: tableSchema.PrimaryKeyColumns,
+		}
+	}
 
 	timePartitionEnabled, err := peerdbenv.PeerDBBigQueryEnableSyncedAtPartitioning(ctx)
 	if err != nil {

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -752,7 +752,7 @@ func (c *BigQueryConnector) RenameTables(ctx context.Context, req *protos.Rename
 		// For a table with replica identity full and a JSON column
 		// the equals to comparison we do down below will fail
 		// so we need to use TO_JSON_STRING for those columns
-		var columnIsJSON = make(map[string]bool, len(renameRequest.TableSchema.Columns))
+		columnIsJSON := make(map[string]bool, len(renameRequest.TableSchema.Columns))
 		columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
 		for _, col := range renameRequest.TableSchema.Columns {
 			quotedCol := "`" + col.Name + "`"

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -787,7 +787,7 @@ func (c *BigQueryConnector) RenameTables(ctx context.Context, req *protos.Rename
 					// We need to use TO_JSON_STRING for comparing JSON columns
 					pkeyOnClauseBuilder.WriteString("TO_JSON_STRING(_pt.")
 					pkeyOnClauseBuilder.WriteString(col)
-					pkeyOnClauseBuilder.WriteString(") = TO_JSON_STRING(_resync.")
+					pkeyOnClauseBuilder.WriteString(")=TO_JSON_STRING(_resync.")
 					pkeyOnClauseBuilder.WriteString(col)
 					pkeyOnClauseBuilder.WriteString(")")
 				} else {

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -793,7 +793,7 @@ func (c *BigQueryConnector) RenameTables(ctx context.Context, req *protos.Rename
 				} else {
 					pkeyOnClauseBuilder.WriteString("_pt.")
 					pkeyOnClauseBuilder.WriteString(col)
-					pkeyOnClauseBuilder.WriteString(" = _resync.")
+					pkeyOnClauseBuilder.WriteString("=_resync.")
 					pkeyOnClauseBuilder.WriteString(col)
 				}
 


### PR DESCRIPTION
When handling soft deletes, we perform equality checks for primary key columns in _resync and original tables. For a replica identity full table, we mark all columns as primary keys.
If one of the columns in that case is a JSON, `=` comparison fails. Need to use TO_JSON_STRING instead like how we do for merge.

Functionally tested