### PR TITLE
BigQuery: check if pkeys can be used for clustering

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -672,12 +672,13 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 	// create the table using the columns
 	schema := bigquery.Schema(columns)
 
-	// cluster by the primary key if < 4 columns.
+	supportedPkeyCols := obtainClusteringColumns(tableSchema)
+	// cluster by the supported primary keys if < 4 columns.
+	numSupportedPkeyCols := len(supportedPkeyCols)
 	var clustering *bigquery.Clustering
-	numPkeyCols := len(tableSchema.PrimaryKeyColumns)
-	if numPkeyCols > 0 && numPkeyCols < 4 {
+	if numSupportedPkeyCols > 0 && numSupportedPkeyCols < 4 {
 		clustering = &bigquery.Clustering{
-			Fields: tableSchema.PrimaryKeyColumns,
+			Fields: supportedPkeyCols,
 		}
 	}
 

--- a/flow/connectors/bigquery/clustering.go
+++ b/flow/connectors/bigquery/clustering.go
@@ -1,0 +1,44 @@
+package connbigquery
+
+import (
+	"cloud.google.com/go/bigquery"
+	"github.com/PeerDB-io/peer-flow/generated/protos"
+)
+
+// Columns in BigQuery which are supported for clustering of tables
+// Reference: https://cloud.google.com/bigquery/docs/clustered-tables#cluster_column_types
+var supportedClusteringTypes = map[bigquery.FieldType]struct{}{
+	bigquery.StringFieldType:     {},
+	bigquery.IntegerFieldType:    {},
+	bigquery.BooleanFieldType:    {},
+	bigquery.TimestampFieldType:  {},
+	bigquery.DateFieldType:       {},
+	bigquery.DateTimeFieldType:   {},
+	bigquery.NumericFieldType:    {},
+	bigquery.BigNumericFieldType: {},
+	bigquery.GeographyFieldType:  {},
+}
+
+func isSupportedClusteringType(fieldType bigquery.FieldType) bool {
+	_, ok := supportedClusteringTypes[fieldType]
+	return ok
+}
+
+func obtainClusteringColumns(tableSchema *protos.TableSchema) []string {
+	numPkeyCols := len(tableSchema.PrimaryKeyColumns)
+	supportedPkeyColsForClustering := make([]string, 0, numPkeyCols)
+	isColPrimary := make(map[string]bool, len(tableSchema.PrimaryKeyColumns))
+	for _, pkeyCol := range tableSchema.PrimaryKeyColumns {
+		isColPrimary[pkeyCol] = true
+	}
+	for _, col := range tableSchema.Columns {
+		if _, ok := isColPrimary[col.Name]; ok {
+			if bigqueryType := qValueKindToBigQueryType(col); ok {
+				if isSupportedClusteringType(bigqueryType.Type) {
+					supportedPkeyColsForClustering = append(supportedPkeyColsForClustering, col.Name)
+				}
+			}
+		}
+	}
+	return supportedPkeyColsForClustering
+}

--- a/flow/connectors/bigquery/clustering.go
+++ b/flow/connectors/bigquery/clustering.go
@@ -28,7 +28,7 @@ func isSupportedClusteringType(fieldType bigquery.FieldType) bool {
 func obtainClusteringColumns(tableSchema *protos.TableSchema) []string {
 	numPkeyCols := len(tableSchema.PrimaryKeyColumns)
 	supportedPkeyColsForClustering := make([]string, 0, numPkeyCols)
-	isColPrimary := make(map[string]bool, len(tableSchema.PrimaryKeyColumns))
+	isColPrimary := make(map[string]bool, numPkeyCols)
 	for _, pkeyCol := range tableSchema.PrimaryKeyColumns {
 		isColPrimary[pkeyCol] = true
 	}

--- a/flow/connectors/bigquery/clustering.go
+++ b/flow/connectors/bigquery/clustering.go
@@ -2,6 +2,7 @@ package connbigquery
 
 import (
 	"cloud.google.com/go/bigquery"
+
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 )
 


### PR DESCRIPTION
When clustering the tables in `SetupNormalize` for BigQuery we must account for: https://cloud.google.com/bigquery/docs/clustered-tables#cluster_column_types