### PR TITLE
LSN Fetch for stats: Make it non-fatal for null LSN

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -436,12 +436,8 @@ func pullCore[Items model.Items](
 	latestLSN, err := c.getCurrentLSN(ctx)
 	if err != nil {
 		c.logger.Error("error getting current LSN", slog.Any("error", err))
-		return fmt.Errorf("failed to get current LSN: %w", err)
-	}
-
-	if err := monitoring.UpdateLatestLSNAtSourceForCDCFlow(ctx, catalogPool, req.FlowJobName, int64(latestLSN)); err != nil {
+	} else if err := monitoring.UpdateLatestLSNAtSourceForCDCFlow(ctx, catalogPool, req.FlowJobName, int64(latestLSN)); err != nil {
 		c.logger.Error("error updating latest LSN at source for CDC flow", slog.Any("error", err))
-		return fmt.Errorf("failed to update latest LSN at source for CDC flow: %w", err)
 	}
 
 	return nil

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -435,6 +435,8 @@ func pullCore[Items model.Items](
 
 	latestLSN, err := c.getCurrentLSN(ctx)
 	if err != nil {
+		// There are cases where the pg_is_in_recovery() returns null - in read replicas for instance
+		// Since this is just a monitoring metric, we can ignore the error
 		c.logger.Error("error getting current LSN", slog.Any("error", err))
 	} else if err := monitoring.UpdateLatestLSNAtSourceForCDCFlow(ctx, catalogPool, req.FlowJobName, int64(latestLSN)); err != nil {
 		c.logger.Error("error updating latest LSN at source for CDC flow", slog.Any("error", err))


### PR DESCRIPTION
Follow-up to https://github.com/PeerDB-io/peerdb/pull/2372

Since this function is just for recording in a stat table, the error can just be logged.