### PR TITLE
TSTZRange: Account for infinity modifier

### DIFF
--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/netip"
 	"strings"
@@ -345,9 +344,7 @@ func parseFieldFromQValueKind(qvalueKind qvalue.QValueKind, value interface{}) (
 
 		return qvalue.QValueString{Val: string(intervalJSON)}, nil
 	case qvalue.QValueKindTSTZRange:
-		slog.Info("tstzrangeValue", slog.Any("value", value))
 		tstzrangeObject := value.(pgtype.Range[interface{}])
-		slog.Info("tstzrangeObject", slog.Any("object", tstzrangeObject))
 		lowerBoundType := tstzrangeObject.LowerType
 		upperBoundType := tstzrangeObject.UpperType
 		lowerTime, err := convertTimeRangeBound(tstzrangeObject.Lower)

--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/netip"
 	"strings"
@@ -344,7 +345,9 @@ func parseFieldFromQValueKind(qvalueKind qvalue.QValueKind, value interface{}) (
 
 		return qvalue.QValueString{Val: string(intervalJSON)}, nil
 	case qvalue.QValueKindTSTZRange:
+		slog.Info("tstzrangeValue", slog.Any("value", value))
 		tstzrangeObject := value.(pgtype.Range[interface{}])
+		slog.Info("tstzrangeObject", slog.Any("object", tstzrangeObject))
 		lowerBoundType := tstzrangeObject.LowerType
 		upperBoundType := tstzrangeObject.UpperType
 		lowerTime, err := convertTimeRangeBound(tstzrangeObject.Lower)
@@ -584,18 +587,22 @@ func customTypeToQKind(typeName string) qvalue.QValueKind {
 // in tstzrange.
 // convertTimeRangeBound removes the +0000 UTC part
 func convertTimeRangeBound(timeBound interface{}) (string, error) {
-	layout := "2006-01-02 15:04:05 -0700 MST"
-	postgresFormat := "2006-01-02 15:04:05"
 	var convertedTime string
-	if timeBound != nil {
-		lowerParsed, err := time.Parse(layout, fmt.Sprint(timeBound))
-		if err != nil {
-			return "", fmt.Errorf("unexpected lower bound value in tstzrange. Error: %v", err)
+	switch timeBound := timeBound.(type) {
+	case pgtype.InfinityModifier:
+		return timeBound.String(), nil
+	default:
+		layout := "2006-01-02 15:04:05 -0700 MST"
+		postgresFormat := "2006-01-02 15:04:05"
+		if timeBound != nil {
+			lowerParsed, err := time.Parse(layout, fmt.Sprint(timeBound))
+			if err != nil {
+				return "", fmt.Errorf("unexpected lower bound value in tstzrange. Error: %v", err)
+			}
+			convertedTime = lowerParsed.Format(postgresFormat)
+		} else {
+			convertedTime = ""
 		}
-		convertedTime = lowerParsed.Format(postgresFormat)
-	} else {
-		convertedTime = ""
 	}
-
 	return convertedTime, nil
 }

--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -594,7 +594,7 @@ func convertTimeRangeBound(timeBound interface{}) (string, error) {
 		if timeBound != nil {
 			lowerParsed, err := time.Parse(layout, fmt.Sprint(timeBound))
 			if err != nil {
-				return "", fmt.Errorf("unexpected lower bound value in tstzrange. Error: %v", err)
+				return "", fmt.Errorf("unexpected bound value in tstzrange. Error: %v", err)
 			}
 			convertedTime = lowerParsed.Format(postgresFormat)
 		} else {

--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -584,22 +584,18 @@ func customTypeToQKind(typeName string) qvalue.QValueKind {
 // in tstzrange.
 // convertTimeRangeBound removes the +0000 UTC part
 func convertTimeRangeBound(timeBound interface{}) (string, error) {
-	var convertedTime string
-	switch timeBound := timeBound.(type) {
-	case pgtype.InfinityModifier:
+	if timeBound, isInfinite := timeBound.(pgtype.InfinityModifier); isInfinite {
 		return timeBound.String(), nil
-	default:
-		layout := "2006-01-02 15:04:05 -0700 MST"
-		postgresFormat := "2006-01-02 15:04:05"
-		if timeBound != nil {
-			lowerParsed, err := time.Parse(layout, fmt.Sprint(timeBound))
-			if err != nil {
-				return "", fmt.Errorf("unexpected bound value in tstzrange. Error: %v", err)
-			}
-			convertedTime = lowerParsed.Format(postgresFormat)
-		} else {
-			convertedTime = ""
-		}
 	}
-	return convertedTime, nil
+
+	layout := "2006-01-02 15:04:05 -0700 MST"
+	postgresFormat := "2006-01-02 15:04:05"
+	if timeBound != nil {
+		lowerParsed, err := time.Parse(layout, fmt.Sprint(timeBound))
+		if err != nil {
+			return "", fmt.Errorf("unexpected bound value in tstzrange. Error: %v", err)
+		}
+		return lowerParsed.Format(postgresFormat), nil
+	}
+	return "", nil
 }


### PR DESCRIPTION
We need to explicity deal with infinity/-infinity tstzrange values as time.Parse cannot parse those