### PR TITLE
feat: add request logging interceptor for API

### DIFF
--- a/flow/cmd/api.go
+++ b/flow/cmd/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/PeerDB-io/peer-flow/middleware"
 	"log"
 	"log/slog"
 	"net"
@@ -25,6 +24,7 @@ import (
 	"google.golang.org/grpc/reflection"
 
 	"github.com/PeerDB-io/peer-flow/generated/protos"
+	"github.com/PeerDB-io/peer-flow/middleware"
 	"github.com/PeerDB-io/peer-flow/peerdbenv"
 	"github.com/PeerDB-io/peer-flow/shared"
 	peerflow "github.com/PeerDB-io/peer-flow/workflows"

--- a/flow/middleware/logging.go
+++ b/flow/middleware/logging.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"context"
+	"github.com/PeerDB-io/peer-flow/peerdbenv"
+	"google.golang.org/grpc"
+	"log/slog"
+)
+
+func RequestLoggingMiddleWare() grpc.UnaryServerInterceptor {
+	if !peerdbenv.PeerDBRAPIRequestLoggingEnabled() {
+		slog.Info("Request Logging Interceptor is disabled")
+		return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+			return handler(ctx, req)
+		}
+	}
+	slog.Info("Setting up request logging middleware")
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		slog.Info("Received gRPC request", slog.String("method", info.FullMethod))
+
+		resp, err := handler(ctx, req)
+		if err != nil {
+			slog.Error("gRPC request failed", slog.String("method", info.FullMethod), slog.Any("error", err))
+		} else {
+			slog.Info("gRPC request completed successfully", slog.String("method", info.FullMethod))
+		}
+		return resp, err
+	}
+}

--- a/flow/middleware/logging.go
+++ b/flow/middleware/logging.go
@@ -2,9 +2,11 @@ package middleware
 
 import (
 	"context"
-	"github.com/PeerDB-io/peer-flow/peerdbenv"
-	"google.golang.org/grpc"
 	"log/slog"
+
+	"google.golang.org/grpc"
+
+	"github.com/PeerDB-io/peer-flow/peerdbenv"
 )
 
 func RequestLoggingMiddleWare() grpc.UnaryServerInterceptor {

--- a/flow/middleware/oauth.go
+++ b/flow/middleware/oauth.go
@@ -57,7 +57,9 @@ func AuthGrpcMiddleware(unauthenticatedMethods []string) (grpc.UnaryServerInterc
 
 		slog.Warn("authentication is disabled")
 
-		return nil, nil
+		return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+			return handler(ctx, req)
+		}, nil
 	}
 
 	if err != nil {

--- a/flow/peerdbenv/config.go
+++ b/flow/peerdbenv/config.go
@@ -161,6 +161,7 @@ func PeerDBGetIncidentIoToken() string {
 func PeerDBRAPIRequestLoggingEnabled() bool {
 	requestLoggingEnabled, err := strconv.ParseBool(GetEnvString("PEERDB_API_REQUEST_LOGGING_ENABLED", "false"))
 	if err != nil {
+		slog.Error("failed to parse PEERDB_API_REQUEST_LOGGING_ENABLED to bool", "error", err)
 		return false
 	}
 	return requestLoggingEnabled

--- a/flow/peerdbenv/config.go
+++ b/flow/peerdbenv/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -155,4 +156,12 @@ func PeerDBGetIncidentIoUrl() string {
 
 func PeerDBGetIncidentIoToken() string {
 	return GetEnvString("PEERDB_INCIDENTIO_TOKEN", "")
+}
+
+func PeerDBRAPIRequestLoggingEnabled() bool {
+	requestLoggingEnabled, err := strconv.ParseBool(GetEnvString("PEERDB_API_REQUEST_LOGGING_ENABLED", "false"))
+	if err != nil {
+		return false
+	}
+	return requestLoggingEnabled
 }

--- a/flow/peerdbenv/oauth.go
+++ b/flow/peerdbenv/oauth.go
@@ -1,6 +1,9 @@
 package peerdbenv
 
-import "strconv"
+import (
+	"log/slog"
+	"strconv"
+)
 
 type PeerDBOAuthConfig struct {
 	// there can be more complex use cases where domain != issuer, but we handle them later if required
@@ -18,6 +21,7 @@ func GetPeerDBOAuthConfig() PeerDBOAuthConfig {
 	oauthDiscoveryEnabledString := GetEnvString("PEERDB_OAUTH_DISCOVERY_ENABLED", "false")
 	oauthDiscoveryEnabled, err := strconv.ParseBool(oauthDiscoveryEnabledString)
 	if err != nil {
+		slog.Error("failed to parse PEERDB_OAUTH_DISCOVERY_ENABLED to bool", "error", err)
 		oauthDiscoveryEnabled = false
 	}
 	oauthKeysetJson := GetEnvString("PEERDB_OAUTH_KEYSET_JSON", "")


### PR DESCRIPTION
Set `PEERDB_API_REQUEST_LOGGING_ENABLED` = true to enable request logging. Separating it from the oauth interceptor incase oauth is disabled and we wish to enable request logging