### PR TITLE
Peer page UI: Allow for editing when connectivity is down

### DIFF
--- a/ui/app/api/peers/slots/peerData/[name]/route.ts
+++ b/ui/app/api/peers/slots/peerData/[name]/route.ts
@@ -1,0 +1,21 @@
+import { PeerSlotResponse } from '@/grpc_generated/route';
+import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: { name: string } }
+) {
+  const flowServiceAddr = GetFlowHttpAddressFromEnv();
+  try {
+    const slotDataRes: PeerSlotResponse = await fetch(
+      `${flowServiceAddr}/v1/peers/slots/${context.params.name}`,
+      { cache: 'no-store' }
+    ).then((res) => res.json());
+
+    return new Response(JSON.stringify(slotDataRes));
+  } catch (e) {
+    console.error('Error fetching slots:', e);
+    return NextResponse.error();
+  }
+}

--- a/ui/app/api/peers/stats/[name]/route.ts
+++ b/ui/app/api/peers/stats/[name]/route.ts
@@ -1,0 +1,25 @@
+import { PeerStatResponse } from '@/grpc_generated/route';
+import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: { name: string } }
+) {
+  try {
+    const flowServiceAddr = GetFlowHttpAddressFromEnv();
+    const peerStats: PeerStatResponse = await fetch(
+      `${flowServiceAddr}/v1/peers/stats/${context.params.name}`,
+      { cache: 'no-store' }
+    )
+      .then((res) => res.json())
+      .catch((e) => {
+        console.error('Error fetching slots:', e);
+        return [];
+      });
+    return NextResponse.json(peerStats.statData);
+  } catch (e) {
+    console.error('Error fetching slots:', e);
+    return NextResponse.error();
+  }
+}

--- a/ui/app/peers/[peerName]/helpers.tsx
+++ b/ui/app/peers/[peerName]/helpers.tsx
@@ -1,3 +1,4 @@
+import { PeerSlotResponse } from '@/grpc_generated/route';
 import { Label } from '@/lib/Label';
 import Link from 'next/link';
 
@@ -6,6 +7,44 @@ const getFlowName = (slotName: string) => {
     return slotName.slice(14);
   }
   return '';
