### PR TITLE
docker fixes

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -133,6 +133,8 @@ services:
       - 8113:8113
     environment:
       <<: [*catalog-config, *flow-worker-env, *minio-config]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       temporal-admin-tools:
         condition: service_healthy
@@ -157,6 +159,8 @@ services:
       target: flow-worker
     environment:
       <<: [*catalog-config, *flow-worker-env, *minio-config]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       temporal-admin-tools:
         condition: service_healthy
@@ -197,7 +201,7 @@ services:
       - flow-api
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2024-07-16T23-46-41Z
     volumes:
       - minio-data:/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,8 @@ services:
       - 8113:8113
     environment:
       <<: [*catalog-config, *flow-worker-env, *minio-config]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       temporal-admin-tools:
         condition: service_healthy
@@ -139,6 +141,8 @@ services:
     restart: unless-stopped
     environment:
       <<: [*catalog-config, *flow-worker-env, *minio-config]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       temporal-admin-tools:
         condition: service_healthy
@@ -176,7 +180,7 @@ services:
       - flow-api
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2024-07-16T23-46-41Z
     restart: unless-stopped
     volumes:
       - minio-data:/data

--- a/stacks/peerdb-server.Dockerfile
+++ b/stacks/peerdb-server.Dockerfile
@@ -19,7 +19,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY nexus /root/nexus
 COPY protos /root/protos
 WORKDIR /root/nexus
-RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo build --release --bin peerdb-server
+RUN cargo build --release --bin peerdb-server
 
 FROM alpine:3.20
 RUN apk add --no-cache ca-certificates postgresql-client curl iputils && \


### PR DESCRIPTION
1. crates.io now defaults to sparse protocol, remove env
2. tagging a particular MinIO version
3. need extra_hosts for MinIO to work on Linux since `host.docker.internal` isn't the default address there