### PR TITLE
bypass cdc storage when handling logical emit message

### DIFF
--- a/flow/connectors/utils/cdc_store.go
+++ b/flow/connectors/utils/cdc_store.go
@@ -168,8 +168,7 @@ func (c *cdcStore[T]) Set(logger log.Logger, key model.TableWithPkey, rec model.
 			if c.pebbleDB == nil {
 				logger.Info(c.thresholdReason,
 					slog.String(string(shared.FlowNameKey), c.flowJobName))
-				err := c.initPebbleDB()
-				if err != nil {
+				if err := c.initPebbleDB(); err != nil {
 					return err
 				}
 			}

--- a/flow/e2e/kafka/kafka_test.go
+++ b/flow/e2e/kafka/kafka_test.go
@@ -169,6 +169,9 @@ func (s KafkaSuite) TestMessage() {
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
+	// insert record to bypass empty cdc store optimization which handles messages at source when message precedes records
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf("insert into %s(val) values ('tick')", srcTableName))
+	require.NoError(s.t, err)
 	_, err = s.Conn().Exec(context.Background(), "SELECT pg_logical_emit_message(false, 'topic', '\\x686561727462656174'::bytea)")
 	require.NoError(s.t, err)
 


### PR DESCRIPTION
avoids empty batches from logical_emit_message heartbeat tripping timeout