### PR TITLE
Alert for syncCore failure

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -372,9 +372,13 @@ func (a *FlowableActivity) SyncRecords(
 			return stream, nil
 		}
 	}
-	return syncCore(ctx, a, config, options, sessionID, adaptStream,
+	syncResponse, err := syncCore(ctx, a, config, options, sessionID, adaptStream,
 		connectors.CDCPullConnector.PullRecords,
 		connectors.CDCSyncConnector.SyncRecords)
+	if err != nil {
+		a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
+	}
+	return syncResponse, err
 }
 
 func (a *FlowableActivity) SyncPg(


### PR DESCRIPTION
Upon killing a publication during a CDC mirror, I noticed there was no error logged in our catalog. 
Noticed that we weren't recording errors from syncCore - its result was being returned as is to the workflow