### PR TITLE
GetQRepParts: increase activity startToClose timeout, retry max interval

### DIFF
--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -179,7 +179,7 @@ func (q *QRepFlowExecution) getPartitions(
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,
 			BackoffCoefficient:     2.,
-			MaximumInterval:        time.Hour,
+			MaximumInterval:        10 * time.Minute,
 			MaximumAttempts:        0,
 			NonRetryableErrorTypes: nil,
 		},

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -174,7 +174,7 @@ func (q *QRepFlowExecution) getPartitions(
 	q.logger.Info("fetching partitions to replicate for peer flow")
 
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 5 * time.Hour,
+		StartToCloseTimeout: 72 * time.Hour,
 		HeartbeatTimeout:    time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,


### PR DESCRIPTION
We are seeing cases where getting min, max, count and partitions can take well over 5 hours
Also apply the same settings as replicateQrepPartition: make sure we dont have 1 hour wait for retry