### PR TITLE
Fix slot guage

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1215,6 +1215,10 @@ func (c *PostgresConnector) HandleSlotInfo(
 	logger.Info(fmt.Sprintf("Checking %s lag for %s", alertKeys.SlotName, alertKeys.PeerName),
 		slog.Float64("LagInMB", float64(slotInfo[0].LagInMb)))
 	alerter.AlertIfSlotLag(ctx, alertKeys, slotInfo[0])
+	if slotMetricGauges.SlotLagGauge == nil {
+		logger.Warn("warning: slotMetricGauges.SlotLagGauge is nil")
+		return nil
+	}
 	slotMetricGauges.SlotLagGauge.Record(ctx, float64(slotInfo[0].LagInMb), metric.WithAttributeSet(attribute.NewSet(
 		attribute.String(otel_metrics.FlowNameKey, alertKeys.FlowName),
 		attribute.String(otel_metrics.PeerNameKey, alertKeys.PeerName),


### PR DESCRIPTION
There seems to be an issue where RecordSlotSize panics in this line with nil pointer dereference
As far as I can see the only thing that can be nil is `slotMetricGauges.SlotLagGauge` 