### PR TITLE
Clickhouse resync: no need to touch peerdb columns

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
-	"time"
 
 	_ "github.com/ClickHouse/clickhouse-go/v2"
 	_ "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -160,38 +158,13 @@ func (c *ClickhouseConnector) ReplayTableSchemaDeltas(ctx context.Context, flowJ
 
 func (c *ClickhouseConnector) RenameTables(ctx context.Context, req *protos.RenameTablesInput) (*protos.RenameTablesOutput, error) {
 	for _, renameRequest := range req.RenameTableOptions {
-		if req.SyncedAtColName != "" {
-			syncedAtCol := strings.ToLower(req.SyncedAtColName)
-			// get the current timestamp in UTC which can be used as SQL's now()
-			currentTimestamp := time.Now().UTC().Format("2006-01-02 15:04:05")
-			err := c.execWithLogging(ctx,
-				fmt.Sprintf("ALTER TABLE %s UPDATE %s='%s' WHERE true",
-					renameRequest.CurrentName, syncedAtCol, currentTimestamp))
-			if err != nil {
-				return nil, fmt.Errorf("unable to set synced at column for table %s: %w",
-					renameRequest.CurrentName, err)
-			}
-		}
-
 		columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
 		for _, col := range renameRequest.TableSchema.Columns {
 			columnNames = append(columnNames, col.Name)
 		}
 
-		allCols := strings.Join(columnNames, ",")
-		pkeyCols := strings.Join(renameRequest.TableSchema.PrimaryKeyColumns, ",")
-		c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", renameRequest.NewName))
-		err := c.execWithLogging(ctx,
-			fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s WHERE (%s) NOT IN (SELECT %s FROM %s)",
-				renameRequest.CurrentName, fmt.Sprintf("%s,%s", allCols, signColName), allCols,
-				signColName,
-				renameRequest.NewName, pkeyCols, pkeyCols, renameRequest.CurrentName))
-		if err != nil {
-			return nil, fmt.Errorf("unable to handle soft-deletes for table %s: %w", renameRequest.NewName, err)
-		}
-
 		// drop the dst table if exists
-		err = c.execWithLogging(ctx, "DROP TABLE IF EXISTS "+renameRequest.NewName)
+		err := c.execWithLogging(ctx, "DROP TABLE IF EXISTS "+renameRequest.NewName)
 		if err != nil {
 			return nil, fmt.Errorf("unable to drop table %s: %w", renameRequest.NewName, err)
 		}


### PR DESCRIPTION
- Not sure why we need to set synced at column to now in RenameTables
- Migrating soft delete rows from the old table is not needed and probably not expected