### PR TITLE
feat: add more metrics

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -783,6 +783,7 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 				syncedTablesGauge.Record(ctx, int64(len(config.TableMappings)), metric.WithAttributeSet(attribute.NewSet(
 					attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
 					attribute.String(otel_metrics.PeerNameKey, peerName),
+					attribute.String(otel_metrics.SourcePeerType, fmt.Sprintf("%T", srcConn)),
 				)))
 			}
 			if err := srcConn.HandleSlotInfo(ctx, a.Alerter, a.CatalogPool, &alerting.AlertKeys{

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -735,46 +735,14 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 	logger := activity.GetLogger(ctx)
 	slotMetricGauges := otel_metrics.SlotMetricGauges{}
 	if a.OtelManager != nil {
-		slotLagGauge, err := a.OtelManager.GetOrInitFloat64Gauge(
-			otel_metrics.BuildMetricName(otel_metrics.SlotLagGaugeName),
-			metric.WithUnit("MiBy"),
-			metric.WithDescription("Postgres replication slot lag in MB"))
-		if err != nil {
-			logger.Error("Failed to get slot lag gauge", slog.Any("error", err))
-		}
-		slotMetricGauges.SlotLagGauge = slotLagGauge
+		slotMetricGauges.SlotLagGauge = a.OtelManager.Metrics.SlotLagGauge
 
-		openConnectionsGauge, err := a.OtelManager.GetOrInitInt64Gauge(
-			otel_metrics.BuildMetricName(otel_metrics.OpenConnectionsGaugeName),
-			metric.WithDescription("Current open connections for PeerDB user"))
-		if err != nil {
-			logger.Error("Failed to get open connections gauge", slog.Any("error", err))
-		}
-		slotMetricGauges.OpenConnectionsGauge = openConnectionsGauge
+		slotMetricGauges.OpenConnectionsGauge = a.OtelManager.Metrics.OpenConnectionsGauge
 
-		openReplicationConnectionsGauge, err := a.OtelManager.GetOrInitInt64Gauge(
-			otel_metrics.BuildMetricName(otel_metrics.OpenReplicationConnectionsGaugeName),
-			metric.WithDescription("Current open replication connections for PeerDB user"))
-		if err != nil {
-			logger.Error("Failed to get open replication connections gauge", slog.Any("error", err))
-		}
-		slotMetricGauges.OpenReplicationConnectionsGauge = openReplicationConnectionsGauge
+		slotMetricGauges.OpenReplicationConnectionsGauge = a.OtelManager.Metrics.OpenReplicationConnectionsGauge
 
-		intervalSinceLastNormalizeGauge, err := a.OtelManager.GetOrInitFloat64Gauge(
-			otel_metrics.BuildMetricName(otel_metrics.IntervalSinceLastNormalizeGaugeName),
-			metric.WithUnit("s"),
-			metric.WithDescription("Interval since last normalize"))
-		if err != nil {
-			logger.Error("Failed to get interval since last normalize gauge", slog.Any("error", err))
-		}
-		slotMetricGauges.IntervalSinceLastNormalizeGauge = intervalSinceLastNormalizeGauge
+		slotMetricGauges.IntervalSinceLastNormalizeGauge = a.OtelManager.Metrics.IntervalSinceLastNormalizeGauge
 
-		instanceStatusGauge, err := a.OtelManager.GetOrInitInt64Gauge(
-			otel_metrics.BuildMetricName(otel_metrics.InstanceStatusGaugeName),
-			metric.WithDescription("Instance status"))
-		if err != nil {
-			logger.Error("Failed to get instance status gauge", slog.Any("error", err))
-		}
 		maintenanceEnabled, err := peerdbenv.PeerDBMaintenanceModeEnabled(ctx, nil)
 		instanceStatus := otel_metrics.InstancestatusReady
 		if err != nil {
@@ -785,7 +753,7 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 			instanceStatus = otel_metrics.InstancestatusMaintenance
 		}
 
-		instanceStatusGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+		a.OtelManager.Metrics.InstanceStatusGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
 			attribute.String(otel_metrics.InstanceStatusKey, instanceStatus),
 		)))
 	}
@@ -811,14 +779,7 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 				return
 			}
 			if a.OtelManager != nil {
-				syncedTablesGauge, err := a.OtelManager.GetOrInitInt64Gauge(
-					otel_metrics.BuildMetricName(otel_metrics.SyncedTablesGaugeName),
-					metric.WithDescription("Number of tables synced"),
-				)
-				if err != nil {
-					logger.Error("Failed to get synced tables gauge", slog.Any("error", err))
-					return
-				}
+				syncedTablesGauge := a.OtelManager.Metrics.SyncedTablesGauge
 				syncedTablesGauge.Record(ctx, int64(len(config.TableMappings)), metric.WithAttributeSet(attribute.NewSet(
 					attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
 					attribute.String(otel_metrics.PeerNameKey, peerName),

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -807,7 +807,6 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 					attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
 					attribute.String(otel_metrics.PeerNameKey, peerName),
 				)))
-
 			}
 
 			if err := srcConn.HandleSlotInfo(ctx, a.Alerter, a.CatalogPool, &alerting.AlertKeys{

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -751,13 +751,13 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 		slotMetricGauges.IntervalSinceLastNormalizeGauge = a.OtelManager.Metrics.IntervalSinceLastNormalizeGauge
 
 		maintenanceEnabled, err := peerdbenv.PeerDBMaintenanceModeEnabled(ctx, nil)
-		instanceStatus := otel_metrics.InstancestatusReady
+		instanceStatus := otel_metrics.InstanceStatusReady
 		if err != nil {
 			logger.Error("Failed to get maintenance mode status", slog.Any("error", err))
-			instanceStatus = otel_metrics.InstanceStatusUknown
+			instanceStatus = otel_metrics.InstanceStatusUnknown
 		}
 		if maintenanceEnabled {
-			instanceStatus = otel_metrics.InstancestatusMaintenance
+			instanceStatus = otel_metrics.InstanceStatusMaintenance
 		}
 
 		a.OtelManager.Metrics.InstanceStatusGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -321,12 +321,6 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 			attribute.String(otel_metrics.SourcePeerType, fmt.Sprintf("%T", srcConn)),
 			attribute.String(otel_metrics.DestinationPeerType, dstConnType),
 		)))
