### PR TITLE
create mirror UI: make publication field clearable

### DIFF
--- a/ui/app/mirrors/create/cdc/fields.tsx
+++ b/ui/app/mirrors/create/cdc/fields.tsx
@@ -78,6 +78,7 @@ const CDCField = ({
               getOptionValue={(option) => option.option}
               theme={SelectTheme}
               isLoading={optionsLoading}
+              isClearable={true}
             />
           </div>
           {setting.tips && (


### PR DESCRIPTION
Currently cannot cancel a dropdown selection of publication name, thus requiring reload