### PR TITLE
BigQuery: better type handling

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -17,11 +17,9 @@ import (
 
 	metadataStore "github.com/PeerDB-io/peer-flow/connectors/external_metadata"
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
-	numeric "github.com/PeerDB-io/peer-flow/datatypes"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/logger"
 	"github.com/PeerDB-io/peer-flow/model"
-	"github.com/PeerDB-io/peer-flow/model/qvalue"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
@@ -231,7 +229,7 @@ func (c *BigQueryConnector) ReplayTableSchemaDeltas(
 				}
 			}
 
-			addedColumnBigQueryType := qValueKindToBigQueryTypeString(addedColumn.Type)
+			addedColumnBigQueryType := qValueKindToBigQueryTypeString(addedColumn)
 			query := c.client.Query(fmt.Sprintf(
 				"ALTER TABLE %s ADD COLUMN IF NOT EXISTS `%s` %s",
 				dstDatasetTable.table, addedColumn.Name, addedColumnBigQueryType))
@@ -632,24 +630,8 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 	// convert the column names and types to bigquery types
 	columns := make([]*bigquery.FieldSchema, 0, len(tableSchema.Columns)+2)
 	for _, column := range tableSchema.Columns {
-		genericColType := column.Type
-		if genericColType == "numeric" {
-			precision, scale := numeric.GetNumericTypeForWarehouse(column.TypeModifier, numeric.BigQueryNumericCompatibility{})
-			columns = append(columns, &bigquery.FieldSchema{
-				Name:      column.Name,
-				Type:      bigquery.BigNumericFieldType,
-				Repeated:  qvalue.QValueKind(genericColType).IsArray(),
-				Precision: int64(precision),
-				Scale:     int64(scale),
-			})
-		} else {
-			bqFieldSchema := qValueKindToBigQueryType(genericColType)
-			columns = append(columns, &bigquery.FieldSchema{
-				Name:     column.Name,
-				Type:     bqFieldSchema.Type,
-				Repeated: bqFieldSchema.Repeated,
-			})
-		}
+		bqFieldSchema := qValueKindToBigQueryType(column)
+		columns = append(columns, &bqFieldSchema)
 	}
 
 	if softDeleteColName != "" {

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -229,7 +229,7 @@ func (c *BigQueryConnector) ReplayTableSchemaDeltas(
 				}
 			}
 
-			addedColumnBigQueryType := qValueKindToBigQueryTypeString(addedColumn)
+			addedColumnBigQueryType := qValueKindToBigQueryTypeString(addedColumn, false)
 			query := c.client.Query(fmt.Sprintf(
 				"ALTER TABLE %s ADD COLUMN IF NOT EXISTS `%s` %s",
 				dstDatasetTable.table, addedColumn.Name, addedColumnBigQueryType))

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -243,7 +243,7 @@ func (c *BigQueryConnector) ReplayTableSchemaDeltas(
 					schemaDelta.DstTableName, err)
 			}
 			c.logger.Info(fmt.Sprintf("[schema delta replay] added column %s with data type %s to table %s",
-				addedColumn.Name, addedColumn.Type, schemaDelta.DstTableName))
+				addedColumn.Name, addedColumnBigQueryType, schemaDelta.DstTableName))
 		}
 	}
 
