### PR TITLE
don't alert for some common errors

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -3,6 +3,7 @@ package activities
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -169,7 +170,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		// wait for the pull goroutine to finish
 		if err := errGroup.Wait(); err != nil {
 			// don't log flow error for "replState changed" and "slot is already active"
-			if !(temporal.IsApplicationError(err) || err == connpostgres.ErrSlotActive) {
+			if !(temporal.IsApplicationError(err) || errors.Is(err, connpostgres.ErrSlotActive)) {
 				a.Alerter.LogFlowError(ctx, flowName, err)
 			}
 			if temporal.IsApplicationError(err) {
@@ -247,7 +248,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 
 	if err := errGroup.Wait(); err != nil {
 		// don't log flow error for "replState changed" and "slot is already active"
-		if !(temporal.IsApplicationError(err) || err == connpostgres.ErrSlotActive) {
+		if !(temporal.IsApplicationError(err) || errors.Is(err, connpostgres.ErrSlotActive)) {
 			a.Alerter.LogFlowError(ctx, flowName, err)
 		}
 		if temporal.IsApplicationError(err) {

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -3,7 +3,6 @@ package activities
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -170,7 +169,8 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		// wait for the pull goroutine to finish
 		if err := errGroup.Wait(); err != nil {
 			// don't log flow error for "replState changed" and "slot is already active"
-			if !(temporal.IsApplicationError(err) || errors.Is(err, connpostgres.ErrSlotActive)) {
+			if !(temporal.IsApplicationError(err) ||
+				shared.CheckSQLStateError(err, connpostgres.SQLStateObjectInUse)) {
 				a.Alerter.LogFlowError(ctx, flowName, err)
 			}
 			if temporal.IsApplicationError(err) {
@@ -248,7 +248,8 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 
 	if err := errGroup.Wait(); err != nil {
 		// don't log flow error for "replState changed" and "slot is already active"
-		if !(temporal.IsApplicationError(err) || errors.Is(err, connpostgres.ErrSlotActive)) {
+		if !(temporal.IsApplicationError(err) ||
+			shared.CheckSQLStateError(err, connpostgres.SQLStateObjectInUse)) {
 			a.Alerter.LogFlowError(ctx, flowName, err)
 		}
 		if temporal.IsApplicationError(err) {

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -171,7 +171,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		if err := errGroup.Wait(); err != nil {
 			// don't log flow error for "replState changed" and "slot is already active"
 			if !(temporal.IsApplicationError(err) ||
-				shared.CheckSQLStateError(err, pgerrcode.ObjectInUse)) {
+				shared.IsSQLStateError(err, pgerrcode.ObjectInUse)) {
 				a.Alerter.LogFlowError(ctx, flowName, err)
 			}
 			if temporal.IsApplicationError(err) {
@@ -250,7 +250,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	if err := errGroup.Wait(); err != nil {
 		// don't log flow error for "replState changed" and "slot is already active"
 		if !(temporal.IsApplicationError(err) ||
-			shared.CheckSQLStateError(err, pgerrcode.ObjectInUse)) {
+			shared.IsSQLStateError(err, pgerrcode.ObjectInUse)) {
 			a.Alerter.LogFlowError(ctx, flowName, err)
 		}
 		if temporal.IsApplicationError(err) {

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -168,7 +168,10 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	if !hasRecords {
 		// wait for the pull goroutine to finish
 		if err := errGroup.Wait(); err != nil {
-			a.Alerter.LogFlowError(ctx, flowName, err)
+			// don't log flow error for "replState changed" and "slot is already active"
+			if !(temporal.IsApplicationError(err) || err == connpostgres.ErrSlotActive) {
+				a.Alerter.LogFlowError(ctx, flowName, err)
+			}
 			if temporal.IsApplicationError(err) {
 				return nil, err
 			} else {
@@ -243,7 +246,10 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	})
 
 	if err := errGroup.Wait(); err != nil {
-		a.Alerter.LogFlowError(ctx, flowName, err)
+		// don't log flow error for "replState changed" and "slot is already active"
+		if !(temporal.IsApplicationError(err) || err == connpostgres.ErrSlotActive) {
+			a.Alerter.LogFlowError(ctx, flowName, err)
+		}
 		if temporal.IsApplicationError(err) {
 			return nil, err
 		} else {

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.temporal.io/sdk/activity"
@@ -170,7 +171,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		if err := errGroup.Wait(); err != nil {
 			// don't log flow error for "replState changed" and "slot is already active"
 			if !(temporal.IsApplicationError(err) ||
-				shared.CheckSQLStateError(err, connpostgres.SQLStateObjectInUse)) {
+				shared.CheckSQLStateError(err, pgerrcode.ObjectInUse)) {
 				a.Alerter.LogFlowError(ctx, flowName, err)
 			}
 			if temporal.IsApplicationError(err) {
@@ -249,7 +250,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	if err := errGroup.Wait(); err != nil {
 		// don't log flow error for "replState changed" and "slot is already active"
 		if !(temporal.IsApplicationError(err) ||
-			shared.CheckSQLStateError(err, connpostgres.SQLStateObjectInUse)) {
+			shared.CheckSQLStateError(err, pgerrcode.ObjectInUse)) {
 			a.Alerter.LogFlowError(ctx, flowName, err)
 		}
 		if temporal.IsApplicationError(err) {

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -428,7 +429,7 @@ func (c *PostgresConnector) createSlotAndPublication(
 
 func (c *PostgresConnector) createMetadataSchema(ctx context.Context) error {
 	_, err := c.execWithLogging(ctx, fmt.Sprintf(createSchemaSQL, c.metadataSchema))
-	if err != nil && !shared.IsUniqueError(err) {
+	if err != nil && !shared.IsSQLStateError(err, pgerrcode.UniqueViolation) {
 		return fmt.Errorf("error while creating internal schema: %w", err)
 	}
 	return nil

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -269,7 +269,7 @@ func (c *PostgresConnector) SetupMetadataTables(ctx context.Context) error {
 
 	_, err = c.conn.Exec(ctx, fmt.Sprintf(createMirrorJobsTableSQL,
 		c.metadataSchema, mirrorJobsTableIdentifier))
-	if err != nil && !shared.IsUniqueError(err) {
+	if err != nil && !shared.CheckSQLStateError(err, pgerrcode.UniqueViolation) {
 		return fmt.Errorf("error creating table %s: %w", mirrorJobsTableIdentifier, err)
 	}
 

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -29,11 +30,6 @@ import (
 	"github.com/PeerDB-io/peer-flow/otel_metrics/peerdb_guages"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
 	"github.com/PeerDB-io/peer-flow/shared"
-)
-
-const (
-	SQLStateDuplicateObject = "42710"
-	SQLStateObjectInUse     = "55006"
 )
 
 type PostgresConnector struct {
@@ -1275,7 +1271,7 @@ func (c *PostgresConnector) AddTablesToPublication(ctx context.Context, req *pro
 				utils.QuoteIdentifier(c.getDefaultPublicationName(req.FlowJobName)),
 				schemaTable.String()))
 			// don't error out if table is already added to our publication
-			if err != nil && !shared.CheckSQLStateError(err, SQLStateDuplicateObject) {
+			if err != nil && !shared.CheckSQLStateError(err, pgerrcode.DuplicateObject) {
 				return fmt.Errorf("failed to alter publication: %w", err)
 			}
 			c.logger.Info("added table to publication",

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -269,7 +269,7 @@ func (c *PostgresConnector) SetupMetadataTables(ctx context.Context) error {
 
 	_, err = c.conn.Exec(ctx, fmt.Sprintf(createMirrorJobsTableSQL,
 		c.metadataSchema, mirrorJobsTableIdentifier))
-	if err != nil && !shared.CheckSQLStateError(err, pgerrcode.UniqueViolation) {
+	if err != nil && !shared.IsSQLStateError(err, pgerrcode.UniqueViolation) {
 		return fmt.Errorf("error creating table %s: %w", mirrorJobsTableIdentifier, err)
 	}
 
@@ -1271,7 +1271,7 @@ func (c *PostgresConnector) AddTablesToPublication(ctx context.Context, req *pro
 				utils.QuoteIdentifier(c.getDefaultPublicationName(req.FlowJobName)),
 				schemaTable.String()))
 			// don't error out if table is already added to our publication
-			if err != nil && !shared.CheckSQLStateError(err, pgerrcode.DuplicateObject) {
+			if err != nil && !shared.IsSQLStateError(err, pgerrcode.DuplicateObject) {
 				return fmt.Errorf("failed to alter publication: %w", err)
 			}
 			c.logger.Info("added table to publication",

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.temporal.io/sdk/log"
@@ -632,7 +633,7 @@ func (c *PostgresConnector) SetupQRepMetadataTables(ctx context.Context, config 
 	)`, metadataTableIdentifier.Sanitize())
 	// execute create table query
 	_, err = c.execWithLogging(ctx, createQRepMetadataTableSQL)
-	if err != nil && !shared.IsUniqueError(err) {
+	if err != nil && !shared.IsSQLStateError(err, pgerrcode.UniqueViolation) {
 		return fmt.Errorf("failed to create table %s: %w", qRepMetadataTableName, err)
 	}
 	c.logger.Info("Setup metadata table.")

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -368,8 +368,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 	dstTableName := "test_types_bq"
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
-		!shared.IsSQLStateError(enumErr, pgerrcode.UniqueViolation) {
+	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -368,7 +368,8 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 	dstTableName := "test_types_bq"
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
+	if enumErr != nil &&
+		!shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -9,7 +9,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
 	"github.com/PeerDB-io/peer-flow/e2e"
@@ -368,9 +367,9 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 	srcTableName := s.attachSchemaSuffix("test_types_bq")
 	dstTableName := "test_types_bq"
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
-	var pgErr *pgconn.PgError
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if errors.As(enumErr, &pgErr) && pgErr.Code != pgerrcode.DuplicateObject && !shared.IsUniqueError(pgErr) {
+	if !shared.CheckSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
+		!shared.CheckSQLStateError(enumErr, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -368,8 +368,8 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 	dstTableName := "test_types_bq"
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if !shared.CheckSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
-		!shared.CheckSQLStateError(enumErr, pgerrcode.UniqueViolation) {
+	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
+		!shared.IsSQLStateError(enumErr, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -159,9 +158,9 @@ func (s PeerFlowE2ETestSuitePG) Test_Enums_PG() {
 	srcTableName := s.attachSchemaSuffix("test_enum_flow")
 	dstTableName := s.attachSchemaSuffix("test_enum_flow_dst")
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
-	var pgErr *pgconn.PgError
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if errors.As(enumErr, &pgErr) && pgErr.Code != pgerrcode.DuplicateObject && !shared.IsUniqueError(enumErr) {
+	if !shared.CheckSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
+		!shared.CheckSQLStateError(enumErr, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -159,7 +159,8 @@ func (s PeerFlowE2ETestSuitePG) Test_Enums_PG() {
 	dstTableName := s.attachSchemaSuffix("test_enum_flow_dst")
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
+	if enumErr != nil &&
+		!shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -159,8 +159,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Enums_PG() {
 	dstTableName := s.attachSchemaSuffix("test_enum_flow_dst")
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
-		!shared.IsSQLStateError(enumErr, pgerrcode.UniqueViolation) {
+	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -159,8 +159,8 @@ func (s PeerFlowE2ETestSuitePG) Test_Enums_PG() {
 	dstTableName := s.attachSchemaSuffix("test_enum_flow_dst")
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if !shared.CheckSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
-		!shared.CheckSQLStateError(enumErr, pgerrcode.UniqueViolation) {
+	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
+		!shared.IsSQLStateError(enumErr, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -26,10 +26,7 @@ func TestPeerFlowE2ETestSuitePG(t *testing.T) {
 
 func (s PeerFlowE2ETestSuitePG) setupSourceTable(tableName string, rowCount int) {
 	require.NoError(s.t, e2e.CreateTableForQRep(s.Conn(), s.suffix, tableName))
-
-	if rowCount > 0 {
-		require.NoError(s.t, e2e.PopulateSourceTable(s.Conn(), s.suffix, tableName, rowCount))
-	}
+	s.populateSourceTable(tableName, rowCount)
 }
 
 func (s PeerFlowE2ETestSuitePG) populateSourceTable(tableName string, rowCount int) {

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -2,13 +2,11 @@ package e2e_snowflake
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
 	"github.com/PeerDB-io/peer-flow/e2e"
@@ -445,9 +443,9 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 	srcTableName := s.attachSchemaSuffix("test_types_sf")
 	dstTableName := fmt.Sprintf("%s.%s", s.sfHelper.testSchemaName, "test_types_sf")
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
-	var pgErr *pgconn.PgError
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if errors.As(enumErr, &pgErr) && pgErr.Code != pgerrcode.DuplicateObject && !shared.IsUniqueError(pgErr) {
+	if !shared.CheckSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
+		!shared.CheckSQLStateError(enumErr, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -444,7 +444,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 	dstTableName := fmt.Sprintf("%s.%s", s.sfHelper.testSchemaName, "test_types_sf")
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
+	if enumErr != nil &&
+		!shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -444,8 +444,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 	dstTableName := fmt.Sprintf("%s.%s", s.sfHelper.testSchemaName, "test_types_sf")
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
-		!shared.IsSQLStateError(enumErr, pgerrcode.UniqueViolation) {
+	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -444,8 +444,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 	dstTableName := fmt.Sprintf("%s.%s", s.sfHelper.testSchemaName, "test_types_sf")
 	createMoodEnum := "CREATE TYPE mood AS ENUM ('happy', 'sad', 'angry');"
 	_, enumErr := s.Conn().Exec(context.Background(), createMoodEnum)
-	if !shared.CheckSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
-		!shared.CheckSQLStateError(enumErr, pgerrcode.UniqueViolation) {
+	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
+		!shared.IsSQLStateError(enumErr, pgerrcode.UniqueViolation) {
 		require.NoError(s.t, enumErr)
 	}
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -278,8 +278,7 @@ func CreateTableForQRep(conn *pgx.Conn, suffix string, tableName string) error {
 	}
 	tblFieldStr := strings.Join(tblFields, ",")
 	_, enumErr := conn.Exec(context.Background(), createMoodEnum)
-	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
-		!shared.IsSQLStateError(enumErr, pgerrcode.UniqueViolation) {
+	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
 		return enumErr
 	}
 	_, err := conn.Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -286,7 +286,6 @@ func CreateTableForQRep(conn *pgx.Conn, suffix string, tableName string) error {
 		CREATE TABLE e2e_test_%s.%s (
 			%s
 		);`, suffix, tableName, tblFieldStr))
-
 	if err != nil {
 		return fmt.Errorf("error creating table for qrep tests: %w", err)
 	}

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -278,7 +278,8 @@ func CreateTableForQRep(conn *pgx.Conn, suffix string, tableName string) error {
 	}
 	tblFieldStr := strings.Join(tblFields, ",")
 	_, enumErr := conn.Exec(context.Background(), createMoodEnum)
-	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
+	if enumErr != nil &&
+		!shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject, pgerrcode.UniqueViolation) {
 		return enumErr
 	}
 	_, err := conn.Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -278,8 +278,8 @@ func CreateTableForQRep(conn *pgx.Conn, suffix string, tableName string) error {
 	}
 	tblFieldStr := strings.Join(tblFields, ",")
 	_, enumErr := conn.Exec(context.Background(), createMoodEnum)
-	if !shared.CheckSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
-		!shared.CheckSQLStateError(enumErr, pgerrcode.UniqueViolation) {
+	if !shared.IsSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
+		!shared.IsSQLStateError(enumErr, pgerrcode.UniqueViolation) {
 		return enumErr
 	}
 	_, err := conn.Exec(context.Background(), fmt.Sprintf(`

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -286,7 +286,11 @@ func CreateTableForQRep(conn *pgx.Conn, suffix string, tableName string) error {
 			%s
 		);`, suffix, tableName, tblFieldStr))
 
-	return err
+	if err != nil {
+		return fmt.Errorf("error creating table for qrep tests: %w", err)
+	}
+
+	return nil
 }
 
 func generate20MBJson() ([]byte, error) {
@@ -355,7 +359,7 @@ func PopulateSourceTable(conn *pgx.Conn, suffix string, tableName string, rowCou
 			) VALUES %s;
 	`, suffix, tableName, strings.Join(rows, ",")))
 	if err != nil {
-		return err
+		return fmt.Errorf("error populating source table with initial data: %w", err)
 	}
 
 	// add a row where all the nullable fields are null

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/enums/v1"
@@ -278,9 +277,9 @@ func CreateTableForQRep(conn *pgx.Conn, suffix string, tableName string) error {
 		"mymac MACADDR",
 	}
 	tblFieldStr := strings.Join(tblFields, ",")
-	var pgErr *pgconn.PgError
 	_, enumErr := conn.Exec(context.Background(), createMoodEnum)
-	if errors.As(enumErr, &pgErr) && pgErr.Code != pgerrcode.DuplicateObject && !shared.IsUniqueError(pgErr) {
+	if !shared.CheckSQLStateError(enumErr, pgerrcode.DuplicateObject) &&
+		!shared.CheckSQLStateError(enumErr, pgerrcode.UniqueViolation) {
 		return enumErr
 	}
 	_, err := conn.Exec(context.Background(), fmt.Sprintf(`

--- a/flow/shared/postgres.go
+++ b/flow/shared/postgres.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -27,11 +26,6 @@ const (
 	POSTGRES_14 PGVersion = 140000
 	POSTGRES_15 PGVersion = 150000
 )
-
-func IsUniqueError(err error) bool {
-	var pgerr *pgconn.PgError
-	return errors.As(err, &pgerr) && pgerr.Code == pgerrcode.UniqueViolation
-}
 
 func GetPGConnectionString(pgConfig *protos.PostgresConfig) string {
 	passwordEscaped := url.QueryEscape(pgConfig.Password)
@@ -128,5 +122,5 @@ func UpdateCDCConfigInCatalog(ctx context.Context, pool *pgxpool.Pool,
 
 func CheckSQLStateError(err error, sqlState string) bool {
 	var pgerr *pgconn.PgError
-	return errors.As(err, &pgerr) && pgerr.SQLState() == sqlState
+	return errors.As(err, &pgerr) && pgerr.Code == sqlState
 }

--- a/flow/shared/postgres.go
+++ b/flow/shared/postgres.go
@@ -125,3 +125,8 @@ func UpdateCDCConfigInCatalog(ctx context.Context, pool *pgxpool.Pool,
 	logger.Info("synced state to catalog: updated config_proto in flows", slog.String("flowName", cfg.FlowJobName))
 	return nil
 }
+
+func CheckSQLStateError(err error, sqlState string) bool {
+	var pgerr *pgconn.PgError
+	return errors.As(err, &pgerr) && pgerr.SQLState() == sqlState
+}

--- a/flow/shared/postgres.go
+++ b/flow/shared/postgres.go
@@ -120,7 +120,7 @@ func UpdateCDCConfigInCatalog(ctx context.Context, pool *pgxpool.Pool,
 	return nil
 }
 
-func CheckSQLStateError(err error, sqlState string) bool {
+func IsSQLStateError(err error, sqlState string) bool {
 	var pgerr *pgconn.PgError
 	return errors.As(err, &pgerr) && pgerr.Code == sqlState
 }

--- a/flow/shared/postgres.go
+++ b/flow/shared/postgres.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -120,7 +121,7 @@ func UpdateCDCConfigInCatalog(ctx context.Context, pool *pgxpool.Pool,
 	return nil
 }
 
-func IsSQLStateError(err error, sqlState string) bool {
-	var pgerr *pgconn.PgError
-	return errors.As(err, &pgerr) && pgerr.Code == sqlState
+func IsSQLStateError(err error, sqlStates ...string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && slices.Contains(sqlStates, pgErr.Code)
 }


### PR DESCRIPTION
1. `replState changed` is usually after something else happened, so no need to alert on its own
2. `slot is active` is annoyingly common, it autorecovers, don't alert