### PR TITLE
RenameTableOptions: remove TableSchema

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -157,7 +157,11 @@ func (c *ClickHouseConnector) ReplayTableSchemaDeltas(ctx context.Context, flowJ
 	return nil
 }
 
-func (c *ClickHouseConnector) RenameTables(ctx context.Context, req *protos.RenameTablesInput) (*protos.RenameTablesOutput, error) {
+func (c *ClickHouseConnector) RenameTables(
+	ctx context.Context,
+	req *protos.RenameTablesInput,
+	tableNameSchemaMapping map[string]*protos.TableSchema,
+) (*protos.RenameTablesOutput, error) {
 	for _, renameRequest := range req.RenameTableOptions {
 		resyncTableExists, err := c.checkIfTableExists(ctx, c.config.Database, renameRequest.CurrentName)
 		if err != nil {
@@ -175,8 +179,9 @@ func (c *ClickHouseConnector) RenameTables(ctx context.Context, req *protos.Rena
 		}
 
 		if originalTableExists {
-			columnNames := make([]string, 0, len(renameRequest.TableSchema.Columns))
-			for _, col := range renameRequest.TableSchema.Columns {
+			tableSchema := tableNameSchemaMapping[renameRequest.CurrentName]
+			columnNames := make([]string, 0, len(tableSchema.Columns))
+			for _, col := range tableSchema.Columns {
 				columnNames = append(columnNames, col.Name)
 			}
 

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -265,7 +265,7 @@ type RawTableConnector interface {
 type RenameTablesConnector interface {
 	Connector
 
-	RenameTables(context.Context, *protos.RenameTablesInput) (*protos.RenameTablesOutput, error)
+	RenameTables(context.Context, *protos.RenameTablesInput, map[string]*protos.TableSchema) (*protos.RenameTablesOutput, error)
 }
 
 func LoadPeerType(ctx context.Context, catalogPool *pgxpool.Pool, peerName string) (protos.DBType, error) {

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -75,7 +75,6 @@ message FlowConnectionConfigs {
 message RenameTableOption {
   string current_name = 1;
   string new_name = 2;
-  TableSchema table_schema = 3;
 }
 
 message RenameTablesInput {


### PR DESCRIPTION
In #2090 I got so caught up fixing bug @heavycrystal pointed out that I forgot I wanted to clean the code out of existence

This has no change in behavior, just cleans up protobuf so there isn't this weird 'workflow send nils into activity, activity fills in at start' protocol