### PR TITLE
drop mirror: ignore `cannot execute DROP PUBLICATION in a read-only transaction (SQLSTATE 25006)`

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1153,7 +1153,9 @@ func (c *PostgresConnector) PullFlowCleanup(ctx context.Context, jobName string)
 	}
 
 	if publicationExists {
-		if _, err := c.conn.Exec(ctx, "DROP PUBLICATION IF EXISTS "+publicationName); err != nil {
+		if _, err := c.conn.Exec(
+			ctx, "DROP PUBLICATION IF EXISTS "+publicationName,
+		); err != nil && !shared.IsSQLStateError(err, pgerrcode.ReadOnlySQLTransaction) {
 			return fmt.Errorf("error dropping publication: %w", err)
 		}
 	}


### PR DESCRIPTION
still report this as an error during validation