### PR TITLE
Drop mirror: introduce opt-in setting to skip destination dropping

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -251,6 +251,7 @@ func (h *FlowRequestHandler) shutdownFlow(
 	ctx context.Context,
 	flowJobName string,
 	deleteStats bool,
+	skipDestinationDrop bool,
 ) error {
 	workflowID, err := h.getWorkflowID(ctx, flowJobName)
 	if err != nil {
@@ -292,6 +293,7 @@ func (h *FlowRequestHandler) shutdownFlow(
 			FlowJobName:           flowJobName,
 			DropFlowStats:         deleteStats,
 			FlowConnectionConfigs: cdcConfig,
+			SkipDestinationDrop:   skipDestinationDrop,
 		})
 	if err != nil {
 		slog.Error("unable to start DropFlow workflow", logs, slog.Any("error", err))
@@ -386,7 +388,7 @@ func (h *FlowRequestHandler) FlowStateChange(
 			)
 		} else if req.RequestedFlowState == protos.FlowStatus_STATUS_TERMINATED && currState != protos.FlowStatus_STATUS_TERMINATED {
 			slog.Info("[flow-state-change] received drop mirror request", logs)
-			err = h.shutdownFlow(ctx, req.FlowJobName, req.DropMirrorStats)
+			err = h.shutdownFlow(ctx, req.FlowJobName, req.DropMirrorStats, req.SkipDestinationDrop)
 		} else if req.RequestedFlowState != currState {
 			slog.Error("illegal state change requested", logs, slog.Any("requestedFlowState", req.RequestedFlowState),
 				slog.Any("currState", currState))
@@ -528,7 +530,7 @@ func (h *FlowRequestHandler) ResyncMirror(
 		return nil, err
 	}
 
-	if err := h.shutdownFlow(ctx, req.FlowJobName, req.DropStats); err != nil {
+	if err := h.shutdownFlow(ctx, req.FlowJobName, req.DropStats, false); err != nil {
 		return nil, err
 	}
 

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -67,6 +67,8 @@ func executeCDCDropActivities(ctx workflow.Context, input *protos.DropFlowInput)
 			PeerName:    input.FlowConnectionConfigs.DestinationName,
 		})
 		selector.AddFuture(dropDestinationFuture, dropDestination)
+	} else {
+		destinationOk = true
 	}
 
 	for {

--- a/nexus/flow-rs/src/grpc.rs
+++ b/nexus/flow-rs/src/grpc.rs
@@ -85,6 +85,7 @@ impl FlowGrpcClient {
             requested_flow_state: state.into(),
             flow_config_update,
             drop_mirror_stats: false,
+            skip_destination_drop: false
         };
         self.client.flow_state_change(state_change_req).await?;
         Ok(())

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -332,6 +332,7 @@ message DropFlowInput {
   string flow_job_name = 1;
   bool drop_flow_stats = 4;
   FlowConnectionConfigs flow_connection_configs = 5;
+  bool skip_destination_drop = 6;
 }
 
 message TableSchemaDelta {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -354,6 +354,7 @@ message FlowStateChangeRequest {
   // only can be sent in certain situations
   optional peerdb_flow.FlowConfigUpdate flow_config_update = 5;
   bool drop_mirror_stats = 6;
+  bool skip_destination_drop = 7;
 }
 message FlowStateChangeResponse {}
 

--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -115,6 +115,7 @@ const EditMirror = ({ params: { mirrorId } }: EditMirrorProps) => {
         cdcFlowConfigUpdate: { ...config, additionalTables, removedTables },
       },
       dropMirrorStats: false,
+      skipDestinationDrop: false,
     };
     const res = await fetch('/api/v1/mirrors/state_change', {
       method: 'POST',

--- a/ui/app/mirrors/[mirrorId]/handlers.ts
+++ b/ui/app/mirrors/[mirrorId]/handlers.ts
@@ -33,6 +33,7 @@ export const changeFlowState = async (
     flowJobName: mirrorName,
     requestedFlowState: flowState,
     dropMirrorStats: dropStats ?? false,
+    skipDestinationDrop: false,
   };
   const res = await fetch('/api/v1/mirrors/state_change', {
     method: 'POST',


### PR DESCRIPTION
This PR introduces a flag for the input of drop mirror to not bother with trying to drop destination peer artifacts.

- Useful in cases where the target data store no longer exists, or if the user wishes for the cdc raw table to remain or has some dependencies on it

Open to renaming or rewiring the flag

Tested with API call:
```bash
curl --request POST \
  --url http://localhost:3003/api/v1/mirrors/state_change \
  --header 'Authorization: Basic OnBlZXJkYg==' \
  --header 'Content-Type: application/json' \
  --data '{
	"flowJobName": "drop_this",
	"requestedFlowState": "STATUS_TERMINATED",
	"skipDestinationDrop": true
}'
```
![Screenshot 2025-01-24 at 12 42 04 AM](https://github.com/user-attachments/assets/03dad644-f307-4534-a914-dbeb84856878)
