### PR TITLE
UI: no initial copy for eventhubs mirror

### DIFF
--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -33,6 +33,10 @@ export const IsQueuePeer = (peerType?: DBType): boolean => {
   );
 };
 
+const IsEventhubsPeer = (peerType?: DBType): boolean => {
+  return !!peerType && peerType === DBType.EVENTHUBS;
+};
+
 const ValidSchemaQualifiedTarget = (
   peerType: DBType,
   tableName: string
@@ -65,6 +69,10 @@ const CDCCheck = (
 
   config.tableMappings = tableNameMapping as TableMapping[];
   config.flowJobName = flowJobName;
+
+  if (IsEventhubsPeer(destinationType)) {
+    config.doInitialSnapshot = false;
+  }
 
   if (config.doInitialSnapshot == false && config.initialSnapshotOnly == true) {
     return 'Initial Snapshot Only cannot be true if Initial Snapshot is false.';


### PR DESCRIPTION
We do not display initial copy setting for eventhubs in UI yet as it is yet to be supported, but the default of that setting is true. This PR sets it to false in case of an Eventhubs mirror

Functionally tested