### PR TITLE
Sync batch pagination

### DIFF
--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -184,6 +184,11 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 		cdcBatches = cdcBatchesResponse.CdcBatches
 	}
 
+	var rowsSynced int64
+	if err := h.pool.QueryRow(ctx, "select coalesce(sum(rows_in_batch), 0) from peerdb_stats.cdc_batches where flow_name=$1", req.FlowJobName).Scan(&rowsSynced); err != nil {
+		return nil, err
+	}
+
 	return &protos.CDCMirrorStatus{
 		Config:          config,
 		SourceType:      srcType,
@@ -192,6 +197,7 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 			Clones: initialLoadResponse.TableSummaries,
 		},
 		CdcBatches: cdcBatches,
+		RowsSynced: rowsSynced,
 	}, nil
 }
 

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -205,8 +205,13 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 
 func (h *FlowRequestHandler) CDCGraph(ctx context.Context, req *protos.GraphRequest) (*protos.GraphResponse, error) {
 	truncField := "minute"
-	if slices.Contains([]string{"hour", "day", "month"}, req.AggregateType) {
-		truncField = req.AggregateType
+	switch req.AggregateType {
+	case "1hour":
+		truncField = "hour"
+	case "1day":
+		truncField = "day"
+	case "1month":
+		truncField = "month"
 	}
 	rows, err := h.pool.Query(ctx, `select tm, coalesce(sum(rows_in_batch), 0)
 	from generate_series(date_trunc($2, now() - $1::INTERVAL * 30), now(), $1::INTERVAL) tm

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -205,8 +205,7 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 
 func (h *FlowRequestHandler) CDCGraph(ctx context.Context, req *protos.GraphRequest) (*protos.GraphResponse, error) {
 	truncField := "minute"
-	switch req.AggregateType {
-	case "hour", "day", "month":
+	if slices.Contains([]string{"hour", "day", "month"}, req.AggregateType) {
 		truncField = req.AggregateType
 	}
 	rows, err := h.pool.Query(ctx, `select tm, coalesce(sum(rows_in_batch), 0)
@@ -512,7 +511,7 @@ func (h *FlowRequestHandler) CDCBatches(ctx context.Context, req *protos.GetCDCB
 		} else if req.AfterId != -1 {
 			queryArgs = append(queryArgs, req.AfterId)
 			whereExpr = fmt.Sprintf(" AND batch_id > $%d", len(queryArgs))
-			sortOrderBy = ""
+			sortOrderBy = "asc"
 		}
 	}
 
@@ -569,7 +568,7 @@ func (h *FlowRequestHandler) CDCBatches(ctx context.Context, req *protos.GetCDCB
 	if batches == nil {
 		batches = []*protos.CDCBatch{}
 	}
-	if req.Ascending != (sortOrderBy == "") {
+	if req.Ascending != (sortOrderBy == "asc") {
 		slices.Reverse(batches)
 	}
 

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -175,12 +175,16 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 		return nil, err
 	}
 
-	cdcBatchesResponse, err := h.GetCDCBatches(ctx, &protos.GetCDCBatchesRequest{
-		FlowJobName: req.FlowJobName,
-		Limit:       0,
-	})
-	if err != nil {
-		return nil, err
+	var cdcBatches []*protos.CDCBatch
+	if !req.ExcludeBatches {
+		cdcBatchesResponse, err := h.GetCDCBatches(ctx, &protos.GetCDCBatchesRequest{
+			FlowJobName: req.FlowJobName,
+			Limit:       0,
+		})
+		if err != nil {
+			return nil, err
+		}
+		cdcBatches = cdcBatchesResponse.CdcBatches
 	}
 
 	return &protos.CDCMirrorStatus{
@@ -190,7 +194,7 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 		SnapshotStatus: &protos.SnapshotStatus{
 			Clones: initialLoadResponse.TableSummaries,
 		},
-		CdcBatches: cdcBatchesResponse.CdcBatches,
+		CdcBatches: cdcBatches,
 	}, nil
 }
 

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -145,6 +145,7 @@ message CreatePeerResponse {
 message MirrorStatusRequest {
   string flow_job_name = 1;
   bool include_flow_info = 2;
+  bool exclude_batches = 3;
 }
 
 message PartitionStatus {
@@ -343,10 +344,14 @@ message InitialLoadSummaryResponse {
 message GetCDCBatchesRequest {
   string flow_job_name = 1;
   uint32 limit = 2;
+  int64 before_id = 3;
+  int64 after_id = 4;
 }
 
 message GetCDCBatchesResponse {
   repeated CDCBatch cdc_batches = 1;
+  int32 total = 2;
+  int32 page = 3;
 }
 
 message MirrorLog {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -354,6 +354,20 @@ message GetCDCBatchesResponse {
   int32 page = 3;
 }
 
+message GraphRequest {
+  string flow_job_name = 1;
+  string aggregate_type = 2; // TODO name?
+}
+
+message GraphResponseItem {
+  double time = 1;
+  double rows = 2;
+}
+
+message GraphResponse {
+  repeated GraphResponseItem data = 1;
+}
+
 message MirrorLog {
   string flow_name = 1;
   string error_message = 2;
@@ -555,6 +569,10 @@ service FlowService {
 
   rpc CDCBatches(GetCDCBatchesRequest) returns (GetCDCBatchesResponse) {
     option (google.api.http) = { post: "/v1/mirrors/cdc/batches", body: "*" };
+  }
+
+  rpc CDCGraph(GraphRequest) returns (GraphResponse) {
+    option (google.api.http) = { post: "/v1/mirrors/cdc/graph", body: "*" };
   }
 
   rpc InitialLoadSummary(InitialLoadSummaryRequest) returns (InitialLoadSummaryResponse) {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -550,11 +550,15 @@ service FlowService {
   }
 
   rpc GetCDCBatches(GetCDCBatchesRequest) returns (GetCDCBatchesResponse) {
-    option (google.api.http) = { get: "/v1/mirrors/cdc/batches/{flow_job_name}"};
+    option (google.api.http) = { get: "/v1/mirrors/cdc/batches/{flow_job_name}" };
+  }
+
+  rpc CDCBatches(GetCDCBatchesRequest) returns (GetCDCBatchesResponse) {
+    option (google.api.http) = { post: "/v1/mirrors/cdc/batches", body: "*" };
   }
 
   rpc InitialLoadSummary(InitialLoadSummaryRequest) returns (InitialLoadSummaryResponse) {
-    option (google.api.http) = { get: "/v1/mirrors/cdc/initial_load/{parent_mirror_name}"};
+    option (google.api.http) = { get: "/v1/mirrors/cdc/initial_load/{parent_mirror_name}" };
   }
 
   rpc GetPeerInfo(PeerInfoRequest) returns (PeerInfoResponse) {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -321,6 +321,7 @@ message CDCMirrorStatus {
   repeated CDCBatch cdc_batches = 3;
   peerdb_peers.DBType source_type = 4;
   peerdb_peers.DBType destination_type = 5;
+  int64 rows_synced = 6;
 }
 
 message MirrorStatusResponse {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -345,8 +345,9 @@ message InitialLoadSummaryResponse {
 message GetCDCBatchesRequest {
   string flow_job_name = 1;
   uint32 limit = 2;
-  int64 before_id = 3;
-  int64 after_id = 4;
+  bool ascending = 3;
+  int64 before_id = 4;
+  int64 after_id = 5;
 }
 
 message GetCDCBatchesResponse {

--- a/ui/app/mirrors/[mirrorId]/aggregatedCountsByInterval.ts
+++ b/ui/app/mirrors/[mirrorId]/aggregatedCountsByInterval.ts
@@ -7,7 +7,7 @@ type timestampType = {
   count: number;
 };
 
-function aggregateCountsByInterval(
+export default function aggregateCountsByInterval(
   timestamps: timestampType[],
   interval: TimeAggregateTypes
 ): [string, number][] {
@@ -83,5 +83,3 @@ function aggregateCountsByInterval(
 
   return resultArray;
 }
-
-export default aggregateCountsByInterval;

--- a/ui/app/mirrors/[mirrorId]/cdc.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdc.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { CDCBatch, MirrorStatusResponse } from '@/grpc_generated/route';
+import { MirrorStatusResponse } from '@/grpc_generated/route';
 import { Label } from '@/lib/Label';
 import { ProgressCircle } from '@/lib/ProgressCircle';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@tremor/react';
@@ -10,14 +10,9 @@ import { SnapshotStatusTable } from './snapshot';
 
 type CDCMirrorStatusProps = {
   status: MirrorStatusResponse;
-  rows: CDCBatch[];
   syncStatusChild?: React.ReactNode;
 };
-export function CDCMirror({
-  status,
-  rows,
-  syncStatusChild,
-}: CDCMirrorStatusProps) {
+export function CDCMirror({ status, syncStatusChild }: CDCMirrorStatusProps) {
   const LocalStorageTabKey = 'cdctab';
   const [selectedTab, setSelectedTab] = useLocalStorage(LocalStorageTabKey, 0);
   const [mounted, setMounted] = useState(false);
@@ -60,7 +55,6 @@ export function CDCMirror({
       <TabPanels>
         <TabPanel>
           <CdcDetails
-            syncs={rows}
             createdAt={status.createdAt}
             mirrorConfig={status.cdcStatus!}
             mirrorStatus={status.currentFlowState}

--- a/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
@@ -20,15 +20,18 @@ type props = {
   createdAt?: Date;
   mirrorStatus: FlowStatus;
 };
-function CdcDetails({ createdAt, mirrorConfig, mirrorStatus }: props) {
-  const [syncInterval, getSyncInterval] = useState<number>();
+
+export default function CdcDetails({
+  createdAt,
+  mirrorConfig,
+  mirrorStatus,
+}: props) {
+  const [syncInterval, setSyncInterval] = useState<number>();
 
   const tablesSynced = mirrorConfig.config?.tableMappings;
   useEffect(() => {
-    getCurrentIdleTimeout(mirrorConfig.config?.flowJobName ?? '').then(
-      (res) => {
-        getSyncInterval(res);
-      }
+    getCurrentIdleTimeout(mirrorConfig.config?.flowJobName ?? '').then((res) =>
+      setSyncInterval(res)
     );
   }, [mirrorConfig.config?.flowJobName]);
   return (
@@ -74,8 +77,8 @@ function CdcDetails({ createdAt, mirrorConfig, mirrorStatus }: props) {
             </div>
             <div>
               <PeerButton
-                peerName={mirrorConfig?.config?.sourceName ?? ''}
-                peerType={dBTypeFromJSON(mirrorConfig?.sourceType)}
+                peerName={mirrorConfig.config?.sourceName ?? ''}
+                peerType={dBTypeFromJSON(mirrorConfig.sourceType)}
               />
             </div>
           </div>
@@ -87,8 +90,8 @@ function CdcDetails({ createdAt, mirrorConfig, mirrorStatus }: props) {
             </div>
             <div>
               <PeerButton
-                peerName={mirrorConfig?.config?.destinationName ?? ''}
-                peerType={dBTypeFromJSON(mirrorConfig?.destinationType)}
+                peerName={mirrorConfig.config?.destinationName ?? ''}
+                peerType={dBTypeFromJSON(mirrorConfig.destinationType)}
               />
             </div>
           </div>
@@ -122,7 +125,7 @@ function CdcDetails({ createdAt, mirrorConfig, mirrorStatus }: props) {
             </div>
             <div>
               <Label variant='body'>
-                {RowDataFormatter(0) /* TODO rows synced */}
+                {RowDataFormatter(mirrorConfig.rowsSynced)}
               </Label>
             </div>
           </div>
@@ -145,8 +148,7 @@ const SyncIntervalLabel: React.FC<{ syncInterval?: number }> = ({
 
   if (!syncInterval) {
     return <ProgressCircle variant='determinate_progress_circle' />;
-  }
-  if (syncInterval >= 3600) {
+  } else if (syncInterval >= 3600) {
     const hours = Math.floor(syncInterval / 3600);
     formattedInterval = `${hours} hour${hours !== 1 ? 's' : ''}`;
   } else if (syncInterval >= 60) {
@@ -158,5 +160,3 @@ const SyncIntervalLabel: React.FC<{ syncInterval?: number }> = ({
 
   return <Label>{formattedInterval}</Label>;
 };
-
-export default CdcDetails;

--- a/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdcDetails.tsx
@@ -5,7 +5,7 @@ import PeerButton from '@/components/PeerComponent';
 import TimeLabel from '@/components/TimeComponent';
 import { FlowStatus } from '@/grpc_generated/flow';
 import { dBTypeFromJSON } from '@/grpc_generated/peers';
-import { CDCBatch, CDCMirrorStatus } from '@/grpc_generated/route';
+import { CDCMirrorStatus } from '@/grpc_generated/route';
 import { Label } from '@/lib/Label';
 import { ProgressCircle } from '@/lib/ProgressCircle';
 import Link from 'next/link';
@@ -16,20 +16,12 @@ import { RowDataFormatter } from './rowsDisplay';
 import TablePairs from './tablePairs';
 
 type props = {
-  syncs: CDCBatch[];
   mirrorConfig: CDCMirrorStatus;
   createdAt?: Date;
   mirrorStatus: FlowStatus;
 };
-function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
+function CdcDetails({ createdAt, mirrorConfig, mirrorStatus }: props) {
   const [syncInterval, getSyncInterval] = useState<number>();
-
-  let rowsSynced = syncs.reduce((acc, sync) => {
-    if (sync.endTime !== null) {
-      return acc + Number(sync.numRows);
-    }
-    return acc;
-  }, 0);
 
   const tablesSynced = mirrorConfig.config?.tableMappings;
   useEffect(() => {
@@ -129,7 +121,9 @@ function CdcDetails({ syncs, createdAt, mirrorConfig, mirrorStatus }: props) {
               </Label>
             </div>
             <div>
-              <Label variant='body'>{RowDataFormatter(rowsSynced)}</Label>
+              <Label variant='body'>
+                {RowDataFormatter(0) /* TODO rows synced */}
+              </Label>
             </div>
           </div>
 

--- a/ui/app/mirrors/[mirrorId]/cdcGraph.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdcGraph.tsx
@@ -29,9 +29,6 @@ export default function CdcGraph({ mirrorName }: CdcGraphProps) {
 
       const res = await fetch('/api/v1/mirrors/cdc/graph', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
         cache: 'no-store',
         body: JSON.stringify(req),
       });

--- a/ui/app/mirrors/[mirrorId]/cdcGraph.tsx
+++ b/ui/app/mirrors/[mirrorId]/cdcGraph.tsx
@@ -1,39 +1,31 @@
 'use client';
 import SelectTheme from '@/app/styles/select';
-import {
-  formatGraphLabel,
-  TimeAggregateTypes,
-  timeOptions,
-} from '@/app/utils/graph';
-import { CDCBatch } from '@/grpc_generated/route';
+import { TimeAggregateTypes, timeOptions } from '@/app/utils/graph';
 import { Label } from '@/lib/Label';
 import { BarChart } from '@tremor/react';
 import { useMemo, useState } from 'react';
 import ReactSelect from 'react-select';
-import aggregateCountsByInterval from './aggregatedCountsByInterval';
 
-type CdcGraphProps = {
-  syncs: CDCBatch[];
-};
+type CdcGraphProps = {};
 
-function CdcGraph({ syncs }: CdcGraphProps) {
+function CdcGraph({}: CdcGraphProps) {
   let [aggregateType, setAggregateType] = useState<TimeAggregateTypes>(
     TimeAggregateTypes.HOUR
   );
 
   const graphValues = useMemo(() => {
+    return []; /* TODO
     const rows = syncs.map((sync) => ({
       timestamp: sync.endTime,
       count: sync.numRows,
     }));
     let timedRowCounts = aggregateCountsByInterval(rows, aggregateType);
-    timedRowCounts = timedRowCounts.slice(0, 29);
-    timedRowCounts = timedRowCounts.reverse();
+    timedRowCounts = timedRowCounts.slice(0, 29).reverse();
     return timedRowCounts.map((count) => ({
       name: formatGraphLabel(new Date(count[0]), aggregateType),
       'Rows synced at a point in time': Number(count[1]),
-    }));
-  }, [syncs, aggregateType]);
+    })); */
+  }, [aggregateType]);
 
   return (
     <div>

--- a/ui/app/mirrors/[mirrorId]/handlers.ts
+++ b/ui/app/mirrors/[mirrorId]/handlers.ts
@@ -12,6 +12,7 @@ export const getMirrorState = async (
     body: JSON.stringify({
       flow_job_name,
       include_flow_info: true,
+      exclude_batches: true,
     }),
   });
   if (!res.ok) throw res.json();

--- a/ui/app/mirrors/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/page.tsx
@@ -53,7 +53,6 @@ export default function ViewMirror({ params: { mirrorId } }: EditMirrorProps) {
   if (mirrorState?.cdcStatus) {
     syncStatusChild = (
       <SyncStatus
-        rows={mirrorState.cdcStatus.cdcBatches}
         flowJobName={mirrorId}
       />
     );
@@ -94,7 +93,6 @@ export default function ViewMirror({ params: { mirrorId } }: EditMirrorProps) {
           {actionsDropdown}
         </div>
         <CDCMirror
-          rows={mirrorState.cdcStatus.cdcBatches}
           syncStatusChild={syncStatusChild}
           status={mirrorState}
         />

--- a/ui/app/mirrors/[mirrorId]/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/page.tsx
@@ -51,11 +51,7 @@ export default function ViewMirror({ params: { mirrorId } }: EditMirrorProps) {
   let actionsDropdown = null;
 
   if (mirrorState?.cdcStatus) {
-    syncStatusChild = (
-      <SyncStatus
-        flowJobName={mirrorId}
-      />
-    );
+    syncStatusChild = <SyncStatus flowJobName={mirrorId} />;
 
     const dbType = dBTypeFromJSON(mirrorState.cdcStatus.destinationType);
 
@@ -92,10 +88,7 @@ export default function ViewMirror({ params: { mirrorId } }: EditMirrorProps) {
           <Header variant='title2'>{mirrorId}</Header>
           {actionsDropdown}
         </div>
-        <CDCMirror
-          syncStatusChild={syncStatusChild}
-          status={mirrorState}
-        />
+        <CDCMirror syncStatusChild={syncStatusChild} status={mirrorState} />
       </LayoutMain>
     );
   } else if (mirrorState?.qrepStatus) {

--- a/ui/app/mirrors/[mirrorId]/qrepGraph.tsx
+++ b/ui/app/mirrors/[mirrorId]/qrepGraph.tsx
@@ -17,22 +17,20 @@ type QRepGraphProps = {
 };
 
 function QrepGraph({ syncs }: QRepGraphProps) {
-  let [aggregateType, setAggregateType] = useState<TimeAggregateTypes>(
+  const [aggregateType, setAggregateType] = useState<TimeAggregateTypes>(
     TimeAggregateTypes.HOUR
   );
   const initialCount: [string, number][] = [];
-  let [counts, setCounts] = useState(initialCount);
+  const [counts, setCounts] = useState(initialCount);
 
   useEffect(() => {
-    let rows = syncs.map((sync) => ({
+    const rows = syncs.map((sync) => ({
       timestamp: sync.startTime!,
       count: Number(sync.rowsInPartition) ?? 0,
     }));
 
-    let counts = aggregateCountsByInterval(rows, aggregateType);
-    counts = counts.slice(0, 29);
-    counts = counts.reverse();
-    setCounts(counts);
+    const counts = aggregateCountsByInterval(rows, aggregateType);
+    setCounts(counts.slice(0, 29).reverse());
   }, [aggregateType, syncs]);
 
   return (

--- a/ui/app/mirrors/[mirrorId]/syncStatus.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatus.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { fetcher } from '@/app/utils/swr';
-import { CDCBatch, CDCTableTotalCountsResponse } from '@/grpc_generated/route';
+import { CDCTableTotalCountsResponse } from '@/grpc_generated/route';
 import useSWR from 'swr';
 import CdcGraph from './cdcGraph';
 import RowsDisplay from './rowsDisplay';
@@ -9,10 +9,9 @@ import TableStats from './tableStats';
 
 type SyncStatusProps = {
   flowJobName: string;
-  rows: CDCBatch[];
 };
 
-export default function SyncStatus({ flowJobName, rows }: SyncStatusProps) {
+export default function SyncStatus({ flowJobName }: SyncStatusProps) {
   const {
     data: tableStats,
     error,
@@ -31,9 +30,9 @@ export default function SyncStatus({ flowJobName, rows }: SyncStatusProps) {
       <div>
         <RowsDisplay totalRowsData={tableStats.totalData} />
         <div className='my-10'>
-          <CdcGraph syncs={rows} />
+          <CdcGraph />
         </div>
-        <SyncStatusTable rows={rows} />
+        <SyncStatusTable />
         <TableStats tableSyncs={tableStats.tablesData} />
       </div>
     )

--- a/ui/app/mirrors/[mirrorId]/syncStatus.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatus.tsx
@@ -32,7 +32,7 @@ export default function SyncStatus({ flowJobName }: SyncStatusProps) {
         <div className='my-10'>
           <CdcGraph />
         </div>
-        <SyncStatusTable />
+        <SyncStatusTable mirrorName={flowJobName} />
         <TableStats tableSyncs={tableStats.tablesData} />
       </div>
     )

--- a/ui/app/mirrors/[mirrorId]/syncStatus.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatus.tsx
@@ -30,7 +30,7 @@ export default function SyncStatus({ flowJobName }: SyncStatusProps) {
       <div>
         <RowsDisplay totalRowsData={tableStats.totalData} />
         <div className='my-10'>
-          <CdcGraph />
+          <CdcGraph mirrorName={flowJobName} />
         </div>
         <SyncStatusTable mirrorName={flowJobName} />
         <TableStats tableSyncs={tableStats.tablesData} />

--- a/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
@@ -11,7 +11,6 @@ import { Button } from '@/lib/Button';
 import { Icon } from '@/lib/Icon';
 import { Label } from '@/lib/Label';
 import { ProgressCircle } from '@/lib/ProgressCircle';
-import { SearchField } from '@/lib/SearchField';
 import { Table, TableCell, TableRow } from '@/lib/Table';
 import moment from 'moment';
 import { useCallback, useEffect, useState } from 'react';
@@ -62,7 +61,6 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
 
   const [totalPages, setTotalPages] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
-  const [searchQuery, setSearchQuery] = useState(-1);
   const [descending, setDescending] = useState(false);
   const [[beforeId, afterId], setBeforeAfterId] = useState([-1, -1]);
   const [batches, setBatches] = useState<CDCBatch[]>([]);
@@ -72,7 +70,7 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
       const req: GetCDCBatchesRequest = {
         flowJobName: mirrorName,
         limit: ROWS_PER_PAGE,
-        // TODO descending, sortField, searchQuery
+        // TODO descending, sortField
         beforeId: beforeId,
         afterId: afterId,
       };
@@ -91,7 +89,7 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
     };
 
     fetchData();
-  }, [mirrorName, descending, sortField, searchQuery, beforeId, afterId]);
+  }, [mirrorName, descending, sortField, beforeId, afterId]);
 
   const nextPage = useCallback(() => {
     if (batches.length === 0) {
@@ -163,14 +161,6 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
               <Icon name='arrow_downward' />
             </button>
           </div>
-        ),
-        right: (
-          <SearchField
-            placeholder='Search by batch ID'
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setSearchQuery(+e.target.value)
-            }
-          />
         ),
       }}
       header={

--- a/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
@@ -63,9 +63,6 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
       };
       const res = await fetch('/api/v1/mirrors/cdc/batches', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
         cache: 'no-store',
         body: JSON.stringify(req),
       });

--- a/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
@@ -76,17 +76,14 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
         beforeId: beforeId,
         afterId: afterId,
       };
-      const res = await fetch(
-        `/api/v1/mirrors/cdc/batches/${encodeURIComponent(mirrorName)}`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          cache: 'no-store',
-          body: JSON.stringify(req),
-        }
-      );
+      const res = await fetch(`/api/v1/mirrors/cdc/batches`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-store',
+        body: JSON.stringify(req),
+      });
       const data: GetCDCBatchesResponse = await res.json();
       setBatches(data.cdcBatches);
       setCurrentPage(data.page);
@@ -100,11 +97,13 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
     if (batches.length === 0) {
       setBeforeAfterId([-1, -1]);
     }
+    setBeforeAfterId([batches[batches.length - 1].batchId, -1]);
   }, [batches]);
   const prevPage = useCallback(() => {
     if (batches.length === 0 || currentPage < 3) {
       setBeforeAfterId([-1, -1]);
     }
+    setBeforeAfterId([-1, batches[0].batchId]);
   }, [batches, currentPage]);
 
   return (

--- a/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
@@ -76,7 +76,7 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
     };
 
     fetchData();
-  }, [mirrorName, beforeId, afterId]);
+  }, [mirrorName, beforeId, afterId, ascending]);
 
   const nextPage = useCallback(() => {
     if (batches.length === 0) {
@@ -86,7 +86,7 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
     } else {
       setBeforeAfterId([batches[batches.length - 1].batchId, -1]);
     }
-  }, [batches]);
+  }, [batches, ascending]);
   const prevPage = useCallback(() => {
     if (batches.length === 0 || currentPage < 3) {
       setBeforeAfterId([-1, ascending ? 0 : -1]);
@@ -95,7 +95,7 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
     } else {
       setBeforeAfterId([-1, batches[0].batchId]);
     }
-  }, [batches, currentPage]);
+  }, [batches, ascending, currentPage]);
 
   return (
     <Table

--- a/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
@@ -56,17 +56,14 @@ const sortOptions = [
 ];
 
 export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
-  const [currentPage, setCurrentPage] = useState(1);
   const [sortField, setSortField] = useState<
     'startTime' | 'endTime' | 'numRows' | 'batchId'
   >('batchId');
 
-  const [sortDir, setSortDir] = useState<'asc' | 'dsc'>('dsc');
-  const [totalPages, setTotalPages] = useState(1); // TODO Math.ceil(rows.length / ROWS_PER_PAGE);
+  const [totalPages, setTotalPages] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
-  const [searchQuery, setSearchQuery] = useState(NaN);
+  const [searchQuery, setSearchQuery] = useState(-1);
   const [descending, setDescending] = useState(false);
-  const [sortBy, setSortBy] = useState('id');
   const [[beforeId, afterId], setBeforeAfterId] = useState([-1, -1]);
   const [batches, setBatches] = useState<CDCBatch[]>([]);
 
@@ -75,11 +72,12 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
       const req: GetCDCBatchesRequest = {
         flowJobName: mirrorName,
         limit: ROWS_PER_PAGE,
+        // TODO descending, sortField, searchQuery
         beforeId: beforeId,
         afterId: afterId,
       };
       const res = await fetch(
-        `/api/v1/mirrors/cdc/batches/${encodeURIComponent(flowJobName)}`,
+        `/api/v1/mirrors/cdc/batches/${encodeURIComponent(mirrorName)}`,
         {
           method: 'POST',
           headers: {
@@ -90,14 +88,13 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
         }
       );
       const data: GetCDCBatchesResponse = await res.json();
-      const numPages = Math.ceil(data.total / req.limit);
       setBatches(data.cdcBatches);
       setCurrentPage(data.page);
-      setTotalPages(numPages);
+      setTotalPages(Math.ceil(data.total / req.limit));
     };
 
     fetchData();
-  });
+  }, [mirrorName, descending, sortField, searchQuery, beforeId, afterId]);
 
   const nextPage = useCallback(() => {
     if (batches.length === 0) {
@@ -152,17 +149,17 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
             </div>
             <button
               className='IconButton'
-              onClick={() => setSortDir('asc')}
+              onClick={() => setDescending(false)}
               aria-label='sort up'
-              style={{ color: sortDir == 'asc' ? 'green' : 'gray' }}
+              style={{ color: descending ? 'gray' : 'green' }}
             >
               <Icon name='arrow_upward' />
             </button>
             <button
               className='IconButton'
-              onClick={() => setSortDir('dsc')}
+              onClick={() => setDescending(true)}
               aria-label='sort down'
-              style={{ color: sortDir == 'dsc' ? 'green' : 'gray' }}
+              style={{ color: descending ? 'green' : 'gray' }}
             >
               <Icon name='arrow_downward' />
             </button>

--- a/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
@@ -76,7 +76,7 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
         beforeId: beforeId,
         afterId: afterId,
       };
-      const res = await fetch(`/api/v1/mirrors/cdc/batches`, {
+      const res = await fetch('/api/v1/mirrors/cdc/batches', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
@@ -14,9 +14,7 @@ import { useMemo, useState } from 'react';
 import ReactSelect from 'react-select';
 import { RowDataFormatter } from './rowsDisplay';
 
-type SyncStatusTableProps = {
-  rows: CDCBatch[];
-};
+type SyncStatusTableProps = {};
 
 function TimeWithDurationOrRunning({
   startTime,
@@ -53,16 +51,18 @@ const sortOptions = [
   { value: 'numRows', label: 'Rows Synced' },
 ];
 
-export const SyncStatusTable = ({ rows }: SyncStatusTableProps) => {
+export const SyncStatusTable = ({}: SyncStatusTableProps) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [sortField, setSortField] = useState<
     'startTime' | 'endTime' | 'numRows' | 'batchId'
   >('batchId');
 
   const [sortDir, setSortDir] = useState<'asc' | 'dsc'>('dsc');
-  const totalPages = Math.ceil(rows.length / ROWS_PER_PAGE);
+  const totalPages = 0; // TODO Math.ceil(rows.length / ROWS_PER_PAGE);
   const [searchQuery, setSearchQuery] = useState(NaN);
-  const displayedRows = useMemo(() => {
+  const displayedRows: CDCBatch[] = useMemo(() => {
+    return [];
+    /* TODO
     const searchRows = rows.filter((row) => row.batchId == searchQuery);
     const shownRows = searchRows.length > 0 ? searchRows : rows;
     shownRows.sort((a, b) => {
@@ -89,8 +89,8 @@ export const SyncStatusTable = ({ rows }: SyncStatusTableProps) => {
     const endRow = startRow + ROWS_PER_PAGE;
     return shownRows.length > ROWS_PER_PAGE
       ? shownRows.slice(startRow, endRow)
-      : shownRows;
-  }, [searchQuery, currentPage, rows, sortField, sortDir]);
+      : shownRows; */
+  }, [searchQuery, currentPage, sortField, sortDir]);
 
   const handlePrevPage = () => {
     if (currentPage > 1) {

--- a/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
+++ b/ui/app/mirrors/[mirrorId]/syncStatusTable.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import SelectTheme from '@/app/styles/select';
 import TimeLabel from '@/components/TimeComponent';
 import {
   CDCBatch,
@@ -14,7 +13,6 @@ import { ProgressCircle } from '@/lib/ProgressCircle';
 import { Table, TableCell, TableRow } from '@/lib/Table';
 import moment from 'moment';
 import { useCallback, useEffect, useState } from 'react';
-import ReactSelect from 'react-select';
 import { RowDataFormatter } from './rowsDisplay';
 
 type SyncStatusTableProps = { mirrorName: string };
@@ -47,18 +45,7 @@ function TimeWithDurationOrRunning({
 }
 
 const ROWS_PER_PAGE = 5;
-const sortOptions = [
-  { value: 'batchId', label: 'Batch ID' },
-  { value: 'startTime', label: 'Start Time' },
-  { value: 'endTime', label: 'End Time' },
-  { value: 'numRows', label: 'Rows Synced' },
-];
-
 export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
-  const [sortField, setSortField] = useState<
-    'startTime' | 'endTime' | 'numRows' | 'batchId'
-  >('batchId');
-
   const [totalPages, setTotalPages] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
   const [ascending, setAscending] = useState(false);
@@ -70,7 +57,6 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
       const req: GetCDCBatchesRequest = {
         flowJobName: mirrorName,
         limit: ROWS_PER_PAGE,
-        // TODO sortField
         beforeId: beforeId,
         afterId: afterId,
         ascending,
@@ -90,7 +76,7 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
     };
 
     fetchData();
-  }, [mirrorName, sortField, beforeId, afterId]);
+  }, [mirrorName, beforeId, afterId]);
 
   const nextPage = useCallback(() => {
     if (batches.length === 0) {
@@ -130,27 +116,6 @@ export const SyncStatusTable = ({ mirrorName }: SyncStatusTableProps) => {
             >
               <Icon name='refresh' />
             </Button>
-            <div style={{ minWidth: '10em' }}>
-              <ReactSelect
-                options={sortOptions}
-                value={{
-                  value: sortField,
-                  label: sortOptions.find((opt) => opt.value === sortField)
-                    ?.label,
-                }}
-                onChange={(val, _) => {
-                  const sortVal =
-                    (val?.value as
-                      | 'startTime'
-                      | 'endTime'
-                      | 'numRows'
-                      | 'batchId') ?? 'batchId';
-                  setSortField(sortVal);
-                }}
-                defaultValue={{ value: 'batchId', label: 'Batch ID' }}
-                theme={SelectTheme}
-              />
-            </div>
             <button
               className='IconButton'
               onClick={() => {

--- a/ui/app/peers/[peerName]/lagGraph.tsx
+++ b/ui/app/peers/[peerName]/lagGraph.tsx
@@ -22,7 +22,7 @@ function parseLSN(lsn: string): number {
   if (!lsn) return 0;
   const [lsn1, lsn2] = lsn.split('/');
   return Number(
-    (BigInt(parseInt(lsn1)) << BigInt(32)) | BigInt(parseInt(lsn2))
+    (BigInt(parseInt(lsn1, 16)) << BigInt(32)) | BigInt(parseInt(lsn2, 16))
   );
 }
 
@@ -135,7 +135,7 @@ export default function LagGraph({ peerName }: LagGraphProps) {
         />
         <input
           type='button'
-          value={showLsn ? 'Show LSN' : 'Show Lag'}
+          value={showLsn ? 'Show Lag' : 'Show LSN'}
           onClick={() => setShowLsn((val) => !val)}
         />
         <ReactSelect
@@ -159,7 +159,7 @@ export default function LagGraph({ peerName }: LagGraphProps) {
           categories={
             showLsn ? ['redoLSN', 'restartLSN', 'confirmedLSN'] : ['Lag in GB']
           }
-          colors={showLsn ? ['maroon', 'red', 'lime'] : ['rose']}
+          colors={showLsn ? ['orange', 'red', 'lime'] : ['rose']}
           showXAxis={false}
         />
       )}

--- a/ui/app/settings/page.tsx
+++ b/ui/app/settings/page.tsx
@@ -123,9 +123,6 @@ const DynamicSettingItem = ({
     const updatedSetting = { ...setting, value: newValue };
     await fetch('/api/v1/dynamic_settings', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
       body: JSON.stringify(updatedSetting),
     });
     setEditMode(false);

--- a/ui/components/LogsTable.tsx
+++ b/ui/components/LogsTable.tsx
@@ -69,9 +69,6 @@ export default function LogsTable({
       try {
         const response = await fetch('/api/v1/mirrors/logs', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
           cache: 'no-store',
           body: JSON.stringify(req),
         });


### PR DESCRIPTION
Some customers have enough batches now that response size was exceeding grpc limit

Changing this meant loading pages & aggregating graph data on server

Removed searching specific batch id & changing sort column from ui