### PR TITLE
Add more information logs for UI logs table

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -531,6 +531,8 @@ func (a *FlowableActivity) GetQRepPartitions(ctx context.Context,
 		}
 	}
 
+	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, fmt.Sprintf("obtained partitions for table %s", config.WatermarkTable))
+
 	return &protos.QRepParitionResult{
 		Partitions: partitions,
 	}, nil
@@ -657,6 +659,8 @@ func (a *FlowableActivity) DropFlowSource(ctx context.Context, req *protos.DropF
 		return pullCleanupErr
 	}
 
+	a.Alerter.LogFlowInfo(ctx, req.FlowJobName, "Cleaned up source peer replication objects. Any replication slot or publication created by PeerDB has been removed.")
+
 	return nil
 }
 
@@ -675,6 +679,8 @@ func (a *FlowableActivity) DropFlowDestination(ctx context.Context, req *protos.
 			exceptions.NewDropFlowError(fmt.Errorf("[DropFlowDestination] failed to clean up destination: %w", err)),
 		)
 	}
+
+	a.Alerter.LogFlowInfo(ctx, req.FlowJobName, "Cleaned up destination peer replication objects. Any PeerDB metadata storage has been dropped.")
 
 	return nil
 }
@@ -1016,6 +1022,8 @@ func (a *FlowableActivity) RenameTables(ctx context.Context, config *protos.Rena
 		}
 	}
 
+	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, "Resync completed for all tables")
+
 	return renameOutput, tx.Commit(ctx)
 }
 
@@ -1093,6 +1101,9 @@ func (a *FlowableActivity) AddTablesToPublication(ctx context.Context, cfg *prot
 	}); err != nil {
 		return a.Alerter.LogFlowError(ctx, cfg.FlowJobName, err)
 	}
+
+	a.Alerter.LogFlowInfo(ctx, cfg.FlowJobName, fmt.Sprintf("ensured %d tables exist in publication %s",
+		len(additionalTableMappings), cfg.PublicationName))
 	return nil
 }
 
@@ -1115,6 +1126,9 @@ func (a *FlowableActivity) RemoveTablesFromPublication(
 	}); err != nil {
 		return a.Alerter.LogFlowError(ctx, cfg.FlowJobName, err)
 	}
+
+	a.Alerter.LogFlowInfo(ctx, cfg.FlowJobName, fmt.Sprintf("removed %d tables from publication %s",
+		len(removedTablesMapping), cfg.PublicationName))
 	return nil
 }
 

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -251,9 +251,8 @@ func (a *FlowableActivity) CreateNormalizedTable(
 	if err != nil {
 		return nil, err
 	}
-	numTablesToSetup.Store(int32(len(tableNameSchemaMapping)))
 
-	a.Alerter.LogFlowInfo(ctx, config.FlowName, "Setting up destination tables")
+	numTablesToSetup.Store(int32(len(tableNameSchemaMapping)))
 	tableExistsMapping := make(map[string]bool, len(tableNameSchemaMapping))
 	for tableIdentifier, tableSchema := range tableNameSchemaMapping {
 		existing, err := conn.SetupNormalizedTable(

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -597,7 +597,7 @@ func (a *FlowableActivity) ReplicateQRepPartitions(ctx context.Context,
 		}
 	}
 
-	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, fmt.Sprintf("replicated all rows for table %s", config.DestinationTableIdentifier))
+	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, fmt.Sprintf("replicated all rows to destination for table %s", config.DestinationTableIdentifier))
 	return nil
 }
 

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -599,7 +599,7 @@ func (a *FlowableActivity) ReplicateQRepPartitions(ctx context.Context,
 		}
 	}
 
-	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, fmt.Sprintf("replicated all rows to destination for table %s", config.DestinationTableIdentifier))
+	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, "replicated all rows to destination for table "+config.DestinationTableIdentifier)
 	return nil
 }
 

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -277,7 +277,6 @@ func (a *FlowableActivity) CreateNormalizedTable(
 		} else {
 			logger.Info("table already exists " + tableIdentifier)
 		}
-
 	}
 
 	if err := conn.FinishSetupNormalizedTables(ctx, tx); err != nil {
@@ -533,7 +532,7 @@ func (a *FlowableActivity) GetQRepPartitions(ctx context.Context,
 		}
 	}
 
-	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, fmt.Sprintf("obtained partitions for table %s", config.WatermarkTable))
+	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, "obtained partitions for table "+config.WatermarkTable)
 
 	return &protos.QRepParitionResult{
 		Partitions: partitions,
@@ -661,7 +660,7 @@ func (a *FlowableActivity) DropFlowSource(ctx context.Context, req *protos.DropF
 		return pullCleanupErr
 	}
 
-	a.Alerter.LogFlowInfo(ctx, req.FlowJobName, "Cleaned up source peer replication objects. Any replication slot or publication created by PeerDB has been removed.")
+	a.Alerter.LogFlowInfo(ctx, req.FlowJobName, "Cleaned up source peer replication objects.")
 
 	return nil
 }
