### PR TITLE
Fix syntax for getting postgres peer in Walheartbeat

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -293,7 +293,7 @@ func (a *FlowableActivity) getPostgresPeerConfigs(ctx context.Context) ([]*proto
 	optionRows, err := a.CatalogPool.Query(ctx, `
 		SELECT p.name, p.options, p.enc_key_id
 		FROM peers p
-		WHERE p.type = $1 AND EXISTS(SELECT * FROM flows f ON p.id = f.source_peer)`, protos.DBType_POSTGRES)
+		WHERE p.type = $1 AND EXISTS(SELECT * FROM flows f WHERE p.id = f.source_peer)`, protos.DBType_POSTGRES)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Syntax error with "ON" usage in 
```
WHERE p.type = $1 AND EXISTS(SELECT * FROM flows f ON p.id = f.source_peer)
```

should be WHERE

functionally tested