### PR TITLE
[snapshot] close stream when fail to get srcConn in errgroup

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -47,6 +47,10 @@ type FlowableActivity struct {
 	OtelManager *otel_metrics.OtelManager
 }
 
+type StreamCloser interface {
+	Close(error)
+}
+
 func (a *FlowableActivity) CheckConnection(
 	ctx context.Context,
 	config *protos.SetupInput,

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -387,7 +387,7 @@ func (a *FlowableActivity) getPostgresPeerConfigs(ctx context.Context) ([]*proto
 }
 
 // replicateQRepPartition replicates a QRepPartition from the source to the destination.
-func replicateQRepPartition[TRead any, TWrite any, TSync connectors.QRepSyncConnectorCore, TPull connectors.QRepPullConnectorCore](
+func replicateQRepPartition[TRead any, TWrite model.StreamCloser, TSync connectors.QRepSyncConnectorCore, TPull connectors.QRepPullConnectorCore](
 	ctx context.Context,
 	a *FlowableActivity,
 	config *protos.QRepConfig,
@@ -440,6 +440,7 @@ func replicateQRepPartition[TRead any, TWrite any, TSync connectors.QRepSyncConn
 		srcConn, err := connectors.GetByNameAs[TPull](ctx, config.Env, a.CatalogPool, config.SourceName)
 		if err != nil {
 			a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
+			stream.Close(err)
 			return fmt.Errorf("failed to get qrep source connector: %w", err)
 		}
 		defer connectors.CloseConnector(ctx, srcConn)

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -387,7 +387,7 @@ func (a *FlowableActivity) getPostgresPeerConfigs(ctx context.Context) ([]*proto
 }
 
 // replicateQRepPartition replicates a QRepPartition from the source to the destination.
-func replicateQRepPartition[TRead any, TWrite model.StreamCloser, TSync connectors.QRepSyncConnectorCore, TPull connectors.QRepPullConnectorCore](
+func replicateQRepPartition[TRead any, TWrite StreamCloser, TSync connectors.QRepSyncConnectorCore, TPull connectors.QRepPullConnectorCore](
 	ctx context.Context,
 	a *FlowableActivity,
 	config *protos.QRepConfig,

--- a/flow/model/qrecord_stream.go
+++ b/flow/model/qrecord_stream.go
@@ -4,6 +4,10 @@ import (
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 )
 
+type StreamCloser interface {
+	Close(error)
+}
+
 type QRecordStream struct {
 	schemaLatch chan struct{}
 	Records     chan []qvalue.QValue

--- a/flow/model/qrecord_stream.go
+++ b/flow/model/qrecord_stream.go
@@ -4,10 +4,6 @@ import (
 	"github.com/PeerDB-io/peer-flow/model/qvalue"
 )
 
-type StreamCloser interface {
-	Close(error)
-}
-
 type QRecordStream struct {
 	schemaLatch chan struct{}
 	Records     chan []qvalue.QValue


### PR DESCRIPTION
if pull connector fails to initialize due to some reason and sync is already stuck on `chan receive`, then partClone workflow will hang indefinitely. fixed by closing stream explicitly before pull side errgroup goroutine returns.