-		a.OtelManager.Metrics.RecordsSyncedGauge.Record(ctx, res.NumRecordsSynced, metric.WithAttributeSet(attribute.NewSet(
-			attribute.String(otel_metrics.FlowNameKey, flowName),
-			attribute.String(otel_metrics.BatchIdKey, strconv.FormatInt(res.CurrentSyncBatchID, 10)),
-			attribute.String(otel_metrics.SourcePeerType, fmt.Sprintf("%T", srcConn)),
-			attribute.String(otel_metrics.DestinationPeerType, dstConnType),
-		)))
 	}
 
 	syncState.Store(shared.Ptr("updating schema"))

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -322,6 +322,17 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 				attribute.String(otel_metrics.FlowNameKey, flowName),
 			)))
 		}
+
+		syncRecordsMetric, err := a.OtelManager.GetOrInitInt64Gauge(
+			otel_metrics.BuildMetricName(otel_metrics.SyncRecordsSyncedGaugeName))
+		if err != nil {
+			logger.Error("Failed to get sync records gauge", slog.Any("error", err))
+		} else {
+			syncRecordsMetric.Record(ctx, res.NumRecordsSynced, metric.WithAttributeSet(attribute.NewSet(
+				attribute.String(otel_metrics.FlowNameKey, flowName),
+			)))
+		}
+
 	}
 
 	syncState.Store(shared.Ptr("updating schema"))

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -400,11 +399,11 @@ func replicateQRepPartition[TRead any, TWrite StreamCloser, TSync connectors.QRe
 	stream TWrite,
 	outstream TRead,
 	pullRecords func(
-		TPull,
-		context.Context, *protos.QRepConfig,
-		*protos.QRepPartition,
-		TWrite,
-	) (int, error),
+	TPull,
+	context.Context, *protos.QRepConfig,
+	*protos.QRepPartition,
+	TWrite,
+) (int, error),
 	syncRecords func(TSync, context.Context, *protos.QRepConfig, *protos.QRepPartition, TRead) (int, error),
 ) error {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
@@ -499,11 +498,11 @@ func replicateXminPartition[TRead any, TWrite any, TSync connectors.QRepSyncConn
 	stream TWrite,
 	outstream TRead,
 	pullRecords func(
-		*connpostgres.PostgresConnector,
-		context.Context, *protos.QRepConfig,
-		*protos.QRepPartition,
-		TWrite,
-	) (int, int64, error),
+	*connpostgres.PostgresConnector,
+	context.Context, *protos.QRepConfig,
+	*protos.QRepPartition,
+	TWrite,
+) (int, int64, error),
 	syncRecords func(TSync, context.Context, *protos.QRepConfig, *protos.QRepPartition, TRead) (int, error),
 ) (int64, error) {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -324,7 +324,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		}
 
 		syncRecordsMetric, err := a.OtelManager.GetOrInitInt64Gauge(
-			otel_metrics.BuildMetricName(otel_metrics.SyncRecordsSyncedGaugeName))
+			otel_metrics.BuildMetricName(otel_metrics.RecordsSyncedGaugeName))
 		if err != nil {
 			logger.Error("Failed to get sync records gauge", slog.Any("error", err))
 		} else {

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -399,11 +399,11 @@ func replicateQRepPartition[TRead any, TWrite StreamCloser, TSync connectors.QRe
 	stream TWrite,
 	outstream TRead,
 	pullRecords func(
-	TPull,
-	context.Context, *protos.QRepConfig,
-	*protos.QRepPartition,
-	TWrite,
-) (int, error),
+		TPull,
+		context.Context, *protos.QRepConfig,
+		*protos.QRepPartition,
+		TWrite,
+	) (int, error),
 	syncRecords func(TSync, context.Context, *protos.QRepConfig, *protos.QRepPartition, TRead) (int, error),
 ) error {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
@@ -498,11 +498,11 @@ func replicateXminPartition[TRead any, TWrite any, TSync connectors.QRepSyncConn
 	stream TWrite,
 	outstream TRead,
 	pullRecords func(
-	*connpostgres.PostgresConnector,
-	context.Context, *protos.QRepConfig,
-	*protos.QRepPartition,
-	TWrite,
-) (int, int64, error),
+		*connpostgres.PostgresConnector,
+		context.Context, *protos.QRepConfig,
+		*protos.QRepPartition,
+		TWrite,
+	) (int, int64, error),
 	syncRecords func(TSync, context.Context, *protos.QRepConfig, *protos.QRepPartition, TRead) (int, error),
 ) (int64, error) {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -313,25 +313,13 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	a.Alerter.LogFlowInfo(ctx, flowName, pushedRecordsWithCount)
 
 	if a.OtelManager != nil {
-		currentBatchID, err := a.OtelManager.GetOrInitInt64Gauge(
-			otel_metrics.BuildMetricName(otel_metrics.CurrentBatchIdGaugeName))
-		if err != nil {
-			logger.Error("Failed to get current batch id gauge", slog.Any("error", err))
-		} else {
-			currentBatchID.Record(ctx, res.CurrentSyncBatchID, metric.WithAttributeSet(attribute.NewSet(
-				attribute.String(otel_metrics.FlowNameKey, flowName),
-			)))
-		}
+		a.OtelManager.Metrics.CurrentBatchIdGauge.Record(ctx, res.CurrentSyncBatchID, metric.WithAttributeSet(attribute.NewSet(
+			attribute.String(otel_metrics.FlowNameKey, flowName),
+		)))
 
-		syncRecordsMetric, err := a.OtelManager.GetOrInitInt64Gauge(
-			otel_metrics.BuildMetricName(otel_metrics.RecordsSyncedGaugeName))
-		if err != nil {
-			logger.Error("Failed to get sync records gauge", slog.Any("error", err))
-		} else {
-			syncRecordsMetric.Record(ctx, res.NumRecordsSynced, metric.WithAttributeSet(attribute.NewSet(
-				attribute.String(otel_metrics.FlowNameKey, flowName),
-			)))
-		}
+		a.OtelManager.Metrics.RecordsSyncedGauge.Record(ctx, res.NumRecordsSynced, metric.WithAttributeSet(attribute.NewSet(
+			attribute.String(otel_metrics.FlowNameKey, flowName),
+		)))
 	}
 
 	syncState.Store(shared.Ptr("updating schema"))
@@ -734,15 +722,9 @@ func (a *FlowableActivity) normalizeLoop(
 					close(req.Done)
 				}
 				if a.OtelManager != nil {
-					lastNormalizedBatchID, err := a.OtelManager.GetOrInitInt64Gauge(
-						otel_metrics.BuildMetricName(otel_metrics.LastNormalizedBatchIdGaugeName))
-					if err != nil {
-						logger.Error("Failed to get normalized batch id gauge", slog.Any("error", err))
-					} else {
-						lastNormalizedBatchID.Record(ctx, req.BatchID, metric.WithAttributeSet(attribute.NewSet(
-							attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
-						)))
-					}
+					a.OtelManager.Metrics.LastNormalizedBatchIdGauge.Record(ctx, req.BatchID, metric.WithAttributeSet(attribute.NewSet(
+						attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
+					)))
 				}
 				break
 			}

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -332,7 +332,6 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 				attribute.String(otel_metrics.FlowNameKey, flowName),
 			)))
 		}
