### PR TITLE
routes: remove ok/error_message

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -432,9 +432,7 @@ func (h *FlowRequestHandler) FlowStateChange(
 		}
 	}
 
-	return &protos.FlowStateChangeResponse{
-		Ok: true,
-	}, nil
+	return &protos.FlowStateChangeResponse{}, nil
 }
 
 func (h *FlowRequestHandler) handleCancelWorkflow(ctx context.Context, workflowID, runID string) error {
@@ -494,19 +492,13 @@ func (h *FlowRequestHandler) DropPeer(
 	req *protos.DropPeerRequest,
 ) (*protos.DropPeerResponse, error) {
 	if req.PeerName == "" {
-		return &protos.DropPeerResponse{
-			Ok:           false,
-			ErrorMessage: fmt.Sprintf("Peer %s not found", req.PeerName),
-		}, fmt.Errorf("peer %s not found", req.PeerName)
+		return nil, fmt.Errorf("peer %s not found", req.PeerName)
 	}
 
 	// Check if peer name is in flows table
 	peerID, _, err := h.getPeerID(ctx, req.PeerName)
 	if err != nil {
-		return &protos.DropPeerResponse{
-			Ok:           false,
-			ErrorMessage: fmt.Sprintf("Failed to obtain peer ID for peer %s: %v", req.PeerName, err),
-		}, fmt.Errorf("failed to obtain peer ID for peer %s: %v", req.PeerName, err)
+		return nil, fmt.Errorf("failed to obtain peer ID for peer %s: %w", req.PeerName, err)
 	}
 
 	var inMirror pgtype.Int8
@@ -514,30 +506,19 @@ func (h *FlowRequestHandler) DropPeer(
 		"SELECT COUNT(*) FROM flows WHERE source_peer=$1 or destination_peer=$2",
 		peerID, peerID).Scan(&inMirror)
 	if queryErr != nil {
-		return &protos.DropPeerResponse{
-			Ok:           false,
-			ErrorMessage: fmt.Sprintf("Failed to check for existing mirrors with peer %s: %v", req.PeerName, queryErr),
-		}, fmt.Errorf("failed to check for existing mirrors with peer %s", req.PeerName)
+		return nil, fmt.Errorf("failed to check for existing mirrors with peer %s: %w", req.PeerName, queryErr)
 	}
 
 	if inMirror.Int64 != 0 {
-		return &protos.DropPeerResponse{
-			Ok:           false,
-			ErrorMessage: fmt.Sprintf("Peer %s is currently involved in an ongoing mirror.", req.PeerName),
-		}, nil
+		return nil, fmt.Errorf("peer %s is currently involved in an ongoing mirror", req.PeerName)
 	}
 
 	_, delErr := h.pool.Exec(ctx, "DELETE FROM peers WHERE name = $1", req.PeerName)
 	if delErr != nil {
-		return &protos.DropPeerResponse{
-			Ok:           false,
-			ErrorMessage: fmt.Sprintf("failed to delete peer %s from metadata table: %v", req.PeerName, delErr),
-		}, fmt.Errorf("failed to delete peer %s from metadata table: %v", req.PeerName, delErr)
+		return nil, fmt.Errorf("failed to delete peer %s from metadata table: %w", req.PeerName, delErr)
 	}
 
-	return &protos.DropPeerResponse{
-		Ok: true,
-	}, nil
+	return &protos.DropPeerResponse{}, nil
 }
 
 func (h *FlowRequestHandler) getWorkflowID(ctx context.Context, flowJobName string) (string, error) {
@@ -590,7 +571,5 @@ func (h *FlowRequestHandler) ResyncMirror(
 	if err != nil {
 		return nil, err
 	}
-	return &protos.ResyncMirrorResponse{
-		Ok: true,
-	}, nil
+	return &protos.ResyncMirrorResponse{}, nil
 }

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -29,53 +29,37 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		mirrorExists, existCheckErr := h.CheckIfMirrorNameExists(ctx, req.ConnectionConfigs.FlowJobName)
 		if existCheckErr != nil {
 			slog.Error("/validatecdc failed to check if mirror name exists", slog.Any("error", existCheckErr))
-			return &protos.ValidateCDCMirrorResponse{
-				Ok: false,
-			}, existCheckErr
+			return nil, existCheckErr
 		}
 
 		if mirrorExists {
 			displayErr := fmt.Errorf("mirror with name %s already exists", req.ConnectionConfigs.FlowJobName)
-			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-				fmt.Sprint(displayErr),
-			)
-			return &protos.ValidateCDCMirrorResponse{
-				Ok: false,
-			}, displayErr
+			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, displayErr.Error())
+			return nil, displayErr
 		}
 	}
 
 	if req.ConnectionConfigs == nil {
 		slog.Error("/validatecdc connection configs is nil")
-		return &protos.ValidateCDCMirrorResponse{
-			Ok: false,
-		}, errors.New("connection configs is nil")
+		return nil, errors.New("connection configs is nil")
 	}
 	sourcePeer, err := connectors.LoadPeer(ctx, h.pool, req.ConnectionConfigs.SourceName)
 	if err != nil {
 		slog.Error("/validatecdc failed to load source peer", slog.String("peer", req.ConnectionConfigs.SourceName))
-		return &protos.ValidateCDCMirrorResponse{
-			Ok: false,
-		}, err
+		return nil, err
 	}
 
 	sourcePeerConfig := sourcePeer.GetPostgresConfig()
 	if sourcePeerConfig == nil {
 		slog.Error("/validatecdc source peer config is not postgres", slog.String("peer", req.ConnectionConfigs.SourceName))
-		return &protos.ValidateCDCMirrorResponse{
-			Ok: false,
-		}, errors.New("source peer config is not postgres")
+		return nil, errors.New("source peer config is not postgres")
 	}
 
 	pgPeer, err := connpostgres.NewPostgresConnector(ctx, sourcePeerConfig)
 	if err != nil {
 		displayErr := fmt.Errorf("failed to create postgres connector: %v", err)
-		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-			fmt.Sprint(displayErr),
-		)
-		return &protos.ValidateCDCMirrorResponse{
-			Ok: false,
-		}, displayErr
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, displayErr.Error())
+		return nil, displayErr
 	}
 	defer pgPeer.Close()
 
