### PR TITLE
[OPS] incident.io wire-up

### DIFF
--- a/flow/go.mod
+++ b/flow/go.mod
@@ -63,7 +63,6 @@ require (
 	go.temporal.io/sdk v1.29.1
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/crypto v0.28.0
-	golang.org/x/mod v0.21.0
 	golang.org/x/sync v0.8.0
 	google.golang.org/api v0.200.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9
@@ -142,6 +141,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 // indirect
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
+	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/term v0.25.0 // indirect
 	google.golang.org/grpc/stats/opentelemetry v0.0.0-20241014145745-ad81c20503be // indirect
 )

--- a/flow/peerdbenv/config.go
+++ b/flow/peerdbenv/config.go
@@ -135,3 +135,11 @@ func PeerDBTemporalClientCert() ([]byte, error) {
 func PeerDBTemporalClientKey() ([]byte, error) {
 	return GetEnvBase64EncodedBytes("TEMPORAL_CLIENT_KEY", nil)
 }
+
+func PeerDBGetIncidentIoUrl() string {
+	return GetEnvString("PEERDB_INCIDENTIO_URL", "")
+}
+
+func PeerDBGetIncidentIoToken() string {
+	return GetEnvString("PEERDB_INCIDENTIO_TOKEN", "")
+}

--- a/flow/shared/telemetry/incidentio_message_sender.go
+++ b/flow/shared/telemetry/incidentio_message_sender.go
@@ -1,0 +1,127 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+)
+
+type IncidentIoAlert struct {
+	Metadata         map[string]string `json:"metadata"`
+	Title            string            `json:"title"`
+	Description      string            `json:"description"`
+	DeduplicationKey string            `json:"deduplication_key"`
+	Status           string            `json:"status"`
+}
+
+type IncidentIoResponse struct {
+	Status           string `json:"status"`
+	Message          string `json:"message"`
+	DeduplicationKey string `json:"deduplication_key"`
+}
+
+type IncidentIoMessageSender struct {
+	Sender
+}
+
+type IncidentIoMessageSenderImpl struct {
+	http   *http.Client
+	config IncidentIoMessageSenderConfig
+}
+
+type IncidentIoMessageSenderConfig struct {
+	URL   string
+	Token string
+}
+
+func (i *IncidentIoMessageSenderImpl) SendMessage(
+	ctx context.Context,
+	subject string,
+	body string,
+	attributes Attributes,
+) (*string, error) {
+	activityInfo := activity.Info{}
+	if activity.IsActivity(ctx) {
+		activityInfo = activity.GetInfo(ctx)
+	}
+
+	deduplicationString := strings.Join([]string{
+		"deployID", attributes.DeploymentUID,
+		"subject", subject,
+		"runID", activityInfo.WorkflowExecution.RunID,
+		"activityName", activityInfo.ActivityType.Name,
+	}, " || ")
+	h := sha256.New()
+	h.Write([]byte(deduplicationString))
+	deduplicationHash := hex.EncodeToString(h.Sum(nil))
+
+	alert := IncidentIoAlert{
+		Title:            subject,
+		Description:      body,
+		DeduplicationKey: deduplicationHash,
+		Status:           "firing",
+		Metadata: map[string]string{
+			"alias":          deduplicationHash,
+			"deploymentUUID": attributes.DeploymentUID,
+			"entity":         attributes.DeploymentUID,
+			"level":          string(attributes.Level),
+			"tags":           strings.Join(attributes.Tags, ","),
+			"type":           attributes.Type,
+		},
+	}
+
+	alertJSON, err := json.Marshal(alert)
+	if err != nil {
+		return nil, fmt.Errorf("error serializing alert %w", err)
+	}
+
+	req, err := http.NewRequest("POST", i.config.URL, bytes.NewBuffer(alertJSON))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", "Bearer "+i.config.Token)
+
+	resp, err := i.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making request %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading incident.io response body %w", err)
+	}
+
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, fmt.Errorf("received unexpected response from incident.io. status: %d. body: %s", resp.StatusCode, respBody)
+	}
+
+	var incidentResponse IncidentIoResponse
+	err = json.Unmarshal(respBody, &incidentResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing incident.io response: %w", err)
+	}
+
+	return &incidentResponse.Status, nil
+}
+
+func NewIncidentIoMessageSender(_ context.Context, config IncidentIoMessageSenderConfig) (Sender, error) {
+	client := &http.Client{
+		Timeout: time.Second * 5,
+	}
+
+	return &IncidentIoMessageSenderImpl{
+		config: config,
+		http:   client,
+	}, nil
+}

