### PR TITLE
Advance LSN when PKM requested before any records received

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -362,6 +362,10 @@ func PullCdcRecords[Items model.Items](
 
 	for {
 		if pkmRequiresResponse {
+			if cdcRecordsStorage.IsEmpty() {
+				req.ConsumedOffset.Store(int64(clientXLogPos))
+			}
+
 			err := sendStandbyAfterReplLock("pkm-response")
 			if err != nil {
 				return err

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -467,9 +467,7 @@ func PullCdcRecords[Items model.Items](
 				return fmt.Errorf("ParsePrimaryKeepaliveMessage failed: %w", err)
 			}
 
-			logger.Debug(
-				fmt.Sprintf("Primary Keepalive Message => ServerWALEnd: %s ServerTime: %s ReplyRequested: %t",
-					pkm.ServerWALEnd, pkm.ServerTime, pkm.ReplyRequested))
+			logger.Debug("Primary Keepalive Message", slog.Any("data", pkm))
 
 			if pkm.ServerWALEnd > clientXLogPos {
 				clientXLogPos = pkm.ServerWALEnd
@@ -485,8 +483,8 @@ func PullCdcRecords[Items model.Items](
 				return fmt.Errorf("ParseXLogData failed: %w", err)
 			}
 
-			logger.Debug(fmt.Sprintf("XLogData => WALStart %s ServerWALEnd %s ServerTime %s\n",
-				xld.WALStart, xld.ServerWALEnd, xld.ServerTime))
+			logger.Debug("XLogData",
+				slog.Any("WALStart", xld.WALStart), slog.Any("ServerWALEnd", xld.ServerWALEnd), slog.Any("ServerTime", xld.ServerTime))
 			rec, err := processMessage(ctx, p, records, xld, clientXLogPos, processor)
 			if err != nil {
 				return fmt.Errorf("error processing message: %w", err)
@@ -699,8 +697,7 @@ func processInsertMessage[Items model.Items](
 	}
 
 	// log lsn and relation id for debugging
-	p.logger.Debug(fmt.Sprintf("InsertMessage => LSN: %d, RelationID: %d, Relation Name: %s",
-		lsn, relID, tableName))
+	p.logger.Debug("InsertMessage", slog.Any("LSN", lsn), slog.Any("RelationID", relID), slog.String("Relation Name", tableName))
 
 	rel, ok := p.relationMessageMapping[relID]
 	if !ok {
@@ -735,8 +732,7 @@ func processUpdateMessage[Items model.Items](
 	}
 
 	// log lsn and relation id for debugging
-	p.logger.Debug(fmt.Sprintf("UpdateMessage => LSN: %d, RelationID: %d, Relation Name: %s",
-		lsn, relID, tableName))
+	p.logger.Debug("UpdateMessage", slog.Any("LSN", lsn), slog.Any("RelationID", relID), slog.String("Relation Name", tableName))
 
 	rel, ok := p.relationMessageMapping[relID]
 	if !ok {
@@ -779,8 +775,7 @@ func processDeleteMessage[Items model.Items](
 	}
 
 	// log lsn and relation id for debugging
-	p.logger.Debug(fmt.Sprintf("DeleteMessage => LSN: %d, RelationID: %d, Relation Name: %s",
-		lsn, relID, tableName))
+	p.logger.Debug("DeleteMessage", slog.Any("LSN", lsn), slog.Any("RelationID", relID), slog.String("Relation Name", tableName))
 
 	rel, ok := p.relationMessageMapping[relID]
 	if !ok {

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -312,8 +312,7 @@ func PullCdcRecords[Items model.Items](
 	var clientXLogPos pglogrepl.LSN
 	if req.LastOffset > 0 {
 		clientXLogPos = pglogrepl.LSN(req.LastOffset)
-		err := sendStandbyAfterReplLock("initial-flush")
-		if err != nil {
+		if err := sendStandbyAfterReplLock("initial-flush"); err != nil {
 			return err
 		}
 	}
@@ -476,9 +475,9 @@ func PullCdcRecords[Items model.Items](
 				clientXLogPos = pkm.ServerWALEnd
 			}
 
-			// always reply to keepalive messages
-			// instead of `pkm.ReplyRequested`
-			pkmRequiresResponse = true
+			if pkm.ReplyRequested {
+				pkmRequiresResponse = true
+			}
 
 		case pglogrepl.XLogDataByteID:
 			xld, err := pglogrepl.ParseXLogData(msg.Data[1:])


### PR DESCRIPTION
When messages are received while cdc storage is empty we do not need to worry about confirming lsn too early before destination has processed previous records, so go ahead & progress lsn