@@ -682,7 +681,8 @@ func (a *FlowableActivity) DropFlowDestination(ctx context.Context, req *protos.
 		)
 	}
 
-	a.Alerter.LogFlowInfo(ctx, req.FlowJobName, "Cleaned up destination peer replication objects. Any PeerDB metadata storage has been dropped.")
+	a.Alerter.LogFlowInfo(ctx, req.FlowJobName,
+		"Cleaned up destination peer replication objects. Any metadata storage has been dropped.")
 
 	return nil
 }

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -230,6 +230,7 @@ func (a *FlowableActivity) CreateNormalizedTable(
 
 	logger := internal.LoggerFromCtx(ctx)
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowName)
+	a.Alerter.LogFlowInfo(ctx, config.FlowName, "Setting up destination tables")
 	conn, err := connectors.GetByNameAs[connectors.NormalizedTablesConnector](ctx, config.Env, a.CatalogPool, config.PeerName)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
@@ -252,6 +253,7 @@ func (a *FlowableActivity) CreateNormalizedTable(
 	}
 	numTablesToSetup.Store(int32(len(tableNameSchemaMapping)))
 
+	a.Alerter.LogFlowInfo(ctx, config.FlowName, "Setting up destination tables")
 	tableExistsMapping := make(map[string]bool, len(tableNameSchemaMapping))
 	for tableIdentifier, tableSchema := range tableNameSchemaMapping {
 		existing, err := conn.SetupNormalizedTable(

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -271,14 +271,18 @@ func (a *FlowableActivity) CreateNormalizedTable(
 		numTablesSetup.Add(1)
 		if !existing {
 			logger.Info("created table " + tableIdentifier)
+			a.Alerter.LogFlowInfo(ctx, config.FlowName, "created table "+tableIdentifier+" in destination")
 		} else {
 			logger.Info("table already exists " + tableIdentifier)
 		}
+
 	}
 
 	if err := conn.FinishSetupNormalizedTables(ctx, tx); err != nil {
 		return nil, fmt.Errorf("failed to commit normalized tables tx: %w", err)
 	}
+
+	a.Alerter.LogFlowInfo(ctx, config.FlowName, "All destination tables have been setup")
 
 	return &protos.SetupNormalizedTableBatchOutput{
 		TableExistsMapping: tableExistsMapping,
@@ -593,6 +597,7 @@ func (a *FlowableActivity) ReplicateQRepPartitions(ctx context.Context,
 		}
 	}
 
+	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, fmt.Sprintf("replicated all rows for table %s", config.DestinationTableIdentifier))
 	return nil
 }
 

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -93,7 +94,7 @@ func (a *FlowableActivity) applySchemaDeltas(
 				for _, addedColumn := range schemaDelta.AddedColumns {
 					a.Alerter.LogFlowInfo(ctx, config.FlowJobName,
 						fmt.Sprintf("added column %s of type %s (nullable: %s) to table %s",
-							addedColumn.Name, addedColumn.Type, fmt.Sprintf("%t", addedColumn.Nullable), schemaDelta.DstTableName))
+							addedColumn.Name, addedColumn.Type, strconv.FormatBool(addedColumn.Nullable), schemaDelta.DstTableName))
 				}
 			}
 			filteredTableMappings = append(filteredTableMappings, tableMapping)

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -84,19 +83,19 @@ func (a *FlowableActivity) applySchemaDeltas(
 	schemaDeltas []*protos.TableSchemaDelta,
 ) error {
 	filteredTableMappings := make([]*protos.TableMapping, 0, len(schemaDeltas))
-	for i, tableMapping := range options.TableMappings {
+	for _, tableMapping := range options.TableMappings {
 		if slices.ContainsFunc(schemaDeltas, func(schemaDelta *protos.TableSchemaDelta) bool {
 			return schemaDelta.SrcTableName == tableMapping.SourceTableIdentifier &&
 				schemaDelta.DstTableName == tableMapping.DestinationTableIdentifier
 		}) {
-			schemaDelta := schemaDeltas[i]
-			if len(schemaDelta.AddedColumns) > 0 {
-				for _, addedColumn := range schemaDelta.AddedColumns {
-					a.Alerter.LogFlowInfo(ctx, config.FlowJobName,
-						fmt.Sprintf("added column %s of type %s (nullable: %s) to destination table %s",
-							addedColumn.Name, addedColumn.Type, strconv.FormatBool(addedColumn.Nullable), schemaDelta.DstTableName))
-				}
-			}
+			// schemaDelta := schemaDeltas[i]
+			// if len(schemaDelta.AddedColumns) > 0 {
+			// 	for _, addedColumn := range schemaDelta.AddedColumns {
+			// 		a.Alerter.LogFlowInfo(ctx, config.FlowJobName,
+			// 			fmt.Sprintf("added column %s of type %s (nullable: %s) to destination table %s",
+			// 				addedColumn.Name, addedColumn.Type, strconv.FormatBool(addedColumn.Nullable), schemaDelta.DstTableName))
+			// 	}
+			// }
 			filteredTableMappings = append(filteredTableMappings, tableMapping)
 		}
 	}

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -227,6 +227,11 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 			return nil, fmt.Errorf("failed to sync schema: %w", err)
 		}
 
+		numberOfSchemaChanges := len(recordBatchSync.SchemaDeltas)
+		if numberOfSchemaChanges > 0 {
+			a.Alerter.LogFlowInfo(ctx, flowName, fmt.Sprintf("synced %d schema changes from source to destination", numberOfSchemaChanges))
+		}
+
 		return nil, a.applySchemaDeltas(ctx, config, options, recordBatchSync.SchemaDeltas)
 	}
 
