### PR TITLE
clickhouse: fix normalizing updates to primary key

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -377,10 +377,10 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		selectQuery.WriteString(tbl)
 		selectQuery.WriteString("'")
 
-		disablePrimaryUpdate, err := peerdbenv.PeerDBDisablePrimaryUpdate(ctx, req.Env)
+		enablePrimaryUpdate, err := peerdbenv.PeerDBEnableClickHousePrimaryUpdate(ctx, req.Env)
 		if err != nil {
 			return nil, err
-		} else if !disablePrimaryUpdate {
+		} else if enablePrimaryUpdate {
 			selectQuery.WriteString("UNION ALL SELECT ")
 			selectQuery.WriteString(projectionUpdate.String())
 			selectQuery.WriteString(" FROM ")

--- a/flow/e2e/clickhouse/clickhouse.go
+++ b/flow/e2e/clickhouse/clickhouse.go
@@ -99,7 +99,7 @@ func (s ClickHouseSuite) GetRows(table string, cols string) (*model.QRecordBatch
 	}
 	rows, err := ch.Query(
 		context.Background(),
-		fmt.Sprintf(`SELECT %s FROM %s FINAL ORDER BY %s SETTINGS use_query_cache = false`, cols, table, firstCol),
+		fmt.Sprintf(`SELECT %s FROM %s FINAL WHERE _peerdb_is_deleted = 0 ORDER BY %s SETTINGS use_query_cache = false`, cols, table, firstCol),
 	)
 	if err != nil {
 		return nil, err

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -289,7 +289,7 @@ func (s ClickHouseSuite) Test_Update_PKey_Env_Disabled() {
 	}
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s.t)
 	flowConnConfig.DoInitialSnapshot = true
-	flowConnConfig.Env = map[string]string{"PEERDB_CLICKHOUSE_DISABLE_PRIMARY_UPDATE": "true"}
+	flowConnConfig.Env = map[string]string{"PEERDB_CLICKHOUSE_ENABLE_PRIMARY_UPDATE": "false"}
 
 	tc := e2e.NewTemporalClient(s.t)
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
@@ -312,7 +312,7 @@ func (s ClickHouseSuite) Test_Update_PKey_Env_Disabled() {
 	e2e.RequireEnvCanceled(s.t, env)
 }
 
-func (s ClickHouseSuite) Test_Update_PKey() {
+func (s ClickHouseSuite) Test_Update_PKey_Env_Enabled() {
 	srcTableName := "test_update_pkey"
 	srcFullName := s.attachSchemaSuffix("test_update_pkey")
 	dstTableName := "test_update_pkey_dst"
@@ -337,6 +337,7 @@ func (s ClickHouseSuite) Test_Update_PKey() {
 	}
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s.t)
 	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.Env = map[string]string{"PEERDB_CLICKHOUSE_ENABLE_PRIMARY_UPDATE": "true"}
 
 	tc := e2e.NewTemporalClient(s.t)
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -263,3 +263,94 @@ func (s ClickHouseSuite) Test_Date32() {
 	env.Cancel()
 	e2e.RequireEnvCanceled(s.t, env)
 }
+
+func (s ClickHouseSuite) Test_Update_PKey_Env_Disabled() {
+	srcTableName := "test_update_pkey"
+	srcFullName := s.attachSchemaSuffix("test_update_pkey")
+	dstTableName := "test_update_pkey_dst"
+
+	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id INT PRIMARY KEY,
+			key TEXT NOT NULL
+		);
+	`, srcFullName))
+	require.NoError(s.t, err)
+
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+	INSERT INTO %s (id,key) VALUES (1,'init');
+	`, srcFullName))
+	require.NoError(s.t, err)
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("clickhouse_date32"),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s.t)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.Env = map[string]string{"PEERDB_CLICKHOUSE_DISABLE_PRIMARY_UPDATE": "true"}
+
+	tc := e2e.NewTemporalClient(s.t)
+	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,key")
+
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+	UPDATE %s SET id = 2, key = 'update' WHERE id = 1;
+	`, srcFullName))
+	require.NoError(s.t, err)
+
+	e2e.EnvWaitFor(s.t, env, time.Minute, "waiting for duplicate row", func() bool {
+		rows, err := s.GetRows(dstTableName, "id")
+		require.NoError(s.t, err)
+		return len(rows.Records) == 2
+	})
+
+	env.Cancel()
+	e2e.RequireEnvCanceled(s.t, env)
+}
+
+func (s ClickHouseSuite) Test_Update_PKey() {
+	srcTableName := "test_update_pkey"
+	srcFullName := s.attachSchemaSuffix("test_update_pkey")
+	dstTableName := "test_update_pkey_dst"
+
+	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id INT PRIMARY KEY,
+			key TEXT NOT NULL
+		);
+	`, srcFullName))
+	require.NoError(s.t, err)
+
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+	INSERT INTO %s (id,key) VALUES (1,'init');
+	`, srcFullName))
+	require.NoError(s.t, err)
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("clickhouse_date32"),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s.t)
+	flowConnConfig.DoInitialSnapshot = true
+
+	tc := e2e.NewTemporalClient(s.t)
+	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,key")
+
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
+	UPDATE %s SET id = 2, key = 'update' WHERE id = 1;
+	`, srcFullName))
+	require.NoError(s.t, err)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,key")
+
+	env.Cancel()
+	e2e.RequireEnvCanceled(s.t, env)
+}

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -265,9 +265,9 @@ func (s ClickHouseSuite) Test_Date32() {
 }
 
 func (s ClickHouseSuite) Test_Update_PKey_Env_Disabled() {
-	srcTableName := "test_update_pkey"
-	srcFullName := s.attachSchemaSuffix("test_update_pkey")
-	dstTableName := "test_update_pkey_dst"
+	srcTableName := "test_update_pkey_disabled"
+	srcFullName := s.attachSchemaSuffix("test_update_pkey_disabled")
+	dstTableName := "test_update_pkey_disabled_dst"
 
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
@@ -283,7 +283,7 @@ func (s ClickHouseSuite) Test_Update_PKey_Env_Disabled() {
 	require.NoError(s.t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix("clickhouse_date32"),
+		FlowJobName:      s.attachSuffix("clickhouse_pkey_update_disabled"),
 		TableNameMapping: map[string]string{srcFullName: dstTableName},
 		Destination:      s.Peer().Name,
 	}
@@ -313,9 +313,9 @@ func (s ClickHouseSuite) Test_Update_PKey_Env_Disabled() {
 }
 
 func (s ClickHouseSuite) Test_Update_PKey_Env_Enabled() {
-	srcTableName := "test_update_pkey"
-	srcFullName := s.attachSchemaSuffix("test_update_pkey")
-	dstTableName := "test_update_pkey_dst"
+	srcTableName := "test_update_pkey_enabled"
+	srcFullName := s.attachSchemaSuffix("test_update_pkey_enabled")
+	dstTableName := "test_update_pkey_enabled_dst"
 
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
@@ -331,7 +331,7 @@ func (s ClickHouseSuite) Test_Update_PKey_Env_Enabled() {
 	require.NoError(s.t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix("clickhouse_date32"),
+		FlowJobName:      s.attachSuffix("clickhouse_pkey_update_enabled"),
 		TableNameMapping: map[string]string{srcFullName: dstTableName},
 		Destination:      s.Peer().Name,
 	}

--- a/flow/peerdbenv/dynamicconf.go
+++ b/flow/peerdbenv/dynamicconf.go
@@ -157,7 +157,7 @@ DROP AGGREGATE PEERDB_EPHEMERAL_HEARTBEAT(float4); END;`,
 		TargetForSetting: protos.DynconfTarget_BIGQUERY,
 	},
 	{
-		Name:             "PEERDB_CLICKHOUSE_DISABLE_PRIMARY_UPDATE",
+		Name:             "PEERDB_CLICKHOUSE_ENABLE_PRIMARY_UPDATE",
 		Description:      "Enable generating deletion records for updates in ClickHouse, avoids stale records when primary key updated",
 		DefaultValue:     "false",
 		ValueType:        protos.DynconfValueType_BOOL,

--- a/flow/peerdbenv/dynamicconf.go
+++ b/flow/peerdbenv/dynamicconf.go
@@ -18,44 +18,58 @@ import (
 
 var DynamicSettings = [...]*protos.DynamicSetting{
 	{
-		Name: "PEERDB_MAX_SYNCS_PER_CDC_FLOW", DefaultValue: "32", ValueType: protos.DynconfValueType_UINT,
+		Name:             "PEERDB_MAX_SYNCS_PER_CDC_FLOW",
 		Description:      "Experimental setting: changes number of syncs per workflow, affects frequency of replication slot disconnects",
+		DefaultValue:     "32",
+		ValueType:        protos.DynconfValueType_UINT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_CDC_CHANNEL_BUFFER_SIZE", DefaultValue: "262144", ValueType: protos.DynconfValueType_INT,
+		Name:             "PEERDB_CDC_CHANNEL_BUFFER_SIZE",
 		Description:      "Advanced setting: changes buffer size of channel PeerDB uses while streaming rows read to destination in CDC",
+		DefaultValue:     "262144",
+		ValueType:        protos.DynconfValueType_INT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_QUEUE_FLUSH_TIMEOUT_SECONDS", DefaultValue: "10", ValueType: protos.DynconfValueType_INT,
+		Name:             "PEERDB_QUEUE_FLUSH_TIMEOUT_SECONDS",
 		Description:      "Frequency of flushing to queue, applicable for PeerDB Streams mirrors only",
+		DefaultValue:     "10",
+		ValueType:        protos.DynconfValueType_INT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_QUEUES,
 	},
 	{
-		Name: "PEERDB_QUEUE_PARALLELISM", DefaultValue: "4", ValueType: protos.DynconfValueType_INT,
+		Name:             "PEERDB_QUEUE_PARALLELISM",
 		Description:      "Parallelism for Lua script processing data, applicable for CDC mirrors to Kakfa and PubSub",
+		DefaultValue:     "4",
+		ValueType:        protos.DynconfValueType_INT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_QUEUES,
 	},
 	{
-		Name: "PEERDB_CDC_DISK_SPILL_RECORDS_THRESHOLD", DefaultValue: "1000000", ValueType: protos.DynconfValueType_INT,
+		Name:             "PEERDB_CDC_DISK_SPILL_RECORDS_THRESHOLD",
 		Description:      "CDC: number of records beyond which records are written to disk instead",
+		DefaultValue:     "1000000",
+		ValueType:        protos.DynconfValueType_INT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_CDC_DISK_SPILL_MEM_PERCENT_THRESHOLD", DefaultValue: "-1", ValueType: protos.DynconfValueType_INT,
+		Name:             "PEERDB_CDC_DISK_SPILL_MEM_PERCENT_THRESHOLD",
 		Description:      "CDC: worker memory usage (in %) beyond which records are written to disk instead, -1 disables",
+		DefaultValue:     "-1",
+		ValueType:        protos.DynconfValueType_INT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_ENABLE_WAL_HEARTBEAT", DefaultValue: "false", ValueType: protos.DynconfValueType_BOOL,
+		Name:             "PEERDB_ENABLE_WAL_HEARTBEAT",
 		Description:      "Enables WAL heartbeat to prevent replication slot lag from increasing during times of no activity",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
@@ -64,65 +78,91 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		DefaultValue: `BEGIN;
 DROP AGGREGATE IF EXISTS PEERDB_EPHEMERAL_HEARTBEAT(float4);
 CREATE AGGREGATE PEERDB_EPHEMERAL_HEARTBEAT(float4) (SFUNC = float4pl, STYPE = float4);
-DROP AGGREGATE PEERDB_EPHEMERAL_HEARTBEAT(float4);
-END;`, ValueType: protos.DynconfValueType_STRING,
+DROP AGGREGATE PEERDB_EPHEMERAL_HEARTBEAT(float4); END;`,
+		ValueType:        protos.DynconfValueType_STRING,
 		Description:      "SQL to run during each WAL heartbeat",
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_ENABLE_PARALLEL_SYNC_NORMALIZE", DefaultValue: "false", ValueType: protos.DynconfValueType_BOOL,
+		Name:             "PEERDB_ENABLE_PARALLEL_SYNC_NORMALIZE",
 		Description:      "Enables parallel sync (moving rows to target) and normalize (updating rows in target table)",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_NULLABLE", DefaultValue: "false", ValueType: protos.DynconfValueType_BOOL,
+		Name:             "PEERDB_NULLABLE",
 		Description:      "Propagate nullability in schema",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_SNOWFLAKE_MERGE_PARALLELISM", DefaultValue: "8", ValueType: protos.DynconfValueType_INT,
+		Name:             "PEERDB_SNOWFLAKE_MERGE_PARALLELISM",
 		Description:      "Parallel MERGE statements to run for CDC mirrors with Snowflake targets. -1 for no limit",
+		DefaultValue:     "8",
+		ValueType:        protos.DynconfValueType_INT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_SNOWFLAKE,
 	},
 	{
-		Name: "PEERDB_CLICKHOUSE_AWS_S3_BUCKET_NAME", DefaultValue: "", ValueType: protos.DynconfValueType_STRING,
+		Name:             "PEERDB_CLICKHOUSE_AWS_S3_BUCKET_NAME",
 		Description:      "S3 buckets to store Avro files for mirrors with ClickHouse target",
+		DefaultValue:     "",
+		ValueType:        protos.DynconfValueType_STRING,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 	{
-		Name: "PEERDB_QUEUE_FORCE_TOPIC_CREATION", DefaultValue: "false", ValueType: protos.DynconfValueType_BOOL,
+		Name:             "PEERDB_QUEUE_FORCE_TOPIC_CREATION",
 		Description:      "Force auto topic creation in mirrors, applies to Kafka and PubSub mirrors",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
 		TargetForSetting: protos.DynconfTarget_QUEUES,
 	},
 	{
-		Name: "PEERDB_ALERTING_GAP_MINUTES", DefaultValue: "15", ValueType: protos.DynconfValueType_UINT,
+		Name:             "PEERDB_ALERTING_GAP_MINUTES",
 		Description:      "Duration in minutes before reraising alerts, 0 disables all alerting entirely",
+		DefaultValue:     "15",
+		ValueType:        protos.DynconfValueType_UINT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_SLOT_LAG_MB_ALERT_THRESHOLD", DefaultValue: "5000", ValueType: protos.DynconfValueType_UINT,
+		Name:             "PEERDB_SLOT_LAG_MB_ALERT_THRESHOLD",
 		Description:      "Lag (in MB) threshold on PeerDB slot to start sending alerts, 0 disables slot lag alerting entirely",
+		DefaultValue:     "5000",
+		ValueType:        protos.DynconfValueType_UINT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD", DefaultValue: "5", ValueType: protos.DynconfValueType_UINT,
+		Name:             "PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD",
 		Description:      "Open connections from PeerDB user threshold to start sending alerts, 0 disables open connections alerting entirely",
+		DefaultValue:     "5",
+		ValueType:        protos.DynconfValueType_UINT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name: "PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS", DefaultValue: "false", ValueType: protos.DynconfValueType_BOOL,
+		Name:             "PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS",
 		Description:      "BigQuery only: create target tables with partitioning by _PEERDB_SYNCED_AT column",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
 		TargetForSetting: protos.DynconfTarget_BIGQUERY,
+	},
+	{
+		Name:             "PEERDB_CLICKHOUSE_DISABLE_PRIMARY_UPDATE",
+		Description:      "Disable generating deletion records for updates in ClickHouse, leaves stale records when primary key updated",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 }
 
@@ -270,6 +310,10 @@ func PeerDBEnableParallelSyncNormalize(ctx context.Context, env map[string]strin
 
 func PeerDBNullable(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_NULLABLE")
+}
+
+func PeerDBDisablePrimaryUpdate(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_DISABLE_PRIMARY_UPDATE")
 }
 
 func PeerDBSnowflakeMergeParallelism(ctx context.Context, env map[string]string) (int64, error) {

--- a/flow/peerdbenv/dynamicconf.go
+++ b/flow/peerdbenv/dynamicconf.go
@@ -158,7 +158,7 @@ DROP AGGREGATE PEERDB_EPHEMERAL_HEARTBEAT(float4); END;`,
 	},
 	{
 		Name:             "PEERDB_CLICKHOUSE_DISABLE_PRIMARY_UPDATE",
-		Description:      "Disable generating deletion records for updates in ClickHouse, leaves stale records when primary key updated",
+		Description:      "Enable generating deletion records for updates in ClickHouse, avoids stale records when primary key updated",
 		DefaultValue:     "false",
 		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
@@ -312,8 +312,8 @@ func PeerDBNullable(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_NULLABLE")
 }
 
-func PeerDBDisablePrimaryUpdate(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_DISABLE_PRIMARY_UPDATE")
+func PeerDBEnableClickHousePrimaryUpdate(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_ENABLE_PRIMARY_UPDATE")
 }
 
 func PeerDBSnowflakeMergeParallelism(ctx context.Context, env map[string]string) (int64, error) {


### PR DESCRIPTION
when primary key updated row becomes duplicate because old version isn't marked outdated,
generate deletion records behind updates

on an update heavy workload where primary keys aren't updated this can be disabled with `PEERDB_CLICKHOUSE_DISABLE_PRIMARY_UPDATE` to omit `UNION ALL`

if custom ordering is on a non replica identity column then row data may be missing,
causing this to fail to prevent duplication