-
 	}
 
 	syncState.Store(shared.Ptr("updating schema"))

--- a/flow/activities/maintenance_activity.go
+++ b/flow/activities/maintenance_activity.go
@@ -251,7 +251,7 @@ func (a *MaintenanceActivity) BackgroundAlerter(ctx context.Context) error {
 			slog.Warn("Maintenance Workflow is still running")
 			a.Alerter.LogNonFlowWarning(ctx, telemetry.MaintenanceWait, "Waiting", "Maintenance mode is still running")
 			if a.OtelManager != nil {
-				a.OtelManager.Metrics.MaintenanceRunningGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+				a.OtelManager.Metrics.MaintenanceStatusGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
 					attribute.String(otel_metrics.WorkflowTypeKey, activity.GetInfo(ctx).WorkflowType.Name),
 				)))
 			}

--- a/flow/activities/maintenance_activity.go
+++ b/flow/activities/maintenance_activity.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/attribute"
@@ -18,6 +17,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/alerting"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/peerdbenv"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/telemetry"

--- a/flow/alerting/alerting.go
+++ b/flow/alerting/alerting.go
@@ -34,12 +34,6 @@ type Alerter struct {
 	snsTelemetrySender        telemetry.Sender
 	incidentIoTelemetrySender telemetry.Sender
 	otelManager               *otel_metrics.OtelManager
-	metrics                   *alertingMetrics
-}
-
-type alertingMetrics struct {
-	ErrorEmittedGauge    metric.Int64Gauge
-	ErrorsEmittedCounter metric.Int64Counter
 }
 
 type AlertSenderConfig struct {
@@ -158,30 +152,12 @@ func NewAlerter(ctx context.Context, catalogPool *pgxpool.Pool, otelManager *ote
 			panic(fmt.Sprintf("unable to setup incident.io telemetry is nil for Alerter %+v", err))
 		}
 	}
-	var metrics alertingMetrics
-	if otelManager != nil {
-		// TODO Currently metrics registration is all over the place. Should we move all the registration to inside the manager?
-		errorEmittedCounter, err := otelManager.GetOrInitInt64Counter(otel_metrics.BuildMetricName(otel_metrics.ErrorsEmittedCounterName),
-			metric.WithDescription("Counter of errors emitted"))
-		if err != nil {
-			panic(fmt.Sprintf("could not get errorEmittedCounter: %+v", err))
-		}
-		metrics.ErrorsEmittedCounter = errorEmittedCounter
-
-		errorEmittedGauge, err := otelManager.GetOrInitInt64Gauge(otel_metrics.BuildMetricName(otel_metrics.ErrorEmittedGaugeName),
-			metric.WithDescription("Whether an error was emitted, 1 if emitted, 0 otherwise"))
-		if err != nil {
-			panic(fmt.Sprintf("could not get errorEmittedGauge: %+v", err))
-		}
-		metrics.ErrorEmittedGauge = errorEmittedGauge
-	}
 
 	return &Alerter{
 		CatalogPool:               catalogPool,
 		snsTelemetrySender:        snsMessageSender,
 		incidentIoTelemetrySender: incidentIoTelemetrySender,
 		otelManager:               otelManager,
-		metrics:                   &metrics,
 	}
 }
 
@@ -499,11 +475,11 @@ func (a *Alerter) LogFlowError(ctx context.Context, flowName string, err error) 
 
 	a.sendTelemetryMessage(ctx, logger, flowName, errorWithStack, telemetry.ERROR, tags...)
 	if a.otelManager != nil {
-		a.metrics.ErrorsEmittedCounter.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+		a.otelManager.Metrics.ErrorsEmittedCounter.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
 			attribute.String(otel_metrics.FlowNameKey, flowName),
 			attribute.String(otel_metrics.ErrorClassKey, errorClassString),
 		)))