--- a/flow/shared/telemetry/incidentio_message_sender_test.go
+++ b/flow/shared/telemetry/incidentio_message_sender_test.go
@@ -1,0 +1,142 @@
+package telemetry
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIncidentIoMessageSenderImpl_SendMessage(t *testing.T) {
+	tests := []struct {
+		serverResponse     IncidentIoResponse
+		name               string
+		subject            string
+		body               string
+		attributes         Attributes
+		serverResponseCode int
+		expectError        bool
+	}{
+		{
+			name: "successful send",
+			attributes: Attributes{
+				DeploymentUID: uuid.New().String(),
+				Level:         "firing",
+				Tags:          []string{"tag1", "tag2"},
+				Type:          "incident",
+			},
+			subject:            "Test Incident",
+			body:               "This is a test incident",
+			serverResponse:     IncidentIoResponse{Status: "success", Message: "Event accepted for processing", DeduplicationKey: "stonik"},
+			serverResponseCode: http.StatusAccepted,
+			expectError:        false,
+		},
+		{
+			name: "unauthenticated",
+			attributes: Attributes{
+				DeploymentUID: uuid.New().String(),
+				Level:         "firing",
+				Tags:          []string{"tag1", "tag2"},
+				Type:          "incident",
+			},
+			subject:            "Test Incident",
+			body:               "This is a test incident",
+			serverResponse:     IncidentIoResponse{Status: "authentication_error"},
+			serverResponseCode: http.StatusUnauthorized,
+			expectError:        true,
+		},
+		{
+			name: "not found",
+			attributes: Attributes{
+				DeploymentUID: uuid.New().String(),
+				Level:         "firing",
+				Tags:          []string{"tag1", "tag2"},
+				Type:          "incident",
+			},
+			subject:            "Test Incident",
+			body:               "This is a test incident",
+			serverResponse:     IncidentIoResponse{Status: "not_found"},
+			serverResponseCode: http.StatusNotFound,
+			expectError:        true,
+		},
+		{
+			name: "server error",
+			attributes: Attributes{
+				DeploymentUID: uuid.New().String(),
+				Level:         "firing",
+				Tags:          []string{"tag1", "tag2"},
+				Type:          "incident",
+			},
+			subject:            "Test Incident",
+			body:               "This is a test incident",
+			serverResponse:     IncidentIoResponse{Status: "error", Message: "Failed to create incident", DeduplicationKey: "stonik"},
+			serverResponseCode: http.StatusInternalServerError,
+			expectError:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeIncidentIoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "application/json", r.Header.Get("Content-Type"))   //nolint:testifylint
+				require.Equal(t, "Bearer test-token", r.Header.Get("Authorization")) //nolint:testifylint
+
+				var alert IncidentIoAlert
+				bodyBytes, err := io.ReadAll(r.Body)
+				require.NoError(t, err) //nolint:testifylint
+
+				err = json.Unmarshal(bodyBytes, &alert)
+				require.NoError(t, err) //nolint:testifylint
+				deduplicationString := strings.Join([]string{
+					"deployID", tt.attributes.DeploymentUID,
+					"subject", tt.subject,
+					"runID", "",
+					"activityName", "",
+				}, " || ")
+
+				h := sha256.New()
+				h.Write([]byte(deduplicationString))
+				deduplicationHash := hex.EncodeToString(h.Sum(nil))
+
+				// Check deduplication hash was generated correctly
+				require.Equal(t, deduplicationHash, alert.DeduplicationKey) //nolint:testifylint
+
+				// mock response
+				w.WriteHeader(tt.serverResponseCode)
+				err = json.NewEncoder(w).Encode(tt.serverResponse)
+				if err != nil {
+					require.Fail(t, "failed to mock response") //nolint:testifylint
+				}
+			}))
+			defer fakeIncidentIoServer.Close()
+
+			config := IncidentIoMessageSenderConfig{
+				URL:   fakeIncidentIoServer.URL,
+				Token: "test-token",
+			}
+			sender := &IncidentIoMessageSenderImpl{
+				http:   &http.Client{Timeout: time.Second * 5},
+				config: config,
+			}
+
+			ctx := context.Background()
+			status, err := sender.SendMessage(ctx, tt.subject, tt.body, tt.attributes)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.serverResponse.Status, *status)
+			}
+		})
+	}
+}

