### PR TITLE
Clickhouse peer UI: change default port to 9440

### DIFF
--- a/ui/app/peers/create/[peerType]/helpers/ch.ts
+++ b/ui/app/peers/create/[peerType]/helpers/ch.ts
@@ -13,7 +13,7 @@ export const clickhouseSetting: PeerSetting[] = [
     stateHandler: (value, setter) =>
       setter((curr) => ({ ...curr, port: parseInt(value as string, 10) })),
     type: 'number', // type for textfield
-    default: 9000,
+    default: 9440,
     tips: 'Specifies the TCP/IP port or local Unix domain socket file extension on which Clickhouse is listening for connections from client applications.',
   },
   {
@@ -89,7 +89,7 @@ export const clickhouseSetting: PeerSetting[] = [
 
 export const blankClickhouseSetting: ClickhouseConfig = {
   host: '',
-  port: 9000,
+  port: 9440,
   user: '',
   password: '',
   database: '',


### PR DESCRIPTION
In the clickhouse peer UI form, change the default textfield value of the Port field to `9440` instead of `9000`
Functionally tested