### PR TITLE
Adapt validate mirror for initial load only

### DIFF
--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -221,7 +221,7 @@ func (h *FlowRequestHandler) GetTablesInSchema(
 			sizeOfTable = tableSize.String
 		}
 		canMirror := false
-		if hasPkeyOrReplica.Valid && hasPkeyOrReplica.Bool {
+		if !req.CdcEnabled || (hasPkeyOrReplica.Valid && hasPkeyOrReplica.Bool) {
 			canMirror = true
 		}
 

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -79,7 +79,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		if err != nil {
 			displayErr := fmt.Errorf("unable to establish replication connectivity: %v", err)
 			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-				fmt.Sprint(displayErr),
+				displayErr.Error(),
 			)
 			return &protos.ValidateCDCMirrorResponse{
 				Ok: false,

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -72,31 +72,33 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 	}
 	defer pgPeer.Close()
 
-	// Check replication connectivity
-	err = pgPeer.CheckReplicationConnectivity(ctx)
-	if err != nil {
-		displayErr := fmt.Errorf("unable to establish replication connectivity: %v", err)
-		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-			fmt.Sprint(displayErr),
-		)
-		return &protos.ValidateCDCMirrorResponse{
-			Ok: false,
-		}, displayErr
+	noCDC := req.ConnectionConfigs.DoInitialSnapshot && req.ConnectionConfigs.InitialSnapshotOnly
+	if !noCDC {
+		// Check replication connectivity
+		err = pgPeer.CheckReplicationConnectivity(ctx)
+		if err != nil {
+			displayErr := fmt.Errorf("unable to establish replication connectivity: %v", err)
+			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
+				fmt.Sprint(displayErr),
+			)
+			return &protos.ValidateCDCMirrorResponse{
+				Ok: false,
+			}, displayErr
+		}
+
+		// Check permissions of postgres peer
+		err = pgPeer.CheckReplicationPermissions(ctx, sourcePeerConfig.User)
+		if err != nil {
+			displayErr := fmt.Errorf("failed to check replication permissions: %v", err)
+			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
+				fmt.Sprint(displayErr),
+			)
+			return &protos.ValidateCDCMirrorResponse{
+				Ok: false,
+			}, displayErr
+		}
 	}
 
