### PR TITLE
UI: Remove script input for DWH mirrors

### DIFF
--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -89,6 +89,7 @@ export default function CDCConfigForm({
       (label.includes('staging path') &&
         defaultSyncMode(destinationType) !== 'AVRO') ||
       (isQueue && label.includes('soft delete')) ||
+      (!isQueue && label.includes('script')) ||
       (destinationType === DBType.EVENTHUBS &&
         (label.includes('initial copy') ||
           label.includes('initial load') ||

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -86,6 +86,10 @@ const CDCCheck = (
     config.softDeleteColName = '';
   }
 
+  if (!IsQueuePeer(destinationType)) {
+    config.script = '';
+  }
+
   return '';
 };
 


### PR DESCRIPTION
This PR removes the 'Script' field in create mirror UI if the target peer is not a queue