+};
+
+export const getSlotData = async (peerName: string) => {
+  try {
+    const peerSlots: PeerSlotResponse = await fetch(
+      `/api/peers/slots/peerData/${peerName}`,
+      {
+        cache: 'no-store',
+      }
+    )
+      .then((res) => res.json())
+      .catch((e) => {
+        console.error('Error fetching slots:', e);
+        return [];
+      });
+
+    const slotArray = peerSlots.slotData ?? [];
+    // slots with 'peerflow_slot' should come first
+    slotArray?.sort((slotA, slotB) => {
+      if (
+        slotA.slotName.startsWith('peerflow_slot') &&
+        !slotB.slotName.startsWith('peerflow_slot')
+      ) {
+        return -1;
+      } else if (
+        !slotA.slotName.startsWith('peerflow_slot') &&
+        slotB.slotName.startsWith('peerflow_slot')
+      ) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+    return slotArray;
+  } catch (e) {
+    console.error('Error fetching slots:', e);
+    return [];
+  }
 };
 
 export const SlotNameDisplay = ({ slotName }: { slotName: string }) => {

--- a/ui/app/peers/[peerName]/lagGraph.tsx
+++ b/ui/app/peers/[peerName]/lagGraph.tsx
@@ -15,13 +15,14 @@ import { LineChart } from '@tremor/react';
 import { useCallback, useEffect, useState } from 'react';
 import ReactSelect from 'react-select';
 import { useLocalStorage } from 'usehooks-ts';
+import { getSlotData } from './helpers';
 
 type LagGraphProps = {
   peerName: string;
-  slotNames: string[];
 };
 
-function LagGraph({ peerName, slotNames }: LagGraphProps) {
+function LagGraph({ peerName }: LagGraphProps) {
+  const [slotNames, setSlotNames] = useState<string[]>([]);
   const [mounted, setMounted] = useState(false);
   const [lagPoints, setLagPoints] = useState<
     { time: string; 'Lag in GB': number }[]
@@ -32,6 +33,12 @@ function LagGraph({ peerName, slotNames }: LagGraphProps) {
   let [timeSince, setTimeSince] = useState<TimeAggregateTypes>(
     TimeAggregateTypes.HOUR
   );
+
+  const fetchSlotNames = useCallback(async () => {
+    const slots = await getSlotData(peerName);
+    setSlotNames(slots.map((slot) => slot.slotName));
+  }, [peerName]);
+
   const fetchLagPoints = useCallback(async () => {
     if (selectedSlot == '') {
       return;
@@ -66,8 +73,9 @@ function LagGraph({ peerName, slotNames }: LagGraphProps) {
 
   useEffect(() => {
     setMounted(true);
+    fetchSlotNames();
     fetchLagPoints();
-  }, [fetchLagPoints]);
+  }, [fetchLagPoints, fetchSlotNames]);
 
   if (!mounted) {
     return (

--- a/ui/app/peers/[peerName]/page.tsx
+++ b/ui/app/peers/[peerName]/page.tsx
@@ -1,8 +1,5 @@
 import { PeerInfo } from '@/components/PeerInfo';
 import ReloadButton from '@/components/ReloadButton';
-import { PeerSlotResponse, PeerStatResponse } from '@/grpc_generated/route';
-import { Label } from '@/lib/Label';
-import { GetFlowHttpAddressFromEnv } from '@/rpc/http';
 import LagGraph from './lagGraph';
 import SlotTable from './slottable';
 import StatTable from './stattable';
@@ -12,50 +9,6 @@ type DataConfigProps = {
 };
 
 const PeerData = async ({ params: { peerName } }: DataConfigProps) => {
-  const getSlotData = async () => {
-    const flowServiceAddr = GetFlowHttpAddressFromEnv();
-
-    const peerSlots: PeerSlotResponse = await fetch(
-      `${flowServiceAddr}/v1/peers/slots/${peerName}`,
-      {
-        cache: 'no-store',
-      }
-    ).then((res) => res.json());
-
-    const slotArray = peerSlots.slotData;
-    // slots with 'peerflow_slot' should come first
-    slotArray?.sort((slotA, slotB) => {
-      if (
-        slotA.slotName.startsWith('peerflow_slot') &&
-        !slotB.slotName.startsWith('peerflow_slot')
-      ) {
-        return -1;
-      } else if (
-        !slotA.slotName.startsWith('peerflow_slot') &&
-        slotB.slotName.startsWith('peerflow_slot')
-      ) {
-        return 1;
-      } else {
-        return 0;
-      }
-    });
-    return slotArray;
-  };
-
-  const getStatData = async () => {
-    const flowServiceAddr = GetFlowHttpAddressFromEnv();
-
-    const peerStats: PeerStatResponse = await fetch(
-      `${flowServiceAddr}/v1/peers/stats/${peerName}`,
-      { cache: 'no-store' }
-    ).then((res) => res.json());
-
-    return peerStats.statData;
-  };
-
-  const slots = await getSlotData();
-  const stats = await getStatData();
-
   return (
     <div
       style={{
@@ -81,28 +34,11 @@ const PeerData = async ({ params: { peerName } }: DataConfigProps) => {
         <ReloadButton />
       </div>
 
-      {slots && stats ? (
-        <div>
-          <SlotTable data={slots} />
-          <LagGraph
-            peerName={peerName}
-            slotNames={slots.map((slot) => slot.slotName)}
-          />
-          <StatTable data={stats} />
-        </div>
-      ) : (
-        <div>
-          <Label
-            as='label'
-            style={{ fontSize: 18, marginTop: '1rem', display: 'block' }}
-          >
-            Peer Statistics
-          </Label>
-          <Label as='label' style={{ fontSize: 15, marginTop: '1rem' }}>
-            No stats to show
-          </Label>
-        </div>
-      )}
+      <div>
+        <SlotTable peerName={peerName} />
+        <LagGraph peerName={peerName} />
+        <StatTable peerName={peerName} />
+      </div>
     </div>
   );
 };

--- a/ui/app/peers/[peerName]/slottable.tsx
+++ b/ui/app/peers/[peerName]/slottable.tsx
@@ -1,10 +1,35 @@
+'use client';
 import { SlotInfo } from '@/grpc_generated/route';
 import { Label } from '@/lib/Label';
+import { ProgressCircle } from '@/lib/ProgressCircle';
 import { Table, TableCell, TableRow } from '@/lib/Table';
-import { SlotNameDisplay } from './helpers';
+import { useEffect, useState } from 'react';
+import { getSlotData, SlotNameDisplay } from './helpers';
 import { tableStyle } from './style';
 
-const SlotTable = ({ data }: { data: SlotInfo[] }) => {
+const SlotTable = ({ peerName }: { peerName: string }) => {
+  const [data, setData] = useState<SlotInfo[]>([]);
+
+  useEffect(() => {
+    getSlotData(peerName).then((slots) => setData(slots));
+  }, [peerName]);
+
+  if (!data || data.length === 0) {
+    return (
+      <div
+        style={{ minHeight: '10%', marginTop: '2rem', marginBottom: '2rem' }}
+      >
+        <Label
+          as='label'
+          variant='subheadline'
+          style={{ marginBottom: '1rem', fontWeight: 'bold' }}
+        >
+          Replication Slot Information
+        </Label>
+        <ProgressCircle variant='determinate_progress_circle' />
+      </div>
+    );
+  }
   return (
     <div style={{ minHeight: '10%', marginTop: '2rem', marginBottom: '2rem' }}>
       <Label


### PR DESCRIPTION
Current design of this page where we await slot and stats data on the server side prevents us from editing peers when the connectivity to the peer is down - the page crashes

Refactored the wiring here to still render the page in this scenario and show what can be shown