### PR TITLE
E2E: retry slot drop in cleanup if active pid

### DIFF
--- a/flow/e2e/congen.go
+++ b/flow/e2e/congen.go
@@ -27,7 +27,7 @@ func cleanPostgres(conn *pgx.Conn, suffix string) error {
 	// drop all open slots with the given suffix
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
-	deadline := time.Now().Add(2 * time.Minute)
+	deadline := time.Now().Add(1 * time.Minute)
 	for {
 		_, err := conn.Exec(
 			context.Background(),


### PR DESCRIPTION
Trying to remove flakiness of E2E tests observed in recent PRs caused by postgres cleanup failures due to active PID. This PR retries dropping slot every 10 seconds with a deadline of 1 minute