-		a.metrics.ErrorEmittedGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+		a.otelManager.Metrics.ErrorEmittedGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
 			attribute.String(otel_metrics.FlowNameKey, flowName),
 			attribute.String(otel_metrics.ErrorClassKey, errorClassString),
 		)))

--- a/flow/alerting/alerting.go
+++ b/flow/alerting/alerting.go
@@ -450,7 +450,6 @@ func (a *Alerter) LogFlowError(ctx context.Context, flowName string, err error) 
 	var tags []string
 	if errors.Is(err, context.Canceled) {
 		tags = append(tags, string(shared.ErrTypeCanceled))
-		// TODO this is only set for context.Canceled, other types need to be added too
 		errorClassString = "context.Canceled"
 	}
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -38,7 +38,7 @@ func NewFlowRequestHandler(temporalClient client.Client, pool *pgxpool.Pool, tas
 		temporalClient:      temporalClient,
 		pool:                pool,
 		peerflowTaskQueueID: taskQueue,
-		alerter:             alerting.NewAlerter(context.Background(), pool),
+		alerter:             alerting.NewAlerter(context.Background(), pool, nil),
 	}
 }
 

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -33,13 +33,13 @@ type WorkerSetupOptions struct {
 	UseMaintenanceTaskQueue            bool
 }
 
