### PR TITLE
Revamp settings page

### DIFF
--- a/ui/app/settings/page.tsx
+++ b/ui/app/settings/page.tsx
@@ -239,7 +239,7 @@ const SettingsPage = () => {
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(2, 1fr)',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
           gap: '16px',
         }}
       >


### PR DESCRIPTION
This PR opts for a card grid display for the settings page rather than a table - as the content was being cramped in to fit in that tabular layout

![Screenshot 2024-11-21 at 6 49 06 PM](https://github.com/user-attachments/assets/08b43cf7-83e7-4c5d-91f2-afc4aacff2de)
