### PR TITLE
SetupReplication: clean up replicationErr handling

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -402,9 +402,7 @@ func (a *FlowableActivity) StartNormalize(
 		conn.DestinationName,
 	)
 	if errors.Is(err, errors.ErrUnsupported) {
-		err = monitoring.UpdateEndTimeForCDCBatch(ctx, a.CatalogPool, input.FlowConnectionConfigs.FlowJobName,
-			input.SyncBatchID)
-		return nil, err
+		return nil, monitoring.UpdateEndTimeForCDCBatch(ctx, a.CatalogPool, input.FlowConnectionConfigs.FlowJobName, input.SyncBatchID)
 	} else if err != nil {
 		return nil, err
 	}
@@ -460,8 +458,7 @@ func (a *FlowableActivity) SetupQRepMetadataTables(ctx context.Context, config *
 	}
 	defer connectors.CloseConnector(ctx, conn)
 
-	err = conn.SetupQRepMetadataTables(ctx, config)
-	if err != nil {
+	if err := conn.SetupQRepMetadataTables(ctx, config); err != nil {
 		a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 		return fmt.Errorf("failed to setup metadata tables: %w", err)
 	}
@@ -613,7 +610,7 @@ func (a *FlowableActivity) CleanupQRepFlow(ctx context.Context, config *protos.Q
 		a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 		return err
 	}
-	defer dst.Close()
+	defer connectors.CloseConnector(ctx, dst)
 
 	return dst.CleanupQRepFlow(ctx, config)
 }

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -432,8 +432,7 @@ func GetByNameAs[T Connector](ctx context.Context, env map[string]string, catalo
 }
 
 func CloseConnector(ctx context.Context, conn Connector) {
-	err := conn.Close()
-	if err != nil {
+	if err := conn.Close(); err != nil {
 		logger.LoggerFromCtx(ctx).Error("error closing connector", slog.Any("error", err))
 	}
 }

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1086,9 +1086,9 @@ func (c *PostgresConnector) SetupReplication(ctx context.Context, signal SlotSig
 		}
 	}
 	// Create the replication slot and publication
-	err = c.createSlotAndPublication(ctx, signal, exists,
-		slotName, publicationName, tableNameMapping, req.DoInitialSnapshot)
-	if err != nil {
+	if err := c.createSlotAndPublication(ctx, signal, exists,
+		slotName, publicationName, tableNameMapping, req.DoInitialSnapshot,
+	); err != nil {
 		return fmt.Errorf("error creating replication slot and publication: %w", err)
 	}
 

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -160,11 +160,7 @@ func (s PeerFlowE2ETestSuitePG) TestSimpleSlotCreation() {
 	}
 
 	signal := connpostgres.NewSlotSignal()
-
-	setupError := make(chan error)
-	go func() {
-		setupError <- s.conn.SetupReplication(context.Background(), signal, setupReplicationInput)
-	}()
+	go s.conn.SetupReplication(context.Background(), signal, setupReplicationInput)
 
 	s.t.Log("waiting for slot creation to complete: " + flowJobName)
 	slotInfo := <-signal.SlotCreated
@@ -172,7 +168,7 @@ func (s PeerFlowE2ETestSuitePG) TestSimpleSlotCreation() {
 	time.Sleep(2 * time.Second)
 	close(signal.CloneComplete)
 
-	require.NoError(s.t, <-setupError)
+	require.NoError(s.t, slotInfo.Err)
 	s.t.Logf("successfully setup replication: %s", flowJobName)
 }
 


### PR DESCRIPTION
defer close(replicationErr) would panic if SetupReplication returns error after defer

replicationErr channel write also hangs indefinitely were SlotCreated written to previously

reuse SlotCreated error mechanism so only one channel is being waited on