### PR TITLE
model toMap: encode to binary faster

### DIFF
--- a/flow/connectors/utils/stream.go
+++ b/flow/connectors/utils/stream.go
@@ -79,7 +79,6 @@ func recordToQRecordOrError[Items model.Items](batchID int64, record model.Recor
 	var entries [8]qvalue.QValue
 	switch typedRecord := record.(type) {
 	case *model.InsertRecord[Items]:
-		// json.Marshal converts bytes in Hex automatically to BASE64 string.
 		itemsJSON, err := model.ItemsToJSON(typedRecord.Items)
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize insert record items to JSON: %w", err)

--- a/flow/model/record_items.go
+++ b/flow/model/record_items.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -88,29 +89,21 @@ func (r RecordItems) toMap(opts ToJSONOptions) (map[string]interface{}, error) {
 
 		switch v := qv.(type) {
 		case qvalue.QValueBit:
-			bitVal := v.Val
-
-			// convert to binary string because
-			// json.Marshal stores byte arrays as
-			// base64
-			binStr := ""
-			for _, b := range bitVal {
-				binStr += fmt.Sprintf("%08b", b)
+			// convert to binary string since json.Marshal stores byte arrays as base64
+			var binStr strings.Builder
+			binStr.Grow(len(v.Val) * 8)
+			for _, b := range v.Val {
+				binStr.WriteString(fmt.Sprintf("%08b", b))
 			}
-
-			jsonStruct[col] = binStr
+			jsonStruct[col] = binStr.String()
 		case qvalue.QValueBytes:
-			bitVal := v.Val
-
-			// convert to binary string because
-			// json.Marshal stores byte arrays as
-			// base64
-			binStr := ""
-			for _, b := range bitVal {
-				binStr += fmt.Sprintf("%08b", b)
+			// convert to binary string since json.Marshal stores byte arrays as base64
+			var binStr strings.Builder
+			binStr.Grow(len(v.Val) * 8)
+			for _, b := range v.Val {
+				binStr.WriteString(fmt.Sprintf("%08b", b))
 			}
-
-			jsonStruct[col] = binStr
+			jsonStruct[col] = binStr.String()
 		case qvalue.QValueUUID:
 			jsonStruct[col] = uuid.UUID(v.Val)
 		case qvalue.QValueQChar:


### PR DESCRIPTION
Ideally we'd handle base64/hex instead of binary strings, but this does the bad thing faster