### PR TITLE
Add env var for scripting

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -201,7 +201,7 @@ services:
       NEXTAUTH_URL: http://localhost:3000
       PEERDB_ALLOWED_TARGETS:
       PEERDB_CLICKHOUSE_ALLOWED_DOMAINS:
-      PEERDB_EXPERIMENTAL_ENABLE_SCRIPTING: false
+      PEERDB_EXPERIMENTAL_ENABLE_SCRIPTING: true
     depends_on:
       - flow-api
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -201,6 +201,7 @@ services:
       NEXTAUTH_URL: http://localhost:3000
       PEERDB_ALLOWED_TARGETS:
       PEERDB_CLICKHOUSE_ALLOWED_DOMAINS:
+      PEERDB_EXPERIMENTAL_ENABLE_SCRIPTING: false
     depends_on:
       - flow-api
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,8 @@ services:
       NEXTAUTH_SECRET: __changeme__
       NEXTAUTH_URL: http://localhost:3000
       PEERDB_ALLOWED_TARGETS:
+      PEERDB_CLICKHOUSE_ALLOWED_DOMAINS:
+      PEERDB_EXPERIMENTAL_ENABLE_SCRIPTING: true
     depends_on:
       - flow-api
 

--- a/ui/app/api/mirror-types/validation/scripting/route.ts
+++ b/ui/app/api/mirror-types/validation/scripting/route.ts
@@ -1,0 +1,8 @@
+import { GetPeerDBEnableScripting } from '@/peerdb-env/experimental_enable_scripting';
+import { NextRequest } from 'next/server';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const scriptingIsEnabled = GetPeerDBEnableScripting();
+  return new Response(JSON.stringify(scriptingIsEnabled));
+}

--- a/ui/peerdb-env/experimental_enable_scripting.ts
+++ b/ui/peerdb-env/experimental_enable_scripting.ts
@@ -1,0 +1,5 @@
+import 'server-only';
+
+export function GetPeerDBEnableScripting() {
+  return process.env.PEERDB_EXPERIMENTAL_ENABLE_SCRIPTING === 'true';
+}


### PR DESCRIPTION
`PEERDB_EXPERIMENTAL_ENABLE_SCRIPTING` has been introduced in the docker compose files. Default is true in the docker-compose files.
The code checks if the var is true and true only so if not specified, it will be taken as false