### PR TITLE
Unnest columns: edge case fix

### DIFF
--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -274,12 +274,9 @@ func (r *RecordItems) ToJSONWithOpts(opts *ToJSONOptions) (string, error) {
 					return "", err
 				}
 
+				delete(jsonStruct, col)
 				for k, v := range unnestStruct {
 					jsonStruct[k] = v
-				}
-
-				if _, ok := unnestStruct[col]; !ok {
-					delete(jsonStruct, col)
 				}
 			}
 		}

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -277,7 +277,10 @@ func (r *RecordItems) ToJSONWithOpts(opts *ToJSONOptions) (string, error) {
 				for k, v := range unnestStruct {
 					jsonStruct[k] = v
 				}
-				delete(jsonStruct, col)
+
+				if _, ok := unnestStruct[col]; !ok {
+					delete(jsonStruct, col)
+				}
 			}
 		}
 	}

--- a/flow/model/model_test.go
+++ b/flow/model/model_test.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/PeerDB-io/peer-flow/model/qvalue"
+)
+
+func TestToJSONWithOptsColKeySame(t *testing.T) {
+	records := NewRecordItemWithData([]string{"col1", "col2", "col3"}, []qvalue.QValue{
+		{Value: "val1", Kind: qvalue.QValueKindString},
+		{Value: "val2", Kind: qvalue.QValueKindString},
+		{Value: `{"key1": "val1", "col3": "something"}`, Kind: qvalue.QValueKindJSON},
+	})
+
+	jsonOpts := NewToJSONOptions([]string{"col3"})
+
+	jsonRes, err := records.ToJSONWithOpts(&ToJSONOptions{
+		UnnestColumns: jsonOpts.UnnestColumns,
+	})
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := `{"col1":"val1","col2":"val2","col3":"something","key1":"val1"}`
+	if jsonRes != expected {
+		t.Errorf("Unexpected result. Expected: %v, but got: %v", expected, jsonRes)
+	}
+}
+
+func TestToJSONWithOptsRegular(t *testing.T) {
+	records := NewRecordItemWithData([]string{"col1", "col2", "col3"}, []qvalue.QValue{
+		{Value: "val1", Kind: qvalue.QValueKindString},
+		{Value: "val2", Kind: qvalue.QValueKindString},
+		{Value: `{"key1": "val1"}`, Kind: qvalue.QValueKindJSON},
+	})
+
+	jsonOpts := NewToJSONOptions([]string{"col3"})
+
+	jsonRes, err := records.ToJSONWithOpts(&ToJSONOptions{
+		UnnestColumns: jsonOpts.UnnestColumns,
+	})
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := `{"col1":"val1","col2":"val2","key1":"val1"}`
+	if jsonRes != expected {
+		t.Errorf("Unexpected result. Expected: %v, but got: %v", expected, jsonRes)
+	}
+}


### PR DESCRIPTION
For a JSON column whose name matches one of its keys in one of its objects, our unnesting logic unnests the fields and then deletes the key with the column name, thereby overwriting and then deleting this one field.

This PR fixes and adds a test for it