### PR TITLE
Actions: Revert to old stable docker image regex

### DIFF
--- a/.github/workflows/stable-docker.yml
+++ b/.github/workflows/stable-docker.yml
@@ -3,7 +3,7 @@ name: Stable Docker images
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+[a-zA-Z]*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   docker-build:


### PR DESCRIPTION
Technical difficulties with new tag-based image releases necessitates this PR which changes the regex for the stable docker image workflow file to an earlier value