### PR TITLE
Fix snowflake table check

### DIFF
--- a/flow/connectors/snowflake/client.go
+++ b/flow/connectors/snowflake/client.go
@@ -95,6 +95,13 @@ func SnowflakeIdentifierNormalize(identifier string) string {
 	return fmt.Sprintf(`"%s"`, identifier)
 }
 
+func SnowflakeQuotelessIdentifierNormalize(identifier string) string {
+	if utils.IsLower(identifier) {
+		return strings.ToUpper(identifier)
+	}
+	return identifier
+}
+
 func snowflakeSchemaTableNormalize(schemaTable *utils.SchemaTable) string {
 	return fmt.Sprintf(`%s.%s`, SnowflakeIdentifierNormalize(schemaTable.Schema),
 		SnowflakeIdentifierNormalize(schemaTable.Table))


### PR DESCRIPTION
The `checkIfTableExists` function needs the input - schema name and table name - to be in the right case. Tested this on Snowflake and also with a mirror
Also we should not skip `SetupNormalize`  if the mirror is a resync mirror so that we can REPLACE the table downstream