### PR TITLE
UI: fix dst table overwrite in QRep mirror creation

### DIFF
--- a/ui/app/mirrors/create/qrep/qrep.tsx
+++ b/ui/app/mirrors/create/qrep/qrep.tsx
@@ -2,7 +2,6 @@
 import SelectTheme from '@/app/styles/select';
 import { RequiredIndicator } from '@/components/RequiredIndicator';
 import { QRepConfig, QRepWriteType } from '@/grpc_generated/flow';
-import { DBType } from '@/grpc_generated/peers';
 import { Label } from '@/lib/Label';
 import { RowWithSelect, RowWithSwitch, RowWithTextField } from '@/lib/Layout';
 import { Switch } from '@/lib/Switch';

--- a/ui/app/mirrors/create/qrep/qrep.tsx
+++ b/ui/app/mirrors/create/qrep/qrep.tsx
@@ -105,17 +105,6 @@ export default function QRepConfigForm({
   ) => {
     if (val) {
       if (setting.label.includes('Table')) {
-        if (mirrorConfig.destinationPeer?.type === DBType.BIGQUERY) {
-          setter((curr) => ({
-            ...curr,
-            destinationTableIdentifier: val.split('.')[1],
-          }));
-        } else {
-          setter((curr) => ({
-            ...curr,
-            destinationTableIdentifier: val,
-          }));
-        }
         loadColumnOptions(val);
       }
       handleChange(val, setting);


### PR DESCRIPTION
When the watermark/source table changed, we had logic to reset the destination table name to the watermark table name. This was done improperly, causing a desync between the displayed value to the user and the actual value in config that the mirror is created with.

Fixed by removing the logic entirely, users should manually change the table if watermark table is updated after destination table.