### PR TITLE
mysql: remove WITH TIMEZONE / WITHOUT TIMEZONE syntax from casts

### DIFF
--- a/flow/connectors/utils/peers.go
+++ b/flow/connectors/utils/peers.go
@@ -57,6 +57,12 @@ func CreatePeerNoValidate(
 			return wrongConfigResponse, nil
 		}
 		innerConfig = s3ConfigObject.S3Config
+	case protos.DBType_MYSQL:
+		myConfigObject, ok := config.(*protos.Peer_MysqlConfig)
+		if !ok {
+			return wrongConfigResponse, nil
+		}
+		innerConfig = myConfigObject.MysqlConfig
 	case protos.DBType_CLICKHOUSE:
 		chConfigObject, ok := config.(*protos.Peer_ClickhouseConfig)
 		if !ok {


### PR DESCRIPTION
Avoids postgres_fdw enriching queries with syntax MySQL doesn't allow since MySQL timestamps always have tzinfo

DateTime is also the more suitable time type in MySQL, & StarRocks only has DateTime