### PR TITLE
Avro JSON size limit based truncation: make it empty object

### DIFF
--- a/flow/model/record_items.go
+++ b/flow/model/record_items.go
@@ -125,7 +125,7 @@ func (r RecordItems) toMap(opts ToJSONOptions) (map[string]interface{}, error) {
 			}
 		case qvalue.QValueJSON:
 			if len(v.Val) > 15*1024*1024 {
-				jsonStruct[col] = ""
+				jsonStruct[col] = "{}"
 			} else if _, ok := opts.UnnestColumns[col]; ok {
 				var unnestStruct map[string]interface{}
 				err := json.Unmarshal([]byte(v.Val), &unnestStruct)


### PR DESCRIPTION
When we truncate jsons for abiding by the avro size limit, we set it to empty string, which is not a valid json. Instead set it to empty object. 
An issue was seen due to this in BigQuery merge statement where parse_json fails
Functionally tested