### PR TITLE
Generate flow-api-client changes to its own branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           workspaces: nexus
 
-
       - name: cargo check
         run: cargo check
         working-directory: ./nexus

--- a/.github/workflows/flow-api-client.yml
+++ b/.github/workflows/flow-api-client.yml
@@ -1,0 +1,26 @@
+name: flow-api-client
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: generate or hydrate protos
+      uses: ./.github/actions/genprotos
+
+    - name: Commit Build Artifacts
+      run: |
+        git config --global user.name "Continuous Integration"
+        git config --global user.email "username@users.noreply.github.com"
+        git fetch origin flow-api-client:flow-api-client
+        git checkout flow-api-client
+        cp flow/generated/protos/* .
+        git add *.*
+        git commit -m "$GITHUB_SHA" && git push --set-upstream origin flow-api-client
+        git checkout "$GITHUB_SHA"


### PR DESCRIPTION
Avoids having to include generated files in PRs, isolating them to a branch

Once this is validated & downstream updates to new module path, generated files can be removed from main