### PR TITLE
PG to PG: Optimize resync query

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1388,7 +1388,9 @@ func (c *PostgresConnector) RenameTables(
 				allCols := strings.Join(columnNames, ",")
 				c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", dst))
 				_, err = c.execWithLoggingTx(ctx,
-					fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s original_table WHERE NOT EXISTS (SELECT 1 FROM %s resync_table WHERE %s)",
+					fmt.Sprintf(
+						"INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s original_table"+
+							"WHERE NOT EXISTS (SELECT 1 FROM %s resync_table WHERE %s)",
 						src, fmt.Sprintf("%s,%s", allCols, QuoteIdentifier(req.SoftDeleteColName)), allCols, req.SoftDeleteColName,
 						dst, src, pkeyColCompareStr), renameTablesTx)
 				if err != nil {

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1376,19 +1376,26 @@ func (c *PostgresConnector) RenameTables(
 				}
 
 				pkeyColumnNames := make([]string, 0, len(tableSchema.PrimaryKeyColumns))
-				for _, col := range tableSchema.PrimaryKeyColumns {
+				var pkeyColCompareStr strings.Builder
+				for i, col := range tableSchema.PrimaryKeyColumns {
 					pkeyColumnNames = append(pkeyColumnNames, QuoteIdentifier(col))
+					pkeyColCompareStr.WriteString("original_table.")
+					pkeyColCompareStr.WriteString(QuoteIdentifier(col))
+					pkeyColCompareStr.WriteString(" = resync_table.")
+					pkeyColCompareStr.WriteString(QuoteIdentifier(col))
+					if i != len(tableSchema.PrimaryKeyColumns)-1 {
+						pkeyColCompareStr.WriteString(" AND ")
+					}
 				}
 
 				allCols := strings.Join(columnNames, ",")
 				pkeyCols := strings.Join(pkeyColumnNames, ",")
 
 				c.logger.Info(fmt.Sprintf("handling soft-deletes for table '%s'...", dst))
-
 				_, err = c.execWithLoggingTx(ctx,
-					fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s WHERE (%s) NOT IN (SELECT %s FROM %s)",
+					fmt.Sprintf("INSERT INTO %s(%s) SELECT %s,true AS %s FROM %s original_table WHERE (%s) NOT EXISTS (SELECT %s FROM %s resync_table WHERE %s)",
 						src, fmt.Sprintf("%s,%s", allCols, QuoteIdentifier(req.SoftDeleteColName)), allCols, req.SoftDeleteColName,
-						dst, pkeyCols, pkeyCols, src), renameTablesTx)
+						dst, pkeyCols, pkeyCols, src, pkeyColCompareStr.String()), renameTablesTx)
 				if err != nil {
 					return nil, fmt.Errorf("unable to handle soft-deletes for table %s: %w", dst, err)
 				}


### PR DESCRIPTION
Current query results in a sequential scan.
Can be optimized to instead use NOT EXISTS and perform index scans

Functionally tested with soft deletes on a composite primary key table