### PR TITLE
E2E: add test for drop mirror

### DIFF
--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -100,7 +100,7 @@ func GetPgRows(conn *connpostgres.PostgresConnector, suffix string, table string
 	)
 }
 
-func CheckIfMirrorEntriesRemoved(conn *connpostgres.PostgresConnector, flowJobName string) (bool, error) {
+func checkIfMirrorEntriesRemoved(conn *connpostgres.PostgresConnector, flowJobName string) (bool, error) {
 	pgQueryExecutor, err := conn.NewQRepQueryExecutor(context.Background(), flowJobName, "testpart")
 	if err != nil {
 		return false, err
@@ -218,7 +218,7 @@ func EnvWaitForEmptyStatsInCatalog(
 
 	EnvWaitFor(t, env, 3*time.Minute, reason, func() bool {
 		t.Helper()
-		catalogIsCleanedUp, err := CheckIfMirrorEntriesRemoved(suite.Connector(), flowName)
+		catalogIsCleanedUp, err := checkIfMirrorEntriesRemoved(suite.Connector(), flowName)
 		if err != nil {
 			t.Log(err)
 			return false

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -100,6 +100,42 @@ func GetPgRows(conn *connpostgres.PostgresConnector, suffix string, table string
 	)
 }
 
+func CheckIfMirrorEntriesRemoved(conn *connpostgres.PostgresConnector, flowJobName string) (bool, error) {
+	pgQueryExecutor, err := conn.NewQRepQueryExecutor(context.Background(), flowJobName, "testpart")
+	if err != nil {
+		return false, err
+	}
+
+	metadataTable := "metadata_last_sync_state"
+
+	catalogTables := []string{
+		metadataTable,
+		"peerdb_stats.cdc_batches",
+		"peerdb_stats.cdc_batch_table",
+		"peerdb_stats.qrep_partitions",
+		"peerdb_stats.qrep_runs",
+	}
+
+	for _, table := range catalogTables {
+		flowNameColumn := "flow_name"
+		if table == metadataTable {
+			flowNameColumn = "job_name"
+		}
+		batch, err := pgQueryExecutor.ExecuteAndProcessQuery(
+			context.Background(),
+			fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE %s = '%s'`, table, flowNameColumn, flowJobName),
+		)
+		if err != nil {
+			return false, err
+		}
+		if batch.Records[0][0].Value() != 0 {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 func RequireEqualTables(suite RowSource, table string, cols string) {
 	t := suite.T()
 	t.Helper()
@@ -168,6 +204,26 @@ func EnvWaitForEqualTablesWithNames(
 		}
 
 		return e2eshared.CheckEqualRecordBatches(t, pgRows, rows)
+	})
+}
+
+func EnvWaitForEmptyStatsInCatalog(
+	env WorkflowRun,
+	suite RowSource,
+	reason string,
+	flowName string,
+) {
+	t := suite.T()
+	t.Helper()
+
+	EnvWaitFor(t, env, 3*time.Minute, reason, func() bool {
+		t.Helper()
+		catalogIsCleanedUp, err := CheckIfMirrorEntriesRemoved(suite.Connector(), flowName)
+		if err != nil {
+			t.Log(err)
+			return false
+		}
+		return catalogIsCleanedUp
 	})
 }
 


### PR DESCRIPTION
Adds a test for drop mirror in ClickHouse E2E:
- New helper functions in `test_utils.go`: `EnvWaitForEmptyStatsInCatalog` and `checkIfMirrorEntriesRemoved`
- Checks if there are any rows pertaining to the mirror in these tables:

```golang
	metadataTable := "metadata_last_sync_state"

	catalogTables := []string{
		metadataTable,
		"peerdb_stats.cdc_batches",
		"peerdb_stats.cdc_batch_table",
		"peerdb_stats.qrep_partitions",
		"peerdb_stats.qrep_runs",
	}
```