### PR TITLE
Implement table rename with atomic exchange

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -196,7 +196,7 @@ func (c *ClickHouseConnector) RenameTables(
 
 			// target table exists, so we can attempt to swap.
 			// in most (all) cases, we will have
-			c.logger.Info("attempting atomic exchange %s to %s", renameRequest.CurrentName, renameRequest.NewName)
+			c.logger.Info(fmt.Sprintf("attempting atomic exchange '%s' to '%s'", renameRequest.CurrentName, renameRequest.NewName))
 			// the clickhouse ATOMIC engine supports a special query to exchange two tables
 			// this means, we can have dependent (materialized) views and dictionaries on these tables.
 			if err = c.execWithLogging(ctx, fmt.Sprintf("EXCHANGE TABLES %s and %s", renameRequest.NewName, renameRequest.CurrentName)); err == nil {

--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -192,8 +192,11 @@ func (c *ClickHouseConnector) RenameTables(
 
 			// target table exists, so we can attempt to swap. In most cases, we will have Atomic engine,
 			// which supports a special query to exchange two tables, allowing dependent (materialized) views and dictionaries on these tables
-			c.logger.Info("attempting atomic exchange", slog.String("OldName", renameRequest.CurrentName), slog.String("NewName", renameRequest.NewName))
-			if err = c.execWithLogging(ctx, fmt.Sprintf("EXCHANGE TABLES %s and %s", renameRequest.NewName, renameRequest.CurrentName)); err == nil {
+			c.logger.Info("attempting atomic exchange",
+				slog.String("OldName", renameRequest.CurrentName), slog.String("NewName", renameRequest.NewName))
+			if err = c.execWithLogging(ctx,
+				fmt.Sprintf("EXCHANGE TABLES %s and %s", renameRequest.NewName, renameRequest.CurrentName),
+			); err == nil {
 				if err := c.execWithLogging(ctx, fmt.Sprintf(dropTableIfExistsSQL, renameRequest.CurrentName)); err != nil {
 					return nil, fmt.Errorf("unable to drop exchanged table %s: %w", renameRequest.CurrentName, err)
 				}
@@ -211,12 +214,15 @@ func (c *ClickHouseConnector) RenameTables(
 				return nil, fmt.Errorf("unable to drop table %s: %w", renameRequest.NewName, err)
 			}
 
-			if err := c.execWithLogging(ctx, fmt.Sprintf("RENAME TABLE %s TO %s", renameRequest.CurrentName, renameRequest.NewName)); err != nil {
+			if err := c.execWithLogging(ctx,
+				fmt.Sprintf("RENAME TABLE %s TO %s", renameRequest.CurrentName, renameRequest.NewName),
+			); err != nil {
 				return nil, fmt.Errorf("unable to rename table %s to %s: %w", renameRequest.CurrentName, renameRequest.NewName, err)
 			}
 		}
 
-		c.logger.Info("successfully renamed table", slog.String("OldName", renameRequest.CurrentName), slog.String("NewName", renameRequest.NewName))
+		c.logger.Info("successfully renamed table",
+			slog.String("OldName", renameRequest.CurrentName), slog.String("NewName", renameRequest.NewName))
 	}
 
 	return &protos.RenameTablesOutput{

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -29,12 +29,11 @@ import (
 
 type ClickHouseConnector struct {
 	*metadataStore.PostgresMetadata
-	database           clickhouse.Conn
-	dbSupportsExchange bool
-	logger             log.Logger
-	config             *protos.ClickhouseConfig
-	credsProvider      *utils.ClickHouseS3Credentials
-	s3Stage            *ClickHouseS3Stage
+	database      clickhouse.Conn
+	logger        log.Logger
+	config        *protos.ClickhouseConfig
+	credsProvider *utils.ClickHouseS3Credentials
+	s3Stage       *ClickHouseS3Stage
 }
 
 func ValidateS3(ctx context.Context, creds *utils.ClickHouseS3Credentials) error {
@@ -115,8 +114,7 @@ func (c *ClickHouseConnector) ValidateCheck(ctx context.Context) error {
 	if err := c.exec(ctx,
 		fmt.Sprintf("EXCHANGE TABLES %s AND %s", validateDummyTableName, validateDummyTableName2),
 	); err != nil {
-		c.logger.Warn("failed to run exchange tables on the database, will fall back to drop/rename", "err", err)
-		c.dbSupportsExchange = false
+		c.logger.Warn("failed to run exchange tables on the database, will fall back to drop/rename", "error", err)
 	}
 
 	// add a column
@@ -209,13 +207,12 @@ func NewClickHouseConnector(
 	}
 
 	connector := &ClickHouseConnector{
-		database:           database,
-		PostgresMetadata:   pgMetadata,
-		dbSupportsExchange: true,
-		config:             config,
-		logger:             logger,
-		credsProvider:      &clickHouseS3CredentialsNew,
-		s3Stage:            NewClickHouseS3Stage(),
+		database:         database,
+		PostgresMetadata: pgMetadata,
+		config:           config,
+		logger:           logger,
+		credsProvider:    &clickHouseS3CredentialsNew,
+		s3Stage:          NewClickHouseS3Stage(),
 	}
 
 	if credentials.AWS.SessionToken != "" {


### PR DESCRIPTION
Currently, peerdb creates a _resync table and then tries to run 

```sql
DROP TABLE IF EXISTS target_table;
RENAME TABLE _resync_table TO target_table;
```

however, the problem is that this procedure breaks, once a depending dictionary is defined on these tables.

In order to enable such behavior, this PR modifies the ClickhouseConnector of Flow to 

- check whether the database engine supports the `EXCHANGE TABLES` command (https://clickhouse.com/docs/en/sql-reference/statements/exchange)
- If it does and the table already existed, runs `EXCHANGE TABLES` followed by a `DROP` which atomically swaps and therefore keeps the dictionary references
- If it doesnt, there's a fallback to the old method.

Currently, this will work with the Atomic() database engine.