### PR TITLE
SSH host key parsing: use ParseAuthorizedKey

### DIFF
--- a/flow/connectors/utils/ssh.go
+++ b/flow/connectors/utils/ssh.go
@@ -45,7 +45,7 @@ func GetSSHClientConfig(config *protos.SSHConfig) (*ssh.ClientConfig, error) {
 
 	var hostKeyCallback ssh.HostKeyCallback
 	if config.HostKey != "" {
-		pubKey, err := ssh.ParsePublicKey([]byte(config.HostKey))
+		pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(config.HostKey))
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse host key: %w", err)
 		}


### PR DESCRIPTION
`ParsePublicKey` expects the public key in a different SSH wire protocol format while `ParseAuthorizedKey` expects what you see in an `id_rsa.pub` file (which gives an error - `short read` when trying to parse it with `ParsePublicKey`)


References:
- [ParsePublicKey](https://pkg.go.dev/golang.org/x/crypto/ssh#ParsePublicKey)
- [ParseAuthorizedKey](https://pkg.go.dev/golang.org/x/crypto/ssh#ParseAuthorizedKey)

- [x] Functionally tested