### PR TITLE
Drop stats via trigger

### DIFF
--- a/nexus/catalog/migrations/V27__drop_stats_trigger.sql
+++ b/nexus/catalog/migrations/V27__drop_stats_trigger.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION clear_mirror_stats() RETURNS TRIGGER AS $$
+DECLARE
+    mirrorName TEXT;
+    cloneMirrorRegex TEXT;
+BEGIN
+    mirrorName := NEW.name;
+    cloneMirrorRegex := 'clone_' || mirrorName || '_%';
+
+    -- Initial Load Stats
+    DELETE FROM peerdb_stats.qrep_partitions WHERE flow_name ILIKE cloneMirrorRegex;
+    DELETE FROM peerdb_stats.qrep_runs WHERE flow_name ILIKE cloneMirrorRegex;
+
+    -- CDC Stats
+    DELETE FROM peerdb_stats.cdc_batches WHERE flow_name = mirrorName;
+    DELETE FROM peerdb_stats.cdc_batch_table WHERE flow_name = mirrorName;
+    DELETE FROM peerdb_stats.cdc_flows WHERE flow_name = mirrorName;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger on inserts to flow table
+CREATE TRIGGER before_insert_clear_stats
+BEFORE INSERT ON flows
+FOR EACH ROW
+EXECUTE FUNCTION clear_mirror_stats();


### PR DESCRIPTION
This PR implements dropping stats of previous mirrors when a new entry is made to the flows table. Essentially, when a user creates (/re-creates) a mirror with the same name, we do not want to display the stats of the previous runs.

Doing this on flow insertion rather than flow deletion has the advantage of the stats of dropped mirrors remaining for our investigative purposes.

This operation is done via a triggered function in Postgres declared in catalog.