### PR TITLE
Revert "Add primary key check for validate mirror (#1773)"

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -171,9 +171,6 @@ func (c *PostgresConnector) getReplicaIdentityIndexColumns(
          WHERE indrelid=$1 AND indisreplident=true`,
 		relID).Scan(&indexRelID)
 	if err != nil {
-		if err == pgx.ErrNoRows {
-			return nil, fmt.Errorf("no replica identity index for table %s", schemaTable)
-		}
 		return nil, fmt.Errorf("error finding replica identity index for table %s: %w", schemaTable, err)
 	}
 

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -171,6 +171,9 @@ func (c *PostgresConnector) getReplicaIdentityIndexColumns(
          WHERE indrelid=$1 AND indisreplident=true`,
 		relID).Scan(&indexRelID)
 	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, fmt.Errorf("no replica identity index for table %s", schemaTable)
+		}
 		return nil, fmt.Errorf("error finding replica identity index for table %s: %w", schemaTable, err)
 	}
 


### PR DESCRIPTION
This reverts commit 0923a68f3139b3347864bb258c6fd7091fad96b4.

Faced an issue with a customer instance where this check was throwing errors but SetupFlow passed successfully on removing the check. 
This blocks mirror creation so getting the reversion in first and then will re-apply the feature fixed