### PR TITLE
fail faster when publication does not exist while setting up replication

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -382,12 +382,13 @@ func pullCore[Items model.Items](
 	}
 
 	if !exists.PublicationExists {
-		c.logger.Warn(fmt.Sprintf("publication %s does not exist", publicationName))
-		publicationName = ""
+		c.logger.Warn("publication does not exist", slog.String("name", publicationName))
+		return temporal.NewNonRetryableApplicationError(
+			fmt.Sprintf("publication %s does not exist, restarting workflow", slotName), "disconnect", nil)
 	}
 
 	if !exists.SlotExists {
-		c.logger.Warn(fmt.Sprintf("slot %s does not exist", slotName))
+		c.logger.Warn("slot does not exist", slog.String("name", slotName))
 		return temporal.NewNonRetryableApplicationError(
 			fmt.Sprintf("replication slot %s does not exist, restarting workflow", slotName), "disconnect", nil)
 	}


### PR DESCRIPTION
changing publicationName to empty string only caused us to error later with the opaque:
error getting replication options: publication name is not set

caused when publication dropped on source