### PR TITLE
CH Sorting Key: Introduce sorting key expression

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -233,7 +233,11 @@ func getOrderedOrderByColumns(
 
 	orderbyColumns := make([]string, len(orderby))
 	for idx, col := range orderby {
-		orderbyColumns[idx] = getColName(colNameMap, col.SourceName)
+		sortingKeyName := col.SourceName
+		if col.SortingKeyExpression != nil && *col.SortingKeyExpression != "" {
+			sortingKeyName = *col.SortingKeyExpression
+		}
+		orderbyColumns[idx] = getColName(colNameMap, sortingKeyName)
 	}
 
 	return orderbyColumns

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -16,6 +16,7 @@ message ColumnSetting {
   string destination_type = 3;
   int32 ordering = 4;
   bool nullable_enabled = 5;
+  optional string sorting_key_expression = 6;
 }
 
 message TableMapping {


### PR DESCRIPTION
This PR introduces the backend to support specifying sorting keys such as `function(column)` Ex: toDate(updated_at)