### PR TITLE
Clickhouse raw table: merge tree, different order by

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -54,7 +54,7 @@ func (c *ClickHouseConnector) CreateRawTable(ctx context.Context, req *protos.Cr
 		_peerdb_match_data String,
 		_peerdb_batch_id Int,
 		_peerdb_unchanged_toast_columns String
-	) ENGINE = ReplacingMergeTree ORDER BY _peerdb_uid;`
+	) ENGINE = MergeTree() ORDER BY (_peerdb_batch_id, _peerdb_destination_table_name);`
 
 	err := c.execWithLogging(ctx,
 		fmt.Sprintf(createRawTableSQL, rawTableName))


### PR DESCRIPTION
Raw table DDL is now featuring merge tree with order by of batch ID and destination table name:

```sql

CREATE TABLE IF NOT EXISTS raw (
		_peerdb_uid String NOT NULL,
		_peerdb_timestamp Int64 NOT NULL,
		_peerdb_destination_table_name String NOT NULL,
		_peerdb_data String NOT NULL,
		_peerdb_record_type Int NOT NULL,
		_peerdb_match_data String,
		_peerdb_batch_id Int,
		_peerdb_unchanged_toast_columns String
) ENGINE = MergeTree() ORDER BY (_peerdb_batch_id, _peerdb_destination_table_name);
```

Functionally tested and normalize IIS seems to be slightly faster than what it is currently