@@ -643,10 +643,11 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 				Scale:     int64(scale),
 			})
 		} else {
+			bqFieldSchema := qValueKindToBigQueryType(genericColType)
 			columns = append(columns, &bigquery.FieldSchema{
 				Name:     column.Name,
-				Type:     qValueKindToBigQueryType(genericColType),
-				Repeated: qvalue.QValueKind(genericColType).IsArray(),
+				Type:     bqFieldSchema.Type,
+				Repeated: bqFieldSchema.Repeated,
 			})
 		}
 	}

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -46,9 +46,10 @@ func (m *mergeStmtGenerator) generateFlattenedCTE(dstTable string, normalizedTab
 			qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64, qvalue.QValueKindArrayString,
 			qvalue.QValueKindArrayBoolean, qvalue.QValueKindArrayTimestamp, qvalue.QValueKindArrayTimestampTZ,
 			qvalue.QValueKindArrayDate:
+			bqArrayElementType := qValueKindToBigQueryType(colType).Type
 			castStmt = fmt.Sprintf("ARRAY(SELECT CAST(element AS %s) FROM "+
 				"UNNEST(CAST(JSON_VALUE_ARRAY(_peerdb_data, '$.%s') AS ARRAY<STRING>)) AS element WHERE element IS NOT null) AS `%s`",
-				bqTypeString, column.Name, shortCol)
+				bqArrayElementType, column.Name, shortCol)
 		case qvalue.QValueKindGeography, qvalue.QValueKindGeometry, qvalue.QValueKindPoint:
 			castStmt = fmt.Sprintf("CAST(ST_GEOGFROMTEXT(JSON_VALUE(_peerdb_data, '$.%s')) AS %s) AS `%s`",
 				column.Name, bqTypeString, shortCol)

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -30,7 +30,7 @@ func (m *mergeStmtGenerator) generateFlattenedCTE(dstTable string, normalizedTab
 
 	for _, column := range normalizedTableSchema.Columns {
 		colType := column.Type
-		bqTypeString := qValueKindToBigQueryTypeString(colType)
+		bqTypeString := qValueKindToBigQueryTypeString(column)
 		var castStmt string
 		shortCol := m.shortColumn[column.Name]
 		switch qvalue.QValueKind(colType) {
@@ -46,7 +46,7 @@ func (m *mergeStmtGenerator) generateFlattenedCTE(dstTable string, normalizedTab
 			qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64, qvalue.QValueKindArrayString,
 			qvalue.QValueKindArrayBoolean, qvalue.QValueKindArrayTimestamp, qvalue.QValueKindArrayTimestampTZ,
 			qvalue.QValueKindArrayDate:
-			bqArrayElementType := qValueKindToBigQueryType(colType).Type
+			bqArrayElementType := qValueKindToBigQueryType(column).Type
 			castStmt = fmt.Sprintf("ARRAY(SELECT CAST(element AS %s) FROM "+
 				"UNNEST(CAST(JSON_VALUE_ARRAY(_peerdb_data, '$.%s') AS ARRAY<STRING>)) AS element WHERE element IS NOT null) AS `%s`",
 				bqArrayElementType, column.Name, shortCol)

--- a/flow/connectors/bigquery/qvalue_convert.go
+++ b/flow/connectors/bigquery/qvalue_convert.go
@@ -6,75 +6,134 @@ import (
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 )
 
-func qValueKindToBigQueryType(colType string) bigquery.FieldType {
+func qValueKindToBigQueryType(colType string) bigquery.FieldSchema {
 	switch qvalue.QValueKind(colType) {
 	// boolean
 	case qvalue.QValueKindBoolean:
-		return bigquery.BooleanFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.BooleanFieldType,
+		}
 	// integer types
 	case qvalue.QValueKindInt16, qvalue.QValueKindInt32, qvalue.QValueKindInt64:
-		return bigquery.IntegerFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.IntegerFieldType,
+		}
 	// decimal types
 	case qvalue.QValueKindFloat32, qvalue.QValueKindFloat64:
-		return bigquery.FloatFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.FloatFieldType,
+		}
 	case qvalue.QValueKindNumeric:
-		return bigquery.BigNumericFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.BigNumericFieldType,
+		}
 	// string related
 	case qvalue.QValueKindString:
-		return bigquery.StringFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.StringFieldType,
+		}
 	// json also is stored as string for now
 	case qvalue.QValueKindJSON, qvalue.QValueKindHStore:
-		return bigquery.JSONFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.JSONFieldType,
+		}
 	// time related
 	case qvalue.QValueKindTimestamp, qvalue.QValueKindTimestampTZ:
-		return bigquery.TimestampFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.TimestampFieldType,
+		}
 	// TODO: https://github.com/PeerDB-io/peerdb/issues/189 - DATE support is incomplete
 	case qvalue.QValueKindDate:
