### PR TITLE
add dynamic config to adjust s3 part size

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -88,7 +88,7 @@ func (c *ClickHouseConnector) syncRecordsViaAvro(
 	}
 
 	avroSyncer := c.avroSyncMethod(req.FlowJobName)
-	numRecords, err := avroSyncer.SyncRecords(ctx, stream, req.FlowJobName, syncBatchID)
+	numRecords, err := avroSyncer.SyncRecords(ctx, req.Env, stream, req.FlowJobName, syncBatchID)
 	if err != nil {
 		return nil, err
 	}

--- a/flow/connectors/s3/qrep.go
+++ b/flow/connectors/s3/qrep.go
@@ -25,7 +25,7 @@ func (c *S3Connector) SyncQRepRecords(
 		return 0, err
 	}
 
-	numRecords, err := c.writeToAvroFile(ctx, stream, avroSchema, partition.PartitionId, config.FlowJobName)
+	numRecords, err := c.writeToAvroFile(ctx, config.Env, stream, avroSchema, partition.PartitionId, config.FlowJobName)
 	if err != nil {
 		return 0, err
 	}
@@ -47,6 +47,7 @@ func getAvroSchema(
 
 func (c *S3Connector) writeToAvroFile(
 	ctx context.Context,
+	env map[string]string,
 	stream *model.QRecordStream,
 	avroSchema *model.QRecordAvroSchemaDefinition,
 	partitionID string,
@@ -60,7 +61,7 @@ func (c *S3Connector) writeToAvroFile(
 	s3AvroFileKey := fmt.Sprintf("%s/%s/%s.avro", s3o.Prefix, jobName, partitionID)
 
 	writer := avro.NewPeerDBOCFWriter(stream, avroSchema, avro.CompressNone, protos.DBType_SNOWFLAKE)
-	avroFile, err := writer.WriteRecordsToS3(ctx, s3o.Bucket, s3AvroFileKey, c.credentialsProvider)
+	avroFile, err := writer.WriteRecordsToS3(ctx, env, s3o.Bucket, s3AvroFileKey, c.credentialsProvider)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write records to S3: %w", err)
 	}

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -423,8 +423,7 @@ func (c *SnowflakeConnector) SyncRecords(ctx context.Context, req *model.SyncRec
 		return nil, err
 	}
 
-	err = c.FinishBatch(ctx, req.FlowJobName, req.SyncBatchID, res.LastSyncedCheckpointID)
-	if err != nil {
+	if err := c.FinishBatch(ctx, req.FlowJobName, req.SyncBatchID, res.LastSyncedCheckpointID); err != nil {
 		return nil, err
 	}
 
@@ -456,7 +455,7 @@ func (c *SnowflakeConnector) syncRecordsViaAvro(
 		return nil, err
 	}
 
-	numRecords, err := avroSyncer.SyncRecords(ctx, destinationTableSchema, stream, req.FlowJobName)
+	numRecords, err := avroSyncer.SyncRecords(ctx, req.Env, destinationTableSchema, stream, req.FlowJobName)
 	if err != nil {
 		return nil, err
 	}

--- a/flow/connectors/utils/avro/avro_writer.go
+++ b/flow/connectors/utils/avro/avro_writer.go
@@ -215,7 +215,12 @@ func (p *peerDBOCFWriter) WriteRecordsToS3(
 		numRows, writeOcfError = p.WriteOCF(ctx, w)
 	}()
 
-	_, err = manager.NewUploader(s3svc).Upload(ctx, &s3.PutObjectInput{
+	// Create the uploader using the AWS SDK v2 manager
+	uploader := manager.NewUploader(s3svc, func(u *manager.Uploader) {
+		u.PartSize = 500 * 1024 * 1024 // Set part size to 500 MB
+	})
+
+	_, err = uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(key),
 		Body:   r,

--- a/flow/connectors/utils/avro/avro_writer.go
+++ b/flow/connectors/utils/avro/avro_writer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/PeerDB-io/peer-flow/connectors/utils"
 	"github.com/PeerDB-io/peer-flow/generated/protos"
 	"github.com/PeerDB-io/peer-flow/model"
+	"github.com/PeerDB-io/peer-flow/peerdbenv"
 	"github.com/PeerDB-io/peer-flow/shared"
 )
 
@@ -187,7 +188,11 @@ func (p *peerDBOCFWriter) WriteOCF(ctx context.Context, w io.Writer) (int, error
 }
 
 func (p *peerDBOCFWriter) WriteRecordsToS3(
-	ctx context.Context, bucketName, key string, s3Creds utils.AWSCredentialsProvider,
+	ctx context.Context,
+	env map[string]string,
+	bucketName string,
+	key string,
+	s3Creds utils.AWSCredentialsProvider,
 ) (*AvroFile, error) {
 	logger := shared.LoggerFromCtx(ctx)
 	s3svc, err := utils.CreateS3Client(ctx, s3Creds)
@@ -215,17 +220,23 @@ func (p *peerDBOCFWriter) WriteRecordsToS3(
 		numRows, writeOcfError = p.WriteOCF(ctx, w)
 	}()
 
+	partSize, err := peerdbenv.PeerDBS3PartSize(ctx, env)
+	if err != nil {
+		return nil, fmt.Errorf("could not get s3 part size config: %w", err)
+	}
+
 	// Create the uploader using the AWS SDK v2 manager
 	uploader := manager.NewUploader(s3svc, func(u *manager.Uploader) {
-		u.PartSize = 500 * 1024 * 1024 // Set part size to 500 MB
+		if partSize > 0 {
+			u.PartSize = partSize
+		}
 	})
 
-	_, err = uploader.Upload(ctx, &s3.PutObjectInput{
+	if _, err := uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(key),
 		Body:   r,
-	})
-	if err != nil {
+	}); err != nil {
 		s3Path := "s3://" + bucketName + "/" + key
 		logger.Error("failed to upload file", slog.Any("error", err), slog.String("s3_path", s3Path))
 		return nil, fmt.Errorf("failed to upload file: %w", err)

--- a/flow/peerdbenv/dynamicconf.go
+++ b/flow/peerdbenv/dynamicconf.go
@@ -117,6 +117,14 @@ DROP AGGREGATE PEERDB_EPHEMERAL_HEARTBEAT(float4); END;`,
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 	{
+		Name:             "PEERDB_S3_PART_SIZE",
+		Description:      "S3 upload part size, may need to increase for large batches",
+		DefaultValue:     "0",
+		ValueType:        protos.DynconfValueType_INT,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_ALL,
+	},
+	{
 		Name:             "PEERDB_QUEUE_FORCE_TOPIC_CREATION",
 		Description:      "Force auto topic creation in mirrors, applies to Kafka and PubSub mirrors",
 		DefaultValue:     "false",
@@ -338,6 +346,10 @@ func PeerDBSnowflakeMergeParallelism(ctx context.Context, env map[string]string)
 
 func PeerDBClickHouseAWSS3BucketName(ctx context.Context, env map[string]string) (string, error) {
 	return dynLookup(ctx, env, "PEERDB_CLICKHOUSE_AWS_S3_BUCKET_NAME")
+}
+
+func PeerDBS3PartSize(ctx context.Context, env map[string]string) (int64, error) {
+	return dynamicConfSigned[int64](ctx, env, "PEERDB_S3_PART_SIZE")
 }
 
 // Kafka has topic auto create as an option, auto.create.topics.enable


### PR DESCRIPTION
fixes #2184 where a user with a large enough batch hit

```
failed to sync records: failed to write records to S3: failed to upload file to path
s3://peerdb-cache/...... 4890f21240e1.avro.zst:
upload multipart failed, upload id: OTA0ZTE5NTMtMTdiMi00MWE5LWJhY.....,
cause: exceeded total allowed configured MaxUploadParts (10000). Adjust PartSize to fit in this limit
```

s3 defaults to 5MiB part sizes, this user was able to fix their upload by changing that to 500MiB