### PR TITLE
[clickhouse] fix checkTablesEmptyAndEngine sql query

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -372,7 +372,7 @@ func (c *ClickHouseConnector) checkTablesEmptyAndEngine(ctx context.Context, tab
 		queryInput = append(queryInput, table)
 	}
 	rows, err := c.query(ctx,
-		fmt.Sprintf("SELECT name,engine,total_rows FROM system.tables WHERE database=? AND table IN (%s)",
+		fmt.Sprintf("SELECT name,engine,total_rows FROM system.tables WHERE database=? AND name IN (%s)",
 			strings.Join(slices.Repeat([]string{"?"}, len(tables)), ",")), queryInput...)
 	if err != nil {
 		return fmt.Errorf("failed to get information for destination tables: %w", err)


### PR DESCRIPTION
I was trying to create mirror from postgresql peer to clickhouse peer and got this error:
```bash
udev21=> create mirror my_test_mirror from mydb1 to clickhouse with table mapping ( public.products: products) WITH (do_initial_copy= true);

ERROR:  unable to submit job: "status: Unknown, message: \"invalid mirror: failed to get information for destination tables: code: 47, message: Missing columns: 'table' while processing query: 'SELECT name, engine, total_rows FROM system.tables WHERE (database = 'default') AND (table IN ('products'))', required columns: 'name' 'engine' 'total_rows' 'database' 'table', maybe you meant: ['name','engine','total_rows','database']\", details: [], metadata: MetadataMap { headers: {\"content-type\": \"application/grpc\"} }"
```
after some research, found out that there's indeed no column named <b>table</b> in system.tables, I guess by table there's meant <b>name</b> column