### PR TITLE
[clickhouse] make table engines a warning instead of an error

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -305,9 +305,10 @@ func (c *ClickhouseConnector) checkTablesEmptyAndEngine(ctx context.Context, tab
 		if totalRows != 0 {
 			return fmt.Errorf("table %s exists and is not empty", tableName)
 		}
+		engine, _ = strings.CutPrefix(engine, "Shared")
 		if !slices.Contains(acceptableTableEngines, engine) {
-			return fmt.Errorf("table %s exists but is not using ReplacingMergeTree/MergeTree engine,"+
-				" and is using %s instead", tableName, engine)
+			c.logger.Warn("[clickhouse] table engine not explicitly supported",
+				slog.String("table", tableName), slog.String("engine", engine))
 		}
 	}
 	if rows.Err() != nil {

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -305,8 +305,7 @@ func (c *ClickhouseConnector) checkTablesEmptyAndEngine(ctx context.Context, tab
 		if totalRows != 0 {
 			return fmt.Errorf("table %s exists and is not empty", tableName)
 		}
-		engine, _ = strings.CutPrefix(engine, "Shared")
-		if !slices.Contains(acceptableTableEngines, engine) {
+		if !slices.Contains(acceptableTableEngines, strings.TrimPrefix(engine, "Shared")) {
 			c.logger.Warn("[clickhouse] table engine not explicitly supported",
 				slog.String("table", tableName), slog.String("engine", engine))
 		}

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -24,7 +24,7 @@ const (
 	versionColType = "Int64"
 )
 
-var acceptableTableEngines = []string{"ReplacingMergeTree", "MergeTree", "SharedReplacingMergeTree"}
+var acceptableTableEngines = []string{"ReplacingMergeTree", "MergeTree"}
 
 func (c *ClickhouseConnector) StartSetupNormalizedTables(_ context.Context) (interface{}, error) {
 	return nil, nil

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -274,7 +274,7 @@ export const chSchema = (hostDomains: string[]) =>
         invalid_type_error: 'User must be a string',
       })
       .min(1, 'User must be non-empty')
-      .max(64, 'User must be less than 64 characters'),
+      .max(256, 'User must be less than 64 characters'),
     password: z
       .string({
         invalid_type_error: 'Password must be a string',

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -274,7 +274,7 @@ export const chSchema = (hostDomains: string[]) =>
         invalid_type_error: 'User must be a string',
       })
       .min(1, 'User must be non-empty')
-      .max(256, 'User must be less than 64 characters'),
+      .max(128, 'User must be less than 128 characters'),
     password: z
       .string({
         invalid_type_error: 'Password must be a string',


### PR DESCRIPTION
There's engines like Distributed and other MergeTree family which could also be used in special workloads. Until we have more understanding on how these work and how common they are, don't block creation of mirrors.