### PR TITLE
Remove TableNameSchemaMapping from temporal state

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -158,11 +158,6 @@ func (a *FlowableActivity) SetupTableSchema(
 		return err
 	}
 	defer shared.RollbackTx(tx, logger)
-	if config.Clear {
-		if _, err = tx.Exec(ctx, "delete from table_schema_mapping where flow_name = $1", config.FlowName); err != nil {
-			return err
-		}
-	}
 
 	for k, v := range processed {
 		processedBytes, err := proto.Marshal(v)

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -850,16 +850,14 @@ func (a *FlowableActivity) RenameTables(ctx context.Context, config *protos.Rena
 	defer shared.RollbackTx(tx, logger)
 
 	for _, option := range config.RenameTableOptions {
-		if option.TableSchema == nil {
-			if _, err := tx.Exec(
-				ctx,
-				"update table_schema_mapping set table_name = $3 where flow_name = $1 and table_name = $2",
-				config.FlowJobName,
-				option.CurrentName,
-				option.NewName,
-			); err != nil {
-				return nil, fmt.Errorf("failed to update table_schema_mapping: %w", err)
-			}
+		if _, err := tx.Exec(
+			ctx,
+			"update table_schema_mapping set table_name = $3 where flow_name = $1 and table_name = $2",
+			config.FlowJobName,
+			option.CurrentName,
+			option.NewName,
+		); err != nil {
+			return nil, fmt.Errorf("failed to update table_schema_mapping: %w", err)
 		}
 	}
 

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -130,7 +130,7 @@ func (a *FlowableActivity) CreateRawTable(
 	return res, nil
 }
 
-// SetupTableSchema populates table_schema_name_mapping
+// SetupTableSchema populates table_schema_mapping
 func (a *FlowableActivity) SetupTableSchema(
 	ctx context.Context,
 	config *protos.SetupTableSchemaBatchInput,
@@ -979,7 +979,7 @@ func (a *FlowableActivity) RemoveTablesFromCatalog(
 
 	_, err := a.CatalogPool.Exec(
 		ctx,
-		"delete from table_name_schema_mapping where flow_name = $1 and table_name = ANY($2)",
+		"delete from table_schema_mapping where flow_name = $1 and table_name = ANY($2)",
 		cfg.FlowJobName,
 		removedTables,
 	)

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -231,10 +231,9 @@ func (a *FlowableActivity) CreateNormalizedTable(
 	}
 
 	numTablesSetup := atomic.Uint32{}
-	totalTables := uint32(len(tableNameSchemaMapping))
 	shutdown := heartbeatRoutine(ctx, func() string {
 		return fmt.Sprintf("setting up normalized tables - %d of %d done",
-			numTablesSetup.Load(), totalTables)
+			numTablesSetup.Load(), len(tableNameSchemaMapping))
 	})
 	defer shutdown()
 

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -130,6 +130,38 @@ func (a *FlowableActivity) CreateRawTable(
 	return res, nil
 }
 
+func (a *FlowableActivity) MigrateTableSchema(
+	ctx context.Context,
+	flowName string,
+	schemas map[string]*protos.TableSchema,
+) error {
+	logger := activity.GetLogger(ctx)
+	tx, err := a.CatalogPool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer shared.RollbackTx(tx, logger)
+
+	for k, v := range schemas {
+		processedBytes, err := proto.Marshal(v)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(
+			ctx,
+			"insert into table_schema_mapping(flow_name, table_name, table_schema) values ($1, $2, $3) "+
+				"on conflict (flow_name, table_name) do update set table_schema = $3",
+			flowName,
+			k,
+			processedBytes,
+		); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
 // SetupTableSchema populates table_schema_mapping
 func (a *FlowableActivity) SetupTableSchema(
 	ctx context.Context,

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -76,10 +76,7 @@ func waitForCdcCache[TPull connectors.CDCPullConnectorCore](ctx context.Context,
 	}
 }
 
-func (a *FlowableActivity) getTableNameSchemaMapping(
-	ctx context.Context,
-	flowName string,
-) (map[string]*protos.TableSchema, error) {
+func (a *FlowableActivity) getTableNameSchemaMapping(ctx context.Context, flowName string) (map[string]*protos.TableSchema, error) {
 	rows, err := a.CatalogPool.Query(ctx, "select table_name, table_schema from table_schema_mapping where flow_name = $1", flowName)
 	if err != nil {
 		return nil, err

--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -178,3 +178,11 @@ func (a *SnapshotActivity) WaitForExportSnapshot(ctx context.Context, sessionID 
 		time.Sleep(time.Second)
 	}
 }
+
+func (a *SnapshotActivity) LoadTableSchema(
+	ctx context.Context,
+	flowName string,
+	tableName string,
+) (*protos.TableSchema, error) {
+	return shared.LoadTableSchemaFromCatalog(ctx, a.CatalogPool, flowName, tableName)
+}

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -187,8 +187,8 @@ func (h *FlowRequestHandler) removeFlowEntryInCatalog(
 	}
 	defer shared.RollbackTx(tx, slog.Default())
 
-	if _, err := tx.Exec(ctx, "DELETE FROM table_name_schema_mapping WHERE flow_name=$1", flowName); err != nil {
-		return fmt.Errorf("unable to clear table_name_schema_mapping to remove flow entry in catalog: %w", err)
+	if _, err := tx.Exec(ctx, "DELETE FROM table_schema_mapping WHERE flow_name=$1", flowName); err != nil {
+		return fmt.Errorf("unable to clear table_schema_mapping to remove flow entry in catalog: %w", err)
 	}
 
 	if _, err := tx.Exec(ctx, "DELETE FROM flows WHERE name=$1", flowName); err != nil {

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -190,10 +190,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		}
 		defer chPeer.Close()
 
-		res, err := pgPeer.GetTableSchema(ctx, &protos.GetTableSchemaBatchInput{
-			TableIdentifiers: srcTableNames,
-			System:           protos.TypeSystem_PG,
-		})
+		res, err := pgPeer.GetTableSchema(ctx, nil, protos.TypeSystem_PG, srcTableNames)
 		if err != nil {
 			displayErr := fmt.Errorf("failed to get source table schema: %v", err)
 			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
@@ -204,7 +201,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 			}, displayErr
 		}
 
-		err = chPeer.CheckDestinationTables(ctx, req.ConnectionConfigs, res.TableNameSchemaMapping)
+		err = chPeer.CheckDestinationTables(ctx, req.ConnectionConfigs, res)
 		if err != nil {
 			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
 				fmt.Sprint(err),

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -602,8 +602,8 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 	tx interface{},
 	config *protos.SetupNormalizedTableBatchInput,
 	tableIdentifier string,
+	tableSchema *protos.TableSchema,
 ) (bool, error) {
-	tableSchema := config.TableNameSchemaMapping[tableIdentifier]
 	datasetTablesSet := tx.(map[datasetTable]struct{})
 
 	// only place where we check for parsing errors

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -42,6 +42,7 @@ func (c *ClickHouseConnector) SetupNormalizedTable(
 	tx interface{},
 	config *protos.SetupNormalizedTableBatchInput,
 	tableIdentifier string,
+	tableSchema *protos.TableSchema,
 ) (bool, error) {
 	tableAlreadyExists, err := c.checkIfTableExists(ctx, c.config.Database, tableIdentifier)
 	if err != nil {
@@ -55,6 +56,7 @@ func (c *ClickHouseConnector) SetupNormalizedTable(
 	normalizedTableCreateSQL, err := generateCreateTableSQLForNormalizedTable(
 		config,
 		tableIdentifier,
+		tableSchema,
 	)
 	if err != nil {
 		return false, fmt.Errorf("error while generating create table sql for normalized table: %w", err)
@@ -76,9 +78,8 @@ func getColName(overrides map[string]string, name string) string {
 func generateCreateTableSQLForNormalizedTable(
 	config *protos.SetupNormalizedTableBatchInput,
 	tableIdentifier string,
+	tableSchema *protos.TableSchema,
 ) (string, error) {
-	tableSchema := config.TableNameSchemaMapping[tableIdentifier]
-
 	var tableMapping *protos.TableMapping
 	for _, tm := range config.TableMappings {
 		if tm.DestinationTableIdentifier == tableIdentifier {
@@ -116,7 +117,6 @@ func generateCreateTableSQLForNormalizedTable(
 						colNameMap[colName] = dstColName
 					}
 					if columnSetting.DestinationType != "" {
-						// TODO can we restrict this to avoid injection?
 						clickHouseType = columnSetting.DestinationType
 					}
 					break

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -132,6 +132,7 @@ type NormalizedTablesConnector interface {
 		tx any,
 		config *protos.SetupNormalizedTableBatchInput,
 		tableIdentifier string,
+		tableSchema *protos.TableSchema,
 	) (bool, error)
 }
 

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -45,7 +45,12 @@ type GetTableSchemaConnector interface {
 	Connector
 
 	// GetTableSchema returns the schema of a table in terms of QValueKind.
-	GetTableSchema(ctx context.Context, req *protos.GetTableSchemaBatchInput) (*protos.GetTableSchemaBatchOutput, error)
+	GetTableSchema(
+		ctx context.Context,
+		env map[string]string,
+		system protos.TypeSystem,
+		tableIdentifiers []string,
+	) (map[string]*protos.TableSchema, error)
 }
 
 type CDCPullConnectorCore interface {

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -845,12 +845,22 @@ func processRelationMessage[Items model.Items](
 	// retrieve current TableSchema for table changed
 	// tableNameSchemaMapping uses dst table name as the key, so annoying lookup
 	prevSchema := p.tableNameSchemaMapping[p.tableNameMapping[p.srcTableIDNameMapping[currRel.RelationID]].Name]
-	// creating maps for lookup later
-	prevRelMap := make(map[string]string)
-	currRelMap := make(map[string]string)
+	if prevSchema == nil {
+		p.logger.Error("MANOSCHEMA",
+			slog.Any("name", p.tableNameMapping[p.srcTableIDNameMapping[currRel.RelationID]].Name),
+			slog.Any("tableNameSchemaMapping", p.tableNameSchemaMapping),
+			slog.Any("tableMapping", p.tableNameMapping),
+			slog.Any("relID", currRel.RelationID),
+			slog.Any("srcTableIDNameMapping", p.srcTableIDNameMapping),
+		)
+		panic("MANOSCHEMA")
+	}
+	prevRelMap := make(map[string]string, len(prevSchema.Columns))
 	for _, column := range prevSchema.Columns {
 		prevRelMap[column.Name] = column.Type
 	}
+
+	currRelMap := make(map[string]string, len(currRel.Columns))
 	for _, column := range currRel.Columns {
 		switch prevSchema.System {
 		case protos.TypeSystem_Q:

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -452,14 +452,13 @@ func getRawTableIdentifier(jobName string) string {
 
 func generateCreateTableSQLForNormalizedTable(
 	config *protos.SetupNormalizedTableBatchInput,
-	tableIdentifier string,
 	dstSchemaTable *utils.SchemaTable,
+	tableSchema *protos.TableSchema,
 ) string {
-	sourceTableSchema := config.TableNameSchemaMapping[tableIdentifier]
-	createTableSQLArray := make([]string, 0, len(sourceTableSchema.Columns)+2)
-	for _, column := range sourceTableSchema.Columns {
+	createTableSQLArray := make([]string, 0, len(tableSchema.Columns)+2)
+	for _, column := range tableSchema.Columns {
 		pgColumnType := column.Type
-		if sourceTableSchema.System == protos.TypeSystem_Q {
+		if tableSchema.System == protos.TypeSystem_Q {
 			pgColumnType = qValueKindToPostgresType(pgColumnType)
 		}
 		if column.Type == "numeric" && column.TypeModifier != -1 {
@@ -467,7 +466,7 @@ func generateCreateTableSQLForNormalizedTable(
 			pgColumnType = fmt.Sprintf("numeric(%d,%d)", precision, scale)
 		}
 		var notNull string
-		if sourceTableSchema.NullableEnabled && !column.Nullable {
+		if tableSchema.NullableEnabled && !column.Nullable {
 			notNull = " NOT NULL"
 		}
 
@@ -486,9 +485,9 @@ func generateCreateTableSQLForNormalizedTable(
 	}
 
 	// add composite primary key to the table
-	if len(sourceTableSchema.PrimaryKeyColumns) > 0 && !sourceTableSchema.IsReplicaIdentityFull {
-		primaryKeyColsQuoted := make([]string, 0, len(sourceTableSchema.PrimaryKeyColumns))
-		for _, primaryKeyCol := range sourceTableSchema.PrimaryKeyColumns {
+	if len(tableSchema.PrimaryKeyColumns) > 0 && !tableSchema.IsReplicaIdentityFull {
+		primaryKeyColsQuoted := make([]string, 0, len(tableSchema.PrimaryKeyColumns))
+		for _, primaryKeyCol := range tableSchema.PrimaryKeyColumns {
 			primaryKeyColsQuoted = append(primaryKeyColsQuoted, QuoteIdentifier(primaryKeyCol))
 		}
 		createTableSQLArray = append(createTableSQLArray, fmt.Sprintf("PRIMARY KEY(%s)",

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -723,11 +723,13 @@ func (c *PostgresConnector) CreateRawTable(ctx context.Context, req *protos.Crea
 
 func (c *PostgresConnector) GetTableSchema(
 	ctx context.Context,
-	req *protos.GetTableSchemaBatchInput,
-) (*protos.GetTableSchemaBatchOutput, error) {
-	res := make(map[string]*protos.TableSchema)
-	for _, tableName := range req.TableIdentifiers {
-		tableSchema, err := c.getTableSchemaForTable(ctx, req.Env, tableName, req.System)
+	env map[string]string,
+	system protos.TypeSystem,
+	tableIdentifiers []string,
+) (map[string]*protos.TableSchema, error) {
+	res := make(map[string]*protos.TableSchema, len(tableIdentifiers))
+	for _, tableName := range tableIdentifiers {
+		tableSchema, err := c.getTableSchemaForTable(ctx, env, tableName, system)
 		if err != nil {
 			c.logger.Info("error fetching schema for table "+tableName, slog.Any("error", err))
 			return nil, err
@@ -736,9 +738,7 @@ func (c *PostgresConnector) GetTableSchema(
 		c.logger.Info("fetched schema for table " + tableName)
 	}
 
-	return &protos.GetTableSchemaBatchOutput{
-		TableNameSchemaMapping: res,
-	}, nil
+	return res, nil
 }
 
 func (c *PostgresConnector) getTableSchemaForTable(

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -863,6 +863,7 @@ func (c *PostgresConnector) SetupNormalizedTable(
 	tx any,
 	config *protos.SetupNormalizedTableBatchInput,
 	tableIdentifier string,
+	tableSchema *protos.TableSchema,
 ) (bool, error) {
 	createNormalizedTablesTx := tx.(pgx.Tx)
 
@@ -889,7 +890,7 @@ func (c *PostgresConnector) SetupNormalizedTable(
 	}
 
 	// convert the column names and types to Postgres types
-	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(config, tableIdentifier, parsedNormalizedTable)
+	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(config, parsedNormalizedTable, tableSchema)
 	_, err = c.execWithLoggingTx(ctx, normalizedTableCreateSQL, createNormalizedTablesTx)
 	if err != nil {
 		return false, fmt.Errorf("error while creating normalized table: %w", err)

--- a/flow/connectors/postgres/postgres_schema_delta_test.go
+++ b/flow/connectors/postgres/postgres_schema_delta_test.go
@@ -71,10 +71,7 @@ func (s PostgresSchemaDeltaTestSuite) TestSimpleAddColumn() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{tableName},
-		System:           protos.TypeSystem_Q,
-	})
+	output, err := s.connector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{tableName})
 	require.NoError(s.t, err)
 	require.Equal(s.t, &protos.TableSchema{
 		TableIdentifier:   tableName,
@@ -92,7 +89,7 @@ func (s PostgresSchemaDeltaTestSuite) TestSimpleAddColumn() {
 				TypeModifier: -1,
 			},
 		},
-	}, output.TableNameSchemaMapping[tableName])
+	}, output[tableName])
 }
 
 func (s PostgresSchemaDeltaTestSuite) TestAddAllColumnTypes() {
@@ -126,12 +123,9 @@ func (s PostgresSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{tableName},
-		System:           protos.TypeSystem_Q,
-	})
+	output, err := s.connector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{tableName})
 	require.NoError(s.t, err)
-	require.Equal(s.t, expectedTableSchema, output.TableNameSchemaMapping[tableName])
+	require.Equal(s.t, expectedTableSchema, output[tableName])
 }
 
 func (s PostgresSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
@@ -165,12 +159,9 @@ func (s PostgresSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{tableName},
-		System:           protos.TypeSystem_Q,
-	})
+	output, err := s.connector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{tableName})
 	require.NoError(s.t, err)
-	require.Equal(s.t, expectedTableSchema, output.TableNameSchemaMapping[tableName])
+	require.Equal(s.t, expectedTableSchema, output[tableName])
 }
 
 func (s PostgresSchemaDeltaTestSuite) TestAddDropWhitespaceColumnNames() {
@@ -204,12 +195,9 @@ func (s PostgresSchemaDeltaTestSuite) TestAddDropWhitespaceColumnNames() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{tableName},
-		System:           protos.TypeSystem_Q,
-	})
+	output, err := s.connector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{tableName})
 	require.NoError(s.t, err)
-	require.Equal(s.t, expectedTableSchema, output.TableNameSchemaMapping[tableName])
+	require.Equal(s.t, expectedTableSchema, output[tableName])
 }
 
 func TestPostgresSchemaDeltaTestSuite(t *testing.T) {

--- a/flow/connectors/snowflake/get_schema_for_tests.go
+++ b/flow/connectors/snowflake/get_schema_for_tests.go
@@ -39,10 +39,12 @@ func (c *SnowflakeConnector) getTableSchemaForTable(ctx context.Context, tableNa
 // only used for testing atm. doesn't return info about pkey or ReplicaIdentity [which is PG specific anyway].
 func (c *SnowflakeConnector) GetTableSchema(
 	ctx context.Context,
-	req *protos.GetTableSchemaBatchInput,
-) (*protos.GetTableSchemaBatchOutput, error) {
-	res := make(map[string]*protos.TableSchema, len(req.TableIdentifiers))
-	for _, tableName := range req.TableIdentifiers {
+	_env map[string]string,
+	_system protos.TypeSystem,
+	tableIdentifiers []string,
+) (map[string]*protos.TableSchema, error) {
+	res := make(map[string]*protos.TableSchema, len(tableIdentifiers))
+	for _, tableName := range tableIdentifiers {
 		tableSchema, err := c.getTableSchemaForTable(ctx, tableName)
 		if err != nil {
 			return nil, err
@@ -50,7 +52,5 @@ func (c *SnowflakeConnector) GetTableSchema(
 		res[tableName] = tableSchema
 	}
 
-	return &protos.GetTableSchemaBatchOutput{
-		TableNameSchemaMapping: res,
-	}, nil
+	return res, nil
 }

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -321,6 +321,7 @@ func (c *SnowflakeConnector) SetupNormalizedTable(
 	tx interface{},
 	config *protos.SetupNormalizedTableBatchInput,
 	tableIdentifier string,
+	tableSchema *protos.TableSchema,
 ) (bool, error) {
 	normalizedSchemaTable, err := utils.ParseSchemaTable(tableIdentifier)
 	if err != nil {
@@ -340,7 +341,7 @@ func (c *SnowflakeConnector) SetupNormalizedTable(
 		return true, nil
 	}
 
-	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(config, tableIdentifier, normalizedSchemaTable)
+	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(config, normalizedSchemaTable, tableSchema)
 	if _, err := c.execWithLogging(ctx, normalizedTableCreateSQL); err != nil {
 		return false, fmt.Errorf("[sf] error while creating normalized table: %w", err)
 	}
@@ -670,12 +671,11 @@ func (c *SnowflakeConnector) checkIfTableExists(
 
 func generateCreateTableSQLForNormalizedTable(
 	config *protos.SetupNormalizedTableBatchInput,
-	tableIdentifier string,
 	dstSchemaTable *utils.SchemaTable,
+	tableSchema *protos.TableSchema,
 ) string {
-	sourceTableSchema := config.TableNameSchemaMapping[tableIdentifier]
-	createTableSQLArray := make([]string, 0, len(sourceTableSchema.Columns)+2)
-	for _, column := range sourceTableSchema.Columns {
+	createTableSQLArray := make([]string, 0, len(tableSchema.Columns)+2)
+	for _, column := range tableSchema.Columns {
 		genericColumnType := column.Type
 		normalizedColName := SnowflakeIdentifierNormalize(column.Name)
 		sfColType, err := qvalue.QValueKind(genericColumnType).ToDWHColumnType(protos.DBType_SNOWFLAKE)
@@ -691,7 +691,7 @@ func generateCreateTableSQLForNormalizedTable(
 		}
 
 		var notNull string
-		if sourceTableSchema.NullableEnabled && !column.Nullable {
+		if tableSchema.NullableEnabled && !column.Nullable {
 			notNull = " NOT NULL"
 		}
 
@@ -712,9 +712,9 @@ func generateCreateTableSQLForNormalizedTable(
 	}
 
 	// add composite primary key to the table
-	if len(sourceTableSchema.PrimaryKeyColumns) > 0 && !sourceTableSchema.IsReplicaIdentityFull {
-		normalizedPrimaryKeyCols := make([]string, 0, len(sourceTableSchema.PrimaryKeyColumns))
-		for _, primaryKeyCol := range sourceTableSchema.PrimaryKeyColumns {
+	if len(tableSchema.PrimaryKeyColumns) > 0 && !tableSchema.IsReplicaIdentityFull {
+		normalizedPrimaryKeyCols := make([]string, 0, len(tableSchema.PrimaryKeyColumns))
+		for _, primaryKeyCol := range tableSchema.PrimaryKeyColumns {
 			normalizedPrimaryKeyCols = append(normalizedPrimaryKeyCols,
 				SnowflakeIdentifierNormalize(primaryKeyCol))
 		}

--- a/flow/e2e/elasticsearch/peer_flow_es_test.go
+++ b/flow/e2e/elasticsearch/peer_flow_es_test.go
@@ -120,7 +120,6 @@ func (s elasticsearchSuite) Test_Composite_PKey_CDC_Mirror() {
 	`, srcTableName, i, i))
 		require.NoError(s.t, err, "failed to insert row")
 	}
-
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "wait for initial snapshot + inserted rows", func() bool {
 		return s.countDocumentsInIndex(srcTableName) == int64(2*rowCount)
 	})

--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -155,12 +155,9 @@ func (s Generic) Test_Simple_Schema_Changes() {
 			},
 		},
 	}
-	output, err := destinationSchemaConnector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{dstTableName},
-		System:           protos.TypeSystem_Q,
-	})
+	output, err := destinationSchemaConnector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{dstTableName})
 	e2e.EnvNoError(t, env, err)
-	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema, output.TableNameSchemaMapping[dstTableName]))
+	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema, output[dstTableName]))
 
 	// alter source table, add column c2 and insert another row.
 	_, err = s.Connector().Conn().Exec(context.Background(), fmt.Sprintf(`
@@ -199,12 +196,9 @@ func (s Generic) Test_Simple_Schema_Changes() {
 			},
 		},
 	}
-	output, err = destinationSchemaConnector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{dstTableName},
-		System:           protos.TypeSystem_Q,
-	})
+	output, err = destinationSchemaConnector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{dstTableName})
 	e2e.EnvNoError(t, env, err)
-	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema, output.TableNameSchemaMapping[dstTableName]))
+	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema, output[dstTableName]))
 	e2e.EnvEqualTablesWithNames(env, s, srcTable, dstTable, "id,c1,c2")
 
 	// alter source table, add column c3, drop column c2 and insert another row.
@@ -249,12 +243,9 @@ func (s Generic) Test_Simple_Schema_Changes() {
 			},
 		},
 	}
-	output, err = destinationSchemaConnector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{dstTableName},
-		System:           protos.TypeSystem_Q,
-	})
+	output, err = destinationSchemaConnector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{dstTableName})
 	e2e.EnvNoError(t, env, err)
-	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema, output.TableNameSchemaMapping[dstTableName]))
+	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema, output[dstTableName]))
 	e2e.EnvEqualTablesWithNames(env, s, srcTable, dstTable, "id,c1,c3")
 
 	// alter source table, drop column c3 and insert another row.
@@ -299,12 +290,9 @@ func (s Generic) Test_Simple_Schema_Changes() {
 			},
 		},
 	}
-	output, err = destinationSchemaConnector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{dstTableName},
-		System:           protos.TypeSystem_Q,
-	})
+	output, err = destinationSchemaConnector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{dstTableName})
 	e2e.EnvNoError(t, env, err)
-	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema, output.TableNameSchemaMapping[dstTableName]))
+	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema, output[dstTableName]))
 	e2e.EnvEqualTablesWithNames(env, s, srcTable, dstTable, "id,c1")
 
 	env.Cancel()

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -938,7 +938,6 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 	assert.EqualValues(s.t, 6, workflowState.SyncFlowOptions.BatchSize)
 	assert.Len(s.t, workflowState.SyncFlowOptions.TableMappings, 1)
 	assert.Len(s.t, workflowState.SyncFlowOptions.SrcTableIdNameMapping, 1)
-	assert.Len(s.t, workflowState.SyncFlowOptions.TableNameSchemaMapping, 1)
 
 	if !s.t.Failed() {
 		e2e.SignalWorkflow(env, model.FlowSignal, model.PauseSignal)
@@ -982,7 +981,6 @@ func (s PeerFlowE2ETestSuitePG) Test_Dynamic_Mirror_Config_Via_Signals() {
 		assert.EqualValues(s.t, 12, workflowState.SyncFlowOptions.BatchSize)
 		assert.Len(s.t, workflowState.SyncFlowOptions.TableMappings, 2)
 		assert.Len(s.t, workflowState.SyncFlowOptions.SrcTableIdNameMapping, 2)
-		assert.Len(s.t, workflowState.SyncFlowOptions.TableNameSchemaMapping, 2)
 	}
 
 	env.Cancel()

--- a/flow/e2e/snowflake/snowflake_schema_delta_test.go
+++ b/flow/e2e/snowflake/snowflake_schema_delta_test.go
@@ -66,9 +66,7 @@ func (s SnowflakeSchemaDeltaTestSuite) TestSimpleAddColumn() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{tableName},
-	})
+	output, err := s.connector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{tableName})
 	require.NoError(s.t, err)
 	require.Equal(s.t, &protos.TableSchema{
 		TableIdentifier: tableName,
@@ -84,7 +82,7 @@ func (s SnowflakeSchemaDeltaTestSuite) TestSimpleAddColumn() {
 				TypeModifier: -1,
 			},
 		},
-	}, output.TableNameSchemaMapping[tableName])
+	}, output[tableName])
 }
 
 func (s SnowflakeSchemaDeltaTestSuite) TestAddAllColumnTypes() {
@@ -176,11 +174,9 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{tableName},
-	})
+	output, err := s.connector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{tableName})
 	require.NoError(s.t, err)
-	require.Equal(s.t, expectedTableSchema, output.TableNameSchemaMapping[tableName])
+	require.Equal(s.t, expectedTableSchema, output[tableName])
 }
 
 func (s SnowflakeSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
@@ -257,11 +253,9 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{tableName},
-	})
+	output, err := s.connector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{tableName})
 	require.NoError(s.t, err)
-	require.Equal(s.t, expectedTableSchema, output.TableNameSchemaMapping[tableName])
+	require.Equal(s.t, expectedTableSchema, output[tableName])
 }
 
 func (s SnowflakeSchemaDeltaTestSuite) TestAddWhitespaceColumnNames() {
@@ -314,11 +308,9 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddWhitespaceColumnNames() {
 	}})
 	require.NoError(s.t, err)
 
-	output, err := s.connector.GetTableSchema(context.Background(), &protos.GetTableSchemaBatchInput{
-		TableIdentifiers: []string{tableName},
-	})
+	output, err := s.connector.GetTableSchema(context.Background(), nil, protos.TypeSystem_Q, []string{tableName})
 	require.NoError(s.t, err)
-	require.Equal(s.t, expectedTableSchema, output.TableNameSchemaMapping[tableName])
+	require.Equal(s.t, expectedTableSchema, output[tableName])
 }
 
 func (s SnowflakeSchemaDeltaTestSuite) Teardown() {

--- a/flow/shared/schema_helpers.go
+++ b/flow/shared/schema_helpers.go
@@ -44,7 +44,7 @@ func BuildProcessedSchemaMapping(
 
 	for _, srcTableName := range sortedSourceTables {
 		tableSchema := tableNameSchemaMapping[srcTableName]
-		dstTableName := srcTableName
+		var dstTableName string
 		for _, mapping := range tableMappings {
 			if mapping.SourceTableIdentifier == srcTableName {
 				dstTableName = mapping.DestinationTableIdentifier

--- a/flow/shared/schema_helpers.go
+++ b/flow/shared/schema_helpers.go
@@ -34,7 +34,8 @@ func AdditionalTablesHasOverlap(currentTableMappings []*protos.TableMapping,
 // given the output of GetTableSchema, processes it to be used by CDCFlow
 // 1) changes the map key to be the destination table name instead of the source table name
 // 2) performs column exclusion using protos.TableMapping as input.
-func BuildProcessedSchemaMapping(tableMappings []*protos.TableMapping,
+func BuildProcessedSchemaMapping(
+	tableMappings []*protos.TableMapping,
 	tableNameSchemaMapping map[string]*protos.TableSchema,
 	logger log.Logger,
 ) map[string]*protos.TableSchema {
@@ -43,13 +44,12 @@ func BuildProcessedSchemaMapping(tableMappings []*protos.TableMapping,
 
 	for _, srcTableName := range sortedSourceTables {
 		tableSchema := tableNameSchemaMapping[srcTableName]
-		var dstTableName string
+		dstTableName := srcTableName
 		for _, mapping := range tableMappings {
 			if mapping.SourceTableIdentifier == srcTableName {
 				dstTableName = mapping.DestinationTableIdentifier
 				if len(mapping.Exclude) != 0 {
-					columnCount := len(tableSchema.Columns)
-					columns := make([]*protos.FieldDescription, 0, columnCount)
+					columns := make([]*protos.FieldDescription, 0, len(tableSchema.Columns))
 					for _, column := range tableSchema.Columns {
 						if !slices.Contains(mapping.Exclude, column.Name) {
 							columns = append(columns, column)

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -410,7 +410,6 @@ func CDCFlowWorkflow(
 			return state, fmt.Errorf("failed to execute setup workflow: %w", err)
 		}
 		state.SyncFlowOptions.SrcTableIdNameMapping = setupFlowOutput.SrcTableIdNameMapping
-		state.SyncFlowOptions.TableNameSchemaMapping = setupFlowOutput.TableNameSchemaMapping
 		state.CurrentFlowStatus = protos.FlowStatus_STATUS_SNAPSHOT
 
 		// next part of the setup is to snapshot-initial-copy and setup replication slots.

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -318,16 +318,14 @@ func CDCFlowWorkflow(
 
 	logger := log.With(workflow.GetLogger(ctx), slog.String(string(shared.FlowNameKey), cfg.FlowJobName))
 	flowSignalChan := model.FlowSignal.GetSignalChannel(ctx)
-	err := workflow.SetQueryHandler(ctx, shared.CDCFlowStateQuery, func() (CDCFlowWorkflowState, error) {
+	if err := workflow.SetQueryHandler(ctx, shared.CDCFlowStateQuery, func() (CDCFlowWorkflowState, error) {
 		return *state, nil
-	})
-	if err != nil {
+	}); err != nil {
 		return state, fmt.Errorf("failed to set `%s` query handler: %w", shared.CDCFlowStateQuery, err)
 	}
-	err = workflow.SetQueryHandler(ctx, shared.FlowStatusQuery, func() (protos.FlowStatus, error) {
+	if err := workflow.SetQueryHandler(ctx, shared.FlowStatusQuery, func() (protos.FlowStatus, error) {
 		return state.CurrentFlowStatus, nil
-	})
-	if err != nil {
+	}); err != nil {
 		return state, fmt.Errorf("failed to set `%s` query handler: %w", shared.FlowStatusQuery, err)
 	}
 
@@ -357,8 +355,7 @@ func CDCFlowWorkflow(
 			}
 
 			if state.FlowConfigUpdate != nil {
-				err = processCDCFlowConfigUpdate(ctx, logger, cfg, state, mirrorNameSearch)
-				if err != nil {
+				if err := processCDCFlowConfigUpdate(ctx, logger, cfg, state, mirrorNameSearch); err != nil {
 					return state, err
 				}
 				syncCountLimit = int(state.SyncFlowOptions.NumberOfSyncs)

--- a/flow/workflows/normalize_flow.go
+++ b/flow/workflows/normalize_flow.go
@@ -13,20 +13,18 @@ import (
 )
 
 type NormalizeState struct {
-	TableNameSchemaMapping map[string]*protos.TableSchema
-	LastSyncBatchID        int64
-	SyncBatchID            int64
-	Wait                   bool
-	Stop                   bool
+	LastSyncBatchID int64
+	SyncBatchID     int64
+	Wait            bool
+	Stop            bool
 }
 
 func NewNormalizeState() *NormalizeState {
 	return &NormalizeState{
-		TableNameSchemaMapping: nil,
-		LastSyncBatchID:        -1,
-		SyncBatchID:            -1,
-		Wait:                   true,
-		Stop:                   false,
+		LastSyncBatchID: -1,
+		SyncBatchID:     -1,
+		Wait:            true,
+		Stop:            false,
 	}
 }
 
@@ -73,9 +71,6 @@ func NormalizeFlowWorkflow(
 		if s.SyncBatchID > state.SyncBatchID {
 			state.SyncBatchID = s.SyncBatchID
 		}
-		if s.TableNameSchemaMapping != nil {
-			state.TableNameSchemaMapping = s.TableNameSchemaMapping
-		}
 
 		state.Wait = false
 	})
@@ -92,9 +87,8 @@ func NormalizeFlowWorkflow(
 
 		logger.Info("executing normalize")
 		startNormalizeInput := &protos.StartNormalizeInput{
-			FlowConnectionConfigs:  config,
-			TableNameSchemaMapping: state.TableNameSchemaMapping,
-			SyncBatchID:            state.SyncBatchID,
+			FlowConnectionConfigs: config,
+			SyncBatchID:           state.SyncBatchID,
 		}
 		fStartNormalize := workflow.ExecuteActivity(normalizeFlowCtx, flowable.StartNormalize, startNormalizeInput)
 

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -109,6 +109,7 @@ func (q *QRepFlowExecution) setupTableSchema(ctx workflow.Context, tableName str
 		FlowName:         q.config.FlowJobName,
 		System:           q.config.System,
 		Env:              q.config.Env,
+		Clear:            true,
 	}
 
 	return workflow.ExecuteActivity(ctx, flowable.SetupTableSchema, tableSchemaInput).Get(ctx, nil)

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -115,7 +115,7 @@ func (q *QRepFlowExecution) setupTableSchema(ctx workflow.Context, tableName str
 		FlowName: q.config.FlowJobName,
 		System:   q.config.System,
 		Env:      q.config.Env,
-		Clear:    true,
+		Clear:    false,
 	}
 
 	return workflow.ExecuteActivity(ctx, flowable.SetupTableSchema, tableSchemaInput).Get(ctx, nil)

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -506,13 +506,11 @@ func QRepFlowWorkflow(
 		state = newQRepFlowState()
 	}
 
-	err := setWorkflowQueries(ctx, state)
-	if err != nil {
+	if err := setWorkflowQueries(ctx, state); err != nil {
 		return state, err
 	}
 
 	signalChan := model.FlowSignal.GetSignalChannel(ctx)
-
 	q := newQRepFlowExecution(ctx, config, originalRunID)
 
 	if state.CurrentFlowStatus == protos.FlowStatus_STATUS_PAUSING ||
@@ -539,19 +537,16 @@ func QRepFlowWorkflow(
 		maxParallelWorkers = int(config.MaxParallelWorkers)
 	}
 
-	err = q.setupWatermarkTableOnDestination(ctx)
-	if err != nil {
+	if err := q.setupWatermarkTableOnDestination(ctx); err != nil {
 		return state, fmt.Errorf("failed to setup watermark table: %w", err)
 	}
 
-	err = q.SetupMetadataTables(ctx)
-	if err != nil {
+	if err := q.SetupMetadataTables(ctx); err != nil {
 		return state, fmt.Errorf("failed to setup metadata tables: %w", err)
 	}
 	q.logger.Info("metadata tables setup for peer flow")
 
-	err = q.handleTableCreationForResync(ctx, state)
-	if err != nil {
+	if err := q.handleTableCreationForResync(ctx, state); err != nil {
 		return state, err
 	}
 
@@ -583,8 +578,7 @@ func QRepFlowWorkflow(
 			return state, nil
 		}
 
-		err = q.handleTableRenameForResync(ctx, state)
-		if err != nil {
+		if err := q.handleTableRenameForResync(ctx, state); err != nil {
 			return state, err
 		}
 

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -115,7 +115,6 @@ func (q *QRepFlowExecution) setupTableSchema(ctx workflow.Context, tableName str
 		FlowName: q.config.FlowJobName,
 		System:   q.config.System,
 		Env:      q.config.Env,
-		Clear:    false,
 	}
 
 	return workflow.ExecuteActivity(ctx, flowable.SetupTableSchema, tableSchemaInput).Get(ctx, nil)

--- a/flow/workflows/setup_flow.go
+++ b/flow/workflows/setup_flow.go
@@ -187,7 +187,7 @@ func (s *SetupFlowExecution) setupNormalizedTables(
 		FlowName:         s.cdcFlowName,
 		System:           flowConnectionConfigs.System,
 		Env:              flowConnectionConfigs.Env,
-		Clear:            true,
+		Clear:            false,
 	}
 
 	if err := workflow.ExecuteActivity(ctx, flowable.SetupTableSchema, tableSchemaInput).Get(ctx, nil); err != nil {
@@ -251,9 +251,7 @@ func (s *SetupFlowExecution) executeSetupFlow(
 }
 
 // SetupFlowWorkflow is the workflow that sets up the flow.
-func SetupFlowWorkflow(ctx workflow.Context,
-	config *protos.FlowConnectionConfigs,
-) (*protos.SetupFlowOutput, error) {
+func SetupFlowWorkflow(ctx workflow.Context, config *protos.FlowConnectionConfigs) (*protos.SetupFlowOutput, error) {
 	tblNameMapping := make(map[string]string, len(config.TableMappings))
 	for _, v := range config.TableMappings {
 		tblNameMapping[v.SourceTableIdentifier] = v.DestinationTableIdentifier

--- a/flow/workflows/setup_flow.go
+++ b/flow/workflows/setup_flow.go
@@ -187,6 +187,7 @@ func (s *SetupFlowExecution) setupNormalizedTables(
 		FlowName:         s.cdcFlowName,
 		System:           flowConnectionConfigs.System,
 		Env:              flowConnectionConfigs.Env,
+		Clear:            true,
 	}
 
 	if err := workflow.ExecuteActivity(ctx, flowable.SetupTableSchema, tableSchemaInput).Get(ctx, nil); err != nil {

--- a/flow/workflows/setup_flow.go
+++ b/flow/workflows/setup_flow.go
@@ -187,7 +187,6 @@ func (s *SetupFlowExecution) setupNormalizedTables(
 		FlowName:         s.cdcFlowName,
 		System:           flowConnectionConfigs.System,
 		Env:              flowConnectionConfigs.Env,
-		Clear:            false,
 	}
 
 	if err := workflow.ExecuteActivity(ctx, flowable.SetupTableSchema, tableSchemaInput).Get(ctx, nil); err != nil {

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -129,7 +129,7 @@ func (s *SnapshotFlowExecution) cloneTable(
 		})
 		return workflow.ExecuteActivity(
 			schemaCtx,
-			flowable.LoadTableSchema,
+			snapshot.LoadTableSchema,
 			s.config.FlowJobName,
 			dstName,
 		).Get(ctx, &tableSchema)

--- a/flow/workflows/sync_flow.go
+++ b/flow/workflows/sync_flow.go
@@ -145,7 +145,6 @@ func SyncFlowWorkflow(
 							TableMappings:    options.TableMappings,
 							FlowName:         config.FlowJobName,
 							System:           config.System,
-							Clear:            false,
 						})
 
 					if err := getModifiedSchemaFuture.Get(ctx, nil); err != nil {

--- a/flow/workflows/sync_flow.go
+++ b/flow/workflows/sync_flow.go
@@ -142,6 +142,7 @@ func SyncFlowWorkflow(
 						&protos.SetupTableSchemaBatchInput{
 							PeerName:         config.SourceName,
 							TableIdentifiers: modifiedSrcTables,
+							TableMappings:    options.TableMappings,
 							FlowName:         config.FlowJobName,
 							System:           config.System,
 							Clear:            false,

--- a/flow/workflows/xmin_flow.go
+++ b/flow/workflows/xmin_flow.go
@@ -28,8 +28,7 @@ func XminFlowWorkflow(
 		state.LastPartition.PartitionId = uuid.New().String()
 	}
 
-	err := setWorkflowQueries(ctx, state)
-	if err != nil {
+	if err := setWorkflowQueries(ctx, state); err != nil {
 		return state, err
 	}
 
@@ -57,19 +56,16 @@ func XminFlowWorkflow(
 		state.CurrentFlowStatus = protos.FlowStatus_STATUS_RUNNING
 	}
 
-	err = q.setupWatermarkTableOnDestination(ctx)
-	if err != nil {
+	if err := q.setupWatermarkTableOnDestination(ctx); err != nil {
 		return state, fmt.Errorf("failed to setup watermark table: %w", err)
 	}
 
-	err = q.SetupMetadataTables(ctx)
-	if err != nil {
+	if err := q.SetupMetadataTables(ctx); err != nil {
 		return state, fmt.Errorf("failed to setup metadata tables: %w", err)
 	}
 	logger.Info("metadata tables setup for peer flow")
 
-	err = q.handleTableCreationForResync(ctx, state)
-	if err != nil {
+	if err := q.handleTableCreationForResync(ctx, state); err != nil {
 		return state, err
 	}
 
@@ -78,14 +74,13 @@ func XminFlowWorkflow(
 		StartToCloseTimeout: 24 * 5 * time.Hour,
 		HeartbeatTimeout:    time.Minute,
 	})
-	err = workflow.ExecuteActivity(
+	if err := workflow.ExecuteActivity(
 		replicateXminPartitionCtx,
 		flowable.ReplicateXminPartition,
 		q.config,
 		state.LastPartition,
 		q.runUUID,
-	).Get(ctx, &lastPartition)
-	if err != nil {
+	).Get(ctx, &lastPartition); err != nil {
 		return state, fmt.Errorf("xmin replication failed: %w", err)
 	}
 
@@ -98,8 +93,7 @@ func XminFlowWorkflow(
 		return state, nil
 	}
 
-	err = q.handleTableRenameForResync(ctx, state)
-	if err != nil {
+	if err := q.handleTableRenameForResync(ctx, state); err != nil {
 		return state, err
 	}
 

--- a/nexus/catalog/migrations/V39__table_schema_mapping.sql
+++ b/nexus/catalog/migrations/V39__table_schema_mapping.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS table_schema_mapping (
-    flow_name varchar(255) not null references flows(name),
+    flow_name varchar(255) not null,
     table_name text not null,
     table_schema bytea not null,
     primary key (flow_name, table_name)

--- a/nexus/catalog/migrations/V39__table_schema_mapping.sql
+++ b/nexus/catalog/migrations/V39__table_schema_mapping.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS table_schema_mapping (
+    flow_name varchar(255) not null references flows(name),
+    table_name text not null,
+    table_schema bytea not null, 
+    primary key (flow_name, table_name)
+);

--- a/nexus/catalog/migrations/V39__table_schema_mapping.sql
+++ b/nexus/catalog/migrations/V39__table_schema_mapping.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS table_schema_mapping (
     flow_name varchar(255) not null references flows(name),
     table_name text not null,
-    table_schema bytea not null, 
+    table_schema bytea not null,
     primary key (flow_name, table_name)
 );

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -112,6 +112,7 @@ message SyncFlowOptions {
   uint32 batch_size = 1;
   uint64 idle_timeout_seconds = 3;
   map<uint32, string> src_table_id_name_mapping = 4;
+  map<string, TableSchema> table_name_schema_mapping = 5;
   repeated TableMapping table_mappings = 6;
   int32 number_of_syncs = 7;
 }

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -112,14 +112,12 @@ message SyncFlowOptions {
   uint32 batch_size = 1;
   uint64 idle_timeout_seconds = 3;
   map<uint32, string> src_table_id_name_mapping = 4;
-  map<string, TableSchema> table_name_schema_mapping = 5;
   repeated TableMapping table_mappings = 6;
   int32 number_of_syncs = 7;
 }
 
 message StartNormalizeInput {
   FlowConnectionConfigs flow_connection_configs = 1;
-  map<string, TableSchema> table_name_schema_mapping = 2;
   int64 SyncBatchID = 3;
 }
 
@@ -187,11 +185,11 @@ message SetupTableSchemaBatchInput {
   TypeSystem system = 4;
   string peer_name = 5;
   repeated TableMapping table_mappings = 6;
+  bool clear = 7;
 }
 
 message SetupNormalizedTableBatchInput {
   map<string, string> env = 1;
-  map<string, TableSchema> table_name_schema_mapping = 2;
   repeated TableMapping table_mappings = 3;
 
   // migration related columns

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -185,7 +185,6 @@ message SetupTableSchemaBatchInput {
   TypeSystem system = 4;
   string peer_name = 5;
   repeated TableMapping table_mappings = 6;
-  bool clear = 7;
 }
 
 message SetupNormalizedTableBatchInput {

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -163,6 +163,7 @@ message CreateRawTableInput {
 
 message CreateRawTableOutput { string table_identifier = 1; }
 
+// stored in catalog table table_schema_mapping, be wary of breaking changes
 message TableSchema {
   string table_identifier = 1;
   repeated string primary_key_columns = 2;

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -180,16 +180,13 @@ message FieldDescription {
   bool nullable = 4;
 }
 
-message GetTableSchemaBatchInput {
+message SetupTableSchemaBatchInput {
   map<string, string> env = 1;
   repeated string table_identifiers = 2;
   string flow_name = 3;
   TypeSystem system = 4;
   string peer_name = 5;
-}
-
-message GetTableSchemaBatchOutput {
-  map<string, TableSchema> table_name_schema_mapping = 1;
+  repeated TableMapping table_mappings = 6;
 }
 
 message SetupNormalizedTableBatchInput {
@@ -413,7 +410,6 @@ message FlowConfigUpdate {
 
 message SetupFlowOutput {
   map<uint32, string> src_table_id_name_mapping = 1;
-  map<string, TableSchema> table_name_schema_mapping = 2;
 }
 
 message AddTablesToPublicationInput {


### PR DESCRIPTION
This data could get pretty large in temporal history, & was being duplicated with each NormalizePayload

Since it's meant to be based on real world state (source database schema), activity replay getting a more up to date schema shouldn't be an issue