### PR TITLE
[clickhouse] defer dropping table during ValidateMirror

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -114,7 +114,7 @@ func (c *ClickHouseConnector) ValidateCheck(ctx context.Context) error {
 	); err != nil {
 		return fmt.Errorf("failed to rename validation table %s: %w", validateDummyTableName, err)
 	}
-	validateDummyTableName = validateDummyTableName + "_renamed"
+	validateDummyTableName += "_renamed"
 
 	// insert a row
 	if err := c.exec(ctx, fmt.Sprintf("INSERT INTO %s VALUES (1, now64())", validateDummyTableName)); err != nil {

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -1143,10 +1143,10 @@ func (s PeerFlowE2ETestSuitePG) Test_TransformRowScript() {
 	require.False(s.t, exists)
 }
 
-func (s PeerFlowE2ETestSuitePG) Test_Simple_Schema_Changes_PG() {
+func (s PeerFlowE2ETestSuitePG) Test_Mixed_Case_Schema_Changes_PG() {
 	tc := e2e.NewTemporalClient(s.t)
 
-	srcTableName := "test_simple_schema_changes_PG"
+	srcTableName := "test_mixed_case_schema_changes_PG"
 	dstTableName := srcTableName + "_dst"
 	quotedSourceTableName := s.attachSchemaSuffix(`"` + srcTableName + `"`)
 	quotedDestTableName := s.attachSchemaSuffix(`"` + dstTableName + `"`)
@@ -1159,7 +1159,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Simple_Schema_Changes_PG() {
 	require.NoError(s.t, err)
 
 	flowConnConfig := &protos.FlowConnectionConfigs{
-		FlowJobName:     s.attachSuffix("test_simple_schema_changes_pg"),
+		FlowJobName:     s.attachSuffix("test_mixed_case_schema_changes_pg"),
 		DestinationName: s.Peer().Name,
 		TableMappings: []*protos.TableMapping{
 			{


### PR DESCRIPTION
We're observing that this function (called while creating or updating a peer to validate it) can sometimes fail midway and leave this table around, trying to reduce the possibility of that