### PR TITLE
cdc flow: only sleep for 10 minutes for panics & application errors

### DIFF
--- a/flow/model/signals.go
+++ b/flow/model/signals.go
@@ -84,11 +84,6 @@ func (self TypedReceiveChannel[T]) ReceiveAsyncWithMoreFlag() (T, bool, bool) {
 	return result, ok, more
 }
 
-func (self TypedReceiveChannel[T]) Drain() {
-	for self.Chan.ReceiveAsync(nil) {
-	}
-}
-
 func (self TypedReceiveChannel[T]) AddToSelector(selector workflow.Selector, f func(T, bool)) workflow.Selector {
 	return selector.AddReceive(self.Chan, func(c workflow.ReceiveChannel, more bool) {
 		var result T
@@ -133,4 +128,12 @@ var FlowSignal = TypedSignal[CDCFlowSignal]{
 
 var CDCDynamicPropertiesSignal = TypedSignal[*protos.CDCFlowConfigUpdate]{
 	Name: "cdc-dynamic-properties",
+}
+
+func SleepFuture(ctx workflow.Context, d time.Duration) workflow.Future {
+	f, set := workflow.NewFuture(ctx)
+	workflow.Go(ctx, func(ctx workflow.Context) {
+		set.Set(nil, workflow.Sleep(ctx, d))
+	})
+	return f
 }

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -493,33 +493,40 @@ func CDCFlowWorkflow(
 	})
 	mainLoopSelector.AddFuture(syncFlowFuture, func(f workflow.Future) {
 		if err := f.Get(ctx, nil); err != nil {
+			var sleepFor time.Duration
 			var panicErr *temporal.PanicError
 			if errors.As(err, &panicErr) {
 				logger.Error(
-					"panic in sync flow, sleeping for 10 minutes",
+					"panic in sync flow, waiting 10 minutes",
 					slog.Any("error", panicErr.Error()),
 					slog.String("stack", panicErr.StackTrace()),
 				)
-				_ = workflow.Sleep(ctx, 10*time.Minute)
+				sleepFor = 10 * time.Minute
 			} else {
 				logger.Error("error in sync flow", slog.Any("error", err))
 
 				// cannot use shared.IsSQLStateError because temporal serialize/deserialize
 				if !temporal.IsApplicationError(err) || strings.Contains(err.Error(), "(SQLSTATE 55006)") {
-					logger.Info("sync flow errored, sleeping for 1 minute before retrying")
-					_ = workflow.Sleep(ctx, time.Minute)
+					logger.Info("sync flow errored, waiting 1 minute before retrying")
+					sleepFor = time.Minute
 				} else {
-					logger.Info("sync flow errored, sleeping for 10 minutes before retrying")
-					_ = workflow.Sleep(ctx, 10*time.Minute)
+					logger.Info("sync flow errored, waiting 10 minutes before retrying")
+					sleepFor = 10 * time.Minute
 				}
 			}
+			mainLoopSelector.AddFuture(model.SleepFuture(ctx, sleepFor), func(_ workflow.Future) {
+				logger.Info("sync finished after waiting after error")
+				finished = true
+				if state.SyncFlowOptions.NumberOfSyncs > 0 {
+					state.ActiveSignal = model.PauseSignal
+				}
+			})
 		} else {
 			logger.Info("sync finished")
-		}
-		syncFlowFuture = nil
-		finished = true
-		if state.SyncFlowOptions.NumberOfSyncs > 0 {
-			state.ActiveSignal = model.PauseSignal
+			finished = true
+			if state.SyncFlowOptions.NumberOfSyncs > 0 {
+				state.ActiveSignal = model.PauseSignal
+			}
 		}
 	})
 
@@ -548,7 +555,7 @@ func CDCFlowWorkflow(
 		}
 
 		if finished {
-			for ctx.Err() == nil && (!finished || mainLoopSelector.HasPending()) {
+			for ctx.Err() == nil && mainLoopSelector.HasPending() {
 				mainLoopSelector.Select(ctx)
 			}
 


### PR DESCRIPTION
In development heartbeat timeout happens between runs, which set off 10 minute timeout

Also, long sleeps in workflows using signals blocks those signals, causing things like taking minutes to start pausing.
Wrap `workflow.Sleep` in `workflow.Go` which sets off a `workflow.Future` which can be waited on alongside signals