### PR TITLE
Slack alerts : can now specify members to tag in the channel

### DIFF
--- a/flow/alerting/slack_alert_sender.go
+++ b/flow/alerting/slack_alert_sender.go
@@ -12,9 +12,9 @@ type SlackAlertSender struct {
 	AlertSender
 	client                        *slack.Client
 	channelIDs                    []string
+	members                       []string
 	slotLagMBAlertThreshold       uint32
 	openConnectionsAlertThreshold uint32
-	members                       []string
 }
 
 func (s *SlackAlertSender) getSlotLagMBAlertThreshold() uint32 {
@@ -28,9 +28,9 @@ func (s *SlackAlertSender) getOpenConnectionsAlertThreshold() uint32 {
 type slackAlertConfig struct {
 	AuthToken                     string   `json:"auth_token"`
 	ChannelIDs                    []string `json:"channel_ids"`
+	Members                       []string `json:"members"`
 	SlotLagMBAlertThreshold       uint32   `json:"slot_lag_mb_alert_threshold"`
 	OpenConnectionsAlertThreshold uint32   `json:"open_connections_alert_threshold"`
-	Members                       []string `json:"members"`
 }
 
 func newSlackAlertSender(config *slackAlertConfig) *SlackAlertSender {

--- a/flow/alerting/slack_alert_sender.go
+++ b/flow/alerting/slack_alert_sender.go
@@ -46,8 +46,9 @@ func newSlackAlertSender(config *slackAlertConfig) *SlackAlertSender {
 func (s *SlackAlertSender) sendAlert(ctx context.Context, alertTitle string, alertMessage string) error {
 	for _, channelID := range s.channelIDs {
 		var ccMembersPart strings.Builder
-		ccMembersPart.WriteString("cc: <!channel>")
-		if len(s.members) > 0 {
+		if len(s.members) == 0 {
+			ccMembersPart.WriteString("cc: <!channel>")
+		} else {
 			ccMembersPart.WriteString("cc: @" + s.members[0])
 			for _, member := range s.members[1:] {
 				ccMembersPart.WriteString(" @" + member)

--- a/flow/alerting/slack_alert_sender.go
+++ b/flow/alerting/slack_alert_sender.go
@@ -51,7 +51,8 @@ func (s *SlackAlertSender) sendAlert(ctx context.Context, alertTitle string, ale
 		} else {
 			ccMembersPart.WriteString("cc:")
 			for _, member := range s.members {
-				ccMembersPart.WriteString(" @" + member)
+				ccMembersPart.WriteString(" @")
+				ccMembersPart.WriteString(member)
 			}
 		}
 		_, _, _, err := s.client.SendMessageContext(ctx, channelID, slack.MsgOptionBlocks(

--- a/flow/alerting/slack_alert_sender.go
+++ b/flow/alerting/slack_alert_sender.go
@@ -49,8 +49,8 @@ func (s *SlackAlertSender) sendAlert(ctx context.Context, alertTitle string, ale
 		if len(s.members) == 0 {
 			ccMembersPart.WriteString("cc: <!channel>")
 		} else {
-			ccMembersPart.WriteString("cc: @" + s.members[0])
-			for _, member := range s.members[1:] {
+			ccMembersPart.WriteString("cc:")
+			for _, member := range s.members {
 				ccMembersPart.WriteString(" @" + member)
 			}
 		}

--- a/flow/alerting/slack_alert_sender.go
+++ b/flow/alerting/slack_alert_sender.go
@@ -13,6 +13,7 @@ type SlackAlertSender struct {
 	channelIDs                    []string
 	slotLagMBAlertThreshold       uint32
 	openConnectionsAlertThreshold uint32
+	members                       []string
 }
 
 func (s *SlackAlertSender) getSlotLagMBAlertThreshold() uint32 {
@@ -28,6 +29,7 @@ type slackAlertConfig struct {
 	ChannelIDs                    []string `json:"channel_ids"`
 	SlotLagMBAlertThreshold       uint32   `json:"slot_lag_mb_alert_threshold"`
 	OpenConnectionsAlertThreshold uint32   `json:"open_connections_alert_threshold"`
+	Members                       []string `json:"members"`
 }
 
 func newSlackAlertSender(config *slackAlertConfig) *SlackAlertSender {
@@ -36,14 +38,22 @@ func newSlackAlertSender(config *slackAlertConfig) *SlackAlertSender {
 		channelIDs:                    config.ChannelIDs,
 		slotLagMBAlertThreshold:       config.SlotLagMBAlertThreshold,
 		openConnectionsAlertThreshold: config.OpenConnectionsAlertThreshold,
+		members:                       config.Members,
 	}
 }
 
 func (s *SlackAlertSender) sendAlert(ctx context.Context, alertTitle string, alertMessage string) error {
 	for _, channelID := range s.channelIDs {
+		ccMembersPart := "cc: <!channel>"
+		if len(s.members) > 0 {
+			ccMembersPart = "cc: @" + s.members[0]
+			for _, member := range s.members[1:] {
+				ccMembersPart += " @" + member
+			}
+		}
 		_, _, _, err := s.client.SendMessageContext(ctx, channelID, slack.MsgOptionBlocks(
 			slack.NewHeaderBlock(slack.NewTextBlockObject("plain_text", ":rotating_light:Alert:rotating_light:: "+alertTitle, true, false)),
-			slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", alertMessage+"\ncc: <!channel>", false, false), nil, nil),
+			slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", alertMessage+"\n"+ccMembersPart, false, false), nil, nil),
 		))
 		if err != nil {
 			return fmt.Errorf("failed to send message to Slack channel %s: %w", channelID, err)

--- a/ui/app/alert-config/new.tsx
+++ b/ui/app/alert-config/new.tsx
@@ -86,8 +86,8 @@ function getSlackProps(
       <div>
         <p>Members</p>
         <Label as='label' style={{ fontSize: 14 }}>
-          Slack usernames to ping for these alerts. If left empty, pings the
-          whole channel
+          Slack usernames to tag in the channel for these alerts. If left empty,
+          pings the whole channel
         </Label>
         <TextField
           key={'members'}

--- a/ui/app/alert-config/new.tsx
+++ b/ui/app/alert-config/new.tsx
@@ -1,6 +1,8 @@
 import { Button } from '@/lib/Button';
+import { Label } from '@/lib/Label/Label';
 import { TextField } from '@/lib/TextField';
 import Image from 'next/image';
+import Link from 'next/link';
 import { Dispatch, SetStateAction, useState } from 'react';
 import ReactSelect from 'react-select';
 import { PulseLoader } from 'react-spinners';
@@ -77,6 +79,26 @@ function getSlackProps(
             setConfig((previous) => ({
               ...previous,
               channel_ids: e.target.value.split(','),
+            }));
+          }}
+        />
+      </div>
+      <div>
+        <p>Members</p>
+        <Label as='label' style={{ fontSize: 14 }}>
+          Slack usernames to ping for these alerts. If left empty, pings the
+          whole channel
+        </Label>
+        <TextField
+          key={'members'}
+          style={{ height: '2.5rem', marginTop: '0.5rem' }}
+          variant='simple'
+          placeholder='Comma separated'
+          value={config.members?.join(',')}
+          onChange={(e) => {
+            setConfig((previous) => ({
+              ...previous,
+              members: e.target.value.split(','),
             }));
           }}
         />
@@ -196,7 +218,7 @@ export function NewConfig(alertProps: AlertConfigProps) {
       style={{
         display: 'flex',
         flexDirection: 'column',
-        rowGap: '2rem',
+        rowGap: '1.5rem',
         marginTop: '3rem',
         width: '40%',
       }}
@@ -225,6 +247,16 @@ export function NewConfig(alertProps: AlertConfigProps) {
           theme={SelectTheme}
         />
       </div>
+      {serviceType === 'slack' && (
+        <Label
+          as={Link}
+          target='_blank'
+          href='https://docs.peerdb.io/features/alerting/slack-alerting'
+          style={{ color: 'teal', cursor: 'pointer', width: 'fit-content' }}
+        >
+          How to setup Slack alerting
+        </Label>
+      )}
       <div>
         <p>Slot Lag Alert Threshold (in GB)</p>
         <TextField

--- a/ui/app/alert-config/validation.ts
+++ b/ui/app/alert-config/validation.ts
@@ -29,6 +29,7 @@ export const slackServiceConfigSchema = z.intersection(
         }
       )
       .min(1, { message: 'Atleast one channel ID is needed' }),
+    members: z.array(z.string().trim()).optional(),
   })
 );
 


### PR DESCRIPTION
Adds a Members field in UI where you can add comma separated slack usernames to tag in the channel. If left empty, tags the whole channel
Also adds a guide to slack alerting in the alerts UI

Functionally tested:
<img width="818" alt="Screenshot 2024-06-14 at 2 00 40 AM" src="https://github.com/PeerDB-io/peerdb/assets/65964360/1acdde2b-6955-49d0-9064-dc5af7338473">

