### PR TITLE
CH Normalize: fix error return

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -474,7 +474,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		case queries <- insertIntoSelectQuery.String():
 		case <-errCtx.Done():
 			close(queries)
-			return nil, ctx.Err()
+			return nil, errCtx.Err()
 		}
 	}
 	close(queries)


### PR DESCRIPTION
This PR fixes a bug where we are returning the wrong error object resulting in flow-worker panics