### PR TITLE
Clickhouse: Fix setting of normalize batch ID

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -156,7 +156,6 @@ func (c *ClickhouseConnector) NormalizeRecords(ctx context.Context, req *model.N
 
 	// model the raw table data as inserts.
 	for _, tbl := range destinationTableNames {
-		// SELECT projection FROM raw_table WHERE _peerdb_batch_id > normalize_batch_id AND _peerdb_batch_id <= sync_batch_id
 		selectQuery := strings.Builder{}
 		selectQuery.WriteString("SELECT ")
 
@@ -233,8 +232,7 @@ func (c *ClickhouseConnector) NormalizeRecords(ctx context.Context, req *model.N
 		}
 	}
 
-	endNormalizeBatchId := normBatchID + 1
-	err = c.UpdateNormalizeBatchID(ctx, req.FlowJobName, endNormalizeBatchId)
+	err = c.UpdateNormalizeBatchID(ctx, req.FlowJobName, req.SyncBatchID)
 	if err != nil {
 		c.logger.Error("[clickhouse] error while updating normalize batch id", "error", err)
 		return nil, err
@@ -242,7 +240,7 @@ func (c *ClickhouseConnector) NormalizeRecords(ctx context.Context, req *model.N
 
 	return &model.NormalizeResponse{
 		Done:         true,
-		StartBatchID: endNormalizeBatchId,
+		StartBatchID: normBatchID + 1,
 		EndBatchID:   req.SyncBatchID,
 	}, nil
 }

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -129,6 +129,7 @@ func (c *ClickhouseConnector) NormalizeRecords(ctx context.Context, req *model.N
 
 	// normalize has caught up with sync, chill until more records are loaded.
 	if normBatchID >= req.SyncBatchID {
+		c.logger.Warn("[clickhouse] encountered normBatchID >= req.SyncBatchID", "normBatchID", normBatchID, "syncBatchID", req.SyncBatchID)
 		return &model.NormalizeResponse{
 			Done:         false,
 			StartBatchID: normBatchID,


### PR DESCRIPTION
At the end of NormalizeRecords in Clickhouse, we were updating the normalize batch ID in metadata with `normBatchID + 1`.
Clickhouse's NormalizeRecords (like postgres) normalizes from normBatchID to syncBatchId. Hence we should update the normalize batch id in metadata to sync batch ID, not normbatchID + 1. This is also what the other destinations do

This PR fixes this batch id setting and also adds a warning log for normbatchid >= syncbatchid