-	// Check permissions of postgres peer
-	err = pgPeer.CheckReplicationPermissions(ctx, sourcePeerConfig.User)
-	if err != nil {
-		displayErr := fmt.Errorf("failed to check replication permissions: %v", err)
-		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-			fmt.Sprint(displayErr),
-		)
-		return &protos.ValidateCDCMirrorResponse{
-			Ok: false,
-		}, displayErr
-	}
-
-	// Check source tables
 	sourceTables := make([]*utils.SchemaTable, 0, len(req.ConnectionConfigs.TableMappings))
 	for _, tableMapping := range req.ConnectionConfigs.TableMappings {
 		parsedTable, parseErr := utils.ParseSchemaTable(tableMapping.SourceTableIdentifier)
@@ -115,7 +117,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 
 	pubName := req.ConnectionConfigs.PublicationName
 
-	if pubName == "" {
+	if pubName == "" && !noCDC {
 		srcTableNames := make([]string, 0, len(sourceTables))
 		for _, srcTable := range sourceTables {
 			srcTableNames = append(srcTableNames, fmt.Sprintf("%s.%s", srcTable.Schema, srcTable.Table))
@@ -133,7 +135,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		}
 	}
 
-	err = pgPeer.CheckSourceTables(ctx, sourceTables, pubName)
+	err = pgPeer.CheckSourceTables(ctx, sourceTables, pubName, noCDC)
 	if err != nil {
 		displayErr := fmt.Errorf("provided source tables invalidated: %v", err)
 		slog.Error(displayErr.Error())

--- a/flow/connectors/postgres/validate.go
+++ b/flow/connectors/postgres/validate.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (c *PostgresConnector) CheckSourceTables(ctx context.Context,
-	tableNames []*utils.SchemaTable, pubName string,
+	tableNames []*utils.SchemaTable, pubName string, noCDC bool,
 ) error {
 	if c.conn == nil {
 		return errors.New("check tables: conn is nil")
@@ -36,7 +36,7 @@ func (c *PostgresConnector) CheckSourceTables(ctx context.Context,
 
 	tableStr := strings.Join(tableArr, ",")
 
-	if pubName != "" {
+	if pubName != "" && !noCDC {
 		// Check if publication exists
 		err := c.conn.QueryRow(ctx, "SELECT pubname FROM pg_publication WHERE pubname=$1", pubName).Scan(nil)
 		if err != nil {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -204,6 +204,7 @@ message PeerPublicationsResponse {
 message SchemaTablesRequest {
   string peer_name = 1;
   string schema_name = 2;
+  bool cdc_enabled = 3;
 }
 
 message SchemaTablesResponse {

--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -190,6 +190,7 @@ const EditMirror = ({ params: { mirrorId } }: EditMirrorProps) => {
         rows={rows}
         setRows={setRows}
         omitAdditionalTablesMapping={omitAdditionalTablesMapping}
+        initialLoadOnly={false}
       />
 
       {isNotPaused && (

--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -117,7 +117,7 @@ export default function CDCConfigForm({
     });
     getScriptingEnabled();
     setLoading(false);
-  }, [mirrorConfig.sourceName]);
+  }, [mirrorConfig.sourceName, mirrorConfig.initialSnapshotOnly]);
 
   if (loading) {
     return <ProgressCircle variant='determinate_progress_circle' />;
@@ -177,6 +177,7 @@ export default function CDCConfigForm({
           setRows={setRows}
           peerType={destinationType}
           omitAdditionalTablesMapping={new Map<string, string[]>()}
+          initialLoadOnly={mirrorConfig.initialSnapshotOnly}
         />
       </>
     );

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -39,6 +39,7 @@ interface SchemaBoxProps {
   >;
   peerType?: DBType;
   omitAdditionalTables: string[] | undefined;
+  initialLoadOnly?: boolean;
 }
 
 const SchemaBox = ({
@@ -50,6 +51,7 @@ const SchemaBox = ({
   tableColumns,
   setTableColumns,
   omitAdditionalTables,
+  initialLoadOnly,
 }: SchemaBoxProps) => {
   const [tablesLoading, setTablesLoading] = useState(false);
   const [columnsLoading, setColumnsLoading] = useState(false);
@@ -164,30 +166,41 @@ const SchemaBox = ({
   const fetchTablesForSchema = useCallback(
     (schemaName: string) => {
       setTablesLoading(true);
-      fetchTables(sourcePeer, schemaName, defaultTargetSchema, peerType).then(
-        (newRows) => {
-          for (const row of newRows) {
-            if (omitAdditionalTables?.includes(row.source)) {
-              row.canMirror = false;
-            }
+      fetchTables(
+        sourcePeer,
+        schemaName,
+        defaultTargetSchema,
+        peerType,
+        initialLoadOnly
+      ).then((newRows) => {
+        for (const row of newRows) {
+          if (omitAdditionalTables?.includes(row.source)) {
+            row.canMirror = false;
           }
-          setRows((oldRows) => {
-            const filteredRows = oldRows.filter(
-              (oldRow) => oldRow.schema !== schemaName
-            );
-            const updatedRows = [...filteredRows, ...newRows];
-            return updatedRows;
-          });
-          setTablesLoading(false);
         }
-      );
+        setRows((oldRows) => {
+          const filteredRows = oldRows.filter(
+            (oldRow) => oldRow.schema !== schemaName
+          );
+          const updatedRows = [...filteredRows, ...newRows];
+          return updatedRows;
+        });
+        setTablesLoading(false);
+      });
     },
-    [setRows, sourcePeer, defaultTargetSchema, peerType, omitAdditionalTables]
+    [
+      setRows,
+      sourcePeer,
+      defaultTargetSchema,
+      peerType,
+      omitAdditionalTables,
+      initialLoadOnly,
+    ]
   );
 
   useEffect(() => {
     fetchTablesForSchema(schema);
-  }, [schema, fetchTablesForSchema]);
+  }, [schema, fetchTablesForSchema, initialLoadOnly]);
 
   return (
     <div style={schemaBoxStyle}>

--- a/ui/app/mirrors/create/cdc/tablemapping.tsx
+++ b/ui/app/mirrors/create/cdc/tablemapping.tsx
@@ -18,6 +18,7 @@ interface TableMappingProps {
   peerType?: DBType;
   // schema -> omitted source table mapping
   omitAdditionalTablesMapping: Map<string, string[]>;
+  initialLoadOnly: boolean;
 }
 
 const TableMapping = ({
@@ -26,6 +27,7 @@ const TableMapping = ({
   setRows,
   peerType,
   omitAdditionalTablesMapping,
+  initialLoadOnly,
 }: TableMappingProps) => {
   const [allSchemas, setAllSchemas] = useState<string[]>();
   const [schemaQuery, setSchemaQuery] = useState('');
@@ -40,7 +42,7 @@ const TableMapping = ({
 
   useEffect(() => {
     fetchSchemas(sourcePeerName).then((res) => setAllSchemas(res));
-  }, [sourcePeerName]);
+  }, [sourcePeerName, initialLoadOnly]);
 
   return (
     <div style={{ marginTop: '1rem' }}>
@@ -109,6 +111,7 @@ const TableMapping = ({
               setTableColumns={setTableColumns}
               peerType={peerType}
               omitAdditionalTables={omitAdditionalTablesMapping.get(schema)}
+              initialLoadOnly={initialLoadOnly}
             />
           ))
         ) : (

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -365,13 +365,14 @@ export async function fetchTables(
   peerName: string,
   schemaName: string,
   targetSchemaName: string,
-  peerType?: DBType
+  peerType?: DBType,
+  initialLoadOnly?: boolean
 ) {
   if (schemaName.length === 0) return [];
   const tablesRes: SchemaTablesResponse = await fetch(
     `/api/v1/peers/tables?peerName=${encodeURIComponent(
       peerName
-    )}&schema_name=${encodeURIComponent(schemaName)}`,
+    )}&schema_name=${encodeURIComponent(schemaName)}&cdc_enabled=${!initialLoadOnly}`,
     {
       cache: 'no-store',
     }


### PR DESCRIPTION
If initial load only is selected in UI, allow non-mirrorable tables to be synced, and validation will not check replication and publication related things.

Functionally tested

One item I tried was also allowing excluding primary key columns when initial load only is selected, but seems like this requires some refactoring on the pull side. Could do it in this PR or follow up