### PR TITLE
Create ClickHouse mirror: New sorting key UI and logic

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -200,10 +200,14 @@ func getOrderedOrderByColumns(
 	orderby := make([]*protos.ColumnSetting, 0)
 	if tableMapping != nil {
 		for _, col := range tableMapping.Columns {
-			if col.Ordering > 0 && !slices.Contains(pkeys, col.SourceName) {
+			if col.Ordering > 0 {
 				orderby = append(orderby, col)
 			}
 		}
+	}
+
+	if len(orderby) == 0 {
+		return pkeys
 	}
 
 	slices.SortStableFunc(orderby, func(a *protos.ColumnSetting, b *protos.ColumnSetting) int {
@@ -214,10 +218,6 @@ func getOrderedOrderByColumns(
 	for idx, col := range orderby {
 		orderbyColumns[idx] = getColName(colNameMap, col.SourceName)
 	}
-
-	// Typically primary keys are not what aggregates are performed on and hence
-	// having them at the start of the order by clause is not beneficial.
-	orderbyColumns = append(orderbyColumns, pkeys...)
 
 	return orderbyColumns
 }

--- a/ui/app/mirrors/create/cdc/columnbox.tsx
+++ b/ui/app/mirrors/create/cdc/columnbox.tsx
@@ -3,7 +3,7 @@ import { TableMapRow } from '@/app/dto/MirrorsDTO';
 import { Checkbox } from '@/lib/Checkbox';
 import { Label } from '@/lib/Label';
 import { RowWithCheckbox } from '@/lib/Layout';
-import { Dispatch, SetStateAction, useEffect } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 
 interface ColumnProps {
   columns: string[];
@@ -43,10 +43,11 @@ export default function ColumnBox({
   return columns.map((column) => {
     const [columnName, columnType, isPkeyStr] = column.split(':');
     const isPkey = isPkeyStr === 'true';
-    const partOfOrderingKey = rows.find((row)=>row.source == tableRow.source)?.columns.some(
-      (col) => col.sourceName === columnName
-      && col.ordering <= 0
-    );
+    const partOfOrderingKey = rows
+      .find((row) => row.source == tableRow.source)
+      ?.columns.some(
+        (col) => col.sourceName === columnName && col.ordering <= 0
+      );
     return (
       <RowWithCheckbox
         key={columnName}

--- a/ui/app/mirrors/create/cdc/columnbox.tsx
+++ b/ui/app/mirrors/create/cdc/columnbox.tsx
@@ -3,8 +3,7 @@ import { TableMapRow } from '@/app/dto/MirrorsDTO';
 import { Checkbox } from '@/lib/Checkbox';
 import { Label } from '@/lib/Label';
 import { RowWithCheckbox } from '@/lib/Layout';
-import { TextField } from '@/lib/TextField';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 
 interface ColumnProps {
   columns: string[];
@@ -20,7 +19,6 @@ export default function ColumnBox({
   rows,
   setRows,
   disabled,
-  showOrdering,
 }: ColumnProps) {
   const handleColumnExclusion = (column: string, include: boolean) => {
     const source = tableRow.source;
@@ -41,36 +39,14 @@ export default function ColumnBox({
       setRows(currRows);
     }
   };
-  const handleColumnOrdering = (column: string, ordering: number) => {
-    const source = tableRow.source;
-    const currRows = [...rows];
-    const rowIndex = currRows.findIndex((row) => row.source === source);
-    if (rowIndex !== -1) {
-      const sourceRow = currRows[rowIndex];
-      const columns = [...sourceRow.columns];
-      const colIndex = columns.findIndex((col) => col.sourceName === column);
-      if (colIndex !== -1) {
-        columns[colIndex] = { ...columns[colIndex], ordering };
-      } else {
-        columns.push({
-          sourceName: column,
-          destinationName: '',
-          destinationType: '',
-          nullableEnabled: false,
-          ordering,
-        });
-      }
-      currRows[rowIndex] = {
-        ...sourceRow,
-        columns,
-      };
-      setRows(currRows);
-    }
-  };
 
   return columns.map((column) => {
     const [columnName, columnType, isPkeyStr] = column.split(':');
     const isPkey = isPkeyStr === 'true';
+    const partOfOrderingKey = rows.find((row)=>row.source == tableRow.source)?.columns.some(
+      (col) => col.sourceName === columnName
+      && col.ordering <= 0
+    );
     return (
       <RowWithCheckbox
         key={columnName}
@@ -92,26 +68,12 @@ export default function ColumnBox({
             >
               {columnType}
             </p>
-            {showOrdering && !disabled && !isPkey && (
-              <TextField
-                variant='simple'
-                type='number'
-                style={{ width: '3rem', marginLeft: '1rem', fontSize: 13 }}
-                value={
-                  tableRow.columns.find((col) => col.sourceName === columnName)
-                    ?.ordering ?? 0
-                }
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleColumnOrdering(columnName, +e.target.value)
-                }
-              />
-            )}
           </Label>
         }
         action={
           <Checkbox
             style={{ cursor: 'pointer' }}
-            disabled={isPkey || disabled}
+            disabled={isPkey || disabled || partOfOrderingKey}
             checked={!tableRow.exclude.has(columnName)}
             onCheckedChange={(state: boolean) =>
               handleColumnExclusion(columnName, state)

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -37,6 +37,8 @@ import {
 
 import { Divider } from '@tremor/react';
 import ReactSelect from 'react-select';
+import SelectSortingKeys from './sortingkey';
+import { Button } from '@/lib/Button/Button';
 
 interface SchemaBoxProps {
   sourcePeer: string;
@@ -69,7 +71,6 @@ export default function SchemaBox({
   const [tableQuery, setTableQuery] = useState<string>('');
   const [defaultTargetSchema, setDefaultTargetSchema] =
     useState<string>(schema);
-
   const searchedTables = useMemo(() => {
     const tableQueryLower = tableQuery.toLowerCase();
     return rows
@@ -389,13 +390,45 @@ export default function SchemaBox({
                     {row.selected && (
                       <div className='ml-5 mt-3' style={{ width: '100%' }}>
                         <Divider style={columnBoxDividerStyle} />
-                        <Label
-                          as='label'
-                          colorName='lowContrast'
-                          style={{ fontSize: 13 }}
+
+                        <div
+                          style={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            rowGap:'0.5rem',
+                            width: '100%',
+                          }}
                         >
-                          Columns
-                        </Label>
+                          <Label
+                            as='label'
+                            colorName='lowContrast'
+                            style={{ fontSize: 13 }}
+                          >
+                            Columns
+                          </Label>
+
+                          {peerType?.toString() ===
+                          DBType[DBType.CLICKHOUSE].toString() && <div style={{width:'50%',display:'flex',flexDirection:'column',rowGap:'0.5rem'}}>
+<SelectSortingKeys
+                            columns={
+                              columns?.map((column) => {
+                                const [columnName, columnType, isPkeyStr] =
+                                  column.split(':');
+                                const isPkey = isPkeyStr === 'true';
+                                return {
+                                  value: columnName,
+                                  label: columnName,
+                                  isPkey: isPkey,
+                                };
+                              }) ?? []
+                            }
+                            loading={columnsLoading}
+                            tableRow={row}
+                            setRows={setRows}
+                          />
+                          <Divider style={{...columnBoxDividerStyle, marginTop:'0.5rem'}} />
+                          </div>}
+                        </div>
                         {columns ? (
                           <ColumnBox
                             columns={columns}

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -38,7 +38,6 @@ import {
 import { Divider } from '@tremor/react';
 import ReactSelect from 'react-select';
 import SelectSortingKeys from './sortingkey';
-import { Button } from '@/lib/Button/Button';
 
 interface SchemaBoxProps {
   sourcePeer: string;
@@ -395,7 +394,7 @@ export default function SchemaBox({
                           style={{
                             display: 'flex',
                             flexDirection: 'column',
-                            rowGap:'0.5rem',
+                            rowGap: '0.5rem',
                             width: '100%',
                           }}
                         >
@@ -408,26 +407,40 @@ export default function SchemaBox({
                           </Label>
 
                           {peerType?.toString() ===
-                          DBType[DBType.CLICKHOUSE].toString() && <div style={{width:'50%',display:'flex',flexDirection:'column',rowGap:'0.5rem'}}>
-<SelectSortingKeys
-                            columns={
-                              columns?.map((column) => {
-                                const [columnName, columnType, isPkeyStr] =
-                                  column.split(':');
-                                const isPkey = isPkeyStr === 'true';
-                                return {
-                                  value: columnName,
-                                  label: columnName,
-                                  isPkey: isPkey,
-                                };
-                              }) ?? []
-                            }
-                            loading={columnsLoading}
-                            tableRow={row}
-                            setRows={setRows}
-                          />
-                          <Divider style={{...columnBoxDividerStyle, marginTop:'0.5rem'}} />
-                          </div>}
+                            DBType[DBType.CLICKHOUSE].toString() && (
+                            <div
+                              style={{
+                                width: '50%',
+                                display: 'flex',
+                                flexDirection: 'column',
+                                rowGap: '0.5rem',
+                              }}
+                            >
+                              <SelectSortingKeys
+                                columns={
+                                  columns?.map((column) => {
+                                    const [columnName, columnType, isPkeyStr] =
+                                      column.split(':');
+                                    const isPkey = isPkeyStr === 'true';
+                                    return {
+                                      value: columnName,
+                                      label: columnName,
+                                      isPkey: isPkey,
+                                    };
+                                  }) ?? []
+                                }
+                                loading={columnsLoading}
+                                tableRow={row}
+                                setRows={setRows}
+                              />
+                              <Divider
+                                style={{
+                                  ...columnBoxDividerStyle,
+                                  marginTop: '0.5rem',
+                                }}
+                              />
+                            </div>
+                          )}
                         </div>
                         {columns ? (
                           <ColumnBox

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -405,50 +405,54 @@ export default function SchemaBox({
                           >
                             Columns
                           </Label>
-
-                          {peerType?.toString() ===
-                            DBType[DBType.CLICKHOUSE].toString() && (
-                            <div
-                              style={{
-                                width: '50%',
-                                display: 'flex',
-                                flexDirection: 'column',
-                                rowGap: '0.5rem',
-                              }}
-                            >
-                              <SelectSortingKeys
-                                columns={
-                                  columns?.map((column) => {
-                                    const [columnName, columnType, isPkeyStr] =
-                                      column.split(':');
-                                    return columnName;
-                                  }) ?? []
-                                }
-                                loading={columnsLoading}
-                                tableRow={row}
-                                setRows={setRows}
-                              />
-                              <Divider
-                                style={{
-                                  ...columnBoxDividerStyle,
-                                  marginTop: '0.5rem',
-                                }}
-                              />
-                            </div>
-                          )}
                         </div>
                         {columns ? (
-                          <ColumnBox
-                            columns={columns}
-                            tableRow={row}
-                            rows={rows}
-                            setRows={setRows}
-                            disabled={row.editingDisabled}
-                            showOrdering={
-                              peerType?.toString() ===
-                              DBType[DBType.CLICKHOUSE].toString()
-                            }
-                          />
+                          <>
+                            <ColumnBox
+                              columns={columns}
+                              tableRow={row}
+                              rows={rows}
+                              setRows={setRows}
+                              disabled={row.editingDisabled}
+                              showOrdering={
+                                peerType?.toString() ===
+                                DBType[DBType.CLICKHOUSE].toString()
+                              }
+                            />
+                            {peerType?.toString() ===
+                              DBType[DBType.CLICKHOUSE].toString() && (
+                              <div
+                                style={{
+                                  width: '50%',
+                                  display: 'flex',
+                                  flexDirection: 'column',
+                                  rowGap: '0.5rem',
+                                }}
+                              >
+                                <Divider
+                                  style={{
+                                    ...columnBoxDividerStyle,
+                                    marginTop: '0.5rem',
+                                  }}
+                                />
+                                <SelectSortingKeys
+                                  columns={
+                                    columns?.map((column) => {
+                                      const [
+                                        columnName,
+                                        columnType,
+                                        isPkeyStr,
+                                      ] = column.split(':');
+                                      return columnName;
+                                    }) ?? []
+                                  }
+                                  loading={columnsLoading}
+                                  tableRow={row}
+                                  setRows={setRows}
+                                />
+                              </div>
+                            )}
+                          </>
                         ) : columnsLoading ? (
                           <BarLoader />
                         ) : (

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -421,12 +421,7 @@ export default function SchemaBox({
                                   columns?.map((column) => {
                                     const [columnName, columnType, isPkeyStr] =
                                       column.split(':');
-                                    const isPkey = isPkeyStr === 'true';
-                                    return {
-                                      value: columnName,
-                                      label: columnName,
-                                      isPkey: isPkey,
-                                    };
+                                    return columnName;
                                   }) ?? []
                                 }
                                 loading={columnsLoading}

--- a/ui/app/mirrors/create/cdc/sortingkey.tsx
+++ b/ui/app/mirrors/create/cdc/sortingkey.tsx
@@ -108,6 +108,7 @@ const SelectSortingKeys = ({
         display: 'flex',
         flexDirection: 'column',
         alignContent: 'center',
+        rowGap: '0.5rem',
       }}
     >
       <ToastContainer containerId={'sorting_key_warning'} />

--- a/ui/app/mirrors/create/cdc/sortingkey.tsx
+++ b/ui/app/mirrors/create/cdc/sortingkey.tsx
@@ -1,21 +1,16 @@
 'use client';
-import {
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useState,
-} from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import ReactSelect from 'react-select';
 
 import { TableMapRow } from '@/app/dto/MirrorsDTO';
 import SelectTheme from '@/app/styles/select';
-import { Icon } from '@/lib/Icon';
-import { engineOptionStyles } from './styles';
-import { Button } from '@/lib/Button';
-import { RowWithCheckbox } from '@/lib/Layout';
-import { Label } from '@/lib/Label';
-import { Checkbox } from '@/lib/Checkbox';
 import { notifySortingKey } from '@/app/utils/notify';
+import { Button } from '@/lib/Button';
+import { Checkbox } from '@/lib/Checkbox';
+import { Icon } from '@/lib/Icon';
+import { Label } from '@/lib/Label';
+import { RowWithCheckbox } from '@/lib/Layout';
+import { engineOptionStyles } from './styles';
 
 interface SortingKeyType {
   name: string;
@@ -35,129 +30,179 @@ const SelectSortingKeys = ({
   tableRow,
   setRows,
 }: SortingKeysProps) => {
-  const [sortingKeysSelections, setSortingKeysSelections] = useState<SortingKeyType[]>([]);
+  const [sortingKeysSelections, setSortingKeysSelections] = useState<
+    SortingKeyType[]
+  >([]);
   const [showSortingKey, setShowSortingKey] = useState(false);
 
   const handleSortingKey = (col: SortingKeyType, action: 'add' | 'remove') => {
-    if (action === 'add'){
-        if(sortingKeysSelections.findIndex((key) => key.name === col.name) === -1){
-            setSortingKeysSelections((prev) => {
-                return [col,...prev];
-            });
-        }
-    }
-    else if (action === 'remove' && !col.disabled) {
+    if (action === 'add') {
+      if (
+        sortingKeysSelections.findIndex((key) => key.name === col.name) === -1
+      ) {
         setSortingKeysSelections((prev) => {
-            return prev.filter((prevCol) => prevCol.name !== col.name);
+          return [col, ...prev];
         });
+      }
+    } else if (action === 'remove' && !col.disabled) {
+      setSortingKeysSelections((prev) => {
+        return prev.filter((prevCol) => prevCol.name !== col.name);
+      });
     }
   };
 
   const registerSortingKeys = () => {
     setRows((prevRows) => {
-        const source = tableRow.source;
-        const rowIndex = prevRows.findIndex((row) => row.source === source);
-        if (rowIndex !== -1) {
-            const sourceRow = prevRows[rowIndex];
-            const newColumns = [...sourceRow.columns];
-            sortingKeysSelections.forEach((sortingKeyCol, orderingIndex) => {
-            const colIndex = newColumns.findIndex((currentCol) => currentCol.sourceName === sortingKeyCol.name);
-            if (colIndex !== -1) {
-                newColumns[colIndex] = { ...newColumns[colIndex], ordering: orderingIndex + 1 };
-            } else {
-                newColumns.push({
-                sourceName: sortingKeyCol.name,
-                destinationName: '',
-                destinationType: '',
-                ordering: 1,
-                });
-            }
-            });
-            prevRows[rowIndex] = {
-            ...sourceRow,
-            columns: newColumns,
+      const source = tableRow.source;
+      const rowIndex = prevRows.findIndex((row) => row.source === source);
+      if (rowIndex !== -1) {
+        const sourceRow = prevRows[rowIndex];
+        const newColumns = [...sourceRow.columns];
+        sortingKeysSelections.forEach((sortingKeyCol, orderingIndex) => {
+          const colIndex = newColumns.findIndex(
+            (currentCol) => currentCol.sourceName === sortingKeyCol.name
+          );
+          if (colIndex !== -1) {
+            newColumns[colIndex] = {
+              ...newColumns[colIndex],
+              ordering: orderingIndex + 1,
             };
-        }
-        return prevRows;
-  });
-}
+          } else {
+            newColumns.push({
+              sourceName: sortingKeyCol.name,
+              destinationName: '',
+              destinationType: '',
+              ordering: 1,
+            });
+          }
+        });
+        prevRows[rowIndex] = {
+          ...sourceRow,
+          columns: newColumns,
+        };
+      }
+      return prevRows;
+    });
+  };
 
-const handleShowSortingKey = (state: boolean) => {
+  const handleShowSortingKey = (state: boolean) => {
     setShowSortingKey(state);
     if (!state) {
-        setSortingKeysSelections([]);
-        registerSortingKeys();
+      setSortingKeysSelections([]);
+      registerSortingKeys();
     } else {
-        notifySortingKey('')
+      notifySortingKey('');
     }
-}
+  };
 
- useEffect(() => {
-    if(sortingKeysSelections.length === 0 && columns.length > 0){
-        setSortingKeysSelections(
+  useEffect(() => {
+    if (sortingKeysSelections.length === 0 && columns.length > 0) {
+      setSortingKeysSelections(
         columns
-            .filter((col) =>col.isPkey)
-            .map((col) => {
+          .filter((col) => col.isPkey)
+          .map((col) => {
             return { name: col.label, disabled: true };
-            })
-        );
+          })
+      );
     }
   }, [columns]);
 
   useEffect(() => {
     registerSortingKeys();
-  }
-    , [sortingKeysSelections]);
+  }, [sortingKeysSelections]);
 
   return (
-    <div style={{display:'flex', flexDirection:'column', alignContent:'center'}}>
-    <RowWithCheckbox
-    label={<Label as='label' style={{ fontSize: 13 }}>Use a custom sorting key</Label>}
-    action={
-      <Checkbox
-      style={{marginLeft:0}}
-      checked={showSortingKey}
-      onCheckedChange={handleShowSortingKey}
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignContent: 'center',
+      }}
+    >
+      <RowWithCheckbox
+        label={
+          <Label as='label' style={{ fontSize: 13 }}>
+            Use a custom sorting key
+          </Label>
+        }
+        action={
+          <Checkbox
+            style={{ marginLeft: 0 }}
+            checked={showSortingKey}
+            onCheckedChange={handleShowSortingKey}
+          />
+        }
       />
-    }
-    />
-    {showSortingKey && <div style={{display:'flex', flexDirection:'column', alignContent:'center'}}>
-      <ReactSelect
-        menuPlacement='top'
-        placeholder={'Select sorting keys'}
-        onChange={(val, action) => {
-          val &&
-            handleSortingKey({ name: val.value, disabled: val.isPkey }, 'add');
-        }}
-        isOptionDisabled={(option) => option?.isPkey||sortingKeysSelections.findIndex((key) => key.name === option?.label) !== -1}
-        isLoading={loading}
-        value={null}
-        styles={engineOptionStyles}
-        options={columns}
-        theme={SelectTheme}
-        isClearable
-      />
-      <div
-        style={{ display: 'flex', marginTop: '0.5rem', columnGap:'0.5rem',rowGap:'0.5rem', alignItems: 'center', flexWrap: 'wrap' }}
-      >
-        {sortingKeysSelections.map((col: SortingKeyType) => {
-          return (
-            <div key={col.name} style={{display:'flex', columnGap:'0.3rem', alignItems:'center',
-            border:'1px solid #e5e7eb', borderRadius:'1rem', paddingLeft:'0.5rem', paddingRight:'0.5rem'}}>
-              <p style={{fontSize:'0.7rem'}}>{col.name}</p>
-              <Button
-                variant='normalBorderless'
-                onClick={() => handleSortingKey(col, 'remove')}
-                style={{padding:0}}
-                disabled={col.disabled}
-              >
-                <Icon name='close'/>
-              </Button>
-            </div>
-          );
-        })}
-      </div>
-    </div>}
+      {showSortingKey && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignContent: 'center',
+          }}
+        >
+          <ReactSelect
+            menuPlacement='top'
+            placeholder={'Select sorting keys'}
+            onChange={(val, action) => {
+              val &&
+                handleSortingKey(
+                  { name: val.value, disabled: val.isPkey },
+                  'add'
+                );
+            }}
+            isOptionDisabled={(option) =>
+              option?.isPkey ||
+              sortingKeysSelections.findIndex(
+                (key) => key.name === option?.label
+              ) !== -1
+            }
+            isLoading={loading}
+            value={null}
+            styles={engineOptionStyles}
+            options={columns}
+            theme={SelectTheme}
+            isClearable
+          />
+          <div
+            style={{
+              display: 'flex',
+              marginTop: '0.5rem',
+              columnGap: '0.5rem',
+              rowGap: '0.5rem',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            {sortingKeysSelections.map((col: SortingKeyType) => {
+              return (
+                <div
+                  key={col.name}
+                  style={{
+                    display: 'flex',
+                    columnGap: '0.3rem',
+                    alignItems: 'center',
+                    border: '1px solid #e5e7eb',
+                    borderRadius: '1rem',
+                    paddingLeft: '0.5rem',
+                    paddingRight: '0.5rem',
+                  }}
+                >
+                  <p style={{ fontSize: '0.7rem' }}>{col.name}</p>
+                  <Button
+                    variant='normalBorderless'
+                    onClick={() => handleSortingKey(col, 'remove')}
+                    style={{ padding: 0 }}
+                    disabled={col.disabled}
+                  >
+                    <Icon name='close' />
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/ui/app/mirrors/create/cdc/sortingkey.tsx
+++ b/ui/app/mirrors/create/cdc/sortingkey.tsx
@@ -1,5 +1,11 @@
 'use client';
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import ReactSelect from 'react-select';
 
 import { TableMapRow } from '@/app/dto/MirrorsDTO';
@@ -10,6 +16,8 @@ import { Checkbox } from '@/lib/Checkbox';
 import { Icon } from '@/lib/Icon';
 import { Label } from '@/lib/Label';
 import { RowWithCheckbox } from '@/lib/Layout';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import { engineOptionStyles } from './styles';
 
 interface SortingKeyType {
@@ -51,7 +59,7 @@ const SelectSortingKeys = ({
     }
   };
 
-  const registerSortingKeys = () => {
+  const registerSortingKeys = useCallback(() => {
     setRows((prevRows) => {
       const source = tableRow.source;
       const rowIndex = prevRows.findIndex((row) => row.source === source);
@@ -73,6 +81,7 @@ const SelectSortingKeys = ({
               destinationName: '',
               destinationType: '',
               ordering: 1,
+              nullableEnabled: false,
             });
           }
         });
@@ -83,7 +92,7 @@ const SelectSortingKeys = ({
       }
       return prevRows;
     });
-  };
+  }, [sortingKeysSelections, setRows, tableRow.source]);
 
   const handleShowSortingKey = (state: boolean) => {
     setShowSortingKey(state);
@@ -91,7 +100,7 @@ const SelectSortingKeys = ({
       setSortingKeysSelections([]);
       registerSortingKeys();
     } else {
-      notifySortingKey('');
+      notifySortingKey();
     }
   };
 
@@ -105,11 +114,11 @@ const SelectSortingKeys = ({
           })
       );
     }
-  }, [columns]);
+  }, [columns, sortingKeysSelections.length]);
 
   useEffect(() => {
     registerSortingKeys();
-  }, [sortingKeysSelections]);
+  }, [registerSortingKeys]);
 
   return (
     <div
@@ -119,6 +128,7 @@ const SelectSortingKeys = ({
         alignContent: 'center',
       }}
     >
+      <ToastContainer containerId={'sorting_key_warning'} />
       <RowWithCheckbox
         label={
           <Label as='label' style={{ fontSize: 13 }}>

--- a/ui/app/mirrors/create/cdc/sortingkey.tsx
+++ b/ui/app/mirrors/create/cdc/sortingkey.tsx
@@ -1,0 +1,165 @@
+'use client';
+import {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useState,
+} from 'react';
+import ReactSelect from 'react-select';
+
+import { TableMapRow } from '@/app/dto/MirrorsDTO';
+import SelectTheme from '@/app/styles/select';
+import { Icon } from '@/lib/Icon';
+import { engineOptionStyles } from './styles';
+import { Button } from '@/lib/Button';
+import { RowWithCheckbox } from '@/lib/Layout';
+import { Label } from '@/lib/Label';
+import { Checkbox } from '@/lib/Checkbox';
+import { notifySortingKey } from '@/app/utils/notify';
+
+interface SortingKeyType {
+  name: string;
+  disabled: boolean;
+}
+
+interface SortingKeysProps {
+  columns: { value: string; label: string; isPkey: boolean }[];
+  tableRow: TableMapRow;
+  loading: boolean;
+  setRows: Dispatch<SetStateAction<TableMapRow[]>>;
+}
+
+const SelectSortingKeys = ({
+  columns,
+  loading,
+  tableRow,
+  setRows,
+}: SortingKeysProps) => {
+  const [sortingKeysSelections, setSortingKeysSelections] = useState<SortingKeyType[]>([]);
+  const [showSortingKey, setShowSortingKey] = useState(false);
+
+  const handleSortingKey = (col: SortingKeyType, action: 'add' | 'remove') => {
+    if (action === 'add'){
+        if(sortingKeysSelections.findIndex((key) => key.name === col.name) === -1){
+            setSortingKeysSelections((prev) => {
+                return [col,...prev];
+            });
+        }
+    }
+    else if (action === 'remove' && !col.disabled) {
+        setSortingKeysSelections((prev) => {
+            return prev.filter((prevCol) => prevCol.name !== col.name);
+        });
+    }
+  };
+
+  const registerSortingKeys = () => {
+    setRows((prevRows) => {
+        const source = tableRow.source;
+        const rowIndex = prevRows.findIndex((row) => row.source === source);
+        if (rowIndex !== -1) {
+            const sourceRow = prevRows[rowIndex];
+            const newColumns = [...sourceRow.columns];
+            sortingKeysSelections.forEach((sortingKeyCol, orderingIndex) => {
+            const colIndex = newColumns.findIndex((currentCol) => currentCol.sourceName === sortingKeyCol.name);
+            if (colIndex !== -1) {
+                newColumns[colIndex] = { ...newColumns[colIndex], ordering: orderingIndex + 1 };
+            } else {
+                newColumns.push({
+                sourceName: sortingKeyCol.name,
+                destinationName: '',
+                destinationType: '',
+                ordering: 1,
+                });
+            }
+            });
+            prevRows[rowIndex] = {
+            ...sourceRow,
+            columns: newColumns,
+            };
+        }
+        return prevRows;
+  });
+}
+
+const handleShowSortingKey = (state: boolean) => {
+    setShowSortingKey(state);
+    if (!state) {
+        setSortingKeysSelections([]);
+        registerSortingKeys();
+    } else {
+        notifySortingKey('')
+    }
+}
+
+ useEffect(() => {
+    if(sortingKeysSelections.length === 0 && columns.length > 0){
+        setSortingKeysSelections(
+        columns
+            .filter((col) =>col.isPkey)
+            .map((col) => {
+            return { name: col.label, disabled: true };
+            })
+        );
+    }
+  }, [columns]);
+
+  useEffect(() => {
+    registerSortingKeys();
+  }
+    , [sortingKeysSelections]);
+
+  return (
+    <div style={{display:'flex', flexDirection:'column', alignContent:'center'}}>
+    <RowWithCheckbox
+    label={<Label as='label' style={{ fontSize: 13 }}>Use a custom sorting key</Label>}
+    action={
+      <Checkbox
+      style={{marginLeft:0}}
+      checked={showSortingKey}
+      onCheckedChange={handleShowSortingKey}
+      />
+    }
+    />
+    {showSortingKey && <div style={{display:'flex', flexDirection:'column', alignContent:'center'}}>
+      <ReactSelect
+        menuPlacement='top'
+        placeholder={'Select sorting keys'}
+        onChange={(val, action) => {
+          val &&
+            handleSortingKey({ name: val.value, disabled: val.isPkey }, 'add');
+        }}
+        isOptionDisabled={(option) => option?.isPkey||sortingKeysSelections.findIndex((key) => key.name === option?.label) !== -1}
+        isLoading={loading}
+        value={null}
+        styles={engineOptionStyles}
+        options={columns}
+        theme={SelectTheme}
+        isClearable
+      />
+      <div
+        style={{ display: 'flex', marginTop: '0.5rem', columnGap:'0.5rem',rowGap:'0.5rem', alignItems: 'center', flexWrap: 'wrap' }}
+      >
+        {sortingKeysSelections.map((col: SortingKeyType) => {
+          return (
+            <div key={col.name} style={{display:'flex', columnGap:'0.3rem', alignItems:'center',
+            border:'1px solid #e5e7eb', borderRadius:'1rem', paddingLeft:'0.5rem', paddingRight:'0.5rem'}}>
+              <p style={{fontSize:'0.7rem'}}>{col.name}</p>
+              <Button
+                variant='normalBorderless'
+                onClick={() => handleSortingKey(col, 'remove')}
+                style={{padding:0}}
+                disabled={col.disabled}
+              >
+                <Icon name='close'/>
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>}
+    </div>
+  );
+};
+
+export default SelectSortingKeys;

--- a/ui/app/utils/notify.tsx
+++ b/ui/app/utils/notify.tsx
@@ -12,17 +12,13 @@ export const notifyErr = (msg: string, ok?: boolean) => {
   }
 };
 
-const SortingKeyToast = () => (
-  <div>
-    
-  </div>
-);
+const SortingKeyToast = () => <div></div>;
 
 export const notifySortingKey = (msg: string) => {
   toast.warn(msg, {
     position: 'bottom-center',
     autoClose: false,
     closeOnClick: false,
-    closeButton: true
+    closeButton: true,
   });
-}
+};

--- a/ui/app/utils/notify.tsx
+++ b/ui/app/utils/notify.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link';
 import { toast } from 'react-toastify';
 
-const orderingKeyDoc = 'https://docs.peerdb.io/mirror/ordering-key-different';
 export const notifyErr = (msg: string, ok?: boolean) => {
   if (ok) {
     toast.success(msg, {
@@ -16,6 +15,8 @@ export const notifyErr = (msg: string, ok?: boolean) => {
 
 // TODO: add a link to the document when ready
 const SortingKeyToast = () => {
+  const orderingKeyDoc = 'https://docs.peerdb.io/mirror/ordering-key-different';
+
   return (
     <div>
       <p>

--- a/ui/app/utils/notify.tsx
+++ b/ui/app/utils/notify.tsx
@@ -11,3 +11,18 @@ export const notifyErr = (msg: string, ok?: boolean) => {
     });
   }
 };
+
+const SortingKeyToast = () => (
+  <div>
+    
+  </div>
+);
+
+export const notifySortingKey = (msg: string) => {
+  toast.warn(msg, {
+    position: 'bottom-center',
+    autoClose: false,
+    closeOnClick: false,
+    closeButton: true
+  });
+}

--- a/ui/app/utils/notify.tsx
+++ b/ui/app/utils/notify.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { toast } from 'react-toastify';
 
 export const notifyErr = (msg: string, ok?: boolean) => {
@@ -12,13 +13,28 @@ export const notifyErr = (msg: string, ok?: boolean) => {
   }
 };
 
-const SortingKeyToast = () => <div></div>;
+// TODO: add a link to the document when ready
+const SortingKeyToast = () => {
+  return (
+    <div>
+      <p>
+        Using ordering keys in ClickHouse that differ from the primary key in
+        Postgres has some caveats. Please read{' '}
+        <Link style={{ color: 'teal' }} href={''} target='_blank'>
+          this document
+        </Link>{' '}
+        carefully.
+      </p>
+    </div>
+  );
+};
 
-export const notifySortingKey = (msg: string) => {
-  toast.warn(msg, {
+export const notifySortingKey = () => {
+  toast.warn(SortingKeyToast, {
     position: 'bottom-center',
     autoClose: false,
     closeOnClick: false,
     closeButton: true,
+    toastId: 'sorting_key_warning',
   });
 };

--- a/ui/app/utils/notify.tsx
+++ b/ui/app/utils/notify.tsx
@@ -13,7 +13,6 @@ export const notifyErr = (msg: string, ok?: boolean) => {
   }
 };
 
-// TODO: add a link to the document when ready
 const SortingKeyToast = () => {
   const orderingKeyDoc = 'https://docs.peerdb.io/mirror/ordering-key-different';
 

--- a/ui/app/utils/notify.tsx
+++ b/ui/app/utils/notify.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { toast } from 'react-toastify';
 
+const orderingKeyDoc = 'https://docs.peerdb.io/mirror/ordering-key-different';
 export const notifyErr = (msg: string, ok?: boolean) => {
   if (ok) {
     toast.success(msg, {
@@ -20,8 +21,8 @@ const SortingKeyToast = () => {
       <p>
         Using ordering keys in ClickHouse that differ from the primary key in
         Postgres has some caveats. Please read{' '}
-        <Link style={{ color: 'teal' }} href={''} target='_blank'>
-          this document
+        <Link style={{ color: 'teal' }} href={orderingKeyDoc} target='_blank'>
+          this doc
         </Link>{' '}
         carefully.
       </p>


### PR DESCRIPTION

![Screenshot 2024-10-22 at 4 04 20 AM](https://github.com/user-attachments/assets/b63865f1-99cc-40b2-88e8-b78fb5c61260)



User can now specify order key list by selecting from a dropdown. If they do this, then a warning banner also pops up. This links to a document explaining the various caveats of custom order keys

Instead of suffixing the primary keys at the end of the ordering key, the behaviour is now:
If user doesn't define order key - PKEY and ORDER BY in CH is PKEY in Postgres.
If user defines order key - PKEY and ORDER BY in CH is defined Order Key in Postgres.
