### PR TITLE
fixing misc UI issues

### DIFF
--- a/ui/app/mirrors/[mirrorId]/configValues.ts
+++ b/ui/app/mirrors/[mirrorId]/configValues.ts
@@ -26,6 +26,12 @@ const MirrorValues = (mirrorConfig: FlowConnectionConfigs | undefined) => {
       value: mirrorConfig?.script,
       label: 'Script',
     },
+    {
+      value:
+        mirrorConfig?.publicationName ||
+        `peerflow_pub_${mirrorConfig?.flowJobName}`,
+      label: 'Publication Name',
+    },
   ];
 };
 export default MirrorValues;

--- a/ui/app/mirrors/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/page.tsx
@@ -96,9 +96,8 @@ export default async function ViewMirror({
       mirrorStatus.currentFlowState.toString() !==
       FlowStatus[FlowStatus.STATUS_PAUSED];
     const canResync =
-      (mirrorStatus.currentFlowState.toString() ===
-        FlowStatus[FlowStatus.STATUS_RUNNING] ||
-        !isNotPaused) &&
+      mirrorStatus.currentFlowState.toString() !==
+        FlowStatus[FlowStatus.STATUS_SETUP] &&
       (dbType.valueOf() === DBType.BIGQUERY.valueOf() ||
         dbType.valueOf() === DBType.SNOWFLAKE.valueOf());
 

--- a/ui/app/mirrors/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/page.tsx
@@ -92,8 +92,10 @@ export default async function ViewMirror({
 
     const dbType = mirrorConfig.destination!.type;
     const canResync =
-      dbType.valueOf() === DBType.BIGQUERY.valueOf() ||
-      dbType.valueOf() === DBType.SNOWFLAKE.valueOf();
+      mirrorStatus.currentFlowState.toString() ===
+        FlowStatus[FlowStatus.STATUS_RUNNING] &&
+      (dbType.valueOf() === DBType.BIGQUERY.valueOf() ||
+        dbType.valueOf() === DBType.SNOWFLAKE.valueOf());
 
     const isNotPaused =
       mirrorStatus.currentFlowState.toString() !==

--- a/ui/app/mirrors/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/page.tsx
@@ -91,15 +91,16 @@ export default async function ViewMirror({
     );
 
     const dbType = mirrorConfig.destination!.type;
-    const canResync =
-      mirrorStatus.currentFlowState.toString() ===
-        FlowStatus[FlowStatus.STATUS_RUNNING] &&
-      (dbType.valueOf() === DBType.BIGQUERY.valueOf() ||
-        dbType.valueOf() === DBType.SNOWFLAKE.valueOf());
 
     const isNotPaused =
       mirrorStatus.currentFlowState.toString() !==
       FlowStatus[FlowStatus.STATUS_PAUSED];
+    const canResync =
+      (mirrorStatus.currentFlowState.toString() ===
+        FlowStatus[FlowStatus.STATUS_RUNNING] ||
+        !isNotPaused) &&
+      (dbType.valueOf() === DBType.BIGQUERY.valueOf() ||
+        dbType.valueOf() === DBType.SNOWFLAKE.valueOf());
 
     actionsDropdown = (
       <MirrorActions

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -91,7 +91,11 @@ export default function CDCConfigForm({
         mirrorConfig.destination?.type !== DBType.POSTGRES) &&
         label.includes('type system')) ||
       (mirrorConfig.destination?.type !== DBType.BIGQUERY &&
-        label.includes('column name'))
+        label.includes('column name')) ||
+      (label.includes('soft delete') &&
+        ![DBType.BIGQUERY, DBType.POSTGRES, DBType.SNOWFLAKE].includes(
+          mirrorConfig.destination?.type ?? DBType.UNRECOGNIZED
+        ))
     ) {
       return false;
     }

--- a/ui/app/mirrors/create/qrep/qrep.tsx
+++ b/ui/app/mirrors/create/qrep/qrep.tsx
@@ -27,6 +27,13 @@ const WriteModes = ['Append', 'Upsert', 'Overwrite'].map((value) => ({
   label: value,
   value,
 }));
+const allowedTypesForWatermarkColumn = [
+  'smallint',
+  'integer',
+  'bigint',
+  'timestamp without time zone',
+  'timestamp with time zone',
+];
 
 export default function QRepConfigForm({
   settings,
@@ -88,14 +95,17 @@ export default function QRepConfigForm({
       schema,
       table,
       setLoading
-    ).then((cols) =>
+    ).then((cols) => {
+      const filteredCols = cols?.filter((col) =>
+        allowedTypesForWatermarkColumn.includes(col.split(':')[1])
+      );
       setWatermarkColumns(
-        cols?.map((col) => ({
+        filteredCols.map((col) => ({
           value: col.split(':')[0],
           label: `${col.split(':')[0]} (${col.split(':')[1]})`,
         }))
-      )
-    );
+      );
+    });
   };
 
   const handleSourceChange = (


### PR DESCRIPTION
1. soft delete toggle is only available for BQ, SF and PG destinations since other peers have issues.
2. Resync is only enabled when mirror is running or paused.
3. Watermark column dropdown only displays supported types (currently 5)
4. Publication name is now visible in CDC mirrors status page, if empty in config filling using default publication name

Closes #1778, #1777 and #1767 