### PR TITLE
Query Layer: Add limit 1 for workflow id fetch

### DIFF
--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -468,7 +468,7 @@ impl Catalog {
         let row = self
             .pg
             .query_opt(
-                "SELECT workflow_id, source_peer, destination_peer FROM public.flows WHERE NAME = $1",
+                "SELECT workflow_id, source_peer, destination_peer FROM public.flows WHERE NAME = $1 LIMIT 1",
                 &[&flow_job_name],
             )
             .await?;


### PR DESCRIPTION
Pause and resume currently fails in query layer when there are more than 1 entries for flow name.
The error is 
```
query returned an unexpected number of rows
```
because `query_opt()` errors out when the query returns more than 1 row

Add limit 1 at the end to cover for this