### PR TITLE
pgx: custom LookupFunc during SSH tunneling to delegate DNS lookup

### DIFF
--- a/flow/connectors/postgres/ssh_wrapped_pool.go
+++ b/flow/connectors/postgres/ssh_wrapped_pool.go
@@ -104,7 +104,7 @@ func (tunnel *SSHTunnel) NewPostgresConnFromConfig(
 		}
 		// DNS lookup seems to happen before connection is established which can be an issue if given host
 		// can only be resolved on the SSH host https://github.com/jackc/pgx/issues/1724
-		connConfig.LookupFunc = func(ctx context.Context, host string) (addrs []string, err error) {
+		connConfig.LookupFunc = func(ctx context.Context, host string) ([]string, error) {
 			return []string{host}, nil
 		}
 	}

--- a/flow/connectors/postgres/ssh_wrapped_pool.go
+++ b/flow/connectors/postgres/ssh_wrapped_pool.go
@@ -102,6 +102,11 @@ func (tunnel *SSHTunnel) NewPostgresConnFromConfig(
 			}
 			return &noDeadlineConn{Conn: conn}, nil
 		}
+		// DNS lookup seems to happen before connection is established which can be an issue if given host
+		// can only be resolved on the SSH host https://github.com/jackc/pgx/issues/1724
+		connConfig.LookupFunc = func(ctx context.Context, host string) (addrs []string, err error) {
+			return []string{host}, nil
+		}
 	}
 
 	logger := logger.LoggerFromCtx(ctx)


### PR DESCRIPTION
in cases where provided host is only resolvable on the bastion