### PR TITLE
QRep Overwrite Mode: introduce full refresh code path

### DIFF
--- a/flow/peerdbenv/dynamicconf.go
+++ b/flow/peerdbenv/dynamicconf.go
@@ -92,6 +92,13 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
+		Name:         "PEERDB_FULL_REFRESH_OVERWRITE_MODE",
+		Description:  "Enables full refresh mode for query replication mirrors of overwrite type",
+		DefaultValue: "false",
+		ValueType:    protos.DynconfValueType_BOOL,
+		ApplyMode:    protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
+	},
+	{
 		Name:             "PEERDB_NULLABLE",
 		Description:      "Propagate nullability in schema",
 		DefaultValue:     "false",
@@ -368,6 +375,10 @@ func PeerDBWALHeartbeatQuery(ctx context.Context, env map[string]string) (string
 
 func PeerDBEnableParallelSyncNormalize(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_ENABLE_PARALLEL_SYNC_NORMALIZE")
+}
+
+func PeerDBFullRefreshOverwriteMode(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_FULL_REFRESH_OVERWRITE_MODE")
 }
 
 func PeerDBNullable(ctx context.Context, env map[string]string) (bool, error) {

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -461,8 +461,13 @@ func QRepWaitForNewRowsWorkflow(ctx workflow.Context, config *protos.QRepConfig,
 		return fmt.Errorf("error checking for new rows: %w", err)
 	}
 
+	optedForOverwrite := config.WriteMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE
+	fullRefresh := false
+	if optedForOverwrite {
+		fullRefresh = getQRepOverwriteFullRefreshMode(ctx, logger, config.Env)
+	}
 	// If no new rows are found, continue as new
-	if !hasNewRows {
+	if !hasNewRows || fullRefresh {
 		waitBetweenBatches := 5 * time.Second
 		if config.WaitBetweenBatchesSeconds > 0 {
 			waitBetweenBatches = time.Duration(config.WaitBetweenBatchesSeconds) * time.Second
@@ -473,6 +478,9 @@ func QRepWaitForNewRowsWorkflow(ctx workflow.Context, config *protos.QRepConfig,
 		}
 
 		logger.Info("QRepWaitForNewRowsWorkflow: continuing the loop")
+		if fullRefresh {
+			return nil
+		}
 		return workflow.NewContinueAsNewError(ctx, QRepWaitForNewRowsWorkflow, config, lastPartition)
 	}
 
@@ -545,8 +553,17 @@ func QRepFlowWorkflow(
 		return state, err
 	}
 
-	if !config.InitialCopyOnly && state.LastPartition != nil {
-		if err := q.waitForNewRows(ctx, signalChan, state.LastPartition); err != nil {
+	fullRefresh := false
+	optedForOverwrite := config.WriteMode.WriteType == protos.QRepWriteType_QREP_WRITE_MODE_OVERWRITE
+	lastPartition := state.LastPartition
+	if optedForOverwrite {
+		if fullRefresh = getQRepOverwriteFullRefreshMode(ctx, q.logger, config.Env); fullRefresh {
+			lastPartition = InitialLastPartition
+		}
+	}
+
+	if !config.InitialCopyOnly && lastPartition != nil {
+		if err := q.waitForNewRows(ctx, signalChan, lastPartition); err != nil {
 			return state, err
 		}
 	}
@@ -580,7 +597,7 @@ func QRepFlowWorkflow(
 		q.logger.Info(fmt.Sprintf("%d partitions processed", len(partitions.Partitions)))
 		state.NumPartitionsProcessed += uint64(len(partitions.Partitions))
 
-		if len(partitions.Partitions) > 0 {
+		if len(partitions.Partitions) > 0 && !fullRefresh {
 			state.LastPartition = partitions.Partitions[len(partitions.Partitions)-1]
 		}
 	}

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -32,13 +32,15 @@ type QRepPartitionFlowExecution struct {
 	runUUID         string
 }
 
+var InitialLastPartition = &protos.QRepPartition{
+	PartitionId: "not-applicable-partition",
+	Range:       nil,
+}
+
 // returns a new empty QRepFlowState
 func newQRepFlowState() *protos.QRepFlowState {
 	return &protos.QRepFlowState{
-		LastPartition: &protos.QRepPartition{
-			PartitionId: "not-applicable-partition",
-			Range:       nil,
-		},
+		LastPartition:          InitialLastPartition,
 		NumPartitionsProcessed: 0,
 		NeedsResync:            true,
 		CurrentFlowStatus:      protos.FlowStatus_STATUS_RUNNING,


### PR DESCRIPTION
Currently overwrite mode in query replication has the following behaviour:
Before new rows are synced, truncate the destination table

This PR introduces a dynconf-gated (default false) full refresh mode which if enabled, has the same behaviour as above but pulls the entire data from the source table at every wait time interval