### PR TITLE
fix: use condition instead of coalesce for updates on cdc_batches

### DIFF
--- a/flow/connectors/utils/monitoring/monitoring.go
+++ b/flow/connectors/utils/monitoring/monitoring.go
@@ -97,8 +97,8 @@ func UpdateEndTimeForCDCBatch(
 ) error {
 	_, err := pool.Exec(ctx,
 		`UPDATE peerdb_stats.cdc_batches
-		SET end_time = COALESCE(end_time, NOW())
-		WHERE flow_name = $1 AND batch_id <= $2`,
+		SET end_time = NOW()
+		WHERE flow_name = $1 AND batch_id <= $2 AND end_time IS NULL`,
 		flowJobName, batchID)
 	if err != nil {
 		return fmt.Errorf("error while updating batch in cdc_batch: %w", err)

--- a/nexus/catalog/migrations/v42__add_null_end_time_index_cdc_batches.sql
+++ b/nexus/catalog/migrations/v42__add_null_end_time_index_cdc_batches.sql
@@ -1,1 +1,0 @@
-CREATE INDEX IF NOT EXISTS idx_cdc_batches_end_time_null ON peerdb_stats.cdc_batches(end_time) WHERE end_time IS NULL;

--- a/nexus/catalog/migrations/v42__add_null_end_time_index_cdc_batches.sql
+++ b/nexus/catalog/migrations/v42__add_null_end_time_index_cdc_batches.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_cdc_batches_end_time_null ON peerdb_stats.cdc_batches(end_time) WHERE end_time IS NULL;


### PR DESCRIPTION
Existing query can cause problems on mirrors with very low sync interval as the batches table grows large