### PR TITLE
ClickHouse: Quote table name in insertions

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -418,8 +418,9 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		}
 
 		insertIntoSelectQuery := strings.Builder{}
-		insertIntoSelectQuery.WriteString("INSERT INTO ")
+		insertIntoSelectQuery.WriteString("INSERT INTO `")
 		insertIntoSelectQuery.WriteString(tbl)
+		insertIntoSelectQuery.WriteString("` ")
 		insertIntoSelectQuery.WriteString(colSelector.String())
 		insertIntoSelectQuery.WriteString(selectQuery.String())
 

--- a/flow/connectors/clickhouse/qrep.go
+++ b/flow/connectors/clickhouse/qrep.go
@@ -45,7 +45,7 @@ func (c *ClickHouseConnector) SyncQRepRecords(
 }
 
 func (c *ClickHouseConnector) getTableSchema(ctx context.Context, tableName string) ([]driver.ColumnType, error) {
-	queryString := fmt.Sprintf(`SELECT * FROM %s LIMIT 0`, tableName)
+	queryString := fmt.Sprintf("SELECT * FROM `%s` LIMIT 0", tableName)
 	rows, err := c.query(ctx, queryString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -50,7 +50,7 @@ func (s *ClickHouseAvroSyncMethod) CopyStageToDestination(ctx context.Context, a
 	if creds.AWS.SessionToken != "" {
 		sessionTokenPart = fmt.Sprintf(", '%s'", creds.AWS.SessionToken)
 	}
-	query := fmt.Sprintf("INSERT INTO %s SELECT * FROM s3('%s','%s','%s'%s, 'Avro')",
+	query := fmt.Sprintf("INSERT INTO `%s` SELECT * FROM s3('%s','%s','%s'%s, 'Avro')",
 		s.config.DestinationTableIdentifier, avroFileUrl,
 		creds.AWS.AccessKeyID, creds.AWS.SecretAccessKey, sessionTokenPart)
 
@@ -145,7 +145,7 @@ func (s *ClickHouseAvroSyncMethod) SyncQRepRecords(
 	if creds.AWS.SessionToken != "" {
 		sessionTokenPart = fmt.Sprintf(", '%s'", creds.AWS.SessionToken)
 	}
-	query := fmt.Sprintf("INSERT INTO %s(%s) SELECT %s FROM s3('%s','%s','%s'%s, 'Avro')",
+	query := fmt.Sprintf("INSERT INTO `%s`(%s) SELECT %s FROM s3('%s','%s','%s'%s, 'Avro')",
 		config.DestinationTableIdentifier, selectorStr, selectorStr, avroFileUrl,
 		creds.AWS.AccessKeyID, creds.AWS.SecretAccessKey, sessionTokenPart)
 

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -460,25 +460,25 @@ func (s ClickHouseSuite) Test_Replident_Full_Unchanged_TOAST_Updates() {
 // Replicate a table called "table" and a column with hyphen in it
 func (s ClickHouseSuite) Test_Weird_Table_And_Column() {
 	srcTableName := "table"
-	srcFullName := s.attachSchemaSuffix("table")
+	srcFullName := s.attachSchemaSuffix("\"table\"")
 	dstTableName := "table"
 
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS "%s" (
-			id INT PRIMARY KEY,
+		CREATE TABLE IF NOT EXISTS %s (
+			id SERIAL PRIMARY KEY,
 			"my-key" TEXT NOT NULL
 		);
 	`, srcFullName))
 	require.NoError(s.t, err)
 
 	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-	INSERT INTO "%s" ("my-key",d) VALUES ('init','1935-01-01');
+	INSERT INTO %s ("my-key") VALUES ('init');
 	`, srcFullName))
 	require.NoError(s.t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
 		FlowJobName:      s.attachSuffix("clickhouse_test_weird_table_and_column"),
-		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		TableNameMapping: map[string]string{s.attachSchemaSuffix("table"): dstTableName},
 		Destination:      s.Peer().Name,
 	}
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s.t)
@@ -487,14 +487,14 @@ func (s ClickHouseSuite) Test_Weird_Table_And_Column() {
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,\"my-key\",d")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,\"my-key\"")
 
 	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-	INSERT INTO "%s" ("my-key",d) VALUES ('cdc','1935-01-01');
+	INSERT INTO %s ("my-key") VALUES ('cdc');
 	`, srcFullName))
 	require.NoError(s.t, err)
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,\"my-key\",d")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,\"my-key\"")
 
 	env.Cancel()
 	e2e.RequireEnvCanceled(s.t, env)

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -466,13 +466,13 @@ func (s ClickHouseSuite) Test_Weird_Table_And_Column() {
 	_, err := s.Conn().Exec(context.Background(), fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
 			id SERIAL PRIMARY KEY,
-			"my-key" TEXT NOT NULL
+			key TEXT NOT NULL
 		);
 	`, srcFullName))
 	require.NoError(s.t, err)
 
 	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-	INSERT INTO %s ("my-key") VALUES ('init');
+	INSERT INTO %s (key) VALUES ('init');
 	`, srcFullName))
 	require.NoError(s.t, err)
 
@@ -487,14 +487,14 @@ func (s ClickHouseSuite) Test_Weird_Table_And_Column() {
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,\"my-key\"")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,key")
 
 	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-	INSERT INTO %s ("my-key") VALUES ('cdc');
+	INSERT INTO %s (key) VALUES ('cdc');
 	`, srcFullName))
 	require.NoError(s.t, err)
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,\"my-key\"")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,key")
 
 	env.Cancel()
 	e2e.RequireEnvCanceled(s.t, env)


### PR DESCRIPTION
Quotes table name in our inserts and adds a test with a table called "table" (reserved keyword) in it

- [x] Functionally tested with initial load + CDC