### PR TITLE
drop ORDER BY _peerdb_timestamp in CH normalize statement

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -344,8 +344,6 @@ func (c *ClickhouseConnector) NormalizeRecords(
 		selectQuery.WriteString(tbl)
 		selectQuery.WriteString("'")
 
-		selectQuery.WriteString(" ORDER BY _peerdb_timestamp")
-
 		insertIntoSelectQuery := strings.Builder{}
 		insertIntoSelectQuery.WriteString("INSERT INTO ")
 		insertIntoSelectQuery.WriteString(tbl)


### PR DESCRIPTION
greatly reduces memory usage