--- a/flow/shared/telemetry/incidentio_message_sender_test.go
+++ b/flow/shared/telemetry/incidentio_message_sender_test.go
@@ -27,10 +27,52 @@ func TestIncidentIoMessageSenderImpl_SendMessage(t *testing.T) {
 		expectError        bool
 	}{
 		{
-			name: "successful send",
+			name: "successful send with info alert",
 			attributes: Attributes{
 				DeploymentUID: uuid.New().String(),
-				Level:         "firing",
+				Level:         INFO,
+				Tags:          []string{"tag1", "tag2"},
+				Type:          "incident",
+			},
+			subject:            "Test Incident",
+			body:               "This is a test incident",
+			serverResponse:     IncidentIoResponse{Status: "success", Message: "Event accepted for processing", DeduplicationKey: "stonik"},
+			serverResponseCode: http.StatusAccepted,
+			expectError:        false,
+		},
+		{
+			name: "successful send with warn alert",
+			attributes: Attributes{
+				DeploymentUID: uuid.New().String(),
+				Level:         WARN,
+				Tags:          []string{"tag1", "tag2"},
+				Type:          "incident",
+			},
+			subject:            "Test Incident",
+			body:               "This is a test incident",
+			serverResponse:     IncidentIoResponse{Status: "success", Message: "Event accepted for processing", DeduplicationKey: "stonik"},
+			serverResponseCode: http.StatusAccepted,
+			expectError:        false,
+		},
+		{
+			name: "successful send with error alert",
+			attributes: Attributes{
+				DeploymentUID: uuid.New().String(),
+				Level:         ERROR,
+				Tags:          []string{"tag1", "tag2"},
+				Type:          "incident",
+			},
+			subject:            "Test Incident",
+			body:               "This is a test incident",
+			serverResponse:     IncidentIoResponse{Status: "success", Message: "Event accepted for processing", DeduplicationKey: "stonik"},
+			serverResponseCode: http.StatusAccepted,
+			expectError:        false,
+		},
+		{
+			name: "successful send with critical alert",
+			attributes: Attributes{
+				DeploymentUID: uuid.New().String(),
+				Level:         CRITICAL,
 				Tags:          []string{"tag1", "tag2"},
 				Type:          "incident",
 			},
@@ -109,6 +151,9 @@ func TestIncidentIoMessageSenderImpl_SendMessage(t *testing.T) {
 
 				// Check deduplication hash was generated correctly
 				require.Equal(t, deduplicationHash, alert.DeduplicationKey) //nolint:testifylint
+
+				// Check level was successfully mapped
+				require.Equal(t, string(ResolveIncidentIoLevels(tt.attributes.Level)), alert.Metadata["level"]) //nolint:testifylint
 
 				// mock response
 				w.WriteHeader(tt.serverResponseCode)

--- a/flow/shared/telemetry/interface.go
+++ b/flow/shared/telemetry/interface.go
@@ -15,11 +15,35 @@ type Attributes struct {
 	Tags          []string
 }
 
-type Level string
+type (
+	Level           string
+	IncidentIoLevel string
+)
 
 const (
 	INFO     Level = "INFO"
 	WARN     Level = "WARN"
 	ERROR    Level = "ERROR"
 	CRITICAL Level = "CRITICAL"
+
+	// ClickHouse (incident.io) mapped alert levels
+	IncMedium   IncidentIoLevel = "medium"
+	IncWarning  IncidentIoLevel = "warning"
+	IncHigh     IncidentIoLevel = "high"
+	IncCritical IncidentIoLevel = "critical"
 )
+
+func ResolveIncidentIoLevels(level Level) IncidentIoLevel {
+	switch level {
+	case INFO:
+		return IncMedium
+	case WARN:
+		return IncWarning
+	case ERROR:
+		return IncHigh
+	case CRITICAL:
+		return IncCritical
+	default:
+		return IncMedium
+	}
+}

--- a/flow/shared/telemetry/sns_message_sender.go
+++ b/flow/shared/telemetry/sns_message_sender.go
@@ -105,13 +105,6 @@ func NewSNSMessageSenderWithNewClient(ctx context.Context, config *SNSMessageSen
 	}, nil
 }
 
-func NewSNSMessageSender(client *sns.Client, config *SNSMessageSenderConfig) SNSMessageSender {
-	return &SNSMessageSenderImpl{
-		client: client,
-		topic:  config.Topic,
-	}
-}
-
 func newSnsClient(ctx context.Context, region *string) (*sns.Client, error) {
 	sdkConfig, err := aws_common.LoadSdkConfig(ctx, region)
 	if err != nil {


### PR DESCRIPTION
With ClickHouse migrating from PagerDuty to [incident.io](https://incident.io/), PeerDB needs the ability to hook into their RESTful API.
This PR introduces a telemetry sender alongside the existing SNS publisher to achieve this.