### PR TITLE
dynamically configure number of syncs per CDC flow

### DIFF
--- a/flow/peerdbenv/dynamicconf.go
+++ b/flow/peerdbenv/dynamicconf.go
@@ -163,3 +163,8 @@ func PeerDBClickhouseAWSS3BucketName(ctx context.Context) (string, error) {
 func PeerDBQueueForceTopicCreation(ctx context.Context) (bool, error) {
 	return dynamicConfBool(ctx, "PEERDB_QUEUE_FORCE_TOPIC_CREATION")
 }
+
+// experimental, don't increase to greater than 64
+func PeerDBMaxSyncsPerCDCFlow(ctx context.Context) (uint32, error) {
+	return dynamicConfUnsigned[uint32](ctx, "PEERDB_MAX_SYNCS_PER_CDC_FLOW")
+}

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -81,10 +81,6 @@ func GetChildWorkflowID(
 // CDCFlowWorkflowResult is the result of the PeerFlowWorkflow.
 type CDCFlowWorkflowResult = CDCFlowWorkflowState
 
-const (
-	maxSyncsPerCdcFlow = 32
-)
-
 func processCDCFlowConfigUpdate(
 	ctx workflow.Context,
 	logger log.Logger,
@@ -526,7 +522,7 @@ func CDCFlowWorkflow(
 			return state, err
 		}
 
-		if state.ActiveSignal == model.PauseSignal || syncCount >= maxSyncsPerCdcFlow {
+		if state.ActiveSignal == model.PauseSignal || syncCount >= int(getMaxSyncsPerCDCFlow(ctx, logger)) {
 			restart = true
 			if syncFlowFuture != nil {
 				err := model.SyncStopSignal.SignalChildWorkflow(ctx, syncFlowFuture, struct{}{}).Get(ctx, nil)

--- a/nexus/catalog/migrations/V31__more_more_dynconf_settings.sql
+++ b/nexus/catalog/migrations/V31__more_more_dynconf_settings.sql
@@ -1,0 +1,4 @@
+INSERT INTO dynamic_settings (config_name,config_default_value,config_value_type,config_description,config_apply_mode)
+VALUES
+('PEERDB_MAX_SYNCS_PER_CDC_FLOW','32',3,'Experimental setting: changes number of syncs per workflow, affects frequency of replication slot disconnects',1)
+ ON CONFLICT DO NOTHING;


### PR DESCRIPTION
currently limit to 64, need to raise SyncFlow's restart threshold otherwise