### PR TITLE
[clickhouse] validate certain aspects of existing destination tables

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -25,12 +27,11 @@ import (
 
 type ClickhouseConnector struct {
 	*metadataStore.PostgresMetadata
-	database           clickhouse.Conn
-	tableSchemaMapping map[string]*protos.TableSchema
-	logger             log.Logger
-	config             *protos.ClickhouseConfig
-	credsProvider      *utils.ClickHouseS3Credentials
-	s3Stage            *ClickHouseS3Stage
+	database      clickhouse.Conn
+	logger        log.Logger
+	config        *protos.ClickhouseConfig
+	credsProvider *utils.ClickHouseS3Credentials
+	s3Stage       *ClickHouseS3Stage
 }
 
 func ValidateS3(ctx context.Context, creds *utils.ClickHouseS3Credentials) error {
@@ -195,13 +196,12 @@ func NewClickhouseConnector(
 	}
 
 	return &ClickhouseConnector{
-		database:           database,
-		PostgresMetadata:   pgMetadata,
-		tableSchemaMapping: nil,
-		config:             config,
-		logger:             logger,
-		credsProvider:      &clickHouseS3CredentialsNew,
-		s3Stage:            NewClickHouseS3Stage(),
+		database:         database,
+		PostgresMetadata: pgMetadata,
+		config:           config,
+		logger:           logger,
+		credsProvider:    &clickHouseS3CredentialsNew,
+		s3Stage:          NewClickHouseS3Stage(),
 	}, nil
 }
 
@@ -272,4 +272,137 @@ func (c *ClickhouseConnector) ConnectionActive(ctx context.Context) error {
 func (c *ClickhouseConnector) execWithLogging(ctx context.Context, query string) error {
 	c.logger.Info("[clickhouse] executing DDL statement", slog.String("query", query))
 	return c.database.Exec(ctx, query)
+}
+
+func (c *ClickhouseConnector) checkTablesEmptyAndEngine(ctx context.Context, tables []string) error {
+	queryInput := make([]interface{}, 0, len(tables)+1)
+	queryInput = append(queryInput, c.config.Database)
+	for _, table := range tables {
+		queryInput = append(queryInput, table)
+	}
+	rows, err := c.database.Query(ctx,
+		fmt.Sprintf("SELECT name,engine,total_rows FROM system.tables WHERE database=? AND table IN (%s)",
+			strings.Join(slices.Repeat([]string{"?"}, len(tables)), ",")), queryInput...)
+	if err != nil {
+		return fmt.Errorf("failed to get information for destination tables: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tableName, engine string
+		var totalRows uint64
+		err = rows.Scan(&tableName, &engine, &totalRows)
+		if err != nil {
+			return fmt.Errorf("failed to scan information for tables: %w", err)
+		}
+		if totalRows != 0 {
+			return fmt.Errorf("table %s exists and is not empty", tableName)
+		}
+		if !slices.Contains(acceptableTableEngines, engine) {
+			return fmt.Errorf("table %s exists and is not using ReplacingMergeTree/MergeTree engine", tableName)
+		}
+	}
+	if rows.Err() != nil {
+		return fmt.Errorf("failed to read rows: %w", rows.Err())
+	}
+	return nil
+}
+
+func (c *ClickhouseConnector) getTableColumnsMapping(ctx context.Context,
+	tables []string,
+) (map[string][]*protos.FieldDescription, error) {
+	tableColumnsMapping := make(map[string][]*protos.FieldDescription, len(tables))
+	queryInput := make([]interface{}, 0, len(tables)+1)
+	queryInput = append(queryInput, c.config.Database)
+	for _, table := range tables {
+		queryInput = append(queryInput, table)
+	}
+	rows, err := c.database.Query(ctx,
+		fmt.Sprintf("SELECT name,type,table FROM system.columns WHERE database=? AND table IN (%s)",
+			strings.Join(slices.Repeat([]string{"?"}, len(tables)), ",")), queryInput...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get columns for destination tables: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var tableName string
+		var fieldDescription protos.FieldDescription
+		err = rows.Scan(&fieldDescription.Name, &fieldDescription.Type, &tableName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan columns for tables: %w", err)
+		}
+		tableColumnsMapping[tableName] = append(tableColumnsMapping[tableName], &fieldDescription)
+	}
+	if rows.Err() != nil {
+		return nil, fmt.Errorf("failed to read rows: %w", rows.Err())
+	}
+	return tableColumnsMapping, nil
+}
+
+func (c *ClickhouseConnector) processTableComparison(dstTableName string, srcSchema *protos.TableSchema,
+	dstSchema []*protos.FieldDescription, peerDBColumns []string,
+) error {
+	for _, srcField := range srcSchema.Columns {
+		found := false
+		for _, dstField := range dstSchema {
+			// not doing type checks for now
+			if srcField.Name == dstField.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("field %s not found in destination table", srcField.Name)
+		}
+	}
+	foundPeerDBColumns := 0
+	for _, dstField := range dstSchema {
+		if slices.Contains(peerDBColumns, dstField.Name) {
+			foundPeerDBColumns++
+		}
+	}
+	if foundPeerDBColumns != len(peerDBColumns) {
+		return fmt.Errorf("not all PeerDB columns found in destination table %s", dstTableName)
+	}
+	return nil
+}
+
+func (c *ClickhouseConnector) CheckDestinationTables(ctx context.Context, req *protos.FlowConnectionConfigs,
+	tableNameSchemaMapping map[string]*protos.TableSchema,
+) error {
+	peerDBColumns := []string{signColName, versionColName}
+	if req.SyncedAtColName != "" {
+		peerDBColumns = append(peerDBColumns, req.SyncedAtColName)
+	}
+	// this is for handling column exclusion
+	processedMapping := shared.BuildProcessedSchemaMapping(req.TableMappings, tableNameSchemaMapping, c.logger)
+	dstTableNames := slices.Collect(maps.Keys(processedMapping))
+	err := c.checkTablesEmptyAndEngine(ctx, dstTableNames)
+	if err != nil {
+		return err
+	}
+	// optimization: fetching columns for all tables at once
+	chTableColumnsMapping, err := c.getTableColumnsMapping(ctx, dstTableNames)
+	if err != nil {
+		return err
+	}
+
+	for _, tableMapping := range req.TableMappings {
+		dstTableName := tableMapping.DestinationTableIdentifier
+		if _, ok := processedMapping[dstTableName]; !ok {
+			// if destination table is not a key, that means source table was not a key in the original schema mapping(?)
+			return fmt.Errorf("source table %s not found in schema mapping", tableMapping.SourceTableIdentifier)
+		}
+		// if destination table does not exist, we're good
+		if _, ok := chTableColumnsMapping[dstTableName]; !ok {
+			continue
+		}
+
+		err = c.processTableComparison(dstTableName, processedMapping[dstTableName],
+			chTableColumnsMapping[dstTableName], peerDBColumns)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -24,6 +24,8 @@ const (
 	versionColType = "Int64"
 )
 
+var acceptableTableEngines = []string{"ReplacingMergeTree", "MergeTree"}
+
 func (c *ClickhouseConnector) StartSetupNormalizedTables(_ context.Context) (interface{}, error) {
 	return nil, nil
 }
@@ -396,8 +398,7 @@ func (c *ClickhouseConnector) getDistinctTableNamesInBatch(
 		tableNames = append(tableNames, tableName.String)
 	}
 
-	err = rows.Err()
-	if err != nil {
+	if rows.Err() != nil {
 		return nil, fmt.Errorf("failed to read rows: %w", err)
 	}
 


### PR DESCRIPTION
Partially addresses #2019 

Tests column name equality taking exclusion into account, PeerDB columns, engine and emptiness