### PR TITLE
UI: Fix enum comparisons, remove fluff

### DIFF
--- a/ui/app/mirrors/[mirrorId]/configValues.ts
+++ b/ui/app/mirrors/[mirrorId]/configValues.ts
@@ -18,7 +18,7 @@ export default function MirrorValues(
     },
     {
       value: `${mirrorConfig?.snapshotMaxParallelWorkers} worker(s)`,
-      label: 'Snapshot Parallel Tables',
+      label: 'Snapshot Parallel Workers',
     },
     {
       value: mirrorConfig?.softDeleteColName

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -72,6 +72,11 @@ export default function CDCConfigForm({
       (label.includes('snapshot') && mirrorConfig.doInitialSnapshot !== true) ||
       (label === 'replication slot name' &&
         mirrorConfig.doInitialSnapshot === true) ||
+      (label.includes('staging path') &&
+        !(
+          destinationType.toString() === DBType[DBType.BIGQUERY] ||
+          destinationType.toString() === DBType[DBType.SNOWFLAKE]
+        )) ||
       (IsEventhubsPeer(destinationType) &&
         (label.includes('initial copy') ||
           label.includes('initial load') ||

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/lib/Button';
 import { Icon } from '@/lib/Icon';
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { CDCConfig, MirrorSetter, TableMapRow } from '../../../dto/MirrorsDTO';
-import { IsQueuePeer, fetchPublications } from '../handlers';
+import { IsEventhubsPeer, IsQueuePeer, fetchPublications } from '../handlers';
 import { AdvancedSettingType, MirrorSetting } from '../helpers/common';
 import CDCField from './fields';
 import TableMapping from './tablemapping';
@@ -72,14 +72,15 @@ export default function CDCConfigForm({
       (label.includes('snapshot') && mirrorConfig.doInitialSnapshot !== true) ||
       (label === 'replication slot name' &&
         mirrorConfig.doInitialSnapshot === true) ||
-      (destinationType === DBType.EVENTHUBS &&
+      (IsEventhubsPeer(destinationType) &&
         (label.includes('initial copy') ||
           label.includes('initial load') ||
           label.includes('snapshot'))) ||
-      ((sourceType !== DBType.POSTGRES ||
-        destinationType !== DBType.POSTGRES) &&
+      ((sourceType.toString() !== DBType[DBType.POSTGRES] ||
+        destinationType.toString() !== DBType[DBType.POSTGRES]) &&
         label.includes('type system')) ||
-      (destinationType !== DBType.BIGQUERY && label.includes('column name')) ||
+      (destinationType.toString() !== DBType[DBType.BIGQUERY] &&
+        label.includes('column name')) ||
       (label.includes('soft delete') &&
         !(
           destinationType.toString() === DBType[DBType.POSTGRES] ||

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -81,14 +81,10 @@ export default function CDCConfigForm({
 
   const paramDisplayCondition = (setting: MirrorSetting) => {
     const label = setting.label.toLowerCase();
-    const isQueue = IsQueuePeer(destinationType);
     if (
       (label.includes('snapshot') && mirrorConfig.doInitialSnapshot !== true) ||
       (label === 'replication slot name' &&
         mirrorConfig.doInitialSnapshot === true) ||
-      (label.includes('staging path') &&
-        defaultSyncMode(destinationType) !== 'AVRO') ||
-      (isQueue && label.includes('soft delete')) ||
       (destinationType === DBType.EVENTHUBS &&
         (label.includes('initial copy') ||
           label.includes('initial load') ||
@@ -98,8 +94,10 @@ export default function CDCConfigForm({
         label.includes('type system')) ||
       (destinationType !== DBType.BIGQUERY && label.includes('column name')) ||
       (label.includes('soft delete') &&
-        ![DBType.BIGQUERY, DBType.POSTGRES, DBType.SNOWFLAKE].includes(
-          destinationType ?? DBType.UNRECOGNIZED
+        !(
+          destinationType.toString() === DBType[DBType.POSTGRES] ||
+          destinationType.toString() === DBType[DBType.BIGQUERY] ||
+          destinationType.toString() === DBType[DBType.SNOWFLAKE]
         ))
     ) {
       return false;

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -19,19 +19,6 @@ interface MirrorConfigProps {
   setRows: Dispatch<SetStateAction<TableMapRow[]>>;
 }
 
-export const defaultSyncMode = (dtype: DBType | undefined) => {
-  switch (dtype) {
-    case DBType.POSTGRES:
-      return 'Copy with Binary';
-    case DBType.SNOWFLAKE:
-    case DBType.BIGQUERY:
-    case DBType.S3:
-      return 'AVRO';
-    default:
-      return 'Copy with Binary';
-  }
-};
-
 export default function CDCConfigForm({
   settings,
   mirrorConfig,

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -35,8 +35,11 @@ export const IsQueuePeer = (peerType?: DBType): boolean => {
   );
 };
 
-const IsEventhubsPeer = (peerType?: DBType): boolean => {
-  return !!peerType && peerType === DBType.EVENTHUBS;
+export const IsEventhubsPeer = (peerType?: DBType): boolean => {
+  return (
+    (!!peerType && peerType === DBType.EVENTHUBS) ||
+    peerType?.toString() === DBType[DBType.EVENTHUBS]
+  );
 };
 
 const ValidSchemaQualifiedTarget = (

--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -113,30 +113,6 @@ export const cdcSettings: MirrorSetting[] = [
     advanced: AdvancedSettingType.ALL,
   },
   {
-    label: 'Snapshot Staging Path',
-    stateHandler: (value, setter) =>
-      setter(
-        (curr: CDCConfig): CDCConfig => ({
-          ...curr,
-          snapshotStagingPath: value as string | '',
-        })
-      ),
-    tips: 'You can specify staging path for Snapshot sync mode AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket URL. For BigQuery, this must be either empty or an existing GCS bucket name. In both cases, if empty, the local filesystem will be used.',
-    advanced: AdvancedSettingType.ALL,
-  },
-  {
-    label: 'CDC Staging Path',
-    stateHandler: (value, setter) =>
-      setter(
-        (curr: CDCConfig): CDCConfig => ({
-          ...curr,
-          cdcStagingPath: (value as string) || '',
-        })
-      ),
-    tips: 'You can specify staging path for CDC sync mode AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket URL. For BigQuery, this must be either empty or an existing GCS bucket name. In both cases, if empty, the local filesystem will be used.',
-    advanced: AdvancedSettingType.ALL,
-  },
-  {
     label: 'Soft Delete',
     stateHandler: (value, setter) =>
       setter(

--- a/ui/app/mirrors/create/helpers/cdc.ts
+++ b/ui/app/mirrors/create/helpers/cdc.ts
@@ -113,6 +113,30 @@ export const cdcSettings: MirrorSetting[] = [
     advanced: AdvancedSettingType.ALL,
   },
   {
+    label: 'Snapshot Staging Path',
+    stateHandler: (value, setter) =>
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          snapshotStagingPath: value as string | '',
+        })
+      ),
+    tips: 'You can specify staging path for Snapshot sync mode AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket URL. For BigQuery, this must be either empty or an existing GCS bucket name. In both cases, if empty, the local filesystem will be used.',
+    advanced: AdvancedSettingType.ALL,
+  },
+  {
+    label: 'CDC Staging Path',
+    stateHandler: (value, setter) =>
+      setter(
+        (curr: CDCConfig): CDCConfig => ({
+          ...curr,
+          cdcStagingPath: (value as string) || '',
+        })
+      ),
+    tips: 'You can specify staging path for CDC sync mode AVRO. For Snowflake as destination peer, this must be either empty or an S3 bucket URL. For BigQuery, this must be either empty or an existing GCS bucket name. In both cases, if empty, the local filesystem will be used.',
+    advanced: AdvancedSettingType.ALL,
+  },
+  {
     label: 'Soft Delete',
     stateHandler: (value, setter) =>
       setter(

--- a/ui/app/mirrors/create/helpers/qrep.ts
+++ b/ui/app/mirrors/create/helpers/qrep.ts
@@ -153,4 +153,16 @@ export const qrepSettings: MirrorSetting[] = [
     tips: 'Decide if PeerDB should use native Postgres types directly',
     advanced: AdvancedSettingType.ALL,
   },
+  {
+    label: 'Staging Path',
+    stateHandler: (value, setter) =>
+      setter(
+        (curr: QRepConfig): QRepConfig => ({
+          ...curr,
+          stagingPath: value as string | '',
+        })
+      ),
+    tips: 'For Snowflake as destination peer, this must be either empty or an S3 bucket URL. For BigQuery, this must be either empty or an existing GCS bucket name. In both cases, if empty, the local filesystem will be used.',
+    advanced: AdvancedSettingType.ALL,
+  },
 ];

--- a/ui/app/mirrors/create/qrep/qrep.tsx
+++ b/ui/app/mirrors/create/qrep/qrep.tsx
@@ -12,7 +12,6 @@ import { useEffect, useState } from 'react';
 import ReactSelect from 'react-select';
 import { InfoPopover } from '../../../../components/InfoPopover';
 import { MirrorSetter } from '../../../dto/MirrorsDTO';
-import { defaultSyncMode } from '../cdc/cdc';
 import { fetchAllTables, fetchColumns } from '../handlers';
 import { MirrorSetting, blankQRepSetting } from '../helpers/common';
 import UpsertColsDisplay from './upsertcols';
@@ -83,8 +82,6 @@ export default function QRepConfigForm({
       (label.includes('upsert') &&
         mirrorConfig.writeMode?.writeType !=
           QRepWriteType.QREP_WRITE_MODE_UPSERT) ||
-      (label.includes('staging') &&
-        defaultSyncMode(destinationType) !== 'AVRO') ||
       (label.includes('watermark column') && xmin) ||
       (label.includes('initial copy') && xmin)
     ) {

--- a/ui/app/mirrors/create/qrep/qrep.tsx
+++ b/ui/app/mirrors/create/qrep/qrep.tsx
@@ -82,6 +82,11 @@ export default function QRepConfigForm({
       (label.includes('upsert') &&
         mirrorConfig.writeMode?.writeType !=
           QRepWriteType.QREP_WRITE_MODE_UPSERT) ||
+      (label.includes('staging') &&
+        !(
+          destinationType.toString() === DBType[DBType.BIGQUERY] ||
+          destinationType.toString() === DBType[DBType.SNOWFLAKE]
+        )) ||
       (label.includes('watermark column') && xmin) ||
       (label.includes('initial copy') && xmin)
     ) {


### PR DESCRIPTION
- Bunch of settings (soft-delete, pg type system etc.) were not showing up in create cdc mirror UI - now these are restored
- Staging path fields shown only for BQ and SF targets
- Fix 'parallel tables' typo -> parallel workers