### PR TITLE
added option to disable all PeerDB columns

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -140,14 +140,6 @@ func (h *FlowRequestHandler) CreateCDCFlow(
 		},
 	}
 
-	if req.ConnectionConfigs.SoftDeleteColName == "" {
-		req.ConnectionConfigs.SoftDeleteColName = "_PEERDB_IS_DELETED"
-	}
-
-	if req.ConnectionConfigs.SyncedAtColName == "" {
-		req.ConnectionConfigs.SyncedAtColName = "_PEERDB_SYNCED_AT"
-	}
-
 	err := h.createCdcJobEntry(ctx, req, workflowID)
 	if err != nil {
 		slog.Error("unable to create flow job entry", slog.Any("error", err))

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -760,7 +760,7 @@ func (c *BigQueryConnector) RenameTables(ctx context.Context, req *protos.Rename
 			columnIsJSON[quotedCol] = (col.Type == "json" || col.Type == "jsonb")
 		}
 
-		if req.SoftDeleteColName != nil {
+		if req.SoftDeleteColName != nil && *req.SoftDeleteColName != "" {
 			allColsBuilder := strings.Builder{}
 			for idx, col := range columnNames {
 				allColsBuilder.WriteString("_pt.")
@@ -826,7 +826,7 @@ func (c *BigQueryConnector) RenameTables(ctx context.Context, req *protos.Rename
 			}
 		}
 
-		if req.SyncedAtColName != nil {
+		if req.SyncedAtColName != nil && *req.SyncedAtColName != "" {
 			c.logger.Info(fmt.Sprintf("setting synced at column for table '%s'...", srcDatasetTable.string()))
 
 			query := c.client.Query(

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -156,10 +156,12 @@ func (m *mergeStmtGenerator) generateMergeStmt(dstTable string, dstDatasetTable 
 		shortBacktickColNames = append(shortBacktickColNames, fmt.Sprintf("`%s`", shortCol))
 		pureColNames = append(pureColNames, col.Name)
 	}
-	csep := strings.Join(backtickColNames, ", ")
-	shortCsep := strings.Join(shortBacktickColNames, ", ")
-	insertColumnsSQL := csep + fmt.Sprintf(", `%s`", m.peerdbCols.SyncedAtColName)
-	insertValuesSQL := shortCsep + ",CURRENT_TIMESTAMP"
+	insertColumnsSQL := strings.Join(backtickColNames, ", ")
+	insertValuesSQL := strings.Join(shortBacktickColNames, ", ")
+	if m.peerdbCols.SyncedAtColName != "" {
+		insertColumnsSQL = insertColumnsSQL + fmt.Sprintf(", `%s`", m.peerdbCols.SyncedAtColName)
+		insertValuesSQL = insertValuesSQL + ",CURRENT_TIMESTAMP"
+	}
 
 	updateStatementsforToastCols := m.generateUpdateStatements(pureColNames, unchangedToastColumns)
 	if m.peerdbCols.SoftDelete {

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -212,7 +212,7 @@ and updating the other columns (not the unchanged toast columns)
 7. Return the list of generated update statements.
 */
 func (m *mergeStmtGenerator) generateUpdateStatements(allCols []string, unchangedToastColumns []string) []string {
-	handleSoftDelete := m.peerdbCols.SoftDelete && (m.peerdbCols.SoftDeleteColName != "")
+	handleSoftDelete := m.peerdbCols.SoftDeleteColName != ""
 	// weird way of doing it but avoids prealloc lint
 	updateStmts := make([]string, 0, func() int {
 		if handleSoftDelete {

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -159,8 +159,8 @@ func (m *mergeStmtGenerator) generateMergeStmt(dstTable string, dstDatasetTable 
 	insertColumnsSQL := strings.Join(backtickColNames, ", ")
 	insertValuesSQL := strings.Join(shortBacktickColNames, ", ")
 	if m.peerdbCols.SyncedAtColName != "" {
-		insertColumnsSQL = insertColumnsSQL + fmt.Sprintf(", `%s`", m.peerdbCols.SyncedAtColName)
-		insertValuesSQL = insertValuesSQL + ",CURRENT_TIMESTAMP"
+		insertColumnsSQL += fmt.Sprintf(", `%s`", m.peerdbCols.SyncedAtColName)
+		insertValuesSQL += ",CURRENT_TIMESTAMP"
 	}
 
 	updateStatementsforToastCols := m.generateUpdateStatements(pureColNames, unchangedToastColumns)

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -164,7 +164,7 @@ func (m *mergeStmtGenerator) generateMergeStmt(dstTable string, dstDatasetTable 
 	}
 
 	updateStatementsforToastCols := m.generateUpdateStatements(pureColNames, unchangedToastColumns)
-	if m.peerdbCols.SoftDelete {
+	if m.peerdbCols.SoftDeleteColName != "" {
 		softDeleteInsertColumnsSQL := insertColumnsSQL + fmt.Sprintf(",`%s`", m.peerdbCols.SoftDeleteColName)
 		softDeleteInsertValuesSQL := insertValuesSQL + ",TRUE"
 
@@ -179,7 +179,7 @@ func (m *mergeStmtGenerator) generateMergeStmt(dstTable string, dstDatasetTable 
 	pkeySelectSQL := strings.Join(pkeySelectSQLArray, " AND ")
 
 	deletePart := "DELETE"
-	if m.peerdbCols.SoftDelete {
+	if m.peerdbCols.SoftDeleteColName != "" {
 		colName := m.peerdbCols.SoftDeleteColName
 		deletePart = fmt.Sprintf("UPDATE SET %s=TRUE", colName)
 		if m.peerdbCols.SyncedAtColName != "" {

--- a/flow/connectors/bigquery/merge_stmt_generator_test.go
+++ b/flow/connectors/bigquery/merge_stmt_generator_test.go
@@ -19,7 +19,7 @@ func TestGenerateUpdateStatement(t *testing.T) {
 		},
 		peerdbCols: &protos.PeerDBColumns{
 			SoftDelete:        false,
-			SoftDeleteColName: "deleted",
+			SoftDeleteColName: "",
 			SyncedAtColName:   "synced_at",
 		},
 	}
@@ -100,7 +100,7 @@ func TestGenerateUpdateStatement_WithUnchangedToastCols(t *testing.T) {
 		},
 		peerdbCols: &protos.PeerDBColumns{
 			SoftDelete:        false,
-			SoftDeleteColName: "deleted",
+			SoftDeleteColName: "",
 			SyncedAtColName:   "synced_at",
 		},
 	}

--- a/flow/connectors/postgres/normalize_stmt_generator_test.go
+++ b/flow/connectors/postgres/normalize_stmt_generator_test.go
@@ -21,7 +21,7 @@ func TestGenerateMergeUpdateStatement(t *testing.T) {
 		peerdbCols: &protos.PeerDBColumns{
 			SoftDelete:        false,
 			SyncedAtColName:   "_peerdb_synced_at",
-			SoftDeleteColName: "_peerdb_soft_delete",
+			SoftDeleteColName: "",
 		},
 	}
 	result := normalizeGen.generateUpdateStatements(allCols, unchangedToastCols)

--- a/flow/connectors/postgres/normalize_stmt_generator_test.go
+++ b/flow/connectors/postgres/normalize_stmt_generator_test.go
@@ -85,7 +85,7 @@ func TestGenerateMergeUpdateStatement_WithUnchangedToastCols(t *testing.T) {
 		peerdbCols: &protos.PeerDBColumns{
 			SoftDelete:        false,
 			SyncedAtColName:   "_peerdb_synced_at",
-			SoftDeleteColName: "_peerdb_soft_delete",
+			SoftDeleteColName: "",
 		},
 	}
 	result := normalizeGen.generateUpdateStatements(allCols, unchangedToastCols)

--- a/flow/connectors/snowflake/merge_stmt_generator.go
+++ b/flow/connectors/snowflake/merge_stmt_generator.go
@@ -104,7 +104,7 @@ func (m *mergeStmtGenerator) generateMergeStmt(dstTable string) (string, error) 
 	// handling the case when an insert and delete happen in the same batch, with updates in the middle
 	// with soft-delete, we want the row to be in the destination with SOFT_DELETE true
 	// the current merge statement doesn't do that, so we add another case to insert the DeleteRecord
-	if m.peerdbCols.SoftDelete && (m.peerdbCols.SoftDeleteColName != "") {
+	if m.peerdbCols.SoftDeleteColName != "" {
 		softDeleteInsertColumnsSQL := strings.Join(append(quotedUpperColNames,
 			m.peerdbCols.SoftDeleteColName), ",")
 		softDeleteInsertValuesSQL := insertValuesSQL + ",TRUE"
@@ -126,7 +126,7 @@ func (m *mergeStmtGenerator) generateMergeStmt(dstTable string) (string, error) 
 	pkeySelectSQL := strings.Join(pkeySelectSQLArray, " AND ")
 
 	deletePart := "DELETE"
-	if m.peerdbCols.SoftDelete {
+	if m.peerdbCols.SoftDeleteColName != "" {
 		colName := m.peerdbCols.SoftDeleteColName
 		deletePart = fmt.Sprintf("UPDATE SET %s = TRUE", colName)
 		if m.peerdbCols.SyncedAtColName != "" {
@@ -167,7 +167,7 @@ and updating the other columns.
 7. Return the list of generated update statements.
 */
 func (m *mergeStmtGenerator) generateUpdateStatements(allCols []string, unchangedToastColumns []string) []string {
-	handleSoftDelete := m.peerdbCols.SoftDelete && (m.peerdbCols.SoftDeleteColName != "")
+	handleSoftDelete := m.peerdbCols.SoftDeleteColName != ""
 	stmtCount := len(unchangedToastColumns)
 	if handleSoftDelete {
 		stmtCount *= 2

--- a/flow/connectors/snowflake/merge_stmt_generator.go
+++ b/flow/connectors/snowflake/merge_stmt_generator.go
@@ -80,10 +80,12 @@ func (m *mergeStmtGenerator) generateMergeStmt(dstTable string) (string, error) 
 		quotedUpperColNames = append(quotedUpperColNames, SnowflakeIdentifierNormalize(column.Name))
 		columnNames = append(columnNames, column.Name)
 	}
-	// append synced_at column
-	quotedUpperColNames = append(quotedUpperColNames,
-		fmt.Sprintf(`"%s"`, strings.ToUpper(m.peerdbCols.SyncedAtColName)),
-	)
+	if m.peerdbCols.SyncedAtColName != "" {
+		// append synced_at column
+		quotedUpperColNames = append(quotedUpperColNames,
+			fmt.Sprintf(`"%s"`, strings.ToUpper(m.peerdbCols.SyncedAtColName)),
+		)
+	}
 
 	insertColumnsSQL := strings.Join(quotedUpperColNames, ",")
 
@@ -92,8 +94,10 @@ func (m *mergeStmtGenerator) generateMergeStmt(dstTable string) (string, error) 
 		normalizedColName := SnowflakeIdentifierNormalize(column.Name)
 		insertValuesSQLArray = append(insertValuesSQLArray, "SOURCE."+normalizedColName)
 	}
-	// fill in synced_at column
-	insertValuesSQLArray = append(insertValuesSQLArray, "CURRENT_TIMESTAMP")
+	if m.peerdbCols.SyncedAtColName != "" {
+		// fill in synced_at column
+		insertValuesSQLArray = append(insertValuesSQLArray, "CURRENT_TIMESTAMP")
+	}
 	insertValuesSQL := strings.Join(insertValuesSQLArray, ",")
 	updateStatementsforToastCols := m.generateUpdateStatements(columnNames, unchangedToastColumns)
 

--- a/flow/connectors/snowflake/merge_stmt_generator_test.go
+++ b/flow/connectors/snowflake/merge_stmt_generator_test.go
@@ -21,7 +21,7 @@ func TestGenerateUpdateStatement(t *testing.T) {
 		peerdbCols: &protos.PeerDBColumns{
 			SoftDelete:        false,
 			SyncedAtColName:   "_PEERDB_SYNCED_AT",
-			SoftDeleteColName: "_PEERDB_SOFT_DELETE",
+			SoftDeleteColName: "",
 		},
 	}
 	result := mergeGen.generateUpdateStatements(allCols, unchangedToastCols)
@@ -89,7 +89,7 @@ func TestGenerateUpdateStatement_WithUnchangedToastCols(t *testing.T) {
 		peerdbCols: &protos.PeerDBColumns{
 			SoftDelete:        false,
 			SyncedAtColName:   "_PEERDB_SYNCED_AT",
-			SoftDeleteColName: "_PEERDB_SOFT_DELETE",
+			SoftDeleteColName: "",
 		},
 	}
 	result := mergeGen.generateUpdateStatements(allCols, unchangedToastCols)

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -757,7 +757,7 @@ func (c *SnowflakeConnector) RenameTables(ctx context.Context, req *protos.Renam
 
 		c.logger.Info(fmt.Sprintf("setting synced at column for table '%s'...", src))
 
-		if req.SyncedAtColName != nil {
+		if req.SyncedAtColName != nil && *req.SyncedAtColName != "" {
 			_, err = renameTablesTx.ExecContext(ctx,
 				fmt.Sprintf("UPDATE %s SET %s = CURRENT_TIMESTAMP", src, *req.SyncedAtColName))
 			if err != nil {
@@ -765,7 +765,7 @@ func (c *SnowflakeConnector) RenameTables(ctx context.Context, req *protos.Renam
 			}
 		}
 
-		if req.SoftDeleteColName != nil {
+		if req.SoftDeleteColName != nil && *req.SoftDeleteColName != "" {
 			columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
 			for _, col := range renameRequest.TableSchema.Columns {
 				columnNames = append(columnNames, SnowflakeIdentifierNormalize(col.Name))

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -794,6 +794,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Composite_PKey_Toast_1_BQ() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.MaxBatchSize = 100
+	flowConnConfig.DisablePeerdbColumns = true
 
 	// wait for PeerFlowStatusQuery to finish setup
 	// and then insert, update and delete rows in the table.
@@ -1302,6 +1303,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_JSON_PKey_BQ() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.MaxBatchSize = 100
+	flowConnConfig.DisablePeerdbColumns = true
 
 	tc := e2e.NewTemporalClient(s.t)
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -794,7 +794,9 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Composite_PKey_Toast_1_BQ() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.MaxBatchSize = 100
-	flowConnConfig.DisablePeerdbColumns = true
+	flowConnConfig.SoftDelete = false
+	flowConnConfig.SoftDeleteColName = ""
+	flowConnConfig.SyncedAtColName = ""
 
 	// wait for PeerFlowStatusQuery to finish setup
 	// and then insert, update and delete rows in the table.
@@ -1303,7 +1305,9 @@ func (s PeerFlowE2ETestSuiteBQ) Test_JSON_PKey_BQ() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.MaxBatchSize = 100
-	flowConnConfig.DisablePeerdbColumns = true
+	flowConnConfig.SoftDelete = false
+	flowConnConfig.SoftDeleteColName = ""
+	flowConnConfig.SyncedAtColName = ""
 
 	tc := e2e.NewTemporalClient(s.t)
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -117,7 +117,9 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.MaxBatchSize = 100
-	flowConnConfig.DisablePeerdbColumns = true
+	flowConnConfig.SoftDelete = false
+	flowConnConfig.SoftDeleteColName = ""
+	flowConnConfig.SyncedAtColName = ""
 
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
@@ -1031,7 +1033,9 @@ func (s PeerFlowE2ETestSuitePG) Test_TypeSystem_PG() {
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.DoInitialSnapshot = true
 	flowConnConfig.System = protos.TypeSystem_PG
-	flowConnConfig.DisablePeerdbColumns = true
+	flowConnConfig.SoftDelete = false
+	flowConnConfig.SoftDeleteColName = ""
+	flowConnConfig.SyncedAtColName = ""
 
 	tc := e2e.NewTemporalClient(s.t)
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -117,6 +117,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.MaxBatchSize = 100
+	flowConnConfig.DisablePeerdbColumns = true
 
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
@@ -1030,6 +1031,7 @@ func (s PeerFlowE2ETestSuitePG) Test_TypeSystem_PG() {
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.DoInitialSnapshot = true
 	flowConnConfig.System = protos.TypeSystem_PG
+	flowConnConfig.DisablePeerdbColumns = true
 
 	tc := e2e.NewTemporalClient(s.t)
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
@@ -1045,7 +1047,7 @@ func (s PeerFlowE2ETestSuitePG) Test_TypeSystem_PG() {
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "normalize rows", func() bool {
 		err := s.comparePGTables(srcTableName, dstTableName, "id,created_at,updated_at,j::text,jb,aa32,currency")
 		if err != nil {
-			s.t.Log("PGPGPG", err)
+			s.t.Log("error while comparing rows", err)
 		}
 		return err == nil
 	})

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -1253,5 +1253,5 @@ func (s PeerFlowE2ETestSuiteSF) Test_Column_Exclusion_With_Schema_Changes() {
 	for _, field := range sfRows.Schema.Fields {
 		require.NotEqual(s.t, "c2", field.Name)
 	}
-	require.Len(s.t, sfRows.Schema.Fields, 5)
+	require.Len(s.t, sfRows.Schema.Fields, 4)
 }

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -675,7 +675,9 @@ func (s PeerFlowE2ETestSuiteSF) Test_Composite_PKey_Toast_1_SF() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.MaxBatchSize = 100
-	flowConnConfig.DisablePeerdbColumns = true
+	flowConnConfig.SoftDelete = false
+	flowConnConfig.SoftDeleteColName = ""
+	flowConnConfig.SyncedAtColName = ""
 
 	// wait for PeerFlowStatusQuery to finish setup
 	// and then insert, update and delete rows in the table.
@@ -1204,10 +1206,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Column_Exclusion_With_Schema_Changes() {
 				Exclude:                    []string{"c2"},
 			},
 		},
-		Source:               e2e.GeneratePostgresPeer(),
-		SyncedAtColName:      "_PEERDB_SYNCED_AT",
-		MaxBatchSize:         100,
-		DisablePeerdbColumns: true,
+		Source:       e2e.GeneratePostgresPeer(),
+		MaxBatchSize: 100,
 	}
 
 	// wait for PeerFlowStatusQuery to finish setup

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -675,6 +675,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Composite_PKey_Toast_1_SF() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
 	flowConnConfig.MaxBatchSize = 100
+	flowConnConfig.DisablePeerdbColumns = true
 
 	// wait for PeerFlowStatusQuery to finish setup
 	// and then insert, update and delete rows in the table.
@@ -1203,9 +1204,10 @@ func (s PeerFlowE2ETestSuiteSF) Test_Column_Exclusion_With_Schema_Changes() {
 				Exclude:                    []string{"c2"},
 			},
 		},
-		Source:          e2e.GeneratePostgresPeer(),
-		SyncedAtColName: "_PEERDB_SYNCED_AT",
-		MaxBatchSize:    100,
+		Source:               e2e.GeneratePostgresPeer(),
+		SyncedAtColName:      "_PEERDB_SYNCED_AT",
+		MaxBatchSize:         100,
+		DisablePeerdbColumns: true,
 	}
 
 	// wait for PeerFlowStatusQuery to finish setup

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -226,6 +226,14 @@ func CDCFlowWorkflow(
 	logger := log.With(workflow.GetLogger(ctx), slog.String(string(shared.FlowNameKey), cfg.FlowJobName))
 	flowSignalChan := model.FlowSignal.GetSignalChannel(ctx)
 
+	// ugly, find a better way to represent this later
+	if cfg.DisablePeerdbColumns {
+		logger.Info("force disabling peerdb columns")
+		cfg.SoftDelete = false
+		cfg.SoftDeleteColName = ""
+		cfg.SyncedAtColName = ""
+	}
+
 	err := workflow.SetQueryHandler(ctx, shared.CDCFlowStateQuery, func() (CDCFlowWorkflowState, error) {
 		return *state, nil
 	})

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -226,14 +226,6 @@ func CDCFlowWorkflow(
 	logger := log.With(workflow.GetLogger(ctx), slog.String(string(shared.FlowNameKey), cfg.FlowJobName))
 	flowSignalChan := model.FlowSignal.GetSignalChannel(ctx)
 
-	// ugly, find a better way to represent this later
-	if cfg.DisablePeerdbColumns {
-		logger.Info("force disabling peerdb columns")
-		cfg.SoftDelete = false
-		cfg.SoftDeleteColName = ""
-		cfg.SyncedAtColName = ""
-	}
-
 	err := workflow.SetQueryHandler(ctx, shared.CDCFlowStateQuery, func() (CDCFlowWorkflowState, error) {
 		return *state, nil
 	})

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -280,20 +280,6 @@ impl StatementAnalyzer for PeerDDLAnalyzer {
                             _ => false,
                         };
 
-                        let push_parallelism: Option<i64> = match raw_options
-                            .remove("push_parallelism")
-                        {
-                            Some(Expr::Value(ast::Value::Number(n, _))) => Some(n.parse::<i64>()?),
-                            _ => None,
-                        };
-
-                        let push_batch_size: Option<i64> = match raw_options
-                            .remove("push_batch_size")
-                        {
-                            Some(Expr::Value(ast::Value::Number(n, _))) => Some(n.parse::<i64>()?),
-                            _ => None,
-                        };
-
                         let max_batch_size: Option<u32> = match raw_options.remove("max_batch_size")
                         {
                             Some(Expr::Value(ast::Value::Number(n, _))) => Some(n.parse::<u32>()?),
@@ -334,12 +320,17 @@ impl StatementAnalyzer for PeerDDLAnalyzer {
                             _ => "Q".to_string(),
                         };
 
+                        let disable_peerdb_columns =
+                            match raw_options.remove("disable_peerdb_columns") {
+                                Some(Expr::Value(ast::Value::Boolean(b))) => *b,
+                                _ => false,
+                            };
+
                         let flow_job = FlowJob {
                             name: cdc.mirror_name.to_string().to_lowercase(),
                             source_peer: cdc.source_peer.to_string().to_lowercase(),
                             target_peer: cdc.target_peer.to_string().to_lowercase(),
                             table_mappings: flow_job_table_mappings,
-                            description: "".to_string(), // TODO: add description
                             do_initial_copy,
                             publication_name,
                             snapshot_num_rows_per_partition,
@@ -349,8 +340,6 @@ impl StatementAnalyzer for PeerDDLAnalyzer {
                             cdc_staging_path,
                             soft_delete,
                             replication_slot_name,
-                            push_batch_size,
-                            push_parallelism,
                             max_batch_size,
                             sync_interval,
                             resync,
@@ -359,6 +348,7 @@ impl StatementAnalyzer for PeerDDLAnalyzer {
                             initial_snapshot_only: initial_copy_only,
                             script,
                             system,
+                            disable_peerdb_columns,
                         };
 
                         if initial_copy_only && !do_initial_copy {

--- a/nexus/flow-rs/src/grpc.rs
+++ b/nexus/flow-rs/src/grpc.rs
@@ -176,6 +176,7 @@ impl FlowGrpcClient {
             script: job.script.clone(),
             system: system as i32,
             idle_timeout_seconds: job.sync_interval.unwrap_or_default(),
+            disable_peerdb_columns: job.disable_peerdb_columns,
         };
 
         self.start_peer_flow(flow_conn_cfg).await

--- a/nexus/pt/src/flow_model.rs
+++ b/nexus/pt/src/flow_model.rs
@@ -17,7 +17,6 @@ pub struct FlowJob {
     pub source_peer: String,
     pub target_peer: String,
     pub table_mappings: Vec<FlowJobTableMapping>,
-    pub description: String,
     pub do_initial_copy: bool,
     pub publication_name: Option<String>,
     pub snapshot_num_rows_per_partition: Option<u32>,
@@ -27,8 +26,6 @@ pub struct FlowJob {
     pub cdc_staging_path: Option<String>,
     pub soft_delete: bool,
     pub replication_slot_name: Option<String>,
-    pub push_parallelism: Option<i64>,
-    pub push_batch_size: Option<i64>,
     pub max_batch_size: Option<u32>,
     pub sync_interval: Option<u64>,
     pub resync: bool,
@@ -37,6 +34,7 @@ pub struct FlowJob {
     pub initial_snapshot_only: bool,
     pub script: String,
     pub system: String,
+    pub disable_peerdb_columns: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -73,9 +73,6 @@ message FlowConnectionConfigs {
   string script = 20;
 
   TypeSystem system = 21;
-
-  // soft_delete, synced_at etc. should not be created in the destination table
-  bool disable_peerdb_columns = 22;
 }
 
 message RenameTableOption {

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -73,6 +73,9 @@ message FlowConnectionConfigs {
   string script = 20;
 
   TypeSystem system = 21;
+
+  // soft_delete, synced_at etc. should not be created in the destination table
+  bool disable_peerdb_columns = 22;
 }
 
 message RenameTableOption {

--- a/ui/app/dto/MirrorsDTO.ts
+++ b/ui/app/dto/MirrorsDTO.ts
@@ -21,7 +21,9 @@ export type UDropMirrorResponse = {
   errorMessage: string;
 };
 
-export type CDCConfig = FlowConnectionConfigs;
+export type CDCConfig = FlowConnectionConfigs & {
+  disablePeerDBColumns: boolean;
+};
 export type MirrorConfig = CDCConfig | QRepConfig;
 export type MirrorSetter = Dispatch<SetStateAction<CDCConfig | QRepConfig>>;
 export type TableMapRow = {

--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -183,4 +183,16 @@ export const cdcSettings: MirrorSetting[] = [
     tips: 'A field to set the name of PeerDBs soft delete column.',
     advanced: AdvancedSettingType.ALL,
   },
+  {
+    label: 'Disable all PeerDB columns (overrides any other setting)',
+    stateHandler: (value, setter) =>
+      setter((curr: CDCConfig) => ({
+        ...curr,
+        disablePeerdbColumns: value as boolean,
+      })),
+    type: 'switch',
+    default: false,
+    tips: 'Disables columns like synced_at, soft_delete etc. from being added to the destination table',
+    advanced: AdvancedSettingType.ALL,
+  },
 ];

--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -5,10 +5,12 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Initial Copy',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        doInitialSnapshot: (value as boolean) ?? true,
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          doInitialSnapshot: (value as boolean) ?? true,
+        })
+      ),
     tips: 'Specify if you want initial load to happen for your tables.',
     type: 'switch',
     default: true,
@@ -17,10 +19,12 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Pull Batch Size',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        maxBatchSize: (value as number) || 1000000,
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          maxBatchSize: (value as number) || 1000000,
+        })
+      ),
     tips: 'The number of rows PeerDB will pull from source at a time. If left empty, the default value is 1,000,000 rows.',
     type: 'number',
     default: '1000000',
@@ -29,10 +33,12 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Sync Interval (Seconds)',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        idleTimeoutSeconds: (value as number) || 60,
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          idleTimeoutSeconds: (value as number) || 60,
+        })
+      ),
     tips: 'Time after which a Sync flow ends, if it happens before pull batch size is reached. Defaults to 60 seconds.',
     helpfulLink: 'https://docs.peerdb.io/metrics/important_cdc_configs',
     type: 'number',
@@ -43,10 +49,12 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Publication Name',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        publicationName: (value as string) || '',
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          publicationName: (value as string) || '',
+        })
+      ),
     type: 'select',
     tips: 'PeerDB requires a publication associated with the tables you wish to sync.',
     helpfulLink:
@@ -56,19 +64,23 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Replication Slot Name',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        replicationSlotName: (value as string) || '',
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          replicationSlotName: (value as string) || '',
+        })
+      ),
     tips: 'If set, PeerDB will use this slot for the mirror.',
   },
   {
     label: 'Snapshot Number of Rows Per Partition',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        snapshotNumRowsPerPartition: parseInt(value as string, 10) || 1000000,
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          snapshotNumRowsPerPartition: parseInt(value as string, 10) || 1000000,
+        })
+      ),
     tips: 'PeerDB splits up table data into partitions for increased performance. This setting controls the number of rows per partition. The default value is 1000000.',
     default: '1000000',
     type: 'number',
@@ -89,10 +101,12 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Snapshot Number of Tables In Parallel',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        snapshotNumTablesInParallel: parseInt(value as string, 10) || 1,
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          snapshotNumTablesInParallel: parseInt(value as string, 10) || 1,
+        })
+      ),
     tips: 'Specify the number of tables to sync perform initial load for, in parallel. The default value is 1.',
     default: '1',
     type: 'number',
@@ -101,30 +115,37 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Snapshot Staging Path',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        snapshotStagingPath: value as string | '',
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          snapshotStagingPath: value as string | '',
+        })
+      ),
     tips: 'You can specify staging path for Snapshot sync mode AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket URL. For BigQuery, this must be either empty or an existing GCS bucket name. In both cases, if empty, the local filesystem will be used.',
     advanced: AdvancedSettingType.ALL,
   },
   {
     label: 'CDC Staging Path',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        cdcStagingPath: (value as string) || '',
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          cdcStagingPath: (value as string) || '',
+        })
+      ),
     tips: 'You can specify staging path for CDC sync mode AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket URL. For BigQuery, this must be either empty or an existing GCS bucket name. In both cases, if empty, the local filesystem will be used.',
     advanced: AdvancedSettingType.ALL,
   },
   {
     label: 'Soft Delete',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        softDelete: (value as boolean) ?? true,
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          softDelete: (value as boolean) ?? true,
+          softDeleteColName: (value as boolean) ? curr.softDeleteColName : '',
+        })
+      ),
     tips: 'Allows you to mark some records as deleted without actual erasure from the database',
     default: true,
     type: 'switch',
@@ -133,10 +154,12 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Initial Copy Only',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        initialSnapshotOnly: (value as boolean) ?? false,
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          initialSnapshotOnly: (value as boolean) ?? false,
+        })
+      ),
     tips: 'If set, PeerDB will only perform initial load and will not perform CDC sync.',
     type: 'switch',
     advanced: AdvancedSettingType.ALL,
@@ -144,10 +167,12 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Script',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        script: (value as string) || '',
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          script: (value as string) || '',
+        })
+      ),
     tips: 'Associate PeerDB script with this mirror.',
     advanced: AdvancedSettingType.ALL,
   },
