### PR TITLE
CH Mirror: no script field

### DIFF
--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -91,7 +91,9 @@ export default function CDCConfigForm({
           destinationType.toString() === DBType[DBType.POSTGRES] ||
           destinationType.toString() === DBType[DBType.BIGQUERY] ||
           destinationType.toString() === DBType[DBType.SNOWFLAKE]
-        ))
+        )) ||
+      (label.includes('script') &&
+        destinationType.toString() === DBType[DBType.CLICKHOUSE])
     ) {
       return false;
     }


### PR DESCRIPTION
For Clickhouse mirrors in create CDC mirror UI, do not show the script field