### PR TITLE
kms: cache results

### DIFF
--- a/flow/peerdbenv/config.go
+++ b/flow/peerdbenv/config.go
@@ -67,7 +67,7 @@ func PeerDBCatalogUser() string {
 
 // PEERDB_CATALOG_PASSWORD
 func PeerDBCatalogPassword(ctx context.Context) string {
-	val, err := GetKMSDecryptedEnvString(ctx, "PEERDB_CATALOG_PASSWORD", "")
+	val, err := GetKmsDecryptedEnvString(ctx, "PEERDB_CATALOG_PASSWORD", "")
 	if err != nil {
 		slog.Error("failed to decrypt PEERDB_CATALOG_PASSWORD", "error", err)
 		panic(err)
@@ -108,7 +108,7 @@ func PeerDBCurrentEncKeyID() string {
 }
 
 func PeerDBEncKeys(ctx context.Context) shared.PeerDBEncKeys {
-	val, err := GetKMSDecryptedEnvString(ctx, "PEERDB_ENC_KEYS", "")
+	val, err := GetKmsDecryptedEnvString(ctx, "PEERDB_ENC_KEYS", "")
 	if err != nil {
 		slog.Error("failed to decrypt PEERDB_ENC_KEYS", "error", err)
 		panic(err)
@@ -142,11 +142,11 @@ func PeerDBTemporalEnableCertAuth() bool {
 }
 
 func PeerDBTemporalClientCert(ctx context.Context) ([]byte, error) {
-	return GetEnvBase64EncodedBytes(ctx, "TEMPORAL_CLIENT_CERT", nil)
+	return GetKmsDecryptedEnvBase64EncodedBytes(ctx, "TEMPORAL_CLIENT_CERT", nil)
 }
 
 func PeerDBTemporalClientKey(ctx context.Context) ([]byte, error) {
-	return GetEnvBase64EncodedBytes(ctx, "TEMPORAL_CLIENT_KEY", nil)
+	return GetKmsDecryptedEnvBase64EncodedBytes(ctx, "TEMPORAL_CLIENT_KEY", nil)
 }
 
 func PeerDBGetIncidentIoUrl() string {


### PR DESCRIPTION
kms should not be polled repeatedly, keep an in-memory cache of decrypted kms env variables