### PR TITLE
replace actions/cache with ubicloud/cache

### DIFF
--- a/.github/actions/genprotos/action.yml
+++ b/.github/actions/genprotos/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/checkout@v4
     - name: check cache
       id: cache
-      uses: actions/cache@v4
+      uses: ubicloud/cache@v4
       with:
         path: |
           ./flow/generated/protos

--- a/.github/actions/genprotos/action.yml
+++ b/.github/actions/genprotos/action.yml
@@ -21,6 +21,8 @@ runs:
         cache: false
     - if: steps.cache.outputs.cache-hit != 'true'
       uses: bufbuild/buf-setup-action@v1.29.0-1
+      with:
+        github_token: ${{ github.token }}
     - if: steps.cache.outputs.cache-hit != 'true'
       uses: dtolnay/rust-toolchain@stable
     - if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
rest of our caching is handled by dependencies,
but that means we get 10GB free just for generated protobuf files