### PR TITLE
UI: Reflect column and engine values for existing tables

### DIFF
--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -49,7 +49,7 @@ interface SchemaBoxProps {
     SetStateAction<{ tableName: string; columns: string[] }[]>
   >;
   peerType?: DBType;
-  alreadySelectedTables: TableMapping[] | undefined;
+  alreadySelectedTables: TableMapping[];
   initialLoadOnly?: boolean;
 }
 
@@ -196,20 +196,18 @@ export default function SchemaBox({
         for (const row of newRows) {
           if (
             alreadySelectedTables
-              ?.map((tableMap) => tableMap.sourceTableIdentifier)
+              .map((tableMap) => tableMap.sourceTableIdentifier)
               .includes(row.source)
           ) {
-            const existingRow = alreadySelectedTables?.find(
+            const existingRow = alreadySelectedTables.find(
               (tableMap) => tableMap.sourceTableIdentifier === row.source
             );
             row.selected = true;
-            row.engine = existingRow?.engine ?? TableEngine.CH_ENGINE_REPLACING_MERGE_TREE;
+            row.engine =
+              existingRow?.engine ?? TableEngine.CH_ENGINE_REPLACING_MERGE_TREE;
             row.editingDisabled = true;
             row.exclude = new Set(existingRow?.exclude ?? []);
             row.destination = existingRow?.destinationTableIdentifier ?? '';
-            alreadySelectedTables?.find(
-              (tableMap) => tableMap.sourceTableIdentifier === row.source
-            )?.destinationTableIdentifier ?? '';
             addTableColumns(row.source);
           }
         }

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -199,12 +199,16 @@ export default function SchemaBox({
               ?.map((tableMap) => tableMap.sourceTableIdentifier)
               .includes(row.source)
           ) {
+            const existingRow = alreadySelectedTables?.find(
+              (tableMap) => tableMap.sourceTableIdentifier === row.source
+            );
             row.selected = true;
             row.editingDisabled = true;
-            row.destination =
-              alreadySelectedTables?.find(
-                (tableMap) => tableMap.sourceTableIdentifier === row.source
-              )?.destinationTableIdentifier ?? '';
+            row.exclude = new Set(existingRow?.exclude ?? []);
+            row.destination = existingRow?.destinationTableIdentifier ?? '';
+            alreadySelectedTables?.find(
+              (tableMap) => tableMap.sourceTableIdentifier === row.source
+            )?.destinationTableIdentifier ?? '';
             addTableColumns(row.source);
           }
         }

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -203,6 +203,7 @@ export default function SchemaBox({
               (tableMap) => tableMap.sourceTableIdentifier === row.source
             );
             row.selected = true;
+            row.engine = existingRow?.engine ?? TableEngine.CH_ENGINE_REPLACING_MERGE_TREE;
             row.editingDisabled = true;
             row.exclude = new Set(existingRow?.exclude ?? []);
             row.destination = existingRow?.destinationTableIdentifier ?? '';
@@ -373,6 +374,7 @@ export default function SchemaBox({
                               Engine:
                             </p>
                             <ReactSelect
+                              isDisabled={row.editingDisabled}
                               styles={engineOptionStyles}
                               options={engineOptions}
                               placeholder='ReplacingMergeTree (default)'

--- a/ui/app/mirrors/create/cdc/tablemapping.tsx
+++ b/ui/app/mirrors/create/cdc/tablemapping.tsx
@@ -114,7 +114,9 @@ export default function TablePicker({
               tableColumns={tableColumns}
               setTableColumns={setTableColumns}
               peerType={peerType}
-              alreadySelectedTables={alreadySelectedTablesMapping.get(schema)}
+              alreadySelectedTables={
+                alreadySelectedTablesMapping.get(schema) ?? []
+              }
               initialLoadOnly={initialLoadOnly}
             />
           ))


### PR DESCRIPTION
Currently, excluded columns and engine selection are not populated in the table box for an existing table in the mirror (where the destination field, engine, columns are disabled)

This PR wires those through. Tested

