### PR TITLE
Fix addition of tables to a resynced mirror

### DIFF
--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -125,7 +125,7 @@ func processCDCFlowConfigUpdate(
 		additionalTablesCfg.DoInitialSnapshot = true
 		additionalTablesCfg.InitialSnapshotOnly = true
 		additionalTablesCfg.TableMappings = flowConfigUpdate.AdditionalTables
-
+		additionalTablesCfg.Resync = false
 		// execute the sync flow as a child workflow
 		childAdditionalTablesCDCFlowOpts := workflow.ChildWorkflowOptions{
 			WorkflowID:        childAdditionalTablesCDCFlowID,


### PR DESCRIPTION
Currently, when we add a table to a mirror which has been resynced (therefore the mirror config has resync = true), the add tables flow inherits the resync = true property and so tries to "resync" the added tables, which fails at the soft delete handling step as the table was never pre-existing on target
This PR sets resync to false for add tables flow