-		return bigquery.DateFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.DateFieldType,
+		}
 	// TODO: https://github.com/PeerDB-io/peerdb/issues/189 - TIME/TIMETZ support is incomplete
 	case qvalue.QValueKindTime, qvalue.QValueKindTimeTZ:
-		return bigquery.TimeFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.TimeFieldType,
+		}
 	// TODO: https://github.com/PeerDB-io/peerdb/issues/189 - handle INTERVAL types again,
 	// bytes
 	case qvalue.QValueKindBit, qvalue.QValueKindBytes:
-		return bigquery.BytesFieldType
-	// For Arrays we return the types of the individual elements,
-	// and wherever this function is called, the 'Repeated' attribute of
-	// FieldSchema must be set to true.
+		return bigquery.FieldSchema{
+			Type: bigquery.BytesFieldType,
+		}
 	case qvalue.QValueKindArrayInt16, qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64:
-		return bigquery.IntegerFieldType
+		return bigquery.FieldSchema{
+			Type:     bigquery.IntegerFieldType,
+			Repeated: true,
+		}
 	case qvalue.QValueKindArrayFloat32, qvalue.QValueKindArrayFloat64:
-		return bigquery.FloatFieldType
+		return bigquery.FieldSchema{
+			Type:     bigquery.FloatFieldType,
+			Repeated: true,
+		}
 	case qvalue.QValueKindArrayBoolean:
-		return bigquery.BooleanFieldType
+		return bigquery.FieldSchema{
+			Type:     bigquery.BooleanFieldType,
+			Repeated: true,
+		}
 	case qvalue.QValueKindArrayTimestamp, qvalue.QValueKindArrayTimestampTZ:
-		return bigquery.TimestampFieldType
+		return bigquery.FieldSchema{
+			Type:     bigquery.TimestampFieldType,
+			Repeated: true,
+		}
 	case qvalue.QValueKindArrayDate:
-		return bigquery.DateFieldType
+		return bigquery.FieldSchema{
+			Type:     bigquery.DateFieldType,
+			Repeated: true,
+		}
+	case qvalue.QValueKindArrayString:
+		return bigquery.FieldSchema{
+			Type:     bigquery.StringFieldType,
+			Repeated: true,
+		}
 	case qvalue.QValueKindGeography, qvalue.QValueKindGeometry, qvalue.QValueKindPoint:
-		return bigquery.GeographyFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.GeographyFieldType,
+		}
 	// rest will be strings
 	default:
-		return bigquery.StringFieldType
+		return bigquery.FieldSchema{
+			Type: bigquery.StringFieldType,
+		}
 	}
 }
 
 // BigQueryTypeToQValueKind converts a bigquery.FieldType to a QValueKind
