### PR TITLE
[clickhouse] apply TableSchemaDeltas in normalize

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -391,6 +391,7 @@ func pullCore[Items model.Items](
 		CatalogPool:            catalogPool,
 		FlowJobName:            req.FlowJobName,
 		RelationMessageMapping: c.relationMessageMapping,
+		SyncBatchID:            req.SyncBatchID,
 	})
 
 	if err := PullCdcRecords(ctx, cdc, req, processor, &c.replLock); err != nil {

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -80,6 +80,7 @@ type PullRecordsRequest[T Items] struct {
 	MaxBatchSize uint32
 	// IdleTimeout is the timeout to wait for new records.
 	IdleTimeout time.Duration
+	SyncBatchID int64
 }
 
 type ToJSONOptions struct {


### PR DESCRIPTION
TableSchemaDeltas are already stored in catalog for audit
instead of applying in SyncFlow like other connectors, apply them during normalize
as part of the philosophy of not connecting to CH during SyncFlow