### PR TITLE
crypt: support special key id `kms` to use KMS for encrypting catalog

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -352,7 +352,7 @@ func (a *FlowableActivity) getPostgresPeerConfigs(ctx context.Context) ([]*proto
 			return nil, err
 		}
 
-		peerOptions, err := peerdbenv.Decrypt(encKeyID, encPeerOptions)
+		peerOptions, err := peerdbenv.Decrypt(ctx, encKeyID, encPeerOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/alerting/alerting.go
+++ b/flow/alerting/alerting.go
@@ -66,7 +66,7 @@ func (a *Alerter) registerSendersFromPool(ctx context.Context) ([]AlertSenderCon
 		if err != nil {
 			return alertSenderConfig, err
 		}
-		serviceConfig, err := key.Decrypt(serviceConfigEnc)
+		serviceConfig, err := key.Decrypt(ctx, serviceConfigEnc)
 		if err != nil {
 			return alertSenderConfig, err
 		}

--- a/flow/cmd/alerts.go
+++ b/flow/cmd/alerts.go
@@ -23,7 +23,7 @@ func (h *FlowRequestHandler) GetAlertConfigs(ctx context.Context, req *protos.Ge
 		if err := row.Scan(&config.Id, &config.ServiceType, &serviceConfigPayload, &encKeyID, &config.AlertForMirrors); err != nil {
 			return nil, err
 		}
-		serviceConfig, err := peerdbenv.Decrypt(encKeyID, serviceConfigPayload)
+		serviceConfig, err := peerdbenv.Decrypt(ctx, encKeyID, serviceConfigPayload)
 		if err != nil {
 			return nil, err
 		}
@@ -42,7 +42,7 @@ func (h *FlowRequestHandler) PostAlertConfig(ctx context.Context, req *protos.Po
 	if err != nil {
 		return nil, err
 	}
-	serviceConfig, err := key.Encrypt(shared.UnsafeFastStringToReadOnlyBytes(req.Config.ServiceConfig))
+	serviceConfig, err := key.Encrypt(ctx, shared.UnsafeFastStringToReadOnlyBytes(req.Config.ServiceConfig))
 	if err != nil {
 		return nil, err
 	}

--- a/flow/cmd/api.go
+++ b/flow/cmd/api.go
@@ -98,14 +98,14 @@ func recryptDatabase(
 			continue
 		}
 
-		options, err = oldKey.Decrypt(options)
+		options, err = oldKey.Decrypt(ctx, options)
 		if err != nil {
 			slog.Warn("recrypt failed to decrypt, skipping",
 				slog.String("tag", tag), slog.Any("error", err), slog.Int64("id", int64(id)))
 			continue
 		}
 
-		options, err = key.Encrypt(options)
+		options, err = key.Encrypt(ctx, options)
 		if err != nil {
 			slog.Warn("recrypt failed to encrypt, skipping",
 				slog.String("tag", tag), slog.Any("error", err), slog.Int64("id", int64(id)))

--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -45,7 +45,7 @@ func (h *FlowRequestHandler) getPGPeerConfig(ctx context.Context, peerName strin
 		return nil, err
 	}
 
-	peerOptions, err := peerdbenv.Decrypt(encKeyID, encPeerOptions)
+	peerOptions, err := peerdbenv.Decrypt(ctx, encKeyID, encPeerOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load peer: %w", err)
 	}

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -294,7 +294,7 @@ func LoadPeer(ctx context.Context, catalogPool *pgxpool.Pool, peerName string) (
 		return nil, fmt.Errorf("failed to load peer: %w", err)
 	}
 
-	peerOptions, err := peerdbenv.Decrypt(encKeyID, encPeerOptions)
+	peerOptions, err := peerdbenv.Decrypt(ctx, encKeyID, encPeerOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load peer: %w", err)
 	}

--- a/flow/connectors/utils/peers.go
+++ b/flow/connectors/utils/peers.go
@@ -104,7 +104,7 @@ func CreatePeerNoValidate(
 		return nil, encodingErr
 	}
 
-	encryptedConfig, keyID, err := encryptPeerOptions(encodedConfig)
+	encryptedConfig, keyID, err := encryptPeerOptions(ctx, encodedConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt peer configuration: %w", err)
 	}
@@ -134,13 +134,13 @@ func CreatePeerNoValidate(
 	}, nil
 }
 
-func encryptPeerOptions(peerOptions []byte) ([]byte, string, error) {
+func encryptPeerOptions(ctx context.Context, peerOptions []byte) ([]byte, string, error) {
 	key, err := peerdbenv.PeerDBCurrentEncKey()
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get current encryption key: %w", err)
 	}
 
-	encrypted, err := key.Encrypt(peerOptions)
+	encrypted, err := key.Encrypt(ctx, peerOptions)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to encrypt peer options: %w", err)
 	}

--- a/flow/peerdbenv/crypt.go
+++ b/flow/peerdbenv/crypt.go
@@ -1,6 +1,10 @@
 package peerdbenv
 
-func Decrypt(encKeyID string, payload []byte) ([]byte, error) {
+import (
+	"context"
+)
+
+func Decrypt(ctx context.Context, encKeyID string, payload []byte) ([]byte, error) {
 	if encKeyID == "" {
 		return payload, nil
 	}
@@ -11,5 +15,5 @@ func Decrypt(encKeyID string, payload []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	return key.Decrypt(payload)
+	return key.Decrypt(ctx, payload)
 }


### PR DESCRIPTION
value of the `kms` key must be an empty string