### PR TITLE
Numeric type: improved interface, fix Clickhouse support

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -300,14 +300,15 @@ func (c *ClickhouseConnector) NormalizeRecords(
 
 			colSelector.WriteString(fmt.Sprintf("`%s`,", dstColName))
 			if clickhouseType == "" {
-				var err error
-				clickhouseType, err = colType.ToDWHColumnType(protos.DBType_CLICKHOUSE)
-				if err != nil {
-					return nil, fmt.Errorf("error while converting column type to clickhouse type: %w", err)
-				}
 				if colType == qvalue.QValueKindNumeric {
 					precision, scale := datatypes.GetNumericTypeForWarehouse(column.TypeModifier, datatypes.ClickHouseNumericCompatibility{})
 					clickhouseType = fmt.Sprintf("Decimal(%d, %d)", precision, scale)
+				} else {
+					var err error
+					clickhouseType, err = colType.ToDWHColumnType(protos.DBType_CLICKHOUSE)
+					if err != nil {
+						return nil, fmt.Errorf("error while converting column type to clickhouse type: %w", err)
+					}
 				}
 			}
 

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -305,6 +305,10 @@ func (c *ClickhouseConnector) NormalizeRecords(
 				if err != nil {
 					return nil, fmt.Errorf("error while converting column type to clickhouse type: %w", err)
 				}
+				if colType == qvalue.QValueKindNumeric {
+					precision, scale := datatypes.GetNumericTypeForWarehouse(column.TypeModifier, datatypes.ClickHouseNumericCompatibility{})
+					clickhouseType = fmt.Sprintf("Decimal(%d, %d)", precision, scale)
+				}
 			}
 
 			switch clickhouseType {

--- a/flow/datatypes/numeric.go
+++ b/flow/datatypes/numeric.go
@@ -14,7 +14,6 @@ type WarehouseNumericCompatibility interface {
 	DefaultPrecisionAndScale() (int16, int16)
 	IsValidPrecisionAndScale(precision, scale int16) bool
 	IsValidPrecision(precision int16) bool
-	IsValidScale(scale int16) bool
 }
 
 type ClickHouseNumericCompatibility struct{}
@@ -32,15 +31,11 @@ func (c ClickHouseNumericCompatibility) DefaultPrecisionAndScale() (int16, int16
 }
 
 func (c ClickHouseNumericCompatibility) IsValidPrecisionAndScale(precision, scale int16) bool {
-	return c.IsValidPrecision(precision) && c.IsValidScale(scale) && scale < precision
+	return c.IsValidPrecision(precision) && scale >= 0 && scale < precision
 }
 
 func (c ClickHouseNumericCompatibility) IsValidPrecision(precision int16) bool {
 	return precision > 0 && precision <= c.MaxPrecision()
-}
-
-func (ClickHouseNumericCompatibility) IsValidScale(scale int16) bool {
-	return scale >= 0
 }
 
 type SnowflakeNumericCompatibility struct{}
@@ -58,15 +53,11 @@ func (s SnowflakeNumericCompatibility) DefaultPrecisionAndScale() (int16, int16)
 }
 
 func (s SnowflakeNumericCompatibility) IsValidPrecisionAndScale(precision, scale int16) bool {
-	return s.IsValidPrecision(precision) && s.IsValidScale(scale) && scale < precision
+	return s.IsValidPrecision(precision) && scale >= 0 && scale < precision
 }
 
 func (s SnowflakeNumericCompatibility) IsValidPrecision(precision int16) bool {
 	return precision > 0 && precision <= s.MaxPrecision()
-}
-
-func (SnowflakeNumericCompatibility) IsValidScale(scale int16) bool {
-	return scale >= 0
 }
 
 type BigQueryNumericCompatibility struct{}
@@ -84,15 +75,11 @@ func (b BigQueryNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) 
 }
 
 func (b BigQueryNumericCompatibility) IsValidPrecisionAndScale(precision, scale int16) bool {
-	return b.IsValidPrecision(precision) && b.IsValidScale(scale) && scale < precision
+	return b.IsValidPrecision(precision) && scale >= 0 && scale < precision
 }
 
 func (b BigQueryNumericCompatibility) IsValidPrecision(precision int16) bool {
 	return precision > 0 && precision <= b.MaxPrecision()
-}
-
-func (BigQueryNumericCompatibility) IsValidScale(scale int16) bool {
-	return scale >= 0
 }
 
 type DefaultNumericCompatibility struct{}
@@ -110,15 +97,11 @@ func (DefaultNumericCompatibility) DefaultPrecisionAndScale() (int16, int16) {
 }
 
 func (d DefaultNumericCompatibility) IsValidPrecisionAndScale(precision, scale int16) bool {
-	return d.IsValidPrecision(precision) && d.IsValidScale(scale) && scale < precision
+	return d.IsValidPrecision(precision) && scale >= 0 && scale < precision
 }
 
 func (d DefaultNumericCompatibility) IsValidPrecision(precision int16) bool {
 	return precision > 0 && precision <= d.MaxPrecision()
-}
-
-func (DefaultNumericCompatibility) IsValidScale(scale int16) bool {
-	return scale >= 0
 }
 
 func MakeNumericTypmod(precision int32, scale int32) int32 {
@@ -145,11 +128,6 @@ func GetNumericTypeForWarehouse(typmod int32, warehouseNumeric WarehouseNumericC
 	precision, scale := ParseNumericTypmod(typmod)
 	if !warehouseNumeric.IsValidPrecision(precision) {
 		precision = warehouseNumeric.MaxPrecision()
-	}
-
-	if !warehouseNumeric.IsValidScale(scale) {
-		_, defaultScale := warehouseNumeric.DefaultPrecisionAndScale()
-		scale = defaultScale
 	}
 
 	if !warehouseNumeric.IsValidPrecisionAndScale(precision, scale) {

--- a/flow/model/qvalue/dwh.go
+++ b/flow/model/qvalue/dwh.go
@@ -22,11 +22,7 @@ func DetermineNumericSettingForDWH(precision int16, scale int16, dwh protos.DBTy
 		warehouseNumeric = numeric.DefaultNumericCompatibility{}
 	}
 
-	if !warehouseNumeric.IsValidPrecisionAndScale(precision, scale) {
-		precision, scale = warehouseNumeric.DefaultPrecisionAndScale()
-	}
-
-	return precision, scale
+	return numeric.GetNumericTypeForWarehouse(numeric.MakeNumericTypmod(int32(precision), int32(scale)), warehouseNumeric)
 }
 
 // Bigquery will not allow timestamp if it is less than 1AD and more than 9999AD


### PR DESCRIPTION
This PR:
- Fixes casting of numeric values in Normalize insert-into-select statements in the Clickhouse connector
- Changes the behaviour of our default precision and scale setting. We now first check if we can reduce the precision to the maximum supported value, and only if not possible do we set it to our default. So for example for a numeric column on Postgres of type `numeric(78,70)`:

Previous behaviour for Clickhouse:
Since 78 is higher than the maximum supported precision on Clickhouse, we would set it to PeerDB's chosen default precision (76) and default scale (38)

New behaviour:
We first see that the precision is above max so we just change precision to the max of 76. 
Then we check if the new (precision, scale) tuple is valid. If not, then fallback to the behaviour from before and set it to defaults chosen by PeerDB. In this case it will now be valid, so the numeric on target will be `Decimal(76, 70)`. Notice how we do not change the scale unlike above

Motivation:
This allows us to now instead of setting a numeric like (78,0) to (76,36), to now just set it to (76,0) - which is more supportive than (76,36) when the incoming numerics are not going to have any fractional parts


- [x] Functionally tested