### PR TITLE
Validate publication via create and drop

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -325,6 +325,30 @@ func (c *PostgresConnector) GetSlotInfo(ctx context.Context, slotName string) ([
 	return getSlotInfo(ctx, c.conn, slotName, c.config.Database)
 }
 
+func (c *PostgresConnector) CreatePublication(
+	ctx context.Context,
+	srcTableNames []string,
+	publication string,
+) error {
+	tableNameString := strings.Join(srcTableNames, ", ")
+	// check and enable publish_via_partition_root
+	pgversion, err := c.MajorVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("[publication-creation]:error checking Postgres version: %w", err)
+	}
+	var pubViaRootString string
+	if pgversion >= shared.POSTGRES_13 {
+		pubViaRootString = " WITH(publish_via_partition_root=true)"
+	}
+	// Create the publication to help filter changes only for the given tables
+	stmt := fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s%s", publication, tableNameString, pubViaRootString)
+	if _, err = c.execWithLogging(ctx, stmt); err != nil {
+		c.logger.Warn(fmt.Sprintf("Error creating publication '%s': %v", publication, err))
+		return fmt.Errorf("error creating publication '%s' : %w", publication, err)
+	}
+	return nil
+}
+
 // createSlotAndPublication creates the replication slot and publication.
 func (c *PostgresConnector) createSlotAndPublication(
 	ctx context.Context,
@@ -342,26 +366,13 @@ func (c *PostgresConnector) createSlotAndPublication(
 		for srcTableName := range tableNameMapping {
 			parsedSrcTableName, err := utils.ParseSchemaTable(srcTableName)
 			if err != nil {
-				return fmt.Errorf("source table identifier %s is invalid", srcTableName)
+				return fmt.Errorf("[publication-creation]:source table identifier %s is invalid", srcTableName)
 			}
 			srcTableNames = append(srcTableNames, parsedSrcTableName.String())
 		}
-		tableNameString := strings.Join(srcTableNames, ", ")
-
-		// check and enable publish_via_partition_root
-		pgversion, err := c.MajorVersion(ctx)
+		err := c.CreatePublication(ctx, srcTableNames, publication)
 		if err != nil {
-			return fmt.Errorf("error checking Postgres version: %w", err)
-		}
-		var pubViaRootString string
-		if pgversion >= shared.POSTGRES_13 {
-			pubViaRootString = " WITH(publish_via_partition_root=true)"
-		}
-		// Create the publication to help filter changes only for the given tables
-		stmt := fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s%s", publication, tableNameString, pubViaRootString)
-		if _, err = c.execWithLogging(ctx, stmt); err != nil {
-			c.logger.Warn(fmt.Sprintf("Error creating publication '%s': %v", publication, err))
-			return fmt.Errorf("error creating publication '%s' : %w", publication, err)
+			return err
 		}
 	}
 

--- a/flow/connectors/postgres/validate.go
+++ b/flow/connectors/postgres/validate.go
@@ -133,16 +133,13 @@ func (c *PostgresConnector) CheckReplicationConnectivity(ctx context.Context) er
 }
 
 func (c *PostgresConnector) CheckPublicationCreationPermissions(ctx context.Context, srcTableNames []string) error {
-	// Check if we can create a publication
-	// First create a dummy publication
 	pubName := "_peerdb_unused_publication_" + shared.RandomString(5)
 	err := c.CreatePublication(ctx, srcTableNames, pubName)
 	if err != nil {
 		return err
 	}
 
-	// Drop the dummy publication
-	_, err = c.conn.Exec(ctx, fmt.Sprintf("DROP PUBLICATION %s;", pubName))
+	_, err = c.conn.Exec(ctx, "DROP PUBLICATION "+pubName)
 	if err != nil {
 		return fmt.Errorf("failed to drop publication: %v", err)
 	}

--- a/flow/connectors/postgres/validate.go
+++ b/flow/connectors/postgres/validate.go
@@ -133,7 +133,7 @@ func (c *PostgresConnector) CheckReplicationConnectivity(ctx context.Context) er
 }
 
 func (c *PostgresConnector) CheckPublicationCreationPermissions(ctx context.Context, srcTableNames []string) error {
-	pubName := "_peerdb_unused_publication_" + shared.RandomString(5)
+	pubName := "_peerdb_tmp_test_publication_" + shared.RandomString(5)
 	err := c.CreatePublication(ctx, srcTableNames, pubName)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR adds validation in create mirror for creating a publication when no publication is selected.
Refactored existing publication creation code into a common function used by setup flow and validate mirror

![Screenshot 2024-08-26 at 8 11 09 PM](https://github.com/user-attachments/assets/2f4d5146-0b87-40d4-83bc-d41a83e0c798)
