### PR TITLE
Add Limit as a field for cdc stats request

### DIFF
--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -485,8 +485,13 @@ func (h *FlowRequestHandler) getMirrorCreatedAt(ctx context.Context, flowJobName
 
 func (h *FlowRequestHandler) GetCDCBatches(ctx context.Context, req *protos.GetCDCBatchesRequest) (*protos.GetCDCBatchesResponse, error) {
 	mirrorName := req.FlowJobName
+	limit := req.Limit
+	limitClause := ""
+	if limit > 0 {
+		limitClause = fmt.Sprintf(" LIMIT %d", limit)
+	}
 	q := `SELECT DISTINCT ON(batch_id) batch_id,start_time,end_time,rows_in_batch,batch_start_lsn,batch_end_lsn FROM peerdb_stats.cdc_batches
-	  WHERE flow_name=$1 AND start_time IS NOT NULL ORDER BY batch_id DESC, start_time DESC`
+	  WHERE flow_name=$1 AND start_time IS NOT NULL ORDER BY batch_id DESC, start_time DESC` + limitClause
 	rows, err := h.pool.Query(ctx, q, mirrorName)
 	if err != nil {
 		slog.Error(fmt.Sprintf("unable to query cdc batches - %s: %s", mirrorName, err.Error()))

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -207,7 +207,10 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 		return nil, err
 	}
 
-	cdcBatchesResponse, err := h.GetCDCBatches(ctx, &protos.GetCDCBatchesRequest{FlowJobName: req.FlowJobName})
+	cdcBatchesResponse, err := h.GetCDCBatches(ctx, &protos.GetCDCBatchesRequest{
+		FlowJobName: req.FlowJobName,
+		Limit:       0,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -344,7 +344,6 @@ message GetCDCBatchesRequest {
 
 message GetCDCBatchesResponse {
   repeated CDCBatch cdc_batches = 1;
-  uint32 total_records = 2;
 }
 
 message MirrorLog {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -339,10 +339,12 @@ message InitialLoadSummaryResponse {
 
 message GetCDCBatchesRequest {
   string flow_job_name = 1;
+  uint32 limit = 2;
 }
 
 message GetCDCBatchesResponse {
   repeated CDCBatch cdc_batches = 1;
+  uint32 total_records = 2;
 }
 
 message MirrorLog {


### PR DESCRIPTION
Add a limit field to the request for the cdc stats endpoint. Default of 0 corresponds to no limiting