### PR TITLE
feat(clickhouse): add default precision/scale for numeric columns

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -82,6 +82,12 @@ func getColName(overrides map[string]string, name string) string {
 }
 
 func getClickhouseTypeForNumericColumn(column *protos.FieldDescription) string {
+	if column.TypeModifier == -1 {
+		// use default precision and scale when unset.
+		precision, scale := datatypes.ClickHouseNumericCompatibility{}.DefaultPrecisionAndScale()
+		return fmt.Sprintf("Decimal(%d, %d)", precision, scale)
+	}
+
 	rawPrecision, _ := datatypes.ParseNumericTypmod(column.TypeModifier)
 	if rawPrecision > datatypes.PeerDBClickHouseMaxPrecision {
 		return "String"


### PR DESCRIPTION
When TypeModifier is -1 (unset), use default precision and scale values from ClickHouseNumericCompatibility instead of raw values. This ensures numeric columns have appropriate precision/scale settings even when not explicitly specified.