@@ -87,20 +71,14 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
 				displayErr.Error(),
 			)
-			return &protos.ValidateCDCMirrorResponse{
-				Ok: false,
-			}, displayErr
+			return nil, displayErr
 		}
 
 		// Check permissions of postgres peer
 		if err := pgPeer.CheckReplicationPermissions(ctx, sourcePeerConfig.User); err != nil {
 			displayErr := fmt.Errorf("failed to check replication permissions: %v", err)
-			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-				fmt.Sprint(displayErr),
-			)
-			return &protos.ValidateCDCMirrorResponse{
-				Ok: false,
-			}, displayErr
+			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, displayErr.Error())
+			return nil, displayErr
 		}
 	}
 
@@ -110,12 +88,8 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		parsedTable, parseErr := utils.ParseSchemaTable(tableMapping.SourceTableIdentifier)
 		if parseErr != nil {
 			displayErr := fmt.Errorf("invalid source table identifier: %s", parseErr)
-			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-				fmt.Sprint(displayErr),
-			)
-			return &protos.ValidateCDCMirrorResponse{
-				Ok: false,
-			}, displayErr
+			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, displayErr.Error())
+			return nil, displayErr
 		}
 
 		sourceTables = append(sourceTables, parsedTable)
@@ -135,37 +109,25 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 
 		if err := pgPeer.CheckPublicationCreationPermissions(ctx, srcTableNames); err != nil {
 			displayErr := fmt.Errorf("invalid publication creation permissions: %v", err)
-			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-				fmt.Sprint(displayErr),
-			)
-			return &protos.ValidateCDCMirrorResponse{
-				Ok: false,
-			}, displayErr
+			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, displayErr.Error())
+			return nil, displayErr
 		}
 	}
 
 	if err := pgPeer.CheckSourceTables(ctx, sourceTables, pubName, noCDC); err != nil {
 		displayErr := fmt.Errorf("provided source tables invalidated: %v", err)
 		slog.Error(displayErr.Error())
-		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-			fmt.Sprint(displayErr),
-		)
-		return &protos.ValidateCDCMirrorResponse{
-			Ok: false,
-		}, displayErr
+		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName, displayErr.Error())
+		return nil, displayErr
 	}
 
 	for _, tm := range req.ConnectionConfigs.TableMappings {
 		for _, col := range tm.Columns {
 			if !CustomColumnTypeRegex.MatchString(col.DestinationType) {
-				return &protos.ValidateCDCMirrorResponse{
-					Ok: false,
-				}, fmt.Errorf("invalid custom column type %s", col.DestinationType)
+				return nil, fmt.Errorf("invalid custom column type %s", col.DestinationType)
 			}
 			if !CustomColumnNameRegex.MatchString(col.DestinationName) {
-				return &protos.ValidateCDCMirrorResponse{
-					Ok: false,
-				}, fmt.Errorf("invalid custom column name %s", col.DestinationName)
+				return nil, fmt.Errorf("invalid custom column name %s", col.DestinationName)
 			}
 		}
 	}