-type workerSetupResponse struct {
+type WorkerSetupResponse struct {
 	Client      client.Client
 	Worker      worker.Worker
 	OtelManager *otel_metrics.OtelManager
 }
 
-func (w *workerSetupResponse) Close() {
+func (w *WorkerSetupResponse) Close() {
 	w.Client.Close()
 	if w.OtelManager != nil {
 		if err := w.OtelManager.Close(context.Background()); err != nil {
@@ -89,7 +89,7 @@ func setupPyroscope(opts *WorkerSetupOptions) {
 	}
 }
 
-func WorkerSetup(opts *WorkerSetupOptions) (*workerSetupResponse, error) {
+func WorkerSetup(opts *WorkerSetupOptions) (*WorkerSetupResponse, error) {
 	if opts.EnableProfiling {
 		setupPyroscope(opts)
 	}
@@ -166,17 +166,17 @@ func WorkerSetup(opts *WorkerSetupOptions) (*workerSetupResponse, error) {
 
 	w.RegisterActivity(&activities.FlowableActivity{
 		CatalogPool: conn,
-		Alerter:     alerting.NewAlerter(context.Background(), conn),
+		Alerter:     alerting.NewAlerter(context.Background(), conn, otelManager),
 		OtelManager: otelManager,
 	})
 
 	w.RegisterActivity(&activities.MaintenanceActivity{
 		CatalogPool:    conn,
-		Alerter:        alerting.NewAlerter(context.Background(), conn),
+		Alerter:        alerting.NewAlerter(context.Background(), conn, otelManager),
 		TemporalClient: c,
 	})
 
-	return &workerSetupResponse{
+	return &WorkerSetupResponse{
 		Client:      c,
 		Worker:      w,
 		OtelManager: otelManager,

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -173,6 +173,7 @@ func WorkerSetup(opts *WorkerSetupOptions) (*WorkerSetupResponse, error) {
 	w.RegisterActivity(&activities.MaintenanceActivity{
 		CatalogPool:    conn,
 		Alerter:        alerting.NewAlerter(context.Background(), conn, otelManager),
+		OtelManager:    otelManager,
 		TemporalClient: c,
 	})
 

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -40,6 +40,7 @@ type WorkerSetupResponse struct {
 }
 
 func (w *WorkerSetupResponse) Close() {
+	slog.Info("Shutting down worker")
 	w.Client.Close()
 	if w.OtelManager != nil {
 		if err := w.OtelManager.Close(context.Background()); err != nil {

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -482,6 +482,7 @@ func PullCdcRecords[Items model.Items](
 		if p.otelManager != nil {
 			p.otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(msg.Data)), metric.WithAttributeSet(attribute.NewSet(
 				attribute.String(otel_metrics.FlowNameKey, req.FlowJobName),
+				attribute.String(otel_metrics.SourcePeerType, fmt.Sprintf("%T", p)),
 			)))
 		}
 

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -372,16 +372,6 @@ func PullCdcRecords[Items model.Items](
 		return nil
 	}
 
-	var fetchedBytesCounter metric.Int64Counter
-	if p.otelManager != nil {
-		var err error
-		fetchedBytesCounter, err = p.otelManager.GetOrInitInt64Counter(otel_metrics.BuildMetricName(otel_metrics.FetchedBytesCounterName),
-			metric.WithUnit("By"), metric.WithDescription("Bytes received of CopyData over replication slot"))
-		if err != nil {
-			return fmt.Errorf("could not get FetchedBytesCounter: %w", err)
-		}
-	}
-
 	pkmRequiresResponse := false
 	waitingForCommit := false
 
@@ -489,8 +479,8 @@ func PullCdcRecords[Items model.Items](
 			continue
 		}
 
-		if fetchedBytesCounter != nil {
-			fetchedBytesCounter.Add(ctx, int64(len(msg.Data)), metric.WithAttributeSet(attribute.NewSet(
+		if p.otelManager != nil {
+			p.otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(msg.Data)), metric.WithAttributeSet(attribute.NewSet(
 				attribute.String(otel_metrics.FlowNameKey, req.FlowJobName),
 			)))
 		}

--- a/flow/main.go
+++ b/flow/main.go
@@ -162,17 +162,19 @@ func main() {
 				Name: "snapshot-worker",
 				Action: func(ctx context.Context, clicmd *cli.Command) error {
 					temporalHostPort := clicmd.String("temporal-host-port")
-					c, w, err := cmd.SnapshotWorkerMain(&cmd.SnapshotWorkerOptions{
+					res, err := cmd.SnapshotWorkerMain(&cmd.SnapshotWorkerOptions{
+						EnableOtelMetrics: clicmd.Bool("enable-otel-metrics"),
 						TemporalHostPort:  temporalHostPort,
 						TemporalNamespace: clicmd.String("temporal-namespace"),
 					})
 					if err != nil {
 						return err
 					}
-					defer c.Close()
-					return w.Run(worker.InterruptCh())
+					defer res.Close()
+					return res.Worker.Run(worker.InterruptCh())
 				},
 				Flags: []cli.Flag{
+					otelMetricsFlag,
 					temporalHostPortFlag,
 					temporalNamespaceFlag,
 				},

--- a/flow/otel_metrics/attributes.go
+++ b/flow/otel_metrics/attributes.go
@@ -7,6 +7,7 @@ const (
 	DeploymentUidKey  string = "deploymentUID"
 	ErrorClassKey     string = "errorClass"
 	InstanceStatusKey string = "instanceStatus"
+	WorkflowTypeKey   string = "workflowType"
 )
 
 const (

--- a/flow/otel_metrics/attributes.go
+++ b/flow/otel_metrics/attributes.go
@@ -1,9 +1,16 @@
 package otel_metrics
 
 const (
-	PeerNameKey      string = "peerName"
-	SlotNameKey      string = "slotName"
-	FlowNameKey      string = "flowName"
-	DeploymentUidKey string = "deploymentUID"
-	ErrorClassKey    string = "errorClass"
+	PeerNameKey       string = "peerName"
+	SlotNameKey       string = "slotName"
+	FlowNameKey       string = "flowName"
+	DeploymentUidKey  string = "deploymentUID"
+	ErrorClassKey     string = "errorClass"
+	InstanceStatusKey string = "instanceStatus"
+)
+
+const (
+	InstancestatusReady       string = "ready"
+	InstancestatusMaintenance string = "maintenance"
+	InstanceStatusUknown      string = "unknown"
 )

--- a/flow/otel_metrics/attributes.go
+++ b/flow/otel_metrics/attributes.go
@@ -5,4 +5,5 @@ const (
 	SlotNameKey      string = "slotName"
 	FlowNameKey      string = "flowName"
 	DeploymentUidKey string = "deploymentUID"
+	ErrorClassKey    string = "errorClass"
 )

--- a/flow/otel_metrics/attributes.go
+++ b/flow/otel_metrics/attributes.go
@@ -1,13 +1,16 @@
 package otel_metrics
 
 const (
-	PeerNameKey       string = "peerName"
-	SlotNameKey       string = "slotName"
-	FlowNameKey       string = "flowName"
-	DeploymentUidKey  string = "deploymentUID"
-	ErrorClassKey     string = "errorClass"
-	InstanceStatusKey string = "instanceStatus"
-	WorkflowTypeKey   string = "workflowType"
+	PeerNameKey         string = "peerName"
+	SlotNameKey         string = "slotName"
+	FlowNameKey         string = "flowName"
+	DeploymentUidKey    string = "deploymentUID"
+	ErrorClassKey       string = "errorClass"
+	InstanceStatusKey   string = "instanceStatus"
+	WorkflowTypeKey     string = "workflowType"
+	BatchIdKey          string = "batchId"
+	SourcePeerType      string = "sourcePeerType"
+	DestinationPeerType string = "destinationPeerType"
 )
 
 const (

--- a/flow/otel_metrics/attributes.go
+++ b/flow/otel_metrics/attributes.go
@@ -1,20 +1,20 @@
 package otel_metrics
 
 const (
-	PeerNameKey         string = "peerName"
-	SlotNameKey         string = "slotName"
-	FlowNameKey         string = "flowName"
-	DeploymentUidKey    string = "deploymentUID"
-	ErrorClassKey       string = "errorClass"
-	InstanceStatusKey   string = "instanceStatus"
-	WorkflowTypeKey     string = "workflowType"
-	BatchIdKey          string = "batchId"
-	SourcePeerType      string = "sourcePeerType"
-	DestinationPeerType string = "destinationPeerType"
+	PeerNameKey         = "peerName"
+	SlotNameKey         = "slotName"
+	FlowNameKey         = "flowName"
+	DeploymentUidKey    = "deploymentUID"
+	ErrorClassKey       = "errorClass"
+	InstanceStatusKey   = "instanceStatus"
+	WorkflowTypeKey     = "workflowType"
+	BatchIdKey          = "batchId"
+	SourcePeerType      = "sourcePeerType"
+	DestinationPeerType = "destinationPeerType"
 )
 
 const (
-	InstancestatusReady       string = "ready"
-	InstancestatusMaintenance string = "maintenance"
-	InstanceStatusUknown      string = "unknown"
+	InstanceStatusMaintenance = "maintenance"
+	InstanceStatusUnknown     = "unknown"
+	InstanceStatusReady       = "ready"
 )

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -30,6 +30,7 @@ const (
 	RecordsSyncedGaugeName              = "records_synced"
 	SyncedTablesGaugeName               = "synced_tables"
 	InstanceStatusGaugeName             = "instance_status"
+	MaintenanceRunning                  = "maintenance_running"
 )
 
 type Metrics struct {
@@ -45,6 +46,7 @@ type Metrics struct {
 	RecordsSyncedGauge              metric.Int64Gauge
 	SyncedTablesGauge               metric.Int64Gauge
 	InstanceStatusGauge             metric.Int64Gauge
+	MaintenanceRunningGauge         metric.Int64Gauge
 }
 
 type SlotMetricGauges struct {
@@ -211,6 +213,13 @@ func (om *OtelManager) setupMetrics() (*Metrics, error) {
 
 	metrics.InstanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(InstanceStatusGaugeName),
 		metric.WithDescription("Status of the instance, always emits a 1 metric with different attributes for different statuses"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics.MaintenanceRunningGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(MaintenanceRunning),
+		metric.WithDescription("Whether maintenance is running, 1 if running with different attributes for start/end"),
 	)
 	if err != nil {
 		return nil, err

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -131,6 +131,7 @@ func (om *OtelManager) GetOrInitInt64Counter(name string, opts ...metric.Int64Co
 }
 
 func (om *OtelManager) setupMetrics() error {
+	slog.Info("Setting up all metrics")
 	var err error
 	om.Metrics.SlotLagGauge, err = om.GetOrInitFloat64Gauge(BuildMetricName(SlotLagGaugeName),
 		metric.WithUnit("MiBy"),
@@ -223,7 +224,7 @@ func (om *OtelManager) setupMetrics() error {
 	if err != nil {
 		return err
 	}
-
+	slog.Info("Finished setting up all metrics")
 	return nil
 }
 

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -25,6 +25,10 @@ const (
 	OpenReplicationConnectionsGaugeName = "open_replication_connections"
 	IntervalSinceLastNormalizeGaugeName = "interval_since_last_normalize"
 	FetchedBytesCounterName             = "fetched_bytes"
+	// ErrorEmittedGaugeName This mostly tells whether an error is emitted or not, used for hooking up event based alerting
+	ErrorEmittedGaugeName = "error_emitted"
+	// ErrorsEmittedCounterName This the actual counter for errors emitted, used for alerting based on error rate/more detailed error analysis
+	ErrorsEmittedCounterName = "errors_emitted"
 )
 
 type SlotMetricGauges struct {
@@ -34,7 +38,6 @@ type SlotMetricGauges struct {
 	OpenConnectionsGauge            metric.Int64Gauge
 	OpenReplicationConnectionsGauge metric.Int64Gauge
 	IntervalSinceLastNormalizeGauge metric.Float64Gauge
-	FetchedBytesCounter             metric.Int64Counter
 }
 
 func BuildMetricName(baseName string) string {

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -47,11 +47,6 @@ type Metrics struct {
 	InstanceStatusGauge             metric.Int64Gauge
 }
 
-type metricMapping struct {
-	FieldPtr any
-	Options  any
-}
-
 type SlotMetricGauges struct {
 	SlotLagGauge                    metric.Float64Gauge
 	CurrentBatchIdGauge             metric.Int64Gauge

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -29,8 +29,8 @@ const (
 	ErrorEmittedGaugeName = "error_emitted"
 	// ErrorsEmittedCounterName This the actual counter for errors emitted, used for alerting based on error rate/more detailed error analysis
 	ErrorsEmittedCounterName = "errors_emitted"
-	// SyncRecordsSyncedGaugeName is the gauge name for the number of records synced for every Sync batch
-	SyncRecordsSyncedGaugeName = "sync_records_synced"
+	// RecordsSyncedGaugeName is the gauge name for the number of records synced for every Sync batch
+	RecordsSyncedGaugeName = "records_synced"
 	// SyncedTablesGaugeName is the gauge name for the number of tables being synced for a mirror
 	SyncedTablesGaugeName = "synced_tables"
 	// InstanceStatusGaugeName  used for notifying the status of the instance, like if it is healthy/under maintenance etc.

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -85,7 +85,7 @@ func NewOtelManager() (*OtelManager, error) {
 		Int64GaugesCache:   make(map[string]metric.Int64Gauge),
 		Int64CountersCache: make(map[string]metric.Int64Counter),
 	}
-	if err = otelManager.setupMetrics(); err != nil {
+	if err := otelManager.setupMetrics(); err != nil {
 		return nil, err
 	}
 	return &otelManager, nil

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -85,7 +85,7 @@ func NewOtelManager() (*OtelManager, error) {
 		Int64GaugesCache:   make(map[string]metric.Int64Gauge),
 		Int64CountersCache: make(map[string]metric.Int64Counter),
 	}
-	_, err = otelManager.setupMetrics()
+	err = otelManager.setupMetrics()
 	if err != nil {
 		return nil, err
 	}
@@ -130,102 +130,101 @@ func (om *OtelManager) GetOrInitInt64Counter(name string, opts ...metric.Int64Co
 	return getOrInitMetric(metric.Meter.Int64Counter, om.Meter, om.Int64CountersCache, name, opts...)
 }
 
-func (om *OtelManager) setupMetrics() (*Metrics, error) {
-	metrics := om.Metrics
+func (om *OtelManager) setupMetrics() error {
 	var err error
-	metrics.SlotLagGauge, err = om.GetOrInitFloat64Gauge(BuildMetricName(SlotLagGaugeName),
+	om.Metrics.SlotLagGauge, err = om.GetOrInitFloat64Gauge(BuildMetricName(SlotLagGaugeName),
 		metric.WithUnit("MiBy"),
 		metric.WithDescription("Postgres replication slot lag in MB"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.CurrentBatchIdGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(CurrentBatchIdGaugeName))
+	om.Metrics.CurrentBatchIdGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(CurrentBatchIdGaugeName))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.LastNormalizedBatchIdGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(LastNormalizedBatchIdGaugeName))
+	om.Metrics.LastNormalizedBatchIdGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(LastNormalizedBatchIdGaugeName))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.OpenConnectionsGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(OpenConnectionsGaugeName),
+	om.Metrics.OpenConnectionsGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(OpenConnectionsGaugeName),
 		metric.WithDescription("Current open connections for PeerDB user"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.OpenReplicationConnectionsGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(OpenReplicationConnectionsGaugeName),
+	om.Metrics.OpenReplicationConnectionsGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(OpenReplicationConnectionsGaugeName),
 		metric.WithDescription("Current open replication connections for PeerDB user"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.IntervalSinceLastNormalizeGauge, err = om.GetOrInitFloat64Gauge(BuildMetricName(IntervalSinceLastNormalizeGaugeName),
+	om.Metrics.IntervalSinceLastNormalizeGauge, err = om.GetOrInitFloat64Gauge(BuildMetricName(IntervalSinceLastNormalizeGaugeName),
 		metric.WithUnit("s"),
 		metric.WithDescription("Interval since last normalize"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.FetchedBytesCounter, err = om.GetOrInitInt64Counter(BuildMetricName(FetchedBytesCounterName),
+	om.Metrics.FetchedBytesCounter, err = om.GetOrInitInt64Counter(BuildMetricName(FetchedBytesCounterName),
 		metric.WithUnit("By"),
 		metric.WithDescription("Bytes received of CopyData over replication slot"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.ErrorEmittedGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(ErrorEmittedGaugeName),
+	om.Metrics.ErrorEmittedGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(ErrorEmittedGaugeName),
 		// This mostly tells whether an error is emitted or not, used for hooking up event based alerting
 		metric.WithDescription("Whether an error was emitted, 1 if emitted, 0 otherwise"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.ErrorsEmittedCounter, err = om.GetOrInitInt64Counter(BuildMetricName(ErrorsEmittedCounterName),
+	om.Metrics.ErrorsEmittedCounter, err = om.GetOrInitInt64Counter(BuildMetricName(ErrorsEmittedCounterName),
 		// This the actual counter for errors emitted, used for alerting based on error rate/more detailed error analysis
 		metric.WithDescription("Counter of errors emitted"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.RecordsSyncedGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(RecordsSyncedGaugeName),
+	om.Metrics.RecordsSyncedGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(RecordsSyncedGaugeName),
 		metric.WithDescription("Number of records synced for every Sync batch"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.SyncedTablesGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(SyncedTablesGaugeName),
+	om.Metrics.SyncedTablesGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(SyncedTablesGaugeName),
 		metric.WithDescription("Number of tables synced"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.InstanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(InstanceStatusGaugeName),
+	om.Metrics.InstanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(InstanceStatusGaugeName),
 		metric.WithDescription("Status of the instance, always emits a 1 metric with different attributes for different statuses"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	metrics.MaintenanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(MaintenanceStatus),
+	om.Metrics.MaintenanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(MaintenanceStatus),
 		metric.WithDescription("Whether maintenance is running, 1 if running with different attributes for start/end"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &metrics, nil
+	return nil
 }
 
 // newOtelResource returns a resource describing this application.

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -30,7 +30,7 @@ const (
 	RecordsSyncedGaugeName              = "records_synced"
 	SyncedTablesGaugeName               = "synced_tables"
 	InstanceStatusGaugeName             = "instance_status"
-	MaintenanceRunning                  = "maintenance_running"
+	MaintenanceStatus                   = "maintenance_status"
 )
 
 type Metrics struct {
@@ -46,7 +46,7 @@ type Metrics struct {
 	RecordsSyncedGauge              metric.Int64Gauge
 	SyncedTablesGauge               metric.Int64Gauge
 	InstanceStatusGauge             metric.Int64Gauge
-	MaintenanceRunningGauge         metric.Int64Gauge
+	MaintenanceStatusGauge          metric.Int64Gauge
 }
 
 type SlotMetricGauges struct {
@@ -218,7 +218,7 @@ func (om *OtelManager) setupMetrics() (*Metrics, error) {
 		return nil, err
 	}
 
-	metrics.MaintenanceRunningGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(MaintenanceRunning),
+	metrics.MaintenanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(MaintenanceStatus),
 		metric.WithDescription("Whether maintenance is running, 1 if running with different attributes for start/end"),
 	)
 	if err != nil {

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -30,7 +30,7 @@ const (
 	RecordsSyncedGaugeName              = "records_synced"
 	SyncedTablesGaugeName               = "synced_tables"
 	InstanceStatusGaugeName             = "instance_status"
-	MaintenanceStatus                   = "maintenance_status"
+	MaintenanceStatusGaugeName          = "maintenance_status"
 )
 
 type Metrics struct {
@@ -85,8 +85,7 @@ func NewOtelManager() (*OtelManager, error) {
 		Int64GaugesCache:   make(map[string]metric.Int64Gauge),
 		Int64CountersCache: make(map[string]metric.Int64Counter),
 	}
-	err = otelManager.setupMetrics()
-	if err != nil {
+	if err = otelManager.setupMetrics(); err != nil {
 		return nil, err
 	}
 	return &otelManager, nil
@@ -131,100 +130,87 @@ func (om *OtelManager) GetOrInitInt64Counter(name string, opts ...metric.Int64Co
 }
 
 func (om *OtelManager) setupMetrics() error {
-	slog.Info("Setting up all metrics")
+	slog.Debug("Setting up all metrics")
 	var err error
-	om.Metrics.SlotLagGauge, err = om.GetOrInitFloat64Gauge(BuildMetricName(SlotLagGaugeName),
+	if om.Metrics.SlotLagGauge, err = om.GetOrInitFloat64Gauge(BuildMetricName(SlotLagGaugeName),
 		metric.WithUnit("MiBy"),
 		metric.WithDescription("Postgres replication slot lag in MB"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.CurrentBatchIdGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(CurrentBatchIdGaugeName))
-	if err != nil {
+	if om.Metrics.CurrentBatchIdGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(CurrentBatchIdGaugeName)); err != nil {
 		return err
 	}
 
-	om.Metrics.LastNormalizedBatchIdGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(LastNormalizedBatchIdGaugeName))
-	if err != nil {
+	if om.Metrics.LastNormalizedBatchIdGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(LastNormalizedBatchIdGaugeName)); err != nil {
 		return err
 	}
 
-	om.Metrics.OpenConnectionsGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(OpenConnectionsGaugeName),
+	if om.Metrics.OpenConnectionsGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(OpenConnectionsGaugeName),
 		metric.WithDescription("Current open connections for PeerDB user"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.OpenReplicationConnectionsGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(OpenReplicationConnectionsGaugeName),
+	if om.Metrics.OpenReplicationConnectionsGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(OpenReplicationConnectionsGaugeName),
 		metric.WithDescription("Current open replication connections for PeerDB user"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.IntervalSinceLastNormalizeGauge, err = om.GetOrInitFloat64Gauge(BuildMetricName(IntervalSinceLastNormalizeGaugeName),
+	if om.Metrics.IntervalSinceLastNormalizeGauge, err = om.GetOrInitFloat64Gauge(BuildMetricName(IntervalSinceLastNormalizeGaugeName),
 		metric.WithUnit("s"),
 		metric.WithDescription("Interval since last normalize"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.FetchedBytesCounter, err = om.GetOrInitInt64Counter(BuildMetricName(FetchedBytesCounterName),
+	if om.Metrics.FetchedBytesCounter, err = om.GetOrInitInt64Counter(BuildMetricName(FetchedBytesCounterName),
 		metric.WithUnit("By"),
 		metric.WithDescription("Bytes received of CopyData over replication slot"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.ErrorEmittedGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(ErrorEmittedGaugeName),
+	if om.Metrics.ErrorEmittedGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(ErrorEmittedGaugeName),
 		// This mostly tells whether an error is emitted or not, used for hooking up event based alerting
 		metric.WithDescription("Whether an error was emitted, 1 if emitted, 0 otherwise"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.ErrorsEmittedCounter, err = om.GetOrInitInt64Counter(BuildMetricName(ErrorsEmittedCounterName),
+	if om.Metrics.ErrorsEmittedCounter, err = om.GetOrInitInt64Counter(BuildMetricName(ErrorsEmittedCounterName),
 		// This the actual counter for errors emitted, used for alerting based on error rate/more detailed error analysis
 		metric.WithDescription("Counter of errors emitted"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.RecordsSyncedGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(RecordsSyncedGaugeName),
+	if om.Metrics.RecordsSyncedGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(RecordsSyncedGaugeName),
 		metric.WithDescription("Number of records synced for every Sync batch"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.SyncedTablesGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(SyncedTablesGaugeName),
+	if om.Metrics.SyncedTablesGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(SyncedTablesGaugeName),
 		metric.WithDescription("Number of tables synced"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.InstanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(InstanceStatusGaugeName),
+	if om.Metrics.InstanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(InstanceStatusGaugeName),
 		metric.WithDescription("Status of the instance, always emits a 1 metric with different attributes for different statuses"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
-	om.Metrics.MaintenanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(MaintenanceStatus),
+	if om.Metrics.MaintenanceStatusGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(MaintenanceStatusGaugeName),
 		metric.WithDescription("Whether maintenance is running, 1 if running with different attributes for start/end"),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
-	slog.Info("Finished setting up all metrics")
+	slog.Debug("Finished setting up all metrics")
 	return nil
 }
 

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -31,6 +31,10 @@ const (
 	ErrorsEmittedCounterName = "errors_emitted"
 	// SyncRecordsSyncedGaugeName is the gauge name for the number of records synced for every Sync batch
 	SyncRecordsSyncedGaugeName = "sync_records_synced"
+	// SyncedTablesGaugeName is the gauge name for the number of tables being synced for a mirror
+	SyncedTablesGaugeName = "synced_tables"
+	// InstanceStatusGaugeName  used for notifying the status of the instance, like if it is healthy/under maintenance etc.
+	InstanceStatusGaugeName = "instance_status"
 )
 
 type SlotMetricGauges struct {
@@ -40,6 +44,7 @@ type SlotMetricGauges struct {
 	OpenConnectionsGauge            metric.Int64Gauge
 	OpenReplicationConnectionsGauge metric.Int64Gauge
 	IntervalSinceLastNormalizeGauge metric.Float64Gauge
+	InstanceStatusGauge             metric.Int64Gauge
 }
 
 func BuildMetricName(baseName string) string {

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -29,6 +29,8 @@ const (
 	ErrorEmittedGaugeName = "error_emitted"
 	// ErrorsEmittedCounterName This the actual counter for errors emitted, used for alerting based on error rate/more detailed error analysis
 	ErrorsEmittedCounterName = "errors_emitted"
+	// SyncRecordsSyncedGaugeName is the gauge name for the number of records synced for every Sync batch
+	SyncRecordsSyncedGaugeName = "sync_records_synced"
 )
 
 type SlotMetricGauges struct {


### PR DESCRIPTION
Adds a few new metrics:
1. `error_emitted` - instantaneous gauge of whether an error is being
   emitted
2. `errors_emitted` - counter of errors emitted over time
3. `records_synced` - number of records synced for every sync batch.
4. `synced_tables` - number of tables configured in each mirror
5. `instance_status` - a constant `1` metric every 5 minutes (same frequency as slots) with attributes differentiating the current status
6. `maintenance_status` - a constant `1` when maintenance is running, also has attributes differentiating the current status

TODO: maybe refactor code so that maybe all gauges/counters are initialized inside the otelManager?


ref #2341 