@@ -166,30 +191,36 @@ export const cdcSettings: MirrorSetting[] = [
   {
     label: 'Synced-At Column Name',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        syncedAtColName: value as string | '',
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          syncedAtColName: value as string | '',
+        })
+      ),
     tips: 'A field to set the name of PeerDBs synced_at column. If not set, a default name will be set',
     advanced: AdvancedSettingType.ALL,
   },
   {
     label: 'Soft Delete Column Name',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        softDeleteColName: value as string | '',
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          softDeleteColName: value as string | '',
+        })
+      ),
     tips: 'A field to set the name of PeerDBs soft delete column.',
     advanced: AdvancedSettingType.ALL,
   },
   {
     label: 'Disable all PeerDB columns (overrides any other setting)',
     stateHandler: (value, setter) =>
-      setter((curr: CDCConfig) => ({
-        ...curr,
-        disablePeerdbColumns: value as boolean,
-      })),
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          disablePeerDBColumns: (value as boolean) ?? false,
+        })
+      ),
     type: 'switch',
     default: false,
     tips: 'Disables columns like synced_at, soft_delete etc. from being added to the destination table',

--- a/ui/app/mirrors/create/helpers/common.ts
+++ b/ui/app/mirrors/create/helpers/common.ts
@@ -1,4 +1,5 @@
-import { FlowConnectionConfigs, TypeSystem } from '@/grpc_generated/flow';
+import { CDCConfig } from '@/app/dto/MirrorsDTO';
+import { TypeSystem } from '@/grpc_generated/flow';
 
 export enum AdvancedSettingType {
   QUEUE = 'queue',
@@ -19,7 +20,7 @@ export interface MirrorSetting {
   command?: string;
 }
 
-export const blankCDCSetting: FlowConnectionConfigs = {
+export const blankCDCSetting: CDCConfig = {
   source: undefined,
   destination: undefined,
   flowJobName: '',
@@ -35,13 +36,13 @@ export const blankCDCSetting: FlowConnectionConfigs = {
   softDelete: true,
   replicationSlotName: '',
   resync: false,
-  softDeleteColName: '',
-  syncedAtColName: '',
+  softDeleteColName: '_PEERDB_IS_DELETED',
+  syncedAtColName: '_PEERDB_SYNCED_AT',
   initialSnapshotOnly: false,
   idleTimeoutSeconds: 60,
   script: '',
   system: TypeSystem.Q,
-  disablePeerdbColumns: false,
+  disablePeerDBColumns: false,
 };
 
 export const blankQRepSetting = {

--- a/ui/app/mirrors/create/helpers/common.ts
+++ b/ui/app/mirrors/create/helpers/common.ts
@@ -41,6 +41,7 @@ export const blankCDCSetting: FlowConnectionConfigs = {
   idleTimeoutSeconds: 60,
   script: '',
   system: TypeSystem.Q,
+  disablePeerdbColumns: false,
 };
 
 export const blankQRepSetting = {

--- a/ui/app/mirrors/create/qrep/upsertcols.tsx
+++ b/ui/app/mirrors/create/qrep/upsertcols.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { MirrorSetter } from '@/app/dto/MirrorsDTO';
 import SelectTheme from '@/app/styles/select';
 import {
   QRepConfig,
@@ -9,7 +10,6 @@ import { Badge } from '@/lib/Badge';
 import { Icon } from '@/lib/Icon';
 import { useEffect, useState } from 'react';
 import ReactSelect from 'react-select';
-import { MirrorSetter } from '../../types';
 import { MirrorSetting } from '../helpers/common';
 
 interface UpsertColsProps {

--- a/ui/app/mirrors/types.ts
+++ b/ui/app/mirrors/types.ts
@@ -1,6 +1,0 @@
-import { FlowConnectionConfigs, QRepConfig } from '@/grpc_generated/flow';
-import { Dispatch, SetStateAction } from 'react';
-
-export type CDCConfig = FlowConnectionConfigs;
-export type MirrorConfig = CDCConfig | QRepConfig;
-export type MirrorSetter = Dispatch<SetStateAction<CDCConfig | QRepConfig>>;

--- a/ui/components/ResyncDialog.tsx
+++ b/ui/components/ResyncDialog.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { CDCConfig } from '@/app/dto/MirrorsDTO';
+import { FlowConnectionConfigs } from '@/grpc_generated/flow';
 import { Button } from '@/lib/Button';
 import { Dialog, DialogClose } from '@/lib/Dialog';
 import { Label } from '@/lib/Label';
@@ -12,7 +12,7 @@ export const ResyncDialog = ({
   mirrorConfig,
   workflowId,
 }: {
-  mirrorConfig: CDCConfig;
+  mirrorConfig: FlowConnectionConfigs;
   workflowId: string;
 }) => {
   const [syncing, setSyncing] = useState(false);


### PR DESCRIPTION
closes #1803 

makes all soft delete logic now depend on not empty column name, fasttrack to removing it entirely