@@ -312,7 +317,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		}
 	}
 
-	pushedRecordsWithCount := fmt.Sprintf("pushed %d records for batch %d in %v",
+	pushedRecordsWithCount := fmt.Sprintf("pushed %d records into intermediate storage for batch %d in %v",
 		res.NumRecordsSynced, res.CurrentSyncBatchID, syncDuration.Truncate(time.Second))
 	a.Alerter.LogFlowInfo(ctx, flowName, pushedRecordsWithCount)
 

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -317,7 +317,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		}
 	}
 
-	pushedRecordsWithCount := fmt.Sprintf("pushed %d records into intermediate storage for batch %d in %v",
+	pushedRecordsWithCount := fmt.Sprintf("stored %d records into intermediate storage for batch %d in %v",
 		res.NumRecordsSynced, res.CurrentSyncBatchID, syncDuration.Truncate(time.Second))
 	a.Alerter.LogFlowInfo(ctx, flowName, pushedRecordsWithCount)
 

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -235,11 +235,6 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 			return nil, fmt.Errorf("failed to sync schema: %w", err)
 		}
 
-		// numberOfSchemaChanges := len(recordBatchSync.SchemaDeltas)
-		// if numberOfSchemaChanges > 0 {
-		// 	a.Alerter.LogFlowInfo(ctx, flowName, fmt.Sprintf("synced %d schema changes from source to destination", numberOfSchemaChanges))
-		// }
-
 		return nil, a.applySchemaDeltas(ctx, config, options, recordBatchSync.SchemaDeltas)
 	}
 

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -93,7 +93,7 @@ func (a *FlowableActivity) applySchemaDeltas(
 			if len(schemaDelta.AddedColumns) > 0 {
 				for _, addedColumn := range schemaDelta.AddedColumns {
 					a.Alerter.LogFlowInfo(ctx, config.FlowJobName,
-						fmt.Sprintf("added column %s of type %s (nullable: %s) to table %s",
+						fmt.Sprintf("added column %s of type %s (nullable: %s) to destination table %s",
 							addedColumn.Name, addedColumn.Type, strconv.FormatBool(addedColumn.Nullable), schemaDelta.DstTableName))
 				}
 			}

--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -58,7 +58,7 @@ func (a *SnapshotActivity) SetupReplication(
 ) (*protos.SetupReplicationOutput, error) {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
 	logger := internal.LoggerFromCtx(ctx)
-
+	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, "Setting up replication slot and publication")
 	a.Alerter.LogFlowEvent(ctx, config.FlowJobName, "Started Snapshot Flow Job")
 
 	conn, err := connectors.GetByNameAs[connectors.CDCPullConnectorCore](ctx, nil, a.CatalogPool, config.PeerName)
@@ -89,6 +89,8 @@ func (a *SnapshotActivity) SetupReplication(
 		snapshotName: slotInfo.SnapshotName,
 		connector:    conn,
 	}
+
+	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, "Replication slot and publication setup complete")
 
 	return &protos.SetupReplicationOutput{
 		SlotName:         slotInfo.SlotName,


### PR DESCRIPTION
Currently the only information logs we store in catalog is "pushed x records"
It is important for us to show users more than just that

Note that this PR pertains to the logs table in UI. It has nothing to do with alerting

This PR logs info about some key moments during replication:
- Setting up of target tables
- Setup of replication slot and publication
- Replication of all partitions in QRep/Initial load
- Schema changes
- Resync completion
- Source cleanup of drop flow
- Destination cleanup of drop flow
- Removal of tables from publication
- Addition of tables from publication

- [x] Functional test