### PR TITLE
Github actions: change stable tag regex

### DIFF
--- a/.github/workflows/stable-docker.yml
+++ b/.github/workflows/stable-docker.yml
@@ -3,7 +3,7 @@ name: Stable Docker images
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+[a-zA-Z]*"
 
 jobs:
   docker-build:


### PR DESCRIPTION
Stable docker image workflow: Allows tags like v0.13.1a where the ending part can have alphabets