### PR TITLE
CH: Resync guard for setup normalize skip

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -47,7 +47,8 @@ func (c *ClickhouseConnector) SetupNormalizedTable(
 	if err != nil {
 		return false, fmt.Errorf("error occurred while checking if normalized table exists: %w", err)
 	}
-	if tableAlreadyExists {
+	if tableAlreadyExists && !config.IsResync {
+		c.logger.Info("[ch] normalized table already exists, skipping", "table", tableIdentifier)
 		return true, nil
 	}
 

--- a/ui/components/ResyncDialog.tsx
+++ b/ui/components/ResyncDialog.tsx
@@ -23,7 +23,10 @@ export const ResyncDialog = ({ mirrorName }: ResyncDialogProps) => {
 
   const handleResync = async () => {
     setSyncing(true);
-    setMsg({ msg: 'Preparing resync...', color: 'base' });
+    setMsg({
+      msg: 'Requesting a resync. You can close this dialog and check the status',
+      color: 'base',
+    });
     const resyncRes = await fetch('/api/v1/mirrors/resync', {
       method: 'POST',
       body: JSON.stringify({


### PR DESCRIPTION
Do no skip table creation in case of resync mirror because we need it to be REPLACEd downstream