### PR TITLE
Change upload size for s3 to work with large tables.

### DIFF
--- a/flow/connectors/utils/avro/avro_writer.go
+++ b/flow/connectors/utils/avro/avro_writer.go
@@ -216,7 +216,12 @@ func (p *peerDBOCFWriter) WriteRecordsToS3(
 		numRows, writeOcfError = p.WriteOCF(ctx, w)
 	}()
 
-	_, err = manager.NewUploader(s3svc).Upload(ctx, &s3.PutObjectInput{
+	// Create the uploader using the AWS SDK v2 manager
+	uploader := manager.NewUploader(s3svc, func(u *manager.Uploader) {
+		u.PartSize = 500 * 1024 * 1024 // Set part size to 500 MB
+	})
+
+	_, err = uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(key),
 		Body:   r,


### PR DESCRIPTION
# Merge Request: Increase Upload Part Size to 500 MB

## Summary

This merge request addresses [Issue #2184](https://github.com/PeerDB-io/peerdb/issues/2184) by increasing the default upload part size from 5 MB to 500 MB. This change makes sure that you don't hit the 10k multipart limit in s3 when uploading a large table.

## Changes

- Increased the default upload part size from 5 MB to 500 MB in the configuration by adding config to the upload manager and 

## Impact

This adjustment optimizes performance for larger uploads, minimizing the number of requests and thus reducing upload time. This is especially beneficial for users dealing with substantial file uploads.

## Testing

- Verified multi-part upload for various file sizes to ensure stable upload behavior with the new part size, success for our 2.3 TB logging table in psql.

## Further improvments

* Suggest someone to add a multipart option or change the defaults to something bigger than 5 MB.

## Related Issue

- Resolves [Issue #2184](https://github.com/PeerDB-io/peerdb/issues/2184).

---

Please review the changes and merge if approved. Thank you!