### PR TITLE
Make resync more reliable for warehouse connectors

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -190,6 +190,7 @@ func (a *FlowableActivity) CreateNormalizedTable(
 			tableSchema,
 			config.SoftDeleteColName,
 			config.SyncedAtColName,
+			config.IsResync,
 		)
 		if err != nil {
 			a.Alerter.LogFlowError(ctx, config.FlowName, err)

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -704,18 +704,16 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 
 	if isResync {
 		_, existsErr := table.Metadata(ctx)
-		if existsErr != nil {
-			if !strings.Contains(existsErr.Error(), "notFound") {
-				return false, fmt.Errorf("error while checking metadata for BigQuery resynced table %s: %w",
-					tableIdentifier, existsErr)
-			}
-		} else {
+		if existsErr == nil {
 			c.logger.Info("[bigquery] deleting existing resync table",
 				slog.String("table", tableIdentifier))
 			deleteErr := table.Delete(ctx)
 			if deleteErr != nil {
 				return false, fmt.Errorf("failed to delete table %s: %w", tableIdentifier, deleteErr)
 			}
+		} else if !strings.Contains(existsErr.Error(), "notFound") {
+			return false, fmt.Errorf("error while checking metadata for BigQuery resynced table %s: %w",
+				tableIdentifier, existsErr)
 		}
 	}
 

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -765,87 +765,103 @@ func (c *BigQueryConnector) RenameTables(ctx context.Context, req *protos.Rename
 		c.logger.Info(fmt.Sprintf("renaming table '%s' to '%s'...", srcDatasetTable.string(),
 			dstDatasetTable.string()))
 
-		// if source table does not exist, log and continue.
+		// if _resync table does not exist, log and continue.
 		dataset := c.client.DatasetInProject(c.projectID, srcDatasetTable.dataset)
 		_, err := dataset.Table(srcDatasetTable.table).Metadata(ctx)
 		if err != nil {
-			c.logger.Info(fmt.Sprintf("table '%s' does not exist, skipping rename", srcDatasetTable.string()))
+			if !strings.Contains(err.Error(), "notFound") {
+				return nil, fmt.Errorf("[renameTable] failed to get metadata for _resync table %s: %w", srcDatasetTable.string(), err)
+			}
+			c.logger.Info(fmt.Sprintf("table '%s' does not exist, skipping...", srcDatasetTable.string()))
 			continue
 		}
 
-		// For a table with replica identity full and a JSON column
-		// the equals to comparison we do down below will fail
-		// so we need to use TO_JSON_STRING for those columns
-		columnIsJSON := make(map[string]bool, len(renameRequest.TableSchema.Columns))
-		columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
-		for _, col := range renameRequest.TableSchema.Columns {
-			quotedCol := "`" + col.Name + "`"
-			columnNames = append(columnNames, quotedCol)
-			columnIsJSON[quotedCol] = (col.Type == "json" || col.Type == "jsonb")
+		// if the original table does not exist, log and skip soft delete step
+		originalTableExists := true
+		_, err = dataset.Table(dstDatasetTable.table).Metadata(ctx)
+		if err != nil {
+			if !strings.Contains(err.Error(), "notFound") {
+				return nil, fmt.Errorf("[renameTable] failed to get metadata for original table %s: %w", dstDatasetTable.string(), err)
+			}
+			originalTableExists = false
+			c.logger.Info(fmt.Sprintf("original table '%s' does not exist, skipping soft delete step...", dstDatasetTable.string()))
 		}
 
-		if req.SoftDeleteColName != "" {
-			allColsBuilder := strings.Builder{}
-			for idx, col := range columnNames {
-				allColsBuilder.WriteString("_pt.")
-				allColsBuilder.WriteString(col)
-				if idx < len(columnNames)-1 {
-					allColsBuilder.WriteString(",")
-				}
+		if originalTableExists {
+			// For a table with replica identity full and a JSON column
+			// the equals to comparison we do down below will fail
+			// so we need to use TO_JSON_STRING for those columns
+			columnIsJSON := make(map[string]bool, len(renameRequest.TableSchema.Columns))
+			columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
+			for _, col := range renameRequest.TableSchema.Columns {
+				quotedCol := "`" + col.Name + "`"
+				columnNames = append(columnNames, quotedCol)
+				columnIsJSON[quotedCol] = (col.Type == "json" || col.Type == "jsonb")
 			}
 
-			allColsWithoutAlias := strings.Join(columnNames, ",")
-			allColsWithAlias := allColsBuilder.String()
-
-			pkeyCols := make([]string, 0, len(renameRequest.TableSchema.PrimaryKeyColumns))
-			for _, pkeyCol := range renameRequest.TableSchema.PrimaryKeyColumns {
-				pkeyCols = append(pkeyCols, "`"+pkeyCol+"`")
-			}
-
-			c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", dstDatasetTable.string()))
-
-			pkeyOnClauseBuilder := strings.Builder{}
-			ljWhereClauseBuilder := strings.Builder{}
-			for idx, col := range pkeyCols {
-				if columnIsJSON[col] {
-					// We need to use TO_JSON_STRING for comparing JSON columns
-					pkeyOnClauseBuilder.WriteString("TO_JSON_STRING(_pt.")
-					pkeyOnClauseBuilder.WriteString(col)
-					pkeyOnClauseBuilder.WriteString(")=TO_JSON_STRING(_resync.")
-					pkeyOnClauseBuilder.WriteString(col)
-					pkeyOnClauseBuilder.WriteString(")")
-				} else {
-					pkeyOnClauseBuilder.WriteString("_pt.")
-					pkeyOnClauseBuilder.WriteString(col)
-					pkeyOnClauseBuilder.WriteString("=_resync.")
-					pkeyOnClauseBuilder.WriteString(col)
+			if req.SoftDeleteColName != "" {
+				allColsBuilder := strings.Builder{}
+				for idx, col := range columnNames {
+					allColsBuilder.WriteString("_pt.")
+					allColsBuilder.WriteString(col)
+					if idx < len(columnNames)-1 {
+						allColsBuilder.WriteString(",")
+					}
 				}
 
-				ljWhereClauseBuilder.WriteString("_resync.")
-				ljWhereClauseBuilder.WriteString(col)
-				ljWhereClauseBuilder.WriteString(" IS NULL")
+				allColsWithoutAlias := strings.Join(columnNames, ",")
+				allColsWithAlias := allColsBuilder.String()
 
-				if idx < len(pkeyCols)-1 {
-					pkeyOnClauseBuilder.WriteString(" AND ")
-					ljWhereClauseBuilder.WriteString(" AND ")
+				pkeyCols := make([]string, 0, len(renameRequest.TableSchema.PrimaryKeyColumns))
+				for _, pkeyCol := range renameRequest.TableSchema.PrimaryKeyColumns {
+					pkeyCols = append(pkeyCols, "`"+pkeyCol+"`")
 				}
-			}
 
-			leftJoin := fmt.Sprintf("LEFT JOIN %s _resync ON %s WHERE %s", srcDatasetTable.string(),
-				pkeyOnClauseBuilder.String(), ljWhereClauseBuilder.String())
+				c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", dstDatasetTable.string()))
 
-			q := fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s _pt %s",
-				srcDatasetTable.string(), fmt.Sprintf("%s,%s", allColsWithoutAlias, req.SoftDeleteColName),
-				allColsWithAlias, req.SoftDeleteColName, dstDatasetTable.string(),
-				leftJoin)
+				pkeyOnClauseBuilder := strings.Builder{}
+				ljWhereClauseBuilder := strings.Builder{}
+				for idx, col := range pkeyCols {
+					if columnIsJSON[col] {
+						// We need to use TO_JSON_STRING for comparing JSON columns
+						pkeyOnClauseBuilder.WriteString("TO_JSON_STRING(_pt.")
+						pkeyOnClauseBuilder.WriteString(col)
+						pkeyOnClauseBuilder.WriteString(")=TO_JSON_STRING(_resync.")
+						pkeyOnClauseBuilder.WriteString(col)
+						pkeyOnClauseBuilder.WriteString(")")
+					} else {
+						pkeyOnClauseBuilder.WriteString("_pt.")
+						pkeyOnClauseBuilder.WriteString(col)
+						pkeyOnClauseBuilder.WriteString("=_resync.")
+						pkeyOnClauseBuilder.WriteString(col)
+					}
 
-			query := c.queryWithLogging(q)
+					ljWhereClauseBuilder.WriteString("_resync.")
+					ljWhereClauseBuilder.WriteString(col)
+					ljWhereClauseBuilder.WriteString(" IS NULL")
 
-			query.DefaultProjectID = c.projectID
-			query.DefaultDatasetID = c.datasetID
-			_, err := query.Read(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("unable to handle soft-deletes for table %s: %w", dstDatasetTable.string(), err)
+					if idx < len(pkeyCols)-1 {
+						pkeyOnClauseBuilder.WriteString(" AND ")
+						ljWhereClauseBuilder.WriteString(" AND ")
+					}
+				}
+
+				leftJoin := fmt.Sprintf("LEFT JOIN %s _resync ON %s WHERE %s", srcDatasetTable.string(),
+					pkeyOnClauseBuilder.String(), ljWhereClauseBuilder.String())
+
+				q := fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s _pt %s",
+					srcDatasetTable.string(), fmt.Sprintf("%s,%s", allColsWithoutAlias, req.SoftDeleteColName),
+					allColsWithAlias, req.SoftDeleteColName, dstDatasetTable.string(),
+					leftJoin)
+
+				query := c.queryWithLogging(q)
+
+				query.DefaultProjectID = c.projectID
+				query.DefaultDatasetID = c.datasetID
+				_, err := query.Read(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("unable to handle soft-deletes for table %s: %w", dstDatasetTable.string(), err)
+				}
 			}
 		}
 

--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -159,21 +159,40 @@ func (c *ClickhouseConnector) ReplayTableSchemaDeltas(ctx context.Context, flowJ
 
 func (c *ClickhouseConnector) RenameTables(ctx context.Context, req *protos.RenameTablesInput) (*protos.RenameTablesOutput, error) {
 	for _, renameRequest := range req.RenameTableOptions {
-		columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
-		for _, col := range renameRequest.TableSchema.Columns {
-			columnNames = append(columnNames, col.Name)
+		resyncTableExists, err := c.checkIfTableExists(ctx, c.config.Database, renameRequest.CurrentName)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check if resync table %s exists: %w", renameRequest.CurrentName, err)
 		}
 
-		allCols := strings.Join(columnNames, ",")
-		pkeyCols := strings.Join(renameRequest.TableSchema.PrimaryKeyColumns, ",")
-		c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", renameRequest.NewName))
-		err := c.execWithLogging(ctx,
-			fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s WHERE (%s) NOT IN (SELECT %s FROM %s)",
-				renameRequest.CurrentName, fmt.Sprintf("%s,%s", allCols, signColName), allCols,
-				signColName,
-				renameRequest.NewName, pkeyCols, pkeyCols, renameRequest.CurrentName))
+		if !resyncTableExists {
+			c.logger.Info(fmt.Sprintf("table '%s' does not exist, skipping rename for it", renameRequest.CurrentName))
+			continue
+		}
+
+		originalTableExists, err := c.checkIfTableExists(ctx, c.config.Database, renameRequest.NewName)
 		if err != nil {
-			return nil, fmt.Errorf("unable to handle soft-deletes for table %s: %w", renameRequest.NewName, err)
+			return nil, fmt.Errorf("unable to check if table %s exists: %w", renameRequest.NewName, err)
+		}
+
+		if originalTableExists {
+			columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
+			for _, col := range renameRequest.TableSchema.Columns {
+				columnNames = append(columnNames, col.Name)
+			}
+
+			allCols := strings.Join(columnNames, ",")
+			pkeyCols := strings.Join(renameRequest.TableSchema.PrimaryKeyColumns, ",")
+			c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", renameRequest.NewName))
+			err = c.execWithLogging(ctx,
+				fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s WHERE (%s) NOT IN (SELECT %s FROM %s)",
+					renameRequest.CurrentName, fmt.Sprintf("%s,%s", allCols, signColName), allCols,
+					signColName,
+					renameRequest.NewName, pkeyCols, pkeyCols, renameRequest.CurrentName))
+			if err != nil {
+				return nil, fmt.Errorf("unable to handle soft-deletes for table %s: %w", renameRequest.NewName, err)
+			}
+		} else {
+			c.logger.Info(fmt.Sprintf("table '%s' does not exist, skipping soft-deletes transfer for it", renameRequest.NewName))
 		}
 
 		// drop the dst table if exists

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -81,7 +81,11 @@ func generateCreateTableSQLForNormalizedTable(
 	if isResync {
 		stmtBuilder.WriteString("OR REPLACE ")
 	}
-	stmtBuilder.WriteString("TABLE IF NOT EXISTS `")
+	stmtBuilder.WriteString("TABLE ")
+	if !isResync {
+		stmtBuilder.WriteString("IF NOT EXISTS ")
+	}
+	stmtBuilder.WriteString("`")
 	stmtBuilder.WriteString(normalizedTable)
 	stmtBuilder.WriteString("` (")
 

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -41,6 +41,7 @@ func (c *ClickhouseConnector) SetupNormalizedTable(
 	tableSchema *protos.TableSchema,
 	softDeleteColName string,
 	syncedAtColName string,
+	isResync bool,
 ) (bool, error) {
 	tableAlreadyExists, err := c.checkIfTableExists(ctx, c.config.Database, tableIdentifier)
 	if err != nil {
@@ -55,6 +56,7 @@ func (c *ClickhouseConnector) SetupNormalizedTable(
 		tableSchema,
 		softDeleteColName,
 		syncedAtColName,
+		isResync,
 	)
 	if err != nil {
 		return false, fmt.Errorf("error while generating create table sql for normalized table: %w", err)
@@ -72,9 +74,16 @@ func generateCreateTableSQLForNormalizedTable(
 	tableSchema *protos.TableSchema,
 	_ string, // softDeleteColName
 	syncedAtColName string,
+	isResync bool,
 ) (string, error) {
 	var stmtBuilder strings.Builder
-	stmtBuilder.WriteString(fmt.Sprintf("CREATE TABLE IF NOT EXISTS `%s` (", normalizedTable))
+	stmtBuilder.WriteString("CREATE ")
+	if isResync {
+		stmtBuilder.WriteString("OR REPLACE ")
+	}
+	stmtBuilder.WriteString("TABLE IF NOT EXISTS `")
+	stmtBuilder.WriteString(normalizedTable)
+	stmtBuilder.WriteString("` (")
 
 	for _, column := range tableSchema.Columns {
 		colName := column.Name

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -128,6 +128,7 @@ type NormalizedTablesConnector interface {
 		tableSchema *protos.TableSchema,
 		softDeleteColName string,
 		syncedAtColName string,
+		isResync bool,
 	) (bool, error)
 }
 

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -40,6 +40,7 @@ const (
 	getLastNormalizeBatchID_SQL       = "SELECT normalize_batch_id FROM %s.%s WHERE mirror_job_name=$1"
 	createNormalizedTableSQL          = "CREATE TABLE IF NOT EXISTS %s(%s)"
 	createOrReplaceNormalizedTableSQL = "CREATE OR REPLACE TABLE IF NOT EXISTS %s(%s)"
+	checkTableExistsSQL               = "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname = $1 AND tablename = $2)"
 	upsertJobMetadataForSyncSQL       = `INSERT INTO %s.%s AS j VALUES ($1,$2,$3,$4)
 	 ON CONFLICT(mirror_job_name) DO UPDATE SET lsn_offset=GREATEST(j.lsn_offset, EXCLUDED.lsn_offset), sync_batch_id=EXCLUDED.sync_batch_id`
 	checkIfJobMetadataExistsSQL          = "SELECT COUNT(1)::TEXT::BOOL FROM %s.%s WHERE mirror_job_name=$1"
@@ -648,6 +649,21 @@ func (c *PostgresConnector) getCurrentLSN(ctx context.Context) (pglogrepl.LSN, e
 
 func (c *PostgresConnector) getDefaultPublicationName(jobName string) string {
 	return "peerflow_pub_" + jobName
+}
+
+func (c *PostgresConnector) checkIfTableExistsWithTx(
+	ctx context.Context,
+	schemaName string,
+	tableName string,
+	tx pgx.Tx) (bool, error) {
+	row := tx.QueryRow(ctx, checkTableExistsSQL, schemaName, tableName)
+	var result pgtype.Bool
+	err := row.Scan(&result)
+	if err != nil {
+		return false, fmt.Errorf("error while running query: %w", err)
+	}
+
+	return result.Bool, nil
 }
 
 func (c *PostgresConnector) ExecuteCommand(ctx context.Context, command string) error {

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -648,7 +648,8 @@ func (c *PostgresConnector) checkIfTableExistsWithTx(
 	ctx context.Context,
 	schemaName string,
 	tableName string,
-	tx pgx.Tx) (bool, error) {
+	tx pgx.Tx,
+) (bool, error) {
 	row := tx.QueryRow(ctx, checkTableExistsSQL, schemaName, tableName)
 	var result pgtype.Bool
 	err := row.Scan(&result)

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -34,13 +34,13 @@ const (
 	createRawTableBatchIDIndexSQL  = "CREATE INDEX IF NOT EXISTS %s_batchid_idx ON %s.%s(_peerdb_batch_id)"
 	createRawTableDstTableIndexSQL = "CREATE INDEX IF NOT EXISTS %s_dst_table_idx ON %s.%s(_peerdb_destination_table_name)"
 
-	getLastOffsetSQL            = "SELECT lsn_offset FROM %s.%s WHERE mirror_job_name=$1"
-	setLastOffsetSQL            = "UPDATE %s.%s SET lsn_offset=GREATEST(lsn_offset, $1) WHERE mirror_job_name=$2"
-	getLastSyncBatchID_SQL      = "SELECT sync_batch_id FROM %s.%s WHERE mirror_job_name=$1"
-	getLastNormalizeBatchID_SQL = "SELECT normalize_batch_id FROM %s.%s WHERE mirror_job_name=$1"
-	createNormalizedTableSQL    = "CREATE TABLE IF NOT EXISTS %s(%s)"
-
-	upsertJobMetadataForSyncSQL = `INSERT INTO %s.%s AS j VALUES ($1,$2,$3,$4)
+	getLastOffsetSQL                  = "SELECT lsn_offset FROM %s.%s WHERE mirror_job_name=$1"
+	setLastOffsetSQL                  = "UPDATE %s.%s SET lsn_offset=GREATEST(lsn_offset, $1) WHERE mirror_job_name=$2"
+	getLastSyncBatchID_SQL            = "SELECT sync_batch_id FROM %s.%s WHERE mirror_job_name=$1"
+	getLastNormalizeBatchID_SQL       = "SELECT normalize_batch_id FROM %s.%s WHERE mirror_job_name=$1"
+	createNormalizedTableSQL          = "CREATE TABLE IF NOT EXISTS %s(%s)"
+	createOrReplaceNormalizedTableSQL = "CREATE OR REPLACE TABLE IF NOT EXISTS %s(%s)"
+	upsertJobMetadataForSyncSQL       = `INSERT INTO %s.%s AS j VALUES ($1,$2,$3,$4)
 	 ON CONFLICT(mirror_job_name) DO UPDATE SET lsn_offset=GREATEST(j.lsn_offset, EXCLUDED.lsn_offset), sync_batch_id=EXCLUDED.sync_batch_id`
 	checkIfJobMetadataExistsSQL          = "SELECT COUNT(1)::TEXT::BOOL FROM %s.%s WHERE mirror_job_name=$1"
 	updateMetadataForNormalizeRecordsSQL = "UPDATE %s.%s SET normalize_batch_id=$1 WHERE mirror_job_name=$2"
@@ -455,6 +455,7 @@ func generateCreateTableSQLForNormalizedTable(
 	sourceTableSchema *protos.TableSchema,
 	softDeleteColName string,
 	syncedAtColName string,
+	isResync bool,
 ) string {
 	createTableSQLArray := make([]string, 0, len(sourceTableSchema.Columns)+2)
 	for _, column := range sourceTableSchema.Columns {
@@ -495,7 +496,12 @@ func generateCreateTableSQLForNormalizedTable(
 			strings.Join(primaryKeyColsQuoted, ",")))
 	}
 
-	return fmt.Sprintf(createNormalizedTableSQL, sourceTableIdentifier, strings.Join(createTableSQLArray, ","))
+	createSQL := createNormalizedTableSQL
+	if isResync {
+		createSQL = createOrReplaceNormalizedTableSQL
+	}
+
+	return fmt.Sprintf(createSQL, sourceTableIdentifier, strings.Join(createTableSQLArray, ","))
 }
 
 func (c *PostgresConnector) GetLastSyncBatchID(ctx context.Context, jobName string) (int64, error) {

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1298,35 +1298,55 @@ func (c *PostgresConnector) RenameTables(ctx context.Context, req *protos.Rename
 		}
 		src := srcTable.String()
 
+		resyncTableExists, err := c.checkIfTableExistsWithTx(ctx, srcTable.Schema, srcTable.Table, renameTablesTx)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check if _resync table exists: %w", err)
+		}
+
+		if !resyncTableExists {
+			c.logger.Info(fmt.Sprintf("table '%s' does not exist, skipping rename", src))
+			continue
+		}
+
 		dstTable, err := utils.ParseSchemaTable(renameRequest.NewName)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse destination %s: %w", renameRequest.NewName, err)
 		}
 		dst := dstTable.String()
 
-		if req.SoftDeleteColName != "" {
-			columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
-			for _, col := range renameRequest.TableSchema.Columns {
-				columnNames = append(columnNames, QuoteIdentifier(col.Name))
+		// if original table does not exist, skip soft delete transfer
+		originalTableExists, err := c.checkIfTableExistsWithTx(ctx, dstTable.Schema, dstTable.Table, renameTablesTx)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check if source table exists: %w", err)
+		}
+
+		if originalTableExists {
+			if req.SoftDeleteColName != "" {
+				columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
+				for _, col := range renameRequest.TableSchema.Columns {
+					columnNames = append(columnNames, QuoteIdentifier(col.Name))
+				}
+
+				pkeyColumnNames := make([]string, 0, len(renameRequest.TableSchema.PrimaryKeyColumns))
+				for _, col := range renameRequest.TableSchema.PrimaryKeyColumns {
+					pkeyColumnNames = append(pkeyColumnNames, QuoteIdentifier(col))
+				}
+
+				allCols := strings.Join(columnNames, ",")
+				pkeyCols := strings.Join(pkeyColumnNames, ",")
+
+				c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", dst))
+
+				_, err = c.execWithLoggingTx(ctx,
+					fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s WHERE (%s) NOT IN (SELECT %s FROM %s)",
+						src, fmt.Sprintf("%s,%s", allCols, QuoteIdentifier(req.SoftDeleteColName)), allCols, req.SoftDeleteColName,
+						dst, pkeyCols, pkeyCols, src), renameTablesTx)
+				if err != nil {
+					return nil, fmt.Errorf("unable to handle soft-deletes for table %s: %w", dst, err)
+				}
 			}
-
-			pkeyColumnNames := make([]string, 0, len(renameRequest.TableSchema.PrimaryKeyColumns))
-			for _, col := range renameRequest.TableSchema.PrimaryKeyColumns {
-				pkeyColumnNames = append(pkeyColumnNames, QuoteIdentifier(col))
-			}
-
-			allCols := strings.Join(columnNames, ",")
-			pkeyCols := strings.Join(pkeyColumnNames, ",")
-
-			c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", dst))
-
-			_, err = c.execWithLoggingTx(ctx,
-				fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s WHERE (%s) NOT IN (SELECT %s FROM %s)",
-					src, fmt.Sprintf("%s,%s", allCols, QuoteIdentifier(req.SoftDeleteColName)), allCols, req.SoftDeleteColName,
-					dst, pkeyCols, pkeyCols, src), renameTablesTx)
-			if err != nil {
-				return nil, fmt.Errorf("unable to handle soft-deletes for table %s: %w", dst, err)
-			}
+		} else {
+			c.logger.Info(fmt.Sprintf("table '%s' did not exist, skipped soft delete transfer", dst))
 		}
 
 		// renaming and dropping such that the _resync table is the new destination

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -876,12 +876,17 @@ func (c *PostgresConnector) SetupNormalizedTable(
 	if tableAlreadyExists {
 		c.logger.Info("[postgres] table already exists, skipping",
 			slog.String("table", tableIdentifier))
+		if isResync {
+			c.ExecuteCommand(ctx, fmt.Sprintf(dropTableIfExistsSQL,
+				QuoteIdentifier(parsedNormalizedTable.Schema),
+				QuoteIdentifier(parsedNormalizedTable.Table)))
+		}
 		return true, nil
 	}
 
 	// convert the column names and types to Postgres types
 	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(
-		parsedNormalizedTable.String(), tableSchema, softDeleteColName, syncedAtColName, isResync)
+		parsedNormalizedTable.String(), tableSchema, softDeleteColName, syncedAtColName)
 	_, err = c.execWithLoggingTx(ctx, normalizedTableCreateSQL, createNormalizedTablesTx)
 	if err != nil {
 		return false, fmt.Errorf("error while creating normalized table: %w", err)

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -877,9 +877,12 @@ func (c *PostgresConnector) SetupNormalizedTable(
 		c.logger.Info("[postgres] table already exists, skipping",
 			slog.String("table", tableIdentifier))
 		if isResync {
-			c.ExecuteCommand(ctx, fmt.Sprintf(dropTableIfExistsSQL,
+			err := c.ExecuteCommand(ctx, fmt.Sprintf(dropTableIfExistsSQL,
 				QuoteIdentifier(parsedNormalizedTable.Schema),
 				QuoteIdentifier(parsedNormalizedTable.Table)))
+			if err != nil {
+				return false, fmt.Errorf("error while dropping _resync table: %w", err)
+			}
 		}
 		return true, nil
 	}

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -861,6 +861,7 @@ func (c *PostgresConnector) SetupNormalizedTable(
 	tableSchema *protos.TableSchema,
 	softDeleteColName string,
 	syncedAtColName string,
+	isResync bool,
 ) (bool, error) {
 	createNormalizedTablesTx := tx.(pgx.Tx)
 
@@ -880,7 +881,7 @@ func (c *PostgresConnector) SetupNormalizedTable(
 
 	// convert the column names and types to Postgres types
 	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(
-		parsedNormalizedTable.String(), tableSchema, softDeleteColName, syncedAtColName)
+		parsedNormalizedTable.String(), tableSchema, softDeleteColName, syncedAtColName, isResync)
 	_, err = c.execWithLoggingTx(ctx, normalizedTableCreateSQL, createNormalizedTablesTx)
 	if err != nil {
 		return false, fmt.Errorf("error while creating normalized table: %w", err)

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -38,7 +38,7 @@ const (
 	createDummyTableSQL               = "CREATE TABLE IF NOT EXISTS %s.%s(_PEERDB_DUMMY_COL STRING)"
 	rawTableMultiValueInsertSQL       = "INSERT INTO %s.%s VALUES%s"
 	createNormalizedTableSQL          = "CREATE TABLE IF NOT EXISTS %s(%s)"
-	createOrReplaceNormalizedTableSQL = "CREATE OR REPLACE TABLE IF NOT EXISTS %s(%s)"
+	createOrReplaceNormalizedTableSQL = "CREATE OR REPLACE TABLE %s(%s)"
 	toVariantColumnName               = "VAR_COLS"
 	mergeStatementSQL                 = `MERGE INTO %s TARGET USING (WITH VARIANT_CONVERTED AS (
 		SELECT _PEERDB_UID,_PEERDB_TIMESTAMP,TO_VARIANT(PARSE_JSON(_PEERDB_DATA)) %s,_PEERDB_RECORD_TYPE,

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -153,6 +153,7 @@ func (q *QRepFlowExecution) setupWatermarkTableOnDestination(ctx workflow.Contex
 			SoftDeleteColName: q.config.SoftDeleteColName,
 			FlowName:          q.config.FlowJobName,
 			Env:               q.config.Env,
+			IsResync:          q.config.DstTableFullResync,
 		}
 
 		future := workflow.ExecuteActivity(ctx, flowable.CreateNormalizedTable, setupConfig)

--- a/flow/workflows/setup_flow.go
+++ b/flow/workflows/setup_flow.go
@@ -208,6 +208,7 @@ func (s *SetupFlowExecution) fetchTableSchemaAndSetupNormalizedTables(
 		SyncedAtColName:        flowConnectionConfigs.SyncedAtColName,
 		FlowName:               flowConnectionConfigs.FlowJobName,
 		Env:                    flowConnectionConfigs.Env,
+		IsResync:               flowConnectionConfigs.Resync,
 	}
 
 	future = workflow.ExecuteActivity(ctx, flowable.CreateNormalizedTable, setupConfig)

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -185,6 +185,7 @@ message SetupNormalizedTableBatchInput {
   string synced_at_col_name = 5;
   string flow_name = 6;
   string peer_name = 7;
+  bool is_resync = 8;
 }
 
 message SetupNormalizedTableOutput {


### PR DESCRIPTION
### Overview
Resync is becoming an increasingly utilized feature. Users of our connectors, particularly Clickhouse, sometimes wish to make small table definition changes on target or source and then want to repopulate data. This is alongside the usual recovery use-cases of resync.

### Failure points

`RenameTables` (or resync in general) currently can fail in the following ways:
1. If, between original mirror kick off and resync, a column was added to the table and a row not inserted after, then that column would not have been added to the target via schema changes. In this case, upon resync, the `_resync` table and the original table have different schemas, causing the soft-delete transfer step to fail. This can then lead to:
2. It processes some tables but not all and hits a failure - upon retrying it tries to resync the first table again but the `_resync `table of it is dropped since it succeeded before.
3. Resyncing again midway through a resync (initial load) can result in duplicate data in the `_resync` table if initial load of that `_resync` table was done already.

### Fixes
In light of these scenarios, this PR puts in place the following guards:

- Perform `CREATE OR REPLACE` in `SetupNormalize()` if it is being called in a resync
- If the `_resync` table does not exist, skip rename for the table
- If the original target table does not exist, skip just the soft-delete transfer step

TODO:
- [x] Functionally test the failure points mentioned above for the warehouse peers.
- [x] Also implement clearing of stats after resync : Done by #2029 