### PR TITLE
Existing tables check in CH: lower case synced_at column

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -385,7 +385,7 @@ func (c *ClickhouseConnector) CheckDestinationTables(ctx context.Context, req *p
 ) error {
 	peerDBColumns := []string{signColName, versionColName}
 	if req.SyncedAtColName != "" {
-		peerDBColumns = append(peerDBColumns, req.SyncedAtColName)
+		peerDBColumns = append(peerDBColumns, strings.ToLower(req.SyncedAtColName))
 	}
 	// this is for handling column exclusion, processed schema does that in a step
 	processedMapping := shared.BuildProcessedSchemaMapping(req.TableMappings, tableNameSchemaMapping, c.logger)


### PR DESCRIPTION
Validation to existing table which peerdb created fails because in SetupNormalize we lower case synced_at column. So that needs to be done in validation as well because by default it is upper case PEERDB_SYNCED_AT