### PR TITLE
Handle syncing UUID arrays into BQ

### DIFF
--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -45,7 +45,7 @@ func (m *mergeStmtGenerator) generateFlattenedCTE(dstTable string, normalizedTab
 		case qvalue.QValueKindArrayFloat32, qvalue.QValueKindArrayFloat64, qvalue.QValueKindArrayInt16,
 			qvalue.QValueKindArrayInt32, qvalue.QValueKindArrayInt64, qvalue.QValueKindArrayString,
 			qvalue.QValueKindArrayBoolean, qvalue.QValueKindArrayTimestamp, qvalue.QValueKindArrayTimestampTZ,
-			qvalue.QValueKindArrayDate:
+			qvalue.QValueKindArrayDate, qvalue.QValueKindArrayUUID:
 			castStmt = fmt.Sprintf("ARRAY(SELECT CAST(element AS %s) FROM "+
 				"UNNEST(CAST(JSON_VALUE_ARRAY(_peerdb_data, '$.%s') AS ARRAY<STRING>)) AS element WHERE element IS NOT null) AS `%s`",
 				bqTypeString, column.Name, shortCol)

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -402,6 +402,8 @@ func QValueToAvro(
 		return c.processArrayDate(v.Val), nil
 	case QValueUUID:
 		return c.processUUID(v.Val), nil
+	case QValueArrayUUID:
+		return c.processArrayUUID(v.Val), nil
 	case QValueGeography, QValueGeometry, QValuePoint:
 		return c.processGeospatial(v.Value().(string)), nil
 	default:
@@ -612,6 +614,19 @@ func (c *QValueAvroConverter) processUUID(byteData uuid.UUID) interface{} {
 		return goavro.Union("string", uuidString)
 	}
 	return uuidString
+}
+
+func (c *QValueAvroConverter) processArrayUUID(arrayData []uuid.UUID) interface{} {
+	UUIDData := make([]string, 0, len(arrayData))
+	for _, uuid := range arrayData {
+		UUIDData = append(UUIDData, uuid.String())
+	}
+
+	if c.Nullable {
+		return goavro.Union("array", UUIDData)
+	}
+
+	return UUIDData
 }
 
 func (c *QValueAvroConverter) processGeospatial(geoString string) interface{} {


### PR DESCRIPTION
Building on top of #2327 there are some missing pieces required to sync this data into BQ

Have tested these changes locally
![image](https://github.com/user-attachments/assets/81d97117-91f7-40c9-8cfc-5c7b5c65a35f)


Using this setup
```sh
#!/usr/bin/env bash
set -xeuo pipefail

# This script creates databases on the PeerDB internal cluster to be used as peers later.

CONNECTION_STRING="${1:-postgres://postgres:postgres@localhost:9901/postgres}"

if ! type psql >/dev/null 2>&1; then
  echo "psql not found on PATH, exiting"
  exit 1
fi

psql "$CONNECTION_STRING" << EOF

--- Create the databases
DROP DATABASE IF EXISTS source;
CREATE DATABASE source;
DROP DATABASE IF EXISTS target;
CREATE DATABASE target;

--- Switch to source database
\c source

CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- Create the source table
DROP TABLE IF EXISTS source CASCADE;
CREATE TABLE source (
    id uuid DEFAULT uuid_generate_v4(),
    related_ids uuid[],
    PRIMARY KEY (id)
);

CREATE PUBLICATION source_publication FOR TABLE source;

-- insert mock rows into source with valid uuid values
-- INSERT INTO source (related_ids) VALUES (ARRAY[uuid_generate_v4(), uuid_generate_v4()]);

-- Switch to target database
\c target

EOF

```