### PR TITLE
Fix soft-delete column creation, rely on checking soft delete setting

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -190,6 +190,7 @@ func (a *FlowableActivity) CreateNormalizedTable(
 			tx,
 			tableIdentifier,
 			tableSchema,
+			config.SoftDeleteEnabled,
 			config.SoftDeleteColName,
 			config.SyncedAtColName,
 		)

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -140,7 +140,7 @@ func (h *FlowRequestHandler) CreateCDCFlow(
 		},
 	}
 
-	if req.ConnectionConfigs.SoftDeleteColName == "" {
+	if req.ConnectionConfigs.SoftDeleteColName == "" && req.ConnectionConfigs.SoftDelete == true {
 		req.ConnectionConfigs.SoftDeleteColName = "_PEERDB_IS_DELETED"
 	}
 

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -589,6 +589,7 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 	tx interface{},
 	tableIdentifier string,
 	tableSchema *protos.TableSchema,
+	softDeleteEnabled bool,
 	softDeleteColName string,
 	syncedAtColName string,
 ) (bool, error) {
@@ -651,7 +652,7 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 		}
 	}
 
-	if softDeleteColName != "" {
+	if softDeleteEnabled {
 		columns = append(columns, &bigquery.FieldSchema{
 			Name:                   softDeleteColName,
 			Type:                   bigquery.BooleanFieldType,
@@ -760,7 +761,7 @@ func (c *BigQueryConnector) RenameTables(ctx context.Context, req *protos.Rename
 			columnIsJSON[quotedCol] = (col.Type == "json" || col.Type == "jsonb")
 		}
 
-		if req.SoftDeleteColName != nil {
+		if req.SoftDeleteColName != nil && req.SoftDeleteEnabled {
 			allColsBuilder := strings.Builder{}
 			for idx, col := range columnNames {
 				allColsBuilder.WriteString("_pt.")

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -761,7 +761,7 @@ func (c *BigQueryConnector) RenameTables(ctx context.Context, req *protos.Rename
 			columnIsJSON[quotedCol] = (col.Type == "json" || col.Type == "jsonb")
 		}
 
-		if req.SoftDeleteColName != nil && req.SoftDeleteEnabled {
+		if req.SoftDeleteColName != nil {
 			allColsBuilder := strings.Builder{}
 			for idx, col := range columnNames {
 				allColsBuilder.WriteString("_pt.")

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -37,6 +37,7 @@ func (c *ClickhouseConnector) SetupNormalizedTable(
 	tx interface{},
 	tableIdentifier string,
 	tableSchema *protos.TableSchema,
+	softDeleteEnabled bool,
 	softDeleteColName string,
 	syncedAtColName string,
 ) (bool, error) {

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -122,6 +122,7 @@ type NormalizedTablesConnector interface {
 		tx any,
 		tableIdentifier string,
 		tableSchema *protos.TableSchema,
+		softDeleteEnabled bool,
 		softDeleteColName string,
 		syncedAtColName string,
 	) (bool, error)

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -431,6 +431,7 @@ func getRawTableIdentifier(jobName string) string {
 func generateCreateTableSQLForNormalizedTable(
 	sourceTableIdentifier string,
 	sourceTableSchema *protos.TableSchema,
+	softDeleteEnabled bool,
 	softDeleteColName string,
 	syncedAtColName string,
 ) string {
@@ -448,7 +449,7 @@ func generateCreateTableSQLForNormalizedTable(
 			fmt.Sprintf("%s %s", QuoteIdentifier(column.Name), pgColumnType))
 	}
 
-	if softDeleteColName != "" {
+	if softDeleteEnabled {
 		createTableSQLArray = append(createTableSQLArray,
 			QuoteIdentifier(softDeleteColName)+` BOOL DEFAULT FALSE`)
 	}

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -847,6 +847,7 @@ func (c *PostgresConnector) SetupNormalizedTable(
 	tx any,
 	tableIdentifier string,
 	tableSchema *protos.TableSchema,
+	softDeleteEnabled bool,
 	softDeleteColName string,
 	syncedAtColName string,
 ) (bool, error) {
@@ -866,7 +867,7 @@ func (c *PostgresConnector) SetupNormalizedTable(
 
 	// convert the column names and types to Postgres types
 	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(
-		parsedNormalizedTable.String(), tableSchema, softDeleteColName, syncedAtColName)
+		parsedNormalizedTable.String(), tableSchema, softDeleteEnabled, softDeleteColName, syncedAtColName)
 	_, err = createNormalizedTablesTx.Exec(ctx, normalizedTableCreateSQL)
 	if err != nil {
 		return false, fmt.Errorf("error while creating normalized table: %w", err)

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -767,7 +767,7 @@ func (c *SnowflakeConnector) RenameTables(ctx context.Context, req *protos.Renam
 			}
 		}
 
-		if req.SoftDeleteColName != nil && req.SoftDeleteEnabled {
+		if req.SoftDeleteColName != nil {
 			columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
 			for _, col := range renameRequest.TableSchema.Columns {
 				columnNames = append(columnNames, SnowflakeIdentifierNormalize(col.Name))

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -369,6 +369,7 @@ func CDCFlowWorkflow(
 			renameOpts.Peer = cfg.Destination
 			if cfg.SoftDelete {
 				renameOpts.SoftDeleteColName = &cfg.SoftDeleteColName
+				renameOpts.SoftDeleteEnabled = cfg.SoftDelete
 			}
 			renameOpts.SyncedAtColName = &cfg.SyncedAtColName
 			correctedTableNameSchemaMapping := make(map[string]*protos.TableSchema)

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -369,7 +369,6 @@ func CDCFlowWorkflow(
 			renameOpts.Peer = cfg.Destination
 			if cfg.SoftDelete {
 				renameOpts.SoftDeleteColName = &cfg.SoftDeleteColName
-				renameOpts.SoftDeleteEnabled = cfg.SoftDelete
 			}
 			renameOpts.SyncedAtColName = &cfg.SyncedAtColName
 			correctedTableNameSchemaMapping := make(map[string]*protos.TableSchema)

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -151,6 +151,7 @@ func (q *QRepFlowExecution) setupWatermarkTableOnDestination(ctx workflow.Contex
 			TableNameSchemaMapping: map[string]*protos.TableSchema{
 				q.config.DestinationTableIdentifier: watermarkTableSchema,
 			},
+			SoftDeleteEnabled: false,
 			SyncedAtColName:   q.config.SyncedAtColName,
 			SoftDeleteColName: q.config.SoftDeleteColName,
 			FlowName:          q.config.FlowJobName,

--- a/flow/workflows/setup_flow.go
+++ b/flow/workflows/setup_flow.go
@@ -208,6 +208,7 @@ func (s *SetupFlowExecution) fetchTableSchemaAndSetupNormalizedTables(
 	setupConfig := &protos.SetupNormalizedTableBatchInput{
 		PeerConnectionConfig:   flowConnectionConfigs.Destination,
 		TableNameSchemaMapping: normalizedTableMapping,
+		SoftDeleteEnabled:      flowConnectionConfigs.SoftDelete,
 		SoftDeleteColName:      flowConnectionConfigs.SoftDeleteColName,
 		SyncedAtColName:        flowConnectionConfigs.SyncedAtColName,
 		FlowName:               flowConnectionConfigs.FlowJobName,

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -87,6 +87,7 @@ message RenameTablesInput {
   repeated RenameTableOption rename_table_options = 3;
   optional string soft_delete_col_name = 4;
   optional string synced_at_col_name = 5;
+  bool soft_delete_enabled = 7;
 }
 
 message RenameTablesOutput {
@@ -192,6 +193,7 @@ message SetupNormalizedTableBatchInput {
   string soft_delete_col_name = 4;
   string synced_at_col_name = 5;
   string flow_name = 6;
+  bool soft_delete_enabled = 7;
 }
 
 message SetupNormalizedTableOutput {

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -87,7 +87,6 @@ message RenameTablesInput {
   repeated RenameTableOption rename_table_options = 3;
   optional string soft_delete_col_name = 4;
   optional string synced_at_col_name = 5;
-  bool soft_delete_enabled = 7;
 }
 
 message RenameTablesOutput {


### PR DESCRIPTION
In `handler.go`, the value of softDeleteColumnName was being set no matter what, and downstream we treated soft delete being on as this column name being non-empty. One issue this was causing was we were creating the soft delete column even if soft delete is off, as we were doing `if softDeleteColumnName is empty`

This PR passes `softDeleteEnabled` as a boolean parameter in code paths where `softDeleteColName` is used, and incorporates `softDeleteEnabled` as well in steps which are conditional on soft delete

All code paths functionally tested:
1. Snowflake - Initial Load + CDC With Soft Delete and Without Soft Delete
2. BigQuery - Initial Load + CDC With Soft Delete and Without Soft Delete
3. Snowflake resync with and without soft delete
4. BigQuery resync with and without soft delete