### PR TITLE
Otel: initialise int64counter

### DIFF
--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -168,6 +168,7 @@ func WorkerSetup(opts *WorkerSetupOptions) (*workerSetupResponse, error) {
 			Meter:              metricsProvider.Meter("io.peerdb.flow-worker"),
 			Float64GaugesCache: make(map[string]metric.Float64Gauge),
 			Int64GaugesCache:   make(map[string]metric.Int64Gauge),
+			Int64CountersCache: make(map[string]metric.Int64Counter),
 		}
 	}
 	w.RegisterActivity(&activities.FlowableActivity{


### PR DESCRIPTION
Currently flow-worker panics due to assignment to nil map entry at the getOrInitMetric call in the int64 counter because the map is nil