### PR TITLE
Table addition validation

### DIFF
--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -200,13 +200,13 @@ func (h *FlowRequestHandler) CheckIfMirrorNameExists(ctx context.Context, mirror
 func (h *FlowRequestHandler) ValidateTableAdditions(ctx context.Context, req *protos.ValidateTableAdditionsRequest) (*protos.ValidateCDCMirrorResponse, error) {
 	sourcePeer, err := connectors.LoadPeer(ctx, h.pool, req.SourcePeerName)
 	if err != nil {
-		slog.Error("/validatecdc failed to load source peer", slog.String("peer", req.SourcePeerName))
+		slog.Error("table addition validation: failed to load source peer", slog.String("peer", req.SourcePeerName))
 		return nil, err
 	}
 
 	sourcePeerConfig := sourcePeer.GetPostgresConfig()
 	if sourcePeerConfig == nil {
-		slog.Error("/validatecdc source peer config is not postgres", slog.String("peer", req.SourcePeerName))
+		slog.Error("table addition validation: source peer config is not postgres", slog.String("peer", req.SourcePeerName))
 		return nil, errors.New("source peer config is not postgres")
 	}
 

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -236,10 +236,12 @@ func (h *FlowRequestHandler) ValidateTableAdditions(ctx context.Context, req *pr
 		srcAddedTableNames = append(srcAddedTableNames, tableMapping.SourceTableIdentifier)
 	}
 
-	publicationErr := pgPeer.CheckIfTablesAreInPublication(ctx, req.PublicationName, addedTableValues)
-	if publicationErr != nil {
-		h.alerter.LogNonFlowWarning(ctx, telemetry.EditMirror, req.FlowJobName, publicationErr.Error())
-		return nil, publicationErr
+	if req.PublicationName != "" {
+		publicationErr := pgPeer.CheckIfTablesAreInPublication(ctx, req.PublicationName, addedTableValues)
+		if publicationErr != nil {
+			h.alerter.LogNonFlowWarning(ctx, telemetry.EditMirror, req.FlowJobName, publicationErr.Error())
+			return nil, publicationErr
+		}
 	}
 
 	dstPeer, err := connectors.LoadPeer(ctx, h.pool, req.DestinationPeerName)

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -37,8 +37,8 @@ type ClickHouseConnector struct {
 }
 
 type ClickHouseDestinationCheckInput struct {
-	TableMappings          []*protos.TableMapping
 	TableNameSchemaMapping map[string]*protos.TableSchema
+	TableMappings          []*protos.TableMapping
 	SyncedAtColName        string
 	Resync                 bool
 	DoInitialSnapshot      bool

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -37,11 +37,11 @@ type ClickHouseConnector struct {
 }
 
 type ClickHouseDestinationCheckInput struct {
-	TableNameSchemaMapping map[string]*protos.TableSchema
-	TableMappings          []*protos.TableMapping
-	SyncedAtColName        string
 	Resync                 bool
 	DoInitialSnapshot      bool
+	SyncedAtColName        string
+	TableNameSchemaMapping map[string]*protos.TableSchema
+	TableMappings          []*protos.TableMapping
 }
 
 func ValidateS3(ctx context.Context, creds *utils.ClickHouseS3Credentials) error {

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -37,11 +37,11 @@ type ClickHouseConnector struct {
 }
 
 type ClickHouseDestinationCheckInput struct {
-	Resync                 bool
-	DoInitialSnapshot      bool
-	SyncedAtColName        string
 	TableNameSchemaMapping map[string]*protos.TableSchema
 	TableMappings          []*protos.TableMapping
+	SyncedAtColName        string
+	Resync                 bool
+	DoInitialSnapshot      bool
 }
 
 func ValidateS3(ctx context.Context, creds *utils.ClickHouseS3Credentials) error {

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -38,10 +38,10 @@ type ClickHouseConnector struct {
 
 type ClickHouseDestinationCheckInput struct {
 	TableMappings          []*protos.TableMapping
+	TableNameSchemaMapping map[string]*protos.TableSchema
 	SyncedAtColName        string
 	Resync                 bool
 	DoInitialSnapshot      bool
-	TableNameSchemaMapping map[string]*protos.TableSchema
 }
 
 func ValidateS3(ctx context.Context, creds *utils.ClickHouseS3Credentials) error {

--- a/flow/connectors/postgres/validate.go
+++ b/flow/connectors/postgres/validate.go
@@ -139,8 +139,11 @@ Requires publication name as string and table values in the form of (schema::tex
 The schema and table names should be quoted and escaped.
 */
 func (c *PostgresConnector) CheckIfTablesAreInPublication(ctx context.Context, pubName string, tableValues []string) error {
-	tableStr := strings.Join(tableValues, ",")
+	if pubName == "" {
+		return errors.New("publication name is empty")
+	}
 
+	tableStr := strings.Join(tableValues, ",")
 	rows, err := c.conn.Query(
 		ctx,
 		fmt.Sprintf(`select schemaname,tablename

--- a/flow/shared/telemetry/event_types.go
+++ b/flow/shared/telemetry/event_types.go
@@ -5,6 +5,7 @@ type EventType string
 const (
 	CreatePeer       EventType = "CreatePeer"
 	CreateMirror     EventType = "CreateMirror"
+	EditMirror       EventType = "EditMirror"
 	StartMaintenance EventType = "StartMaintenance"
 	EndMaintenance   EventType = "EndMaintenance"
 	MaintenanceWait  EventType = "MaintenanceWait"

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -12,6 +12,15 @@ message CreateCDCFlowRequest {
   peerdb_flow.FlowConnectionConfigs connection_configs = 1;
 }
 
+message ValidateTableAdditionsRequest {
+  string flow_job_name = 1;
+  string source_peer_name = 2;
+  string destination_peer_name = 3;
+  string publication_name = 4;
+  string synced_at_col_name = 5;
+  repeated peerdb_flow.TableMapping added_tables = 6;
+}
+
 message CreateCDCFlowResponse { string workflow_id = 1; }
 
 message CreateQRepFlowRequest {
@@ -425,6 +434,13 @@ service FlowService {
       returns (ValidateCDCMirrorResponse) {
     option (google.api.http) = {
       post : "/v1/mirrors/cdc/validate",
+      body : "*"
+    };
+  }
+  rpc ValidateTableAdditions(ValidateTableAdditionsRequest)
+      returns (ValidateCDCMirrorResponse) {
+    option (google.api.http) = {
+      post : "/v1/mirrors/cdc/edit/validate",
       body : "*"
     };
   }

--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -121,16 +121,22 @@ const EditMirror = ({ params: { mirrorId } }: EditMirrorProps) => {
         addedTables: additionalTables,
       };
 
-      const res = await fetch('/api/v1/mirrors/cdc/edit/validate', {
-        method: 'POST',
-        body: JSON.stringify(validateReq),
-        cache: 'no-store',
-      });
+      try {
+        const res = await fetch('/api/v1/mirrors/cdc/edit/validate', {
+          method: 'POST',
+          body: JSON.stringify(validateReq),
+          cache: 'no-store',
+        });
 
-      if (!res.ok) {
-        notifyErr(`Table addition invalidated: ${res.statusText}`);
+        if (!res.ok) {
+          const errRes = await res.json();
+          notifyErr('Table addition invalidated: ' + errRes.message);
+          setLoading(false);
+          return;
+        }
+      } catch (e) {
+        console.error(e);
         setLoading(false);
-        return;
       }
     }
     const req: FlowStateChangeRequest = {


### PR DESCRIPTION
This PR introduces validation for table addition. The validation consists of:
1) Checks if the added tables are part of the publication if it is a user provided publication.
2) Performs ClickHouse destination table checks for the additional tables - these are the same checks as done in mirror creation validation.

A new Flow API endpoint has been made for this, and the UI sends a request to this if there are additional tables selected.

![Screenshot 2025-01-21 at 4 55 26 AM](https://github.com/user-attachments/assets/42eba85f-3e96-4bed-a50b-d8c886ca860c)

![Screenshot 2025-01-21 at 4 57 56 AM](https://github.com/user-attachments/assets/a5470aaa-8724-4e08-b204-0edda517e101)
