### PR TITLE
feat(otel): make metrics namespace configurable

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -739,7 +739,7 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 			if a.OtelManager != nil {
 				slotLagGauge, err := otel_metrics.GetOrInitFloat64SyncGauge(a.OtelManager.Meter,
 					a.OtelManager.Float64GaugesCache,
-					peerdb_gauges.SlotLagGaugeName,
+					peerdb_gauges.BuildGaugeName(peerdb_gauges.SlotLagGaugeName),
 					metric.WithUnit("MiBy"),
 					metric.WithDescription("Postgres replication slot lag in MB"))
 				if err != nil {
@@ -750,7 +750,7 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 
 				openConnectionsGauge, err := otel_metrics.GetOrInitInt64SyncGauge(a.OtelManager.Meter,
 					a.OtelManager.Int64GaugesCache,
-					peerdb_gauges.OpenConnectionsGaugeName,
+					peerdb_gauges.BuildGaugeName(peerdb_gauges.OpenConnectionsGaugeName),
 					metric.WithDescription("Current open connections for PeerDB user"))
 				if err != nil {
 					logger.Error("Failed to get open connections gauge", slog.Any("error", err))
@@ -760,7 +760,7 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 
 				openReplicationConnectionsGauge, err := otel_metrics.GetOrInitInt64SyncGauge(a.OtelManager.Meter,
 					a.OtelManager.Int64GaugesCache,
-					peerdb_gauges.OpenReplicationConnectionsGaugeName,
+					peerdb_gauges.BuildGaugeName(peerdb_gauges.OpenReplicationConnectionsGaugeName),
 					metric.WithDescription("Current open replication connections for PeerDB user"))
 				if err != nil {
 					logger.Error("Failed to get open replication connections gauge", slog.Any("error", err))

--- a/flow/otel_metrics/peerdb_gauges/gauges.go
+++ b/flow/otel_metrics/peerdb_gauges/gauges.go
@@ -1,6 +1,9 @@
 package peerdb_gauges
 
-import "github.com/PeerDB-io/peer-flow/otel_metrics"
+import (
+	"github.com/PeerDB-io/peer-flow/otel_metrics"
+	"github.com/PeerDB-io/peer-flow/peerdbenv"
+)
 
 const (
 	SlotLagGaugeName                    string = "cdc_slot_lag"
@@ -12,4 +15,8 @@ type SlotMetricGauges struct {
 	SlotLagGauge                    *otel_metrics.Float64SyncGauge
 	OpenConnectionsGauge            *otel_metrics.Int64SyncGauge
 	OpenReplicationConnectionsGauge *otel_metrics.Int64SyncGauge
+}
+
+func BuildGaugeName(baseGaugeName string) string {
+	return peerdbenv.GetEnvString("PEERDB_OTEL_METRICS_NAMESPACE", "") + baseGaugeName
 }


### PR DESCRIPTION
This give flexibility wrt metrics names which are emitted from PeerDB