-func BigQueryTypeToQValueKind(fieldType bigquery.FieldType) qvalue.QValueKind {
-	switch fieldType {
+func BigQueryTypeToQValueKind(fieldSchema bigquery.FieldSchema) qvalue.QValueKind {
+	switch fieldSchema.Type {
 	case bigquery.StringFieldType:
+		if fieldSchema.Repeated {
+			return qvalue.QValueKindArrayString
+		}
 		return qvalue.QValueKindString
 	case bigquery.BytesFieldType:
 		return qvalue.QValueKindBytes
 	case bigquery.IntegerFieldType:
+		if fieldSchema.Repeated {
+			return qvalue.QValueKindArrayInt64
+		}
 		return qvalue.QValueKindInt64
 	case bigquery.FloatFieldType:
+		if fieldSchema.Repeated {
+			return qvalue.QValueKindArrayFloat64
+		}
 		return qvalue.QValueKindFloat64
 	case bigquery.BooleanFieldType:
+		if fieldSchema.Repeated {
+			return qvalue.QValueKindArrayBoolean
+		}
 		return qvalue.QValueKindBoolean
 	case bigquery.TimestampFieldType:
+		if fieldSchema.Repeated {
+			return qvalue.QValueKindArrayTimestamp
+		}
 		return qvalue.QValueKindTimestamp
 	case bigquery.DateFieldType:
+		if fieldSchema.Repeated {
+			return qvalue.QValueKindArrayDate
+		}
 		return qvalue.QValueKindDate
 	case bigquery.TimeFieldType:
 		return qvalue.QValueKindTime
@@ -92,22 +151,24 @@ func BigQueryTypeToQValueKind(fieldType bigquery.FieldType) qvalue.QValueKind {
 }
 
 func qValueKindToBigQueryTypeString(colType string) string {
-	bqType := qValueKindToBigQueryType(colType)
-	bqTypeAsString := string(bqType)
-	// string(bigquery.FloatFieldType) is "FLOAT" which is not a BigQuery type.
-	if bqType == bigquery.FloatFieldType {
-		bqTypeAsString = "FLOAT64"
+	bqTypeSchema := qValueKindToBigQueryType(colType)
+	bqType := string(bqTypeSchema.Type)
+	if bqTypeSchema.Type == bigquery.FloatFieldType {
+		bqType = "FLOAT64"
 	}
-	if bqType == bigquery.BooleanFieldType {
-		bqTypeAsString = "BOOL"
+	if bqTypeSchema.Type == bigquery.BooleanFieldType {
+		bqType = "BOOL"
 	}
-	return bqTypeAsString
+	if bqTypeSchema.Repeated {
+		return "ARRAY<" + bqType + ">"
+	}
+	return bqType
 }
 
 func BigQueryFieldToQField(bqField *bigquery.FieldSchema) qvalue.QField {
 	return qvalue.QField{
 		Name:      bqField.Name,
-		Type:      BigQueryTypeToQValueKind(bqField.Type),
+		Type:      BigQueryTypeToQValueKind(*bqField),
 		Precision: int16(bqField.Precision),
 		Scale:     int16(bqField.Scale),
 		Nullable:  !bqField.Required,

--- a/flow/connectors/bigquery/qvalue_convert.go
+++ b/flow/connectors/bigquery/qvalue_convert.go
@@ -77,7 +77,7 @@ func qValueKindToBigQueryType(columnDescription *protos.FieldDescription) bigque
 }
 
 // BigQueryTypeToQValueKind converts a bigquery.FieldType to a QValueKind
-func BigQueryTypeToQValueKind(fieldSchema bigquery.FieldSchema) qvalue.QValueKind {
+func BigQueryTypeToQValueKind(fieldSchema *bigquery.FieldSchema) qvalue.QValueKind {
 	switch fieldSchema.Type {
 	case bigquery.StringFieldType:
 		if fieldSchema.Repeated {
@@ -147,7 +147,7 @@ func qValueKindToBigQueryTypeString(columnDescription *protos.FieldDescription) 
 func BigQueryFieldToQField(bqField *bigquery.FieldSchema) qvalue.QField {
 	return qvalue.QField{
 		Name:      bqField.Name,
-		Type:      BigQueryTypeToQValueKind(*bqField),
+		Type:      BigQueryTypeToQValueKind(bqField),
 		Precision: int16(bqField.Precision),
 		Scale:     int16(bqField.Scale),
 		Nullable:  !bqField.Required,

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -771,18 +771,6 @@ func (s PeerFlowE2ETestSuiteBQ) Test_All_Types_Schema_Changes_BQ() {
 	e2e.EnvNoError(s.t, env, err)
 	s.t.Log("Inserted rows of various types from c2 to c6 in the source table")
 
-	e2e.EnvWaitFor(s.t, env, 5*time.Minute, "normalize altered row c2 to c6 row count", func() bool {
-		rows, err := s.bqHelper.countRows(tableName)
-		if err != nil {
-			s.t.Log(err)
-			return false
-		}
-		if rows != 2 {
-			return false
-		}
-		return true
-	})
-
 	e2e.EnvWaitForEqualTables(env, s, "normalize altered row c2 to c6 table check", tableName,
 		"id,c1,c2,c3,c4,c5,c6")
 

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -763,7 +763,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_All_Types_Schema_Changes_BQ() {
 		ADD COLUMN c11 JSON,
 		ADD COLUMN c12 FLOAT,
 		ADD COLUMN c13 DATE,
-		ADD COLUMN c14 TIMESTAMP,
+		ADD COLUMN c14 TIMESTAMP;
 		`,
 		srcTableName))
 	e2e.EnvNoError(s.t, env, err)

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -713,6 +713,89 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Simple_Schema_Changes_BQ() {
 	e2e.RequireEnvCanceled(s.t, env)
 }
 
+func (s PeerFlowE2ETestSuiteBQ) Test_All_Types_Schema_Changes_BQ() {
+	tc := e2e.NewTemporalClient(s.t)
+
+	tableName := "test_all_types_schema_changes"
+	srcTableName := s.attachSchemaSuffix(tableName)
+
+	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+			c1 BIGINT
+		);
+	`, srcTableName))
+	require.NoError(s.t, err)
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix(tableName),
+		TableNameMapping: map[string]string{srcTableName: tableName},
+		Destination:      s.bqHelper.Peer,
+	}
+
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs()
+	flowConnConfig.MaxBatchSize = 100
+
+	// wait for PeerFlowStatusQuery to finish setup
+	// and then insert and mutate schema repeatedly.
+	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	// insert first row.
+	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+		INSERT INTO %s(c1) VALUES (1)`, srcTableName))
+	e2e.EnvNoError(s.t, env, err)
+	s.t.Log("Inserted initial row in the source table")
+
+	e2e.EnvWaitForEqualTables(env, s, "normalize insert", tableName, "id,c1")
+
+	// alter source table, add column c2 and insert another row.
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+		ALTER TABLE %s
+		ADD COLUMN c2 INTEGER[],
+		ADD COLUMN c3 FLOAT[],
+		ADD COLUMN c4 TEXT[],
+		ADD COLUMN c5 TIMESTAMP[],
+		ADD COLUMN c6 DATE[],
+		ADD COLUMN c7 BOOL[],
+		ADD COLUMN c8 BIGINT,
+		ADD COLUMN c9 NUMERIC,
+		ADD COLUMN c10 DOUBLE PRECISION,
+		ADD COLUMN c11 JSON,
+		ADD COLUMN c12 FLOAT,
+		ADD COLUMN c13 DATE,
+		ADD COLUMN c14 TIMESTAMP,
+		`,
+		srcTableName))
+	e2e.EnvNoError(s.t, env, err)
+	s.t.Log("Altered source table, added column c2")
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+		INSERT INTO %s(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14) VALUES (
+		2,
+		'{4,5,6}',
+		'{43.342,34.111}',
+		'{"derer","asa","vdv"}',
+		'{"2020-01-01 01:01:01","2020-01-02 01:01:01"}',
+		'{"2020-01-01","2020-01-02"}',
+		'{true,false}',
+		2,
+		2.3245234,
+		2.3,
+		'{"sai":1}',
+		2.34343,
+		'2020-01-01',
+		'2020-01-01 01:01:01'
+		)`, srcTableName))
+	e2e.EnvNoError(s.t, env, err)
+	s.t.Log("Inserted rows of various types from c2 to c14 in the source table")
+
+	// verify we got our two rows, if schema did not match up it will error.
+	e2e.EnvWaitForEqualTables(env, s, "normalize altered row", tableName,
+		"id,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14")
+
+	env.Cancel()
+	e2e.RequireEnvCanceled(s.t, env)
+}
+
 func (s PeerFlowE2ETestSuiteBQ) Test_Composite_PKey_BQ() {
 	tc := e2e.NewTemporalClient(s.t)
 


### PR DESCRIPTION
Refactors `qvalue_convert.go` to now use `bigquery.FieldSchema` and not `FieldType`. No need to rely on hacks like `IsArray` while creating tables
Functionally tested with cdc and schema change of array