@@ -173,20 +135,16 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 	dstPeer, err := connectors.LoadPeer(ctx, h.pool, req.ConnectionConfigs.DestinationName)
 	if err != nil {
 		slog.Error("/validatecdc failed to load destination peer", slog.String("peer", req.ConnectionConfigs.DestinationName))
-		return &protos.ValidateCDCMirrorResponse{
-			Ok: false,
-		}, err
+		return nil, err
 	}
 	if dstPeer.GetClickhouseConfig() != nil {
 		chPeer, err := connclickhouse.NewClickHouseConnector(ctx, nil, dstPeer.GetClickhouseConfig())
 		if err != nil {
-			displayErr := fmt.Errorf("failed to create clickhouse connector: %v", err)
+			displayErr := fmt.Errorf("failed to create clickhouse connector: %w", err)
 			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-				fmt.Sprint(displayErr),
+				displayErr.Error(),
 			)
-			return &protos.ValidateCDCMirrorResponse{
-				Ok: false,
-			}, displayErr
+			return nil, displayErr
 		}
 		defer chPeer.Close()
 
@@ -194,27 +152,21 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		if err != nil {
 			displayErr := fmt.Errorf("failed to get source table schema: %v", err)
 			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-				fmt.Sprint(displayErr),
+				displayErr.Error(),
 			)
-			return &protos.ValidateCDCMirrorResponse{
-				Ok: false,
-			}, displayErr
+			return nil, displayErr
 		}
 
 		err = chPeer.CheckDestinationTables(ctx, req.ConnectionConfigs, res)
 		if err != nil {
 			h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
-				fmt.Sprint(err),
+				err.Error(),
 			)
-			return &protos.ValidateCDCMirrorResponse{
-				Ok: false,
-			}, err
+			return nil, err
 		}
 	}
 
