### PR TITLE
API clone summary: replace illegal chars in clone query

### DIFF
--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -180,7 +180,7 @@ func (h *FlowRequestHandler) cloneTableSummary(
 		AVG(EXTRACT(EPOCH FROM (qp.end_time - qp.start_time)) * 1000) FILTER (WHERE qp.end_time IS NOT NULL) AS AvgTimePerPartitionMs
 	FROM peerdb_stats.qrep_partitions qp
 	RIGHT JOIN peerdb_stats.qrep_runs qr ON qp.flow_name = qr.flow_name
-	WHERE qr.flow_name ^@ ($1||qr.destination_table)
+	WHERE qr.flow_name ^@ ($1|| regexp_replace(qr.destination_table, '[^a-zA-Z0-9_]', '_', 'g'))
 	GROUP BY qr.flow_name, qr.destination_table, qr.source_table, qr.start_time, qr.fetch_complete, qr.consolidate_complete;
 	`
 	var flowName pgtype.Text

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -180,7 +180,7 @@ func (h *FlowRequestHandler) cloneTableSummary(
 		AVG(EXTRACT(EPOCH FROM (qp.end_time - qp.start_time)) * 1000) FILTER (WHERE qp.end_time IS NOT NULL) AS AvgTimePerPartitionMs
 	FROM peerdb_stats.qrep_partitions qp
 	RIGHT JOIN peerdb_stats.qrep_runs qr ON qp.flow_name = qr.flow_name
-	WHERE qr.flow_name ^@ ($1|| regexp_replace(qr.destination_table, '[^a-zA-Z0-9_]', '_', 'g'))
+	WHERE qr.flow_name ^@ ($1||regexp_replace(qr.destination_table, '[^a-zA-Z0-9_]', '_', 'g'))
 	GROUP BY qr.flow_name, qr.destination_table, qr.source_table, qr.start_time, qr.fetch_complete, qr.consolidate_complete;
 	`
 	var flowName pgtype.Text


### PR DESCRIPTION
Initial load UI for PG -> PG and SF would not load because dots weren't replaced with underscores for clone name
This PR does the equivalent of our shared code which is used for clone name construction:

```golang
// shared/string.go
var (
	reIllegalIdentifierCharacters = regexp.MustCompile("[^a-zA-Z0-9_]+")
	...
)

func ReplaceIllegalCharactersWithUnderscores(s string) string {
	return reIllegalIdentifierCharacters.ReplaceAllString(s, "_")
}
```

in the clone query:
```sql
WHERE qr.flow_name ^@ ($1||regexp_replace(qr.destination_table, '[^a-zA-Z0-9_]', '_', 'g'))
```

functionally tested