### PR TITLE
SetupNormalize: fix enable nullable

### DIFF
--- a/flow/shared/schema_helpers.go
+++ b/flow/shared/schema_helpers.go
@@ -59,6 +59,7 @@ func BuildProcessedSchemaMapping(tableMappings []*protos.TableMapping,
 						TableIdentifier:       tableSchema.TableIdentifier,
 						PrimaryKeyColumns:     tableSchema.PrimaryKeyColumns,
 						IsReplicaIdentityFull: tableSchema.IsReplicaIdentityFull,
+						NullableEnabled:       tableSchema.NullableEnabled,
 						System:                tableSchema.System,
 						Columns:               columns,
 					}


### PR DESCRIPTION
This PR includes nullableEnabled when building the tableschemamapping for setupNormalize.
Seems like this one wiring was missed for the nullable setting