### PR TITLE
Refactor ClickHouse table creation SQL generation

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -218,10 +218,9 @@ func getOrderedOrderByColumns(
 		orderbyColumns[idx] = getColName(colNameMap, col.SourceName)
 	}
 
-	// append pkeys at the end
-	if len(pkeys) > 0 {
-		orderbyColumns = append(orderbyColumns, pkeys...)
-	}
+	// Typically primary keys are not what aggregates are performed on and hence
+	// having them at the start of the order by clause is not beneficial.
+	orderbyColumns = append(orderbyColumns, pkeys...)
 
 	return orderbyColumns
 }


### PR DESCRIPTION
- Separate order by column logic into new function getOrderedOrderByColumns
- Simplify primary key and order by clause generation
- Ensure primary key columns are always at the end of ORDER BY clause
- Remove redundant code and improve readability