### PR TITLE
PG to Clickhouse: map date to date32

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -315,7 +315,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 			}
 
 			switch clickHouseType {
-			case "Date", "Nullable(Date)":
+			case "Date32", "Nullable(Date32)":
 				projection.WriteString(fmt.Sprintf(
 					"toDate(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'))) AS `%s`,",
 					colName,

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -317,7 +317,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 			switch clickHouseType {
 			case "Date32", "Nullable(Date32)":
 				projection.WriteString(fmt.Sprintf(
-					"toDate(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'))) AS `%s`,",
+					"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'))) AS `%s`,",
 					colName,
 					dstColName,
 				))

--- a/flow/e2e/clickhouse/clickhouse.go
+++ b/flow/e2e/clickhouse/clickhouse.go
@@ -119,6 +119,8 @@ func (s ClickHouseSuite) GetRows(table string, cols string) (*model.QRecordBatch
 			qkind = qvalue.QValueKindInt32
 		case "DateTime64(6)", "Nullable(DateTime64(6))":
 			qkind = qvalue.QValueKindTimestamp
+		case "Date32", "Nullable(Date32)":
+			qkind = qvalue.QValueKindDate
 		default:
 			if strings.Contains(ty.DatabaseTypeName(), "Decimal") {
 				qkind = qvalue.QValueKindNumeric

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -219,3 +219,47 @@ func (s ClickHouseSuite) Test_Nullable() {
 	env.Cancel()
 	e2e.RequireEnvCanceled(s.t, env)
 }
+
+func (s ClickHouseSuite) Test_Date32() {
+	srcTableName := "test_date32"
+	srcFullName := s.attachSchemaSuffix("test_date32")
+	dstTableName := "test_date32_dst"
+
+	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id SERIAL PRIMARY KEY,
+			key TEXT NOT NULL,
+			d DATE NOT NULL
+		);
+	`, srcFullName))
+	require.NoError(s.t, err)
+
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+	INSERT INTO %s (key,d) VALUES ('init','1935-01-01');
+	`, srcFullName))
+	require.NoError(s.t, err)
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("clickhouse_date32"),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s.t)
+	flowConnConfig.DoInitialSnapshot = true
+
+	tc := e2e.NewTemporalClient(s.t)
+	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,key,d")
+
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+	INSERT INTO %s (key) VALUES ('cdc');
+	`, srcFullName))
+	require.NoError(s.t, err)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,key,d")
+
+	env.Cancel()
+	e2e.RequireEnvCanceled(s.t, env)
+}

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -254,7 +254,7 @@ func (s ClickHouseSuite) Test_Date32() {
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,key,d")
 
 	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-	INSERT INTO %s (key) VALUES ('cdc');
+	INSERT INTO %s (key,d) VALUES ('cdc','1935-01-01');
 	`, srcFullName))
 	require.NoError(s.t, err)
 

--- a/flow/model/qvalue/kind.go
+++ b/flow/model/qvalue/kind.go
@@ -110,7 +110,7 @@ var QValueKindToClickHouseTypeMap = map[QValueKind]string{
 	QValueKindTimestamp:   "DateTime64(6)",
 	QValueKindTimestampTZ: "DateTime64(6)",
 	QValueKindTime:        "String",
-	QValueKindDate:        "Date",
+	QValueKindDate:        "Date32",
 	QValueKindBytes:       "String",
 	QValueKindStruct:      "String",
 	QValueKindUUID:        "UUID",


### PR DESCRIPTION
Date in Clickhouse has a limited range of `[1970-01-01, 2149-06-06]`. Whereas Date32 has the same range of DateTime64(6), allowing dates < 1970 to be synced
This PR now maps dates in postgres to date32 instead of date on CH