### PR TITLE
[cdc] don't cache replident during cdc

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -42,10 +42,10 @@ type PostgresCDCSource struct {
 
 	// for storing schema delta audit logs to catalog
 	catalogPool *pgxpool.Pool
-	flowJobName string
-
 	// to store replident info fetched for the sync
 	replicaIdentityMap map[string]ReplicaIdentityType
+
+	flowJobName string
 }
 
 type PostgresCDCConfig struct {
@@ -55,10 +55,10 @@ type PostgresCDCConfig struct {
 	TableNameSchemaMapping map[string]*protos.TableSchema
 	ChildToParentRelIDMap  map[uint32]uint32
 	RelationMessageMapping model.RelationMessageMapping
+	ReplicaIdentityMap     map[string]ReplicaIdentityType
 	FlowJobName            string
 	Slot                   string
 	Publication            string
-	ReplicaIdentityMap     map[string]ReplicaIdentityType
 }
 
 // Create a new PostgresCDCSource
@@ -129,8 +129,6 @@ func GetReplicaIdentityMap(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("error scanning replica identity for tables: %w", err)
 	}
-
-	fmt.Println(replicaIdentityMap)
 
 	return replicaIdentityMap, nil
 }

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -106,10 +106,8 @@ func (c *PostgresConnector) getRelIDForTable(ctx context.Context, schemaTable *u
 }
 
 // getAndValidateReplicaIdentityType returns the replica identity for a table, errors if it is NOTHING
-func (c *PostgresConnector) getAndValidateReplicaIdentityType(
-	ctx context.Context,
-	relID uint32,
-	schemaTable *utils.SchemaTable,
+func (c *PostgresConnector) getAndValidateReplicaIdentityType(ctx context.Context,
+	relID uint32, schemaTable *utils.SchemaTable,
 ) (ReplicaIdentityType, error) {
 	var replicaIdentity rune
 	err := c.conn.QueryRow(ctx,

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -167,6 +167,8 @@ message CreateRawTableOutput { string table_identifier = 1; }
 message TableSchema {
   string table_identifier = 1;
   repeated string primary_key_columns = 2;
+  // only used during SetupFlow, CDC fetches it everytime
+  // TODO: rename at some point
   bool is_replica_identity_full = 3;
   TypeSystem system = 4;
   bool nullable_enabled = 5;


### PR DESCRIPTION
replident can be changed anytime, caching during CDC shouldn't be done
since we store TableSchema in catalog not removing `is_replica_identity_full` for now