-	return &protos.ValidateCDCMirrorResponse{
-		Ok: true,
-	}, nil
+	return &protos.ValidateCDCMirrorResponse{}, nil
 }
 
 func (h *FlowRequestHandler) CheckIfMirrorNameExists(ctx context.Context, mirrorName string) (bool, error) {

--- a/nexus/flow-rs/src/grpc.rs
+++ b/nexus/flow-rs/src/grpc.rs
@@ -70,16 +70,8 @@ impl FlowGrpcClient {
         let drop_peer_req = pt::peerdb_route::DropPeerRequest {
             peer_name: String::from(peer_name),
         };
-        let response = self.client.drop_peer(drop_peer_req).await?;
-        let drop_response = response.into_inner();
-        if drop_response.ok {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!(format!(
-                "failed to drop peer: {:?}",
-                drop_response.error_message
-            )))
-        }
+        self.client.drop_peer(drop_peer_req).await?;
+        Ok(())
     }
 
     pub async fn flow_state_change(
@@ -94,16 +86,8 @@ impl FlowGrpcClient {
             flow_config_update,
             drop_mirror_stats: false,
         };
-        let response = self.client.flow_state_change(state_change_req).await?;
-        let state_change_response = response.into_inner();
-        if state_change_response.ok {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!(format!(
-                "failed to change the state of flow job {}: {:?}",
-                flow_job_name, state_change_response.error_message
-            )))
-        }
+        self.client.flow_state_change(state_change_req).await?;
+        Ok(())
     }
 
     pub async fn start_peer_flow_job(
@@ -308,15 +292,7 @@ impl FlowGrpcClient {
             flow_job_name: flow_job_name.to_owned(),
             drop_stats: true
         };
-        let response = self.client.resync_mirror(resync_mirror_req).await?;
-        let resync_mirror_response = response.into_inner();
-        if resync_mirror_response.ok {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!(format!(
-                "failed to resync mirror for flow job {}: {:?}",
-                flow_job_name, resync_mirror_response.error_message
-            )))
-        }
+        self.client.resync_mirror(resync_mirror_req).await?;
+        Ok(())
     }
 }

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -33,8 +33,6 @@ message CreateCustomSyncRequest {
 message CreateCustomSyncResponse {
   string flow_job_name = 1;
   int32 number_of_syncs = 2;
-  string error_message = 3;
-  bool ok = 4;
 }
 
 message AlertConfig {
@@ -120,8 +118,6 @@ message DropPeerRequest {
 }
 
 message DropPeerResponse {
-  bool ok = 1;
-  string error_message = 2;
 }
 
 enum ValidatePeerStatus {
@@ -323,9 +319,7 @@ message MirrorStatusResponse {
     QRepMirrorStatus qrep_status = 2;
     CDCMirrorStatus cdc_status = 3;
   }
-  string error_message = 4;
   peerdb_flow.FlowStatus current_flow_state = 5;
-  bool ok = 6;
   google.protobuf.Timestamp created_at = 7;
 }
 
@@ -364,7 +358,6 @@ message ListMirrorLogsResponse {
 }
 
 message ValidateCDCMirrorResponse{
-  bool ok = 1;
 }
 
 message ListMirrorsItem {
@@ -398,8 +391,6 @@ message FlowStateChangeRequest {
   bool drop_mirror_stats = 6;
 }
 message FlowStateChangeResponse {
-  bool ok = 1;
-  string error_message = 2;
 }
 
 message PeerDBVersionRequest {
@@ -414,8 +405,6 @@ message ResyncMirrorRequest {
 }
 
 message ResyncMirrorResponse {
-  bool ok = 1;
-  string error_message = 2;
 }
 
 service FlowService {

--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -53,21 +53,20 @@ const EditMirror = ({ params: { mirrorId } }: EditMirrorProps) => {
   const { push } = useRouter();
 
   const fetchStateAndUpdateDeps = useCallback(async () => {
-    await getMirrorState(mirrorId).then((res) => {
-      setMirrorState(res);
+    const res = await getMirrorState(mirrorId);
+    setMirrorState(res);
 
-      setConfig({
-        batchSize:
-          (res as MirrorStatusResponse).cdcStatus?.config?.maxBatchSize ||
-          defaultBatchSize,
-        idleTimeout:
-          (res as MirrorStatusResponse).cdcStatus?.config?.idleTimeoutSeconds ||
-          defaultIdleTimeout,
-        additionalTables: [],
-        removedTables: [],
-        numberOfSyncs: 0,
-        updatedEnv: {},
-      });
+    setConfig({
+      batchSize:
+        (res as MirrorStatusResponse).cdcStatus?.config?.maxBatchSize ||
+        defaultBatchSize,
+      idleTimeout:
+        (res as MirrorStatusResponse).cdcStatus?.config?.idleTimeoutSeconds ||
+        defaultIdleTimeout,
+      additionalTables: [],
+      removedTables: [],
+      numberOfSyncs: 0,
+      updatedEnv: {},
     });
   }, [mirrorId, defaultBatchSize, defaultIdleTimeout]);
 

--- a/ui/app/mirrors/[mirrorId]/handlers.ts
+++ b/ui/app/mirrors/[mirrorId]/handlers.ts
@@ -14,6 +14,7 @@ export const getMirrorState = async (
       include_flow_info: true,
     }),
   });
+  if (!res.ok) throw res.json();
   return res.json();
 };
 

--- a/ui/app/mirrors/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/page.tsx
@@ -23,12 +23,17 @@ type EditMirrorProps = {
 
 export default function ViewMirror({ params: { mirrorId } }: EditMirrorProps) {
   const [mirrorState, setMirrorState] = useState<MirrorStatusResponse>();
+  const [errorMessage, setErrorMessage] = useState('');
   const [mounted, setMounted] = useState(false);
 
   const fetchState = useCallback(async () => {
-    const res = await getMirrorState(mirrorId);
-    setMirrorState(res);
     setMounted(true);
+    try {
+      const res = await getMirrorState(mirrorId);
+      setMirrorState(res);
+    } catch (ex: any) {
+      setErrorMessage(ex.message);
+    }
   }, [mirrorId]);
   useEffect(() => {
     fetchState();
@@ -38,7 +43,7 @@ export default function ViewMirror({ params: { mirrorId } }: EditMirrorProps) {
     return <></>;
   }
 
-  if (mirrorState?.errorMessage) {
+  if (errorMessage) {
     return <NoMirror />;
   }
 

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -18,7 +18,6 @@ import {
   PeerSchemasResponse,
   SchemaTablesResponse,
   TableColumnsResponse,
-  ValidateCDCMirrorResponse,
 } from '@/grpc_generated/route';
 import { Dispatch, SetStateAction } from 'react';
 
@@ -512,10 +511,7 @@ export async function handleValidateCDC(
     }),
   });
   if (statusRes.ok) {
-    const status: ValidateCDCMirrorResponse = await statusRes.json();
-    if (status.ok) {
-      notifyErr('CDC Mirror is valid', true);
-    }
+    notifyErr('CDC Mirror is valid', true);
   } else {
     const errRes = await statusRes.json();
     notifyErr('CDC Mirror is invalid: ' + errRes.message);

--- a/ui/components/DropDialog.tsx
+++ b/ui/components/DropDialog.tsx
@@ -2,7 +2,6 @@
 import { changeFlowState } from '@/app/mirrors/[mirrorId]/handlers';
 import { DeleteScript } from '@/app/scripts/handlers';
 import { FlowStatus } from '@/grpc_generated/flow';
-import { DropPeerResponse } from '@/grpc_generated/route';
 import { Button } from '@/lib/Button';
 import { Checkbox } from '@/lib/Checkbox';
 import { Dialog, DialogClose } from '@/lib/Dialog';
@@ -71,20 +70,21 @@ export const DropDialog = ({
     }
 
     setLoading(true);
-    const dropRes: DropPeerResponse = await fetch('api/v1/peers/drop', {
+    const dropRes = await fetch('api/v1/peers/drop', {
       method: 'POST',
       body: JSON.stringify(dropArgs),
-    }).then((res) => res.json());
+    });
     setLoading(false);
-    if (dropRes.ok !== true)
-      setMsg(
-        `Unable to drop peer ${dropArgs.peerName}. ${
-          dropRes.errorMessage ?? ''
-        }`
-      );
-    else {
+    if (dropRes.ok) {
       setMsg('Peer dropped successfully.');
       window.location.reload();
+    } else {
+      const dropResError = await dropRes.json();
+      setMsg(
+        `Unable to drop peer ${dropArgs.peerName}. ${
+          dropResError.message ?? ''
+        }`
+      );
     }
   };
 

--- a/ui/components/ResyncDialog.tsx
+++ b/ui/components/ResyncDialog.tsx
@@ -30,27 +30,27 @@ export const ResyncDialog = ({ mirrorName }: ResyncDialogProps) => {
       msg: 'Requesting a resync. You can close this dialog and check the status',
       color: 'base',
     });
-    const resyncRes = await fetch('/api/v1/mirrors/resync', {
+    const resyncResponse = await fetch('/api/v1/mirrors/resync', {
       method: 'POST',
       body: JSON.stringify({
         flowJobName: mirrorName,
         dropStats: true,
       } as ResyncMirrorRequest),
-    }).then((res) => res.json());
-    if (resyncRes.ok !== true) {
+    });
+    if (resyncResponse.ok) {
+      setMsg({
+        msg: 'Resync has been initiated. You may reload this window to see the progress.',
+        color: 'positive',
+      });
+      setSyncing(false);
+    } else {
+      const resyncRes = await resyncResponse.json();
       setMsg({
         msg: `Unable to resync mirror ${mirrorName}. ${resyncRes.message ?? ''}`,
         color: 'destructive',
       });
       setSyncing(false);
-      return;
     }
-    setMsg({
-      msg: 'Resync has been initiated. You may reload this window to see the progress.',
-      color: 'positive',
-    });
-    setSyncing(false);
-    return;
   };
 
   return (


### PR DESCRIPTION
We have a mix of ok: false & returning errors,
now that customers are using API this is negatively impacting their UX
(not to mention our own struggles)

Consolidate on consistently returning HTTP errors, rather than 200 OK with ok: false