### PR TITLE
Fix broken link for UI initial load table, add more logs in backend

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -371,12 +371,15 @@ func (h *FlowRequestHandler) FlowStateChange(
 	ctx context.Context,
 	req *protos.FlowStateChangeRequest,
 ) (*protos.FlowStateChangeResponse, error) {
+	slog.Info("FlowStateChange called", slog.String("flowJobName", req.FlowJobName), slog.Any("req", req))
 	workflowID, err := h.getWorkflowID(ctx, req.FlowJobName)
 	if err != nil {
+		slog.Error("[FlowStateChange]unable to get workflowID", slog.Any("error", err))
 		return nil, err
 	}
 	currState, err := h.getWorkflowStatus(ctx, workflowID)
 	if err != nil {
+		slog.Error("[FlowStateChange]unable to get workflow status", slog.Any("error", err))
 		return nil, err
 	}
 
@@ -389,6 +392,7 @@ func (h *FlowRequestHandler) FlowStateChange(
 			req.FlowConfigUpdate.GetCdcFlowConfigUpdate(),
 		)
 		if err != nil {
+			slog.Error("unable to signal workflow", slog.Any("error", err))
 			return nil, fmt.Errorf("unable to signal workflow: %w", err)
 		}
 	}
@@ -419,10 +423,13 @@ func (h *FlowRequestHandler) FlowStateChange(
 				FlowJobName: req.FlowJobName,
 			})
 		} else if req.RequestedFlowState != currState {
+			slog.Error("illegal state change requested", slog.Any("requestedFlowState", req.RequestedFlowState),
+				slog.Any("currState", currState))
 			return nil, fmt.Errorf("illegal state change requested: %v, current state is: %v",
 				req.RequestedFlowState, currState)
 		}
 		if err != nil {
+			slog.Error("unable to signal workflow", slog.Any("error", err))
 			return nil, fmt.Errorf("unable to signal workflow: %w", err)
 		}
 	}

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -26,6 +26,7 @@ func (h *FlowRequestHandler) MirrorStatus(
 
 	workflowID, err := h.getWorkflowID(ctx, req.FlowJobName)
 	if err != nil {
+		slog.Error("unable to get the workflow ID of mirror", slog.Any("error", err))
 		return &protos.MirrorStatusResponse{
 			FlowJobName:      req.FlowJobName,
 			CurrentFlowState: protos.FlowStatus_STATUS_UNKNOWN,
@@ -36,6 +37,7 @@ func (h *FlowRequestHandler) MirrorStatus(
 
 	currState, err := h.getWorkflowStatus(ctx, workflowID)
 	if err != nil {
+		slog.Error("unable to get the running status of mirror", slog.Any("error", err))
 		return &protos.MirrorStatusResponse{
 			FlowJobName:      req.FlowJobName,
 			CurrentFlowState: protos.FlowStatus_STATUS_UNKNOWN,
@@ -47,7 +49,7 @@ func (h *FlowRequestHandler) MirrorStatus(
 	if req.IncludeFlowInfo {
 		cdcFlow, err := h.isCDCFlow(ctx, req.FlowJobName)
 		if err != nil {
-			slog.Error("unable to query flow", slog.Any("error", err))
+			slog.Error("unable to determine if mirror is cdc", slog.Any("error", err))
 			return &protos.MirrorStatusResponse{
 				FlowJobName:      req.FlowJobName,
 				CurrentFlowState: protos.FlowStatus_STATUS_UNKNOWN,
@@ -58,6 +60,7 @@ func (h *FlowRequestHandler) MirrorStatus(
 		if cdcFlow {
 			cdcStatus, err := h.CDCFlowStatus(ctx, req)
 			if err != nil {
+				slog.Error("unable to obtain CDC information for mirror", slog.Any("error", err))
 				return &protos.MirrorStatusResponse{
 					FlowJobName:      req.FlowJobName,
 					CurrentFlowState: protos.FlowStatus_STATUS_UNKNOWN,
@@ -77,6 +80,7 @@ func (h *FlowRequestHandler) MirrorStatus(
 		} else {
 			qrepStatus, err := h.QRepFlowStatus(ctx, req)
 			if err != nil {
+				slog.Error("unable to obtain qrep information for mirror", slog.Any("error", err))
 				return &protos.MirrorStatusResponse{
 					FlowJobName:      req.FlowJobName,
 					CurrentFlowState: protos.FlowStatus_STATUS_UNKNOWN,
@@ -110,14 +114,17 @@ func (h *FlowRequestHandler) CDCFlowStatus(
 	slog.Info("CDC mirror status endpoint called", slog.String(string(shared.FlowNameKey), req.FlowJobName))
 	config, err := h.getFlowConfigFromCatalog(ctx, req.FlowJobName)
 	if err != nil {
+		slog.Error("unable to query flow config from catalog", slog.Any("error", err))
 		return nil, err
 	}
 	workflowID, err := h.getWorkflowID(ctx, req.FlowJobName)
 	if err != nil {
+		slog.Error("unable to get the workflow ID of mirror", slog.Any("error", err))
 		return nil, err
 	}
 	state, err := h.getCDCWorkflowState(ctx, workflowID)
 	if err != nil {
+		slog.Error("unable to get the state of mirror", slog.Any("error", err))
 		return nil, err
 	}
 
@@ -130,15 +137,18 @@ func (h *FlowRequestHandler) CDCFlowStatus(
 
 	srcType, err := connectors.LoadPeerType(ctx, h.pool, config.SourceName)
 	if err != nil {
+		slog.Error("unable to load source peer type", slog.Any("error", err))
 		return nil, err
 	}
 	dstType, err := connectors.LoadPeerType(ctx, h.pool, config.DestinationName)
 	if err != nil {
+		slog.Error("unable to load destination peer type", slog.Any("error", err))
 		return nil, err
 	}
 
 	cloneStatuses, err := h.cloneTableSummary(ctx, req.FlowJobName)
 	if err != nil {
+		slog.Error("unable to query clone table summary", slog.Any("error", err))
 		return nil, err
 	}
 

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -194,7 +194,7 @@ func (h *FlowRequestHandler) cloneTableSummary(
 	var numRowsSynced pgtype.Int8
 	var avgTimePerPartitionMs pgtype.Float8
 
-	rows, err := h.pool.Query(ctx, q, "clone_"+mirrorName+"_%")
+	rows, err := h.pool.Query(ctx, q, "clone\\_"+shared.EscapeForILike(mirrorName)+"_%")
 	if err != nil {
 		slog.Error("unable to query initial load partition",
 			slog.String(string(shared.FlowNameKey), mirrorName), slog.Any("error", err))

--- a/flow/shared/string.go
+++ b/flow/shared/string.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"regexp"
+	"strings"
 	"unsafe"
 )
 
@@ -24,4 +25,9 @@ func ReplaceIllegalCharactersWithUnderscores(s string) string {
 
 func IsValidReplicationName(s string) bool {
 	return reLegalIdentifierLower.MatchString(s)
+}
+
+// Escape a string for use in a LIKE/ILIKE postgres query.
+func EscapeForILike(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "_", "\\_"), "%", "\\%")
 }

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -191,6 +191,7 @@ message CloneTableSummary {
   string source_table = 8;
   bool fetch_completed = 9;
   bool consolidate_completed = 10;
+  string mirror_name = 11;
 }
 
 message SnapshotStatus {

--- a/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { SyncStatusRow } from '@/app/dto/MirrorsDTO';
+import { FormatStatus } from '@/app/utils/flowstatus';
 import MirrorInfo from '@/components/MirrorInfo';
 import PeerButton from '@/components/PeerComponent';
 import TimeLabel from '@/components/TimeComponent';
@@ -60,7 +61,7 @@ function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
               <Link
                 href={`/mirrors/errors/${mirrorConfig.config?.flowJobName}`}
               >
-                <Label>{formatStatus(mirrorStatus)}</Label>
+                <Label>{FormatStatus(mirrorStatus)}</Label>
               </Link>
             </div>
           </div>
@@ -141,17 +142,6 @@ function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
 
       <TablePairs tables={tablesSynced} />
     </>
-  );
-}
-
-function formatStatus(mirrorStatus: FlowStatus) {
-  const mirrorStatusLower = mirrorStatus
-    .toString()
-    .split('_')
-    .at(-1)
-    ?.toLocaleLowerCase()!;
-  return (
-    mirrorStatusLower.at(0)?.toLocaleUpperCase() + mirrorStatusLower.slice(1)
   );
 }
 

--- a/ui/app/mirrors/[mirrorId]/qrepStatusButtons.tsx
+++ b/ui/app/mirrors/[mirrorId]/qrepStatusButtons.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { FlowStatus } from '@/grpc_generated/flow';
+import { Button } from '@/lib/Button';
 
 async function setFlowState(
   flowJobName: string,
@@ -18,17 +19,17 @@ async function setFlowState(
 
 export default function qrepStatusButtons(props: { mirrorId: string }) {
   return (
-    <>
-      <input
-        type='button'
-        value='Pause'
+    <div style={{ display: 'flex', columnGap: '1rem' }}>
+      <Button
         onClick={() => setFlowState(props.mirrorId, FlowStatus.STATUS_PAUSED)}
-      />
-      <input
-        type='button'
-        value='Resume'
-        onClick={() => setFlowState(props.mirrorId, FlowStatus.STATUS_RUNNING)}
-      />
-    </>
+      >
+        Pause
+      </Button>
+      <Button
+        onClick={() => setFlowState(props.mirrorId, FlowStatus.STATUS_PAUSED)}
+      >
+        Resume
+      </Button>
+    </div>
   );
 }

--- a/ui/app/mirrors/[mirrorId]/snapshotTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/snapshotTable.tsx
@@ -200,7 +200,7 @@ const SnapshotTable = ({
           <TableCell>
             <Label>
               <Link
-                href={`/mirrors/status/qrep/${clone.cloneTableSummary.flowJobName}`}
+                href={`/mirrors/${clone.cloneTableSummary.flowJobName}`}
                 className='underline cursor-pointer'
               >
                 {clone.cloneTableSummary.tableName}

--- a/ui/app/mirrors/[mirrorId]/snapshotTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/snapshotTable.tsx
@@ -200,7 +200,7 @@ const SnapshotTable = ({
           <TableCell>
             <Label>
               <Link
-                href={`/mirrors/${clone.cloneTableSummary.flowJobName}`}
+                href={`/mirrors/${clone.cloneTableSummary.flowJobName}?parentMirrorName=${clone.cloneTableSummary.mirrorName}`}
                 className='underline cursor-pointer'
               >
                 {clone.cloneTableSummary.tableName}

--- a/ui/app/utils/flowstatus.ts
+++ b/ui/app/utils/flowstatus.ts
@@ -1,0 +1,12 @@
+import { FlowStatus } from '@/grpc_generated/flow';
+
+export function FormatStatus(mirrorStatus: FlowStatus) {
+  const mirrorStatusLower = mirrorStatus
+    .toString()
+    .split('_')
+    .at(-1)
+    ?.toLocaleLowerCase()!;
+  return (
+    mirrorStatusLower.at(0)?.toLocaleUpperCase() + mirrorStatusLower.slice(1)
+  );
+}


### PR DESCRIPTION
Fix link in snapshot status table
Account for mirrorId being a clone job name instead of a regular name in the mirrors page.
Add logs for mirror status and flow state change endpoints
Functionally tested with initial load and qrep

Also improved UI a little bit on qrep page