### PR TITLE
ci: only run BQ on pg16 & SF on pg17

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -178,3 +178,4 @@ jobs:
           PEERDB_CATALOG_DATABASE: postgres
           PEERDB_QUEUE_FORCE_TOPIC_CREATION: "true"
           ELASTICSEARCH_TEST_ADDRESS: http://localhost:9200
+          CI_PG_VERSION: ${{ matrix.postgres-version }}

--- a/flow/e2e/bigquery/bigquery.go
+++ b/flow/e2e/bigquery/bigquery.go
@@ -103,8 +103,7 @@ func SetupSuite(t *testing.T) PeerFlowE2ETestSuiteBQ {
 		t.Fatalf("Failed to create helper: %v", err)
 	}
 
-	err = bqHelper.RecreateDataset()
-	if err != nil {
+	if err := bqHelper.RecreateDataset(); err != nil {
 		t.Fatalf("Failed to recreate dataset: %v", err)
 	}
 

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -20,6 +21,10 @@ import (
 )
 
 func TestPeerFlowE2ETestSuiteBQ(t *testing.T) {
+	if val, ok := os.LookupEnv("CI_PG_VERSION"); ok && val != "16" {
+		t.Skip("Only running in PG16 to reduce flakiness from high concurrency")
+	}
+
 	e2eshared.RunSuite(t, SetupSuite)
 }
 

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -3,6 +3,7 @@ package e2e_snowflake
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -17,6 +18,10 @@ import (
 )
 
 func TestPeerFlowE2ETestSuiteSF(t *testing.T) {
+	if val, ok := os.LookupEnv("CI_PG_VERSION"); ok && val != "17" {
+		t.Skip("Only running in PG17 to reduce flakiness from high concurrency")
+	}
+
 	e2eshared.RunSuite(t, SetupSuite)
 }
 


### PR DESCRIPTION
BQ was being more flaky after matrix added. Limit concurrency on external services