### PR TITLE
Clickhouse: use mergetree instead in validation

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -52,7 +52,9 @@ func ValidateS3(ctx context.Context, creds *utils.ClickHouseS3Credentials) error
 func (c *ClickhouseConnector) ValidateCheck(ctx context.Context) error {
 	validateDummyTableName := "peerdb_validation_" + shared.RandomString(4)
 	// create a table
-	err := c.database.Exec(ctx, fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id UInt64) ENGINE = Memory",
+	err := c.database.Exec(ctx, fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		id UInt64
+	) ENGINE = ReplacingMergeTree ORDER BY id;`,
 		validateDummyTableName+"_temp"))
 	if err != nil {
 		return fmt.Errorf("failed to create validation table %s: %w", validateDummyTableName, err)


### PR DESCRIPTION
Seems like in some versions/setups of Clickhouse, alter add column is altogether not supported for engine memory. Use mergetree instead when validating 