### PR TITLE
nexus: don't rewrite single identifier relations

### DIFF
--- a/nexus/peer-bigquery/src/ast.rs
+++ b/nexus/peer-bigquery/src/ast.rs
@@ -13,14 +13,10 @@ pub struct BigqueryAst;
 
 impl BigqueryAst {
     pub fn is_timestamp_returning_function(&self, name: &str) -> bool {
-        if name.eq_ignore_ascii_case("now")
+        name.eq_ignore_ascii_case("now")
             || name.eq_ignore_ascii_case("date_trunc")
             || name.eq_ignore_ascii_case("make_timestamp")
             || name.eq_ignore_ascii_case("current_timestamp")
-        {
-            return true;
-        }
-        false
     }
 
     pub fn is_timestamp_expr(&self, e: &Expr) -> bool {
@@ -68,10 +64,12 @@ impl BigqueryAst {
         None
     }
 
-    pub fn rewrite(&self, dataset: &str, query: &mut Query) -> anyhow::Result<()> {
+    pub fn rewrite(&self, peername: &str, dataset: &str, query: &mut Query) -> anyhow::Result<()> {
         // replace peername with the connected dataset.
         visit_relations_mut(query, |table| {
-            table.0[0] = dataset.into();
+            if table.0.len() > 1 && peername.eq_ignore_ascii_case(&table.0[0].value) {
+                table.0[0] = dataset.into();
+            }
             ControlFlow::<()>::Continue(())
         });
 

--- a/nexus/peer-bigquery/src/lib.rs
+++ b/nexus/peer-bigquery/src/lib.rs
@@ -98,7 +98,7 @@ impl QueryExecutor for BigQueryQueryExecutor {
             Statement::Query(query) => {
                 let mut query = query.clone();
                 ast::BigqueryAst
-                    .rewrite(&self.dataset_id, &mut query)
+                    .rewrite(&self.peer_name, &self.dataset_id, &mut query)
                     .context("unable to rewrite query")
                     .map_err(|err| PgWireError::ApiError(err.into()))?;
 
@@ -210,7 +210,7 @@ impl QueryExecutor for BigQueryQueryExecutor {
             Statement::Query(query) => {
                 let mut query = query.clone();
                 ast::BigqueryAst
-                    .rewrite(&self.dataset_id, &mut query)
+                    .rewrite(&self.peer_name, &self.dataset_id, &mut query)
                     .context("unable to rewrite query")
                     .map_err(|err| PgWireError::ApiError(err.into()))?;
 

--- a/nexus/peer-postgres/src/ast.rs
+++ b/nexus/peer-postgres/src/ast.rs
@@ -12,7 +12,7 @@ impl PostgresAst {
         visit_relations_mut(query, |table| {
             // if peer name is first part of table name, remove first part
             if let Some(ref peername) = self.peername {
-                if peername.eq_ignore_ascii_case(&table.0[0].value) {
+                if table.0.len() > 1 && peername.eq_ignore_ascii_case(&table.0[0].value) {
                     table.0.remove(0);
                 }
             }

--- a/nexus/peer-snowflake/src/ast.rs
+++ b/nexus/peer-snowflake/src/ast.rs
@@ -10,7 +10,9 @@ pub struct SnowflakeAst;
 impl SnowflakeAst {
     pub fn rewrite(&self, query: &mut Query) -> anyhow::Result<()> {
         visit_relations_mut(query, |table| {
-            table.0.remove(0);
+            if table.0.len() > 1 {
+                table.0.remove(0);
+            }
             ControlFlow::<()>::Continue(())
         });
 


### PR DESCRIPTION
rewrite rule was screwing up cte identifiers