### PR TITLE
sanitize: support pgtype.TID

### DIFF
--- a/flow/connectors/postgres/sanitize/sanitize.go
+++ b/flow/connectors/postgres/sanitize/sanitize.go
@@ -35,6 +35,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // Part is either a string or an int. A string is raw SQL. An int is a
@@ -86,6 +88,9 @@ func (q *Query) Sanitize(args ...any) (string, error) {
 				str = QuoteString(arg)
 			case time.Time:
 				str = arg.Truncate(time.Microsecond).Format("'2006-01-02 15:04:05.999999999Z07:00:00'")
+			case pgtype.TID:
+				// this case patched on for initial load support in peerdb
+				str = fmt.Sprintf("'(%d,%d)'", arg.BlockNumber, arg.OffsetNumber)
 			default:
 				return "", fmt.Errorf("invalid arg type: %T", arg)
 			}

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -1022,6 +1022,14 @@ func (s PeerFlowE2ETestSuitePG) Test_TypeSystem_PG() {
 		)`, srcTableName))
 	require.NoError(s.t, err)
 
+	for range 3 {
+		_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
+		insert into %s (updated_at, j, jb, aa32, currency) values (
+			NOW(),'{"b" : 123}','{"b" : 123}','{{3,2,1},{6,5,4},{9,8,7}}','ISK'
+		)`, srcTableName))
+		require.NoError(s.t, err)
+	}
+
 	connectionGen := e2e.FlowConnectionGenerationConfig{
 		FlowJobName:      s.attachSuffix("test_typesystem_pg"),
 		TableNameMapping: map[string]string{srcTableName: dstTableName},
@@ -1045,7 +1053,7 @@ func (s PeerFlowE2ETestSuitePG) Test_TypeSystem_PG() {
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "normalize rows", func() bool {
 		err := s.comparePGTables(srcTableName, dstTableName, "id,created_at,updated_at,j::text,jb,aa32,currency")
 		if err != nil {
-			s.t.Log("PGPGPG", err)
+			s.t.Log(err.Error())
 		}
 		return err == nil
 	})


### PR DESCRIPTION
pgvalue cdc initial load was breaking due to sanitize not supporting ctid args