### PR TITLE
Change initial back-off interval for sync-flow to be 30s

### DIFF
--- a/flow/workflows/sync_flow.go
+++ b/flow/workflows/sync_flow.go
@@ -68,6 +68,9 @@ func SyncFlowWorkflow(
 		StartToCloseTimeout: 7 * 24 * time.Hour,
 		HeartbeatTimeout:    time.Minute,
 		WaitForCancellation: true,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval: 30 * time.Second,
+		},
 	})
 	for !stop && ctx.Err() == nil {
 		var syncDone bool


### PR DESCRIPTION
This makes max back-off closer to 1 hour and also prevents alert spam.