### PR TITLE
UI: Fix display of partitioned tables

### DIFF
--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -95,6 +95,7 @@ func (h *FlowRequestHandler) GetTablesInSchema(
 	}
 
 	relKindFilterClause := "t.relkind IN ('r', 'p')"
+	// publish_via_partition_root is only available in PG13 and above
 	if pgVersion <= shared.POSTGRES_13 {
 		relKindFilterClause = "t.relkind = 'r'"
 	}

--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -95,7 +95,7 @@ func (h *FlowRequestHandler) GetTablesInSchema(
 	}
 
 	relKindFilterClause := "t.relkind IN ('r', 'p')"
-	if pgVersion <= shared.POSTGRES_12 {
+	if pgVersion <= shared.POSTGRES_13 {
 		relKindFilterClause = "t.relkind = 'r'"
 	}
 

--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -12,6 +12,7 @@ import (
 
 	connpostgres "github.com/PeerDB-io/peer-flow/connectors/postgres"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/shared"
 )
 
 func (h *FlowRequestHandler) getPGPeerConfig(ctx context.Context, peerName string) (*protos.PostgresConfig, error) {
@@ -87,6 +88,17 @@ func (h *FlowRequestHandler) GetTablesInSchema(
 	defer tunnel.Close()
 	defer peerConn.Close(ctx)
 
+	pgVersion, err := shared.GetMajorVersion(ctx, peerConn)
+	if err != nil {
+		slog.Error("unable to get pgversion for schema tables", slog.Any("error", err))
+		return &protos.SchemaTablesResponse{Tables: nil}, err
+	}
+
+	relKindFilterClause := "t.relkind IN ('r', 'p')"
+	if pgVersion <= shared.POSTGRES_12 {
+		relKindFilterClause = "t.relkind = 'r'"
+	}
+
 	rows, err := peerConn.Query(ctx, `SELECT DISTINCT ON (t.relname)
 		t.relname,
 		(con.contype = 'p' OR t.relreplident in ('i', 'f')) AS can_mirror,
@@ -94,7 +106,9 @@ func (h *FlowRequestHandler) GetTablesInSchema(
 	FROM pg_class t
 	LEFT JOIN pg_namespace n ON t.relnamespace = n.oid
 	LEFT JOIN pg_constraint con ON con.conrelid = t.oid
-	WHERE n.nspname = $1 AND t.relkind = 'r' ORDER BY t.relname, can_mirror DESC;
+	WHERE n.nspname = $1 AND `+
+		relKindFilterClause+
+		`AND t.relispartition IS NOT TRUE ORDER BY t.relname, can_mirror DESC;
 `, req.SchemaName)
 	if err != nil {
 		slog.Info("failed to fetch publications", slog.Any("error", err))


### PR DESCRIPTION
```
t.relispartition IS NOT TRUE ORDER BY t.relname, can_mirror DESC;
```
this is so that we only show the root table as we use publish_via_partition_root