### PR TITLE
flow.Dockerfile: rm -f go.work*

### DIFF
--- a/stacks/flow.Dockerfile
+++ b/stacks/flow.Dockerfile
@@ -12,6 +12,7 @@ RUN go mod download
 
 # Copy all the code
 COPY flow .
+RUN rm -f go.work*
 
 # build the binary from flow folder
 WORKDIR /root/flow


### PR DESCRIPTION
go 1.23.5 released, but image is still 1.23.4

go.work is used for gopls to work correctly,
not required for build but version mismatch breaks build