### PR TITLE
fix: temporal admin tools image version

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -95,7 +95,7 @@ services:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CLI_ADDRESS=temporal:7233
       - TEMPORAL_CLI_SHOW_STACKS=1
-    image: temporalio/admin-tools:1.25
+    image: temporalio/admin-tools:1.25.2-tctl-1.18.1-cli-1.1.1
     stdin_open: true
     tty: true
     entrypoint: /etc/temporal/entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CLI_ADDRESS=temporal:7233
       - TEMPORAL_CLI_SHOW_STACKS=1
-    image: temporalio/admin-tools:1.25
+    image: temporalio/admin-tools:1.25.2-tctl-1.18.1-cli-1.1.1
     stdin_open: true
     tty: true
     entrypoint: /etc/temporal/entrypoint.sh


### PR DESCRIPTION
Image exists, but not tested, should be fine