### PR TITLE
OTEL: change semconv to 1.26.0

### DIFF
--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
 )


### PR DESCRIPTION
Our otel manager currently breaks because of schema url version mismatch