### PR TITLE
Direct access to CDC and initial load stats in API

### DIFF
--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -199,13 +199,15 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 		return nil, err
 	}
 
-	cloneStatuses, err := h.cloneTableSummary(ctx, req.FlowJobName)
+	initialLoadResponse, err := h.InitialLoadSummary(ctx, &protos.InitialLoadSummaryRequest{
+		ParentMirrorName: req.FlowJobName,
+	})
 	if err != nil {
 		slog.Error("unable to query clone table summary", slog.Any("error", err))
 		return nil, err
 	}
 
-	cdcBatches, err := h.getCdcBatches(ctx, req.FlowJobName)
+	cdcBatchesResponse, err := h.GetCDCBatches(ctx, &protos.GetCDCBatchesRequest{FlowJobName: req.FlowJobName})
 	if err != nil {
 		return nil, err
 	}
@@ -215,16 +217,17 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 		SourceType:      srcType,
 		DestinationType: dstType,
 		SnapshotStatus: &protos.SnapshotStatus{
-			Clones: cloneStatuses,
+			Clones: initialLoadResponse.TableSummaries,
 		},
-		CdcBatches: cdcBatches,
+		CdcBatches: cdcBatchesResponse.CdcBatches,
 	}, nil
 }
 
-func (h *FlowRequestHandler) cloneTableSummary(
+func (h *FlowRequestHandler) InitialLoadSummary(
 	ctx context.Context,
-	parentMirrorName string,
-) ([]*protos.CloneTableSummary, error) {
+	req *protos.InitialLoadSummaryRequest,
+) (*protos.InitialLoadSummaryResponse, error) {
+	parentMirrorName := req.ParentMirrorName
 	q := `
 	SELECT
 		distinct qr.flow_name,
@@ -325,7 +328,9 @@ func (h *FlowRequestHandler) cloneTableSummary(
 
 		cloneStatuses = append(cloneStatuses, &res)
 	}
-	return cloneStatuses, nil
+	return &protos.InitialLoadSummaryResponse{
+		TableSummaries: cloneStatuses,
+	}, nil
 }
 
 func (h *FlowRequestHandler) qrepFlowStatus(
@@ -478,16 +483,17 @@ func (h *FlowRequestHandler) getMirrorCreatedAt(ctx context.Context, flowJobName
 	return &createdAt.Time, nil
 }
 
-func (h *FlowRequestHandler) getCdcBatches(ctx context.Context, flowJobName string) ([]*protos.CDCBatch, error) {
+func (h *FlowRequestHandler) GetCDCBatches(ctx context.Context, req *protos.GetCDCBatchesRequest) (*protos.GetCDCBatchesResponse, error) {
+	mirrorName := req.FlowJobName
 	q := `SELECT DISTINCT ON(batch_id) batch_id,start_time,end_time,rows_in_batch,batch_start_lsn,batch_end_lsn FROM peerdb_stats.cdc_batches
 	  WHERE flow_name=$1 AND start_time IS NOT NULL ORDER BY batch_id DESC, start_time DESC`
-	rows, err := h.pool.Query(ctx, q, flowJobName)
+	rows, err := h.pool.Query(ctx, q, mirrorName)
 	if err != nil {
-		slog.Error(fmt.Sprintf("unable to query cdc batches - %s: %s", flowJobName, err.Error()))
-		return nil, fmt.Errorf("unable to query cdc batches - %s: %w", flowJobName, err)
+		slog.Error(fmt.Sprintf("unable to query cdc batches - %s: %s", mirrorName, err.Error()))
+		return nil, fmt.Errorf("unable to query cdc batches - %s: %w", mirrorName, err)
 	}
 
-	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (*protos.CDCBatch, error) {
+	batches, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (*protos.CDCBatch, error) {
 		var batchID pgtype.Int8
 		var startTime pgtype.Timestamp
 		var endTime pgtype.Timestamp
@@ -495,8 +501,8 @@ func (h *FlowRequestHandler) getCdcBatches(ctx context.Context, flowJobName stri
 		var startLSN pgtype.Numeric
 		var endLSN pgtype.Numeric
 		if err := rows.Scan(&batchID, &startTime, &endTime, &numRows, &startLSN, &endLSN); err != nil {
-			slog.Error(fmt.Sprintf("unable to scan cdc batches - %s: %s", flowJobName, err.Error()))
-			return nil, fmt.Errorf("unable to scan cdc batches - %s: %w", flowJobName, err)
+			slog.Error(fmt.Sprintf("unable to scan cdc batches - %s: %s", mirrorName, err.Error()))
+			return nil, fmt.Errorf("unable to scan cdc batches - %s: %w", mirrorName, err)
 		}
 
 		var batch protos.CDCBatch
@@ -522,6 +528,13 @@ func (h *FlowRequestHandler) getCdcBatches(ctx context.Context, flowJobName stri
 
 		return &batch, nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &protos.GetCDCBatchesResponse{
+		CdcBatches: batches,
+	}, nil
 }
 
 func (h *FlowRequestHandler) CDCTableTotalCounts(

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -329,6 +329,22 @@ message MirrorStatusResponse {
   google.protobuf.Timestamp created_at = 7;
 }
 
+message InitialLoadSummaryRequest {
+  string parent_mirror_name = 1;
+}
+
+message InitialLoadSummaryResponse {
+  repeated CloneTableSummary tableSummaries = 1;
+}
+
+message GetCDCBatchesRequest {
+  string flow_job_name = 1;
+}
+
+message GetCDCBatchesResponse {
+  repeated CDCBatch cdc_batches = 1;
+}
+
 message MirrorLog {
   string flow_name = 1;
   string error_message = 2;
@@ -523,6 +539,14 @@ service FlowService {
   }
   rpc MirrorStatus(MirrorStatusRequest) returns (MirrorStatusResponse) {
     option (google.api.http) = { post: "/v1/mirrors/status", body: "*" };
+  }
+
+  rpc GetCDCBatches(GetCDCBatchesRequest) returns (GetCDCBatchesResponse) {
+    option (google.api.http) = { get: "/v1/mirrors/cdc/batches/{flow_job_name}"};
+  }
+
+  rpc InitialLoadStatus(InitialLoadSummaryRequest) returns (InitialLoadSummaryResponse) {
+    option (google.api.http) = { get: "/v1/mirrors/cdc/initial_load/{parent_mirror_name}"};
   }
 
   rpc GetPeerInfo(PeerInfoRequest) returns (peerdb_peers.Peer) {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -545,7 +545,7 @@ service FlowService {
     option (google.api.http) = { get: "/v1/mirrors/cdc/batches/{flow_job_name}"};
   }
 
-  rpc InitialLoadStatus(InitialLoadSummaryRequest) returns (InitialLoadSummaryResponse) {
+  rpc InitialLoadSummary(InitialLoadSummaryRequest) returns (InitialLoadSummaryResponse) {
     option (google.api.http) = { get: "/v1/mirrors/cdc/initial_load/{parent_mirror_name}"};
   }
 


### PR DESCRIPTION
This PR allows us to query the stats for CDC batches and initial load clone summaries without having to go through the status endpoint which first pings Temporal state
<img width="1359" alt="Screenshot 2024-09-20 at 5 28 21 PM" src="https://github.com/user-attachments/assets/6c5e84c6-66b9-433c-abc9-7c2d1277f535">
<img width="1359" alt="Screenshot 2024-09-20 at 5 29 44 PM" src="https://github.com/user-attachments/assets/24e76996-bcc2-438a-bf43-2360bab74f71">
