### PR TITLE
Change to debug log for unsupported message types

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -680,7 +680,7 @@ func processMessage[Items model.Items](
 		}, nil
 
 	default:
-		logger.Warn(fmt.Sprintf("%T not supported", msg))
+		logger.Debug(fmt.Sprintf("%T not supported", msg))
 	}
 
 	return nil, nil


### PR DESCRIPTION
Do not warn for every unsupported message type