### PR TITLE
fix update handler breaking with Temporal update

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -397,10 +397,6 @@ func (h *FlowRequestHandler) FlowStateChange(
 	if req.RequestedFlowState != protos.FlowStatus_STATUS_UNKNOWN {
 		if req.RequestedFlowState == protos.FlowStatus_STATUS_PAUSED &&
 			currState == protos.FlowStatus_STATUS_RUNNING {
-			err = h.updateWorkflowStatus(ctx, workflowID, protos.FlowStatus_STATUS_PAUSING)
-			if err != nil {
-				return nil, err
-			}
 			err = model.FlowSignal.SignalClientWorkflow(
 				ctx,
 				h.temporalClient,
@@ -419,10 +415,6 @@ func (h *FlowRequestHandler) FlowStateChange(
 			)
 		} else if req.RequestedFlowState == protos.FlowStatus_STATUS_TERMINATED &&
 			(currState != protos.FlowStatus_STATUS_TERMINATED) {
-			err = h.updateWorkflowStatus(ctx, workflowID, protos.FlowStatus_STATUS_TERMINATING)
-			if err != nil {
-				return nil, err
-			}
 			_, err = h.ShutdownFlow(ctx, &protos.ShutdownRequest{
 				FlowJobName: req.FlowJobName,
 			})

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgtype"
-	"go.temporal.io/sdk/client"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -368,24 +367,6 @@ func (h *FlowRequestHandler) getWorkflowStatus(ctx context.Context, workflowID s
 			fmt.Errorf("failed to get status in workflow with ID %s: %w", workflowID, err)
 	}
 	return state, nil
-}
-
-func (h *FlowRequestHandler) updateWorkflowStatus(
-	ctx context.Context,
-	workflowID string,
-	state protos.FlowStatus,
-) error {
-	_, err := h.temporalClient.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
-		WorkflowID:   workflowID,
-		UpdateName:   shared.FlowStatusUpdate,
-		Args:         []interface{}{state},
-		WaitForStage: client.WorkflowUpdateStageCompleted,
-	})
-	if err != nil {
-		slog.Error(fmt.Sprintf("failed to update state in workflow with ID %s: %s", workflowID, err.Error()))
-		return fmt.Errorf("failed to update state in workflow with ID %s: %w", workflowID, err)
-	}
-	return nil
 }
 
 func (h *FlowRequestHandler) getCDCWorkflowState(ctx context.Context,

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -376,9 +376,10 @@ func (h *FlowRequestHandler) updateWorkflowStatus(
 	state protos.FlowStatus,
 ) error {
 	_, err := h.temporalClient.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
-		WorkflowID: workflowID,
-		UpdateName: shared.FlowStatusUpdate,
-		Args:       []interface{}{state},
+		WorkflowID:   workflowID,
+		UpdateName:   shared.FlowStatusUpdate,
+		Args:         []interface{}{state},
+		WaitForStage: client.WorkflowUpdateStageCompleted,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("failed to update state in workflow with ID %s: %s", workflowID, err.Error()))

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -14,9 +14,6 @@ const (
 	CDCFlowStateQuery  = "q-cdc-flow-state"
 	QRepFlowStateQuery = "q-qrep-flow-state"
 	FlowStatusQuery    = "q-flow-status"
-
-	// Updates
-	FlowStatusUpdate = "u-flow-status"
 )
 
 const MirrorNameSearchAttribute = "MirrorName"

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -209,13 +209,6 @@ func CDCFlowWorkflow(
 	if err != nil {
 		return state, fmt.Errorf("failed to set `%s` query handler: %w", shared.FlowStatusQuery, err)
 	}
-	err = workflow.SetUpdateHandler(ctx, shared.FlowStatusUpdate, func(_ workflow.Context, status protos.FlowStatus) error {
-		state.CurrentFlowStatus = status
-		return nil
-	})
-	if err != nil {
-		return state, fmt.Errorf("failed to set `%s` update handler: %w", shared.FlowStatusUpdate, err)
-	}
 
 	mirrorNameSearch := map[string]interface{}{
 		shared.MirrorNameSearchAttribute: cfg.FlowJobName,

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -424,17 +424,8 @@ func (q *QRepFlowExecution) handleTableRenameForResync(ctx workflow.Context, sta
 }
 
 func setWorkflowQueries(ctx workflow.Context, state *protos.QRepFlowState) error {
-	// Support an Update for the current status of the qrep flow.
-	err := workflow.SetUpdateHandler(ctx, shared.FlowStatusUpdate, func(_ workflow.Context, status protos.FlowStatus) error {
-		state.CurrentFlowStatus = status
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to register query handler: %w", err)
-	}
-
 	// Support a Query for the current state of the qrep flow.
-	err = workflow.SetQueryHandler(ctx, shared.QRepFlowStateQuery, func() (*protos.QRepFlowState, error) {
+	err := workflow.SetQueryHandler(ctx, shared.QRepFlowStateQuery, func() (*protos.QRepFlowState, error) {
 		return state, nil
 	})
 	if err != nil {


### PR DESCRIPTION
https://pkg.go.dev/go.temporal.io/sdk/client upgrade to v1.27.0 introduced a mandatory field while doing external workflow updates called `WaitForStage`, which is currently experimental,  underdocumented and is breaking our uses of external updates.

Need to find a better fix later, for now removing the update handlers entirely from code. We only have one currently, for setting workflow status to PAUSING or TERMINATING.