### PR TITLE
checkpoint: add text alongside int64

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -83,7 +83,10 @@ func (a *FlowableActivity) CheckMetadataTables(
 	}
 	defer connectors.CloseConnector(ctx, conn)
 
-	needsSetup := conn.NeedsSetupMetadataTables(ctx)
+	needsSetup, err := conn.NeedsSetupMetadataTables(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	return &CheckMetadataTablesResult{
 		NeedsSetupMetadataTables: needsSetup,

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -103,11 +103,11 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 	}
 
 	return &model.SyncResponse{
-		LastSyncedCheckpointID: lastCP,
-		NumRecordsSynced:       int64(numRecords),
-		CurrentSyncBatchID:     syncBatchID,
-		TableNameRowsMapping:   tableNameRowsMapping,
-		TableSchemaDeltas:      req.Records.SchemaDeltas,
+		LastSyncedCheckpoint: lastCP,
+		NumRecordsSynced:     int64(numRecords),
+		CurrentSyncBatchID:   syncBatchID,
+		TableNameRowsMapping: tableNameRowsMapping,
+		TableSchemaDeltas:    req.Records.SchemaDeltas,
 	}, nil
 }
 

--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -97,11 +97,11 @@ func (c *ClickHouseConnector) syncRecordsViaAvro(
 	}
 
 	return &model.SyncResponse{
-		LastSyncedCheckpointID: req.Records.GetLastCheckpoint(),
-		NumRecordsSynced:       int64(numRecords),
-		CurrentSyncBatchID:     syncBatchID,
-		TableNameRowsMapping:   tableNameRowsMapping,
-		TableSchemaDeltas:      req.Records.SchemaDeltas,
+		LastSyncedCheckpoint: req.Records.GetLastCheckpoint(),
+		NumRecordsSynced:     int64(numRecords),
+		CurrentSyncBatchID:   syncBatchID,
+		TableNameRowsMapping: tableNameRowsMapping,
+		TableSchemaDeltas:    req.Records.SchemaDeltas,
 	}, nil
 }
 
@@ -111,7 +111,7 @@ func (c *ClickHouseConnector) SyncRecords(ctx context.Context, req *model.SyncRe
 		return nil, err
 	}
 
-	if err := c.FinishBatch(ctx, req.FlowJobName, req.SyncBatchID, res.LastSyncedCheckpointID); err != nil {
+	if err := c.FinishBatch(ctx, req.FlowJobName, req.SyncBatchID, res.LastSyncedCheckpoint); err != nil {
 		c.logger.Error("failed to increment id", slog.Any("error", err))
 		return nil, err
 	}

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -77,7 +77,7 @@ type CDCPullConnectorCore interface {
 	ReplPing(context.Context) error
 
 	// Called when offset has been confirmed to destination
-	UpdateReplStateLastOffset(lastOffset int64)
+	UpdateReplStateLastOffset(ctx context.Context, lastOffset model.CdcCheckpoint) error
 
 	// PullFlowCleanup drops both the Postgres publication and replication slot, as a part of DROP MIRROR
 	PullFlowCleanup(ctx context.Context, jobName string) error
@@ -153,16 +153,16 @@ type CDCSyncConnectorCore interface {
 	Connector
 
 	// NeedsSetupMetadataTables checks if the metadata table [PEERDB_MIRROR_JOBS] needs to be created.
-	NeedsSetupMetadataTables(ctx context.Context) bool
+	NeedsSetupMetadataTables(ctx context.Context) (bool, error)
 
 	// SetupMetadataTables creates the metadata table [PEERDB_MIRROR_JOBS] if necessary.
 	SetupMetadataTables(ctx context.Context) error
 
 	// GetLastOffset gets the last offset from the metadata table on the destination
-	GetLastOffset(ctx context.Context, jobName string) (int64, error)
+	GetLastOffset(ctx context.Context, jobName string) (model.CdcCheckpoint, error)
 
 	// SetLastOffset updates the last offset on the metadata table on the destination
-	SetLastOffset(ctx context.Context, jobName string, lastOffset int64) error
+	SetLastOffset(ctx context.Context, jobName string, lastOffset model.CdcCheckpoint) error
 
 	// GetLastSyncBatchID gets the last batch synced to the destination from the metadata table
 	GetLastSyncBatchID(ctx context.Context, jobName string) (int64, error)

--- a/flow/connectors/elasticsearch/elasticsearch.go
+++ b/flow/connectors/elasticsearch/elasticsearch.go
@@ -163,7 +163,7 @@ func (esc *ElasticsearchConnector) SyncRecords(ctx context.Context,
 			case <-ticker.C:
 				lastSeen := lastSeenLSN.Load()
 				if lastSeen > req.ConsumedOffset.Load() {
-					if err := esc.SetLastOffset(ctx, req.FlowJobName, lastSeen); err != nil {
+					if err := esc.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{ID: lastSeen}); err != nil {
 						esc.logger.Warn("[es] SetLastOffset error", slog.Any("error", err))
 					} else {
 						shared.AtomicInt64Max(req.ConsumedOffset, lastSeen)
@@ -297,10 +297,10 @@ func (esc *ElasticsearchConnector) SyncRecords(ctx context.Context,
 	}
 
 	return &model.SyncResponse{
-		CurrentSyncBatchID:     req.SyncBatchID,
-		LastSyncedCheckpointID: lastCheckpoint,
-		NumRecordsSynced:       numRecords,
-		TableNameRowsMapping:   tableNameRowsMapping,
-		TableSchemaDeltas:      req.Records.SchemaDeltas,
+		CurrentSyncBatchID:   req.SyncBatchID,
+		LastSyncedCheckpoint: lastCheckpoint,
+		NumRecordsSynced:     numRecords,
+		TableNameRowsMapping: tableNameRowsMapping,
+		TableSchemaDeltas:    req.Records.SchemaDeltas,
 	}, nil
 }

--- a/flow/connectors/external_metadata/store.go
+++ b/flow/connectors/external_metadata/store.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils/monitoring"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/peerdbenv"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
@@ -49,9 +50,8 @@ func NewPostgresMetadataFromCatalog(logger log.Logger, pool *pgxpool.Pool) *Post
 }
 
 func (p *PostgresMetadata) Ping(ctx context.Context) error {
-	pingErr := p.pool.Ping(ctx)
-	if pingErr != nil {
-		return fmt.Errorf("metadata db ping failed: %w", pingErr)
+	if err := p.pool.Ping(ctx); err != nil {
+		return fmt.Errorf("metadata db ping failed: %w", err)
 	}
 
 	return nil
@@ -64,42 +64,39 @@ func (p *PostgresMetadata) LogFlowInfo(ctx context.Context, flowName string, inf
 	return err
 }
 
-func (p *PostgresMetadata) NeedsSetupMetadataTables(_ context.Context) bool {
-	return false
+func (p *PostgresMetadata) NeedsSetupMetadataTables(_ context.Context) (bool, error) {
+	return false, nil
 }
 
 func (p *PostgresMetadata) SetupMetadataTables(_ context.Context) error {
 	return nil
 }
 
-func (p *PostgresMetadata) GetLastOffset(ctx context.Context, jobName string) (int64, error) {
-	row := p.pool.QueryRow(ctx,
-		`SELECT last_offset FROM `+
-			lastSyncStateTableName+
-			` WHERE job_name = $1`, jobName)
-	var offset pgtype.Int8
-	err := row.Scan(&offset)
-	if err != nil {
+func (p *PostgresMetadata) GetLastOffset(ctx context.Context, jobName string) (model.CdcCheckpoint, error) {
+	var offset model.CdcCheckpoint
+	if err := p.pool.QueryRow(ctx,
+		`SELECT last_offset, last_text FROM `+lastSyncStateTableName+` WHERE job_name = $1`,
+		jobName,
+	).Scan(&offset.ID, &offset.Text); err != nil {
 		if err == pgx.ErrNoRows {
-			return 0, nil
+			return offset, nil
 		}
 
 		p.logger.Error("failed to get last offset", "error", err)
-		return 0, err
+		return offset, err
 	}
 
-	p.logger.Info("got last offset for job", "offset", offset.Int64)
+	p.logger.Info("got last offset for job", "offset", offset)
 
-	return offset.Int64, nil
+	return offset, nil
 }
 
 func (p *PostgresMetadata) GetLastSyncBatchID(ctx context.Context, jobName string) (int64, error) {
-	row := p.pool.QueryRow(ctx,
-		`SELECT sync_batch_id FROM `+lastSyncStateTableName+` WHERE job_name = $1`, jobName)
-
 	var syncBatchID pgtype.Int8
-	err := row.Scan(&syncBatchID)
-	if err != nil {
+	if err := p.pool.QueryRow(ctx,
+		`SELECT sync_batch_id FROM `+lastSyncStateTableName+` WHERE job_name = $1`,
+		jobName,
+	).Scan(&syncBatchID); err != nil {
 		// if the job doesn't exist, return 0
 		if err == pgx.ErrNoRows {
 			return 0, nil
@@ -114,14 +111,11 @@ func (p *PostgresMetadata) GetLastSyncBatchID(ctx context.Context, jobName strin
 }
 
 func (p *PostgresMetadata) GetLastNormalizeBatchID(ctx context.Context, jobName string) (int64, error) {
-	rows := p.pool.QueryRow(ctx,
-		`SELECT normalize_batch_id FROM `+
-			lastSyncStateTableName+
-			` WHERE job_name = $1`, jobName)
-
 	var normalizeBatchID pgtype.Int8
-	err := rows.Scan(&normalizeBatchID)
-	if err != nil {
+	if err := p.pool.QueryRow(ctx,
+		`SELECT normalize_batch_id FROM `+lastSyncStateTableName+` WHERE job_name = $1`,
+		jobName,
+	).Scan(&normalizeBatchID); err != nil {
 		// if the job doesn't exist, return 0
 		if err.Error() == "no rows in result set" {
 			return 0, nil
@@ -135,16 +129,17 @@ func (p *PostgresMetadata) GetLastNormalizeBatchID(ctx context.Context, jobName 
 	return normalizeBatchID.Int64, nil
 }
 
-func (p *PostgresMetadata) SetLastOffset(ctx context.Context, jobName string, offset int64) error {
-	p.logger.Debug("updating last offset", slog.String("offset", pglogrepl.LSN(offset).String()))
-	_, err := p.pool.Exec(ctx, `
-		INSERT INTO `+lastSyncStateTableName+` (job_name, last_offset, sync_batch_id)
-		VALUES ($1, $2, $3)
+func (p *PostgresMetadata) SetLastOffset(ctx context.Context, jobName string, offset model.CdcCheckpoint) error {
+	p.logger.Debug("updating last offset", slog.String("offsetID", pglogrepl.LSN(offset.ID).String()), slog.String("offsetText", offset.Text))
+	if _, err := p.pool.Exec(ctx, `
+		INSERT INTO `+lastSyncStateTableName+` (job_name, last_offset, last_text, sync_batch_id)
+		VALUES ($1, $2, $3, 0)
 		ON CONFLICT (job_name)
-		DO UPDATE SET last_offset = GREATEST(`+lastSyncStateTableName+`.last_offset, excluded.last_offset),
+		DO UPDATE SET
+			last_offset = GREATEST(`+lastSyncStateTableName+`.last_offset, excluded.last_offset),
+			last_text = excluded.last_text,
 			updated_at = NOW()
-	`, jobName, offset, 0)
-	if err != nil {
+	`, jobName, offset.ID, offset.Text); err != nil {
 		p.logger.Error("failed to update last offset", "error", err)
 		return err
 	}
@@ -152,18 +147,18 @@ func (p *PostgresMetadata) SetLastOffset(ctx context.Context, jobName string, of
 	return nil
 }
 
-func (p *PostgresMetadata) FinishBatch(ctx context.Context, jobName string, syncBatchID int64, offset int64) error {
+func (p *PostgresMetadata) FinishBatch(ctx context.Context, jobName string, syncBatchID int64, offset model.CdcCheckpoint) error {
 	p.logger.Info("finishing batch", "SyncBatchID", syncBatchID, "offset", offset)
-	_, err := p.pool.Exec(ctx, `
-		INSERT INTO `+lastSyncStateTableName+` (job_name, last_offset, sync_batch_id)
-		VALUES ($1, $2, $3)
+	if _, err := p.pool.Exec(ctx, `
+		INSERT INTO `+lastSyncStateTableName+` (job_name, last_offset, last_text, sync_batch_id)
+		VALUES ($1, $2, $3, $4)
 		ON CONFLICT (job_name)
 		DO UPDATE SET
 			last_offset = GREATEST(`+lastSyncStateTableName+`.last_offset, excluded.last_offset),
+			last_text = excluded.last_text,
 			sync_batch_id = GREATEST(`+lastSyncStateTableName+`.sync_batch_id, excluded.sync_batch_id),
 			updated_at = NOW()
-	`, jobName, offset, syncBatchID)
-	if err != nil {
+	`, jobName, offset.ID, offset.Text, syncBatchID); err != nil {
 		p.logger.Error("failed to finish batch", slog.Any("error", err))
 		return err
 	}
@@ -221,14 +216,13 @@ func (p *PostgresMetadata) IsQRepPartitionSynced(ctx context.Context, req *proto
 }
 
 func (p *PostgresMetadata) SyncFlowCleanup(ctx context.Context, jobName string) error {
-	_, err := p.pool.Exec(ctx,
-		`DELETE FROM `+lastSyncStateTableName+` WHERE job_name = $1`, jobName)
-	if err != nil {
+	if _, err := p.pool.Exec(ctx,
+		`DELETE FROM `+lastSyncStateTableName+` WHERE job_name = $1`, jobName,
+	); err != nil {
 		return err
 	}
 
-	_, err = p.pool.Exec(ctx, `DELETE FROM `+qrepTableName+` WHERE job_name = $1`, jobName)
-	if err != nil {
+	if _, err := p.pool.Exec(ctx, `DELETE FROM `+qrepTableName+` WHERE job_name = $1`, jobName); err != nil {
 		return err
 	}
 

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -326,8 +326,8 @@ func PullCdcRecords[Items model.Items](
 	// clientXLogPos is the last checkpoint id, we need to ack that we have processed
 	// until clientXLogPos each time we send a standby status update.
 	var clientXLogPos pglogrepl.LSN
-	if req.LastOffset > 0 {
-		clientXLogPos = pglogrepl.LSN(req.LastOffset)
+	if req.LastOffset.ID > 0 {
+		clientXLogPos = pglogrepl.LSN(req.LastOffset.ID)
 		if err := sendStandbyAfterReplLock("initial-flush"); err != nil {
 			return err
 		}
@@ -353,8 +353,7 @@ func PullCdcRecords[Items model.Items](
 	})
 	defer shutdown()
 
-	standbyMessageTimeout := req.IdleTimeout
-	nextStandbyMessageDeadline := time.Now().Add(standbyMessageTimeout)
+	nextStandbyMessageDeadline := time.Now().Add(req.IdleTimeout)
 
 	addRecordWithKey := func(key model.TableWithPkey, rec model.Record[Items]) error {
 		if err := cdcRecordsStorage.Set(logger, key, rec); err != nil {
@@ -366,7 +365,7 @@ func PullCdcRecords[Items model.Items](
 
 		if cdcRecordsStorage.Len() == 1 {
 			records.SignalAsNotEmpty()
-			nextStandbyMessageDeadline = time.Now().Add(standbyMessageTimeout)
+			nextStandbyMessageDeadline = time.Now().Add(req.IdleTimeout)
 			logger.Info(fmt.Sprintf("pushing the standby deadline to %s", nextStandbyMessageDeadline))
 		}
 		return nil
@@ -384,7 +383,7 @@ func PullCdcRecords[Items model.Items](
 		if pkmRequiresResponse {
 			if cdcRecordsStorage.IsEmpty() && int64(clientXLogPos) > req.ConsumedOffset.Load() {
 				metadata := connmetadata.NewPostgresMetadataFromCatalog(logger, p.catalogPool)
-				if err := metadata.SetLastOffset(ctx, req.FlowJobName, int64(clientXLogPos)); err != nil {
+				if err := metadata.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{ID: int64(clientXLogPos)}); err != nil {
 					return err
 				}
 				req.ConsumedOffset.Store(int64(clientXLogPos))
@@ -404,8 +403,7 @@ func PullCdcRecords[Items model.Items](
 		}
 
 		if p.commitLock == nil {
-			cdclen := cdcRecordsStorage.Len()
-			if cdclen >= 0 && uint32(cdclen) >= req.MaxBatchSize {
+			if cdcRecordsStorage.Len() >= int(req.MaxBatchSize) {
 				return nil
 			}
 
@@ -439,7 +437,7 @@ func PullCdcRecords[Items model.Items](
 					p.flowJobName),
 				)
 			}
-			nextStandbyMessageDeadline = time.Now().Add(standbyMessageTimeout)
+			nextStandbyMessageDeadline = time.Now().Add(req.IdleTimeout)
 		}
 
 		var receiveCtx context.Context
@@ -470,167 +468,161 @@ func PullCdcRecords[Items model.Items](
 			}
 		}
 
-		if errMsg, ok := rawMsg.(*pgproto3.ErrorResponse); ok {
-			return shared.LogError(logger, fmt.Errorf("received Postgres WAL error: %+v", errMsg))
-		}
-
-		msg, ok := rawMsg.(*pgproto3.CopyData)
-		if !ok {
-			continue
-		}
-
-		if p.otelManager != nil {
-			p.otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(msg.Data)), metric.WithAttributeSet(attribute.NewSet(
-				attribute.String(otel_metrics.FlowNameKey, req.FlowJobName),
-				attribute.String(otel_metrics.SourcePeerType, fmt.Sprintf("%T", p)),
-			)))
-		}
-
-		switch msg.Data[0] {
-		case pglogrepl.PrimaryKeepaliveMessageByteID:
-			pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(msg.Data[1:])
-			if err != nil {
-				return fmt.Errorf("ParsePrimaryKeepaliveMessage failed: %w", err)
+		switch msg := rawMsg.(type) {
+		case *pgproto3.ErrorResponse:
+			return shared.LogError(logger, fmt.Errorf("received Postgres WAL error: %+v", msg))
+		case *pgproto3.CopyData:
+			if p.otelManager != nil {
+				p.otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(msg.Data)), metric.WithAttributeSet(attribute.NewSet(
+					attribute.String(otel_metrics.FlowNameKey, req.FlowJobName),
+					attribute.String(otel_metrics.SourcePeerType, fmt.Sprintf("%T", p)),
+				)))
 			}
+			switch msg.Data[0] {
+			case pglogrepl.PrimaryKeepaliveMessageByteID:
+				pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(msg.Data[1:])
+				if err != nil {
+					return fmt.Errorf("ParsePrimaryKeepaliveMessage failed: %w", err)
+				}
 
-			logger.Debug("Primary Keepalive Message", slog.Bool("replyRequested", pkm.ReplyRequested),
-				slog.String("ServerWALEnd", pkm.ServerWALEnd.String()), slog.String("ServerTime", pkm.ServerTime.String()))
+				if pkm.ServerWALEnd > clientXLogPos {
+					clientXLogPos = pkm.ServerWALEnd
+				}
 
-			if pkm.ServerWALEnd > clientXLogPos {
-				clientXLogPos = pkm.ServerWALEnd
-			}
+				if pkm.ReplyRequested || (pkmEmptyBatchThrottleThresholdSeconds != -1 &&
+					time.Since(lastEmptyBatchPkmSentTime) >= time.Duration(pkmEmptyBatchThrottleThresholdSeconds)*time.Second) {
+					pkmRequiresResponse = true
+				}
 
-			if pkm.ReplyRequested || (pkmEmptyBatchThrottleThresholdSeconds != -1 &&
-				time.Since(lastEmptyBatchPkmSentTime) >= time.Duration(pkmEmptyBatchThrottleThresholdSeconds)*time.Second) {
-				pkmRequiresResponse = true
-			}
+			case pglogrepl.XLogDataByteID:
+				xld, err := pglogrepl.ParseXLogData(msg.Data[1:])
+				if err != nil {
+					return fmt.Errorf("ParseXLogData failed: %w", err)
+				}
 
-		case pglogrepl.XLogDataByteID:
-			xld, err := pglogrepl.ParseXLogData(msg.Data[1:])
-			if err != nil {
-				return fmt.Errorf("ParseXLogData failed: %w", err)
-			}
+				logger.Debug("XLogData",
+					slog.Any("WALStart", xld.WALStart), slog.Any("ServerWALEnd", xld.ServerWALEnd), slog.Any("ServerTime", xld.ServerTime))
+				rec, err := processMessage(ctx, p, records, xld, clientXLogPos, processor)
+				if err != nil {
+					return fmt.Errorf("error processing message: %w", err)
+				}
 
-			logger.Debug("XLogData",
-				slog.Any("WALStart", xld.WALStart), slog.Any("ServerWALEnd", xld.ServerWALEnd), slog.Any("ServerTime", xld.ServerTime))
-			rec, err := processMessage(ctx, p, records, xld, clientXLogPos, processor)
-			if err != nil {
-				return fmt.Errorf("error processing message: %w", err)
-			}
+				if xld.WALStart > clientXLogPos {
+					clientXLogPos = xld.WALStart
+				}
 
-			if xld.WALStart > clientXLogPos {
-				clientXLogPos = xld.WALStart
-			}
-
-			if rec != nil {
-				tableName := rec.GetDestinationTableName()
-				switch r := rec.(type) {
-				case *model.UpdateRecord[Items]:
-					// tableName here is destination tableName.
-					// should be ideally sourceTableName as we are in PullRecords.
-					// will change in future
-					// TODO: replident is cached here, should not cache since it can change
-					isFullReplica := req.TableNameSchemaMapping[tableName].IsReplicaIdentityFull
-					if isFullReplica {
-						if err := addRecordWithKey(model.TableWithPkey{}, rec); err != nil {
-							return err
-						}
-					} else {
-						tablePkeyVal, err := model.RecToTablePKey(req.TableNameSchemaMapping, rec)
-						if err != nil {
-							return err
-						}
-
-						latestRecord, ok, err := cdcRecordsStorage.Get(tablePkeyVal)
-						if err != nil {
-							return err
-						}
-						if ok {
-							// iterate through unchanged toast cols and set them in new record
-							updatedCols := r.NewItems.UpdateIfNotExists(latestRecord.GetItems())
-							for _, col := range updatedCols {
-								delete(r.UnchangedToastColumns, col)
-							}
-						}
-						if err := addRecordWithKey(tablePkeyVal, rec); err != nil {
-							return err
-						}
-					}
-
-				case *model.InsertRecord[Items]:
-					isFullReplica := req.TableNameSchemaMapping[tableName].IsReplicaIdentityFull
-					if isFullReplica {
-						if err := addRecordWithKey(model.TableWithPkey{}, rec); err != nil {
-							return err
-						}
-					} else {
-						tablePkeyVal, err := model.RecToTablePKey(req.TableNameSchemaMapping, rec)
-						if err != nil {
-							return err
-						}
-
-						if err := addRecordWithKey(tablePkeyVal, rec); err != nil {
-							return err
-						}
-					}
-				case *model.DeleteRecord[Items]:
-					isFullReplica := req.TableNameSchemaMapping[tableName].IsReplicaIdentityFull
-					if isFullReplica {
-						if err := addRecordWithKey(model.TableWithPkey{}, rec); err != nil {
-							return err
-						}
-					} else {
-						tablePkeyVal, err := model.RecToTablePKey(req.TableNameSchemaMapping, rec)
-						if err != nil {
-							return err
-						}
-
-						latestRecord, ok, err := cdcRecordsStorage.Get(tablePkeyVal)
-						if err != nil {
-							return err
-						}
-						if ok {
-							r.Items = latestRecord.GetItems()
-							if updateRecord, ok := latestRecord.(*model.UpdateRecord[Items]); ok {
-								r.UnchangedToastColumns = updateRecord.UnchangedToastColumns
-							}
-						} else {
-							// there is nothing to backfill the items in the delete record with,
-							// so don't update the row with this record
-							// add sentinel value to prevent update statements from selecting
-							r.UnchangedToastColumns = map[string]struct{}{
-								"_peerdb_not_backfilled_delete": {},
-							}
-						}
-
-						// A delete can only be followed by an INSERT, which does not need backfilling
-						// No need to store DeleteRecords in memory or disk.
-						if err := addRecordWithKey(model.TableWithPkey{}, rec); err != nil {
-							return err
-						}
-					}
-
-				case *model.RelationRecord[Items]:
-					tableSchemaDelta := r.TableSchemaDelta
-					if len(tableSchemaDelta.AddedColumns) > 0 {
-						logger.Info(fmt.Sprintf("Detected schema change for table %s, addedColumns: %v",
-							tableSchemaDelta.SrcTableName, tableSchemaDelta.AddedColumns))
-						records.AddSchemaDelta(req.TableNameMapping, tableSchemaDelta)
-					}
-
-				case *model.MessageRecord[Items]:
-					// if cdc store empty, we can move lsn,
-					// otherwise push to records so destination can ack once all previous messages processed
-					if cdcRecordsStorage.IsEmpty() {
-						if int64(clientXLogPos) > req.ConsumedOffset.Load() {
-							metadata := connmetadata.NewPostgresMetadataFromCatalog(logger, p.catalogPool)
-							if err := metadata.SetLastOffset(ctx, req.FlowJobName, int64(clientXLogPos)); err != nil {
+				if rec != nil {
+					tableName := rec.GetDestinationTableName()
+					switch r := rec.(type) {
+					case *model.UpdateRecord[Items]:
+						// tableName here is destination tableName.
+						// should be ideally sourceTableName as we are in PullRecords.
+						// will change in future
+						// TODO: replident is cached here, should not cache since it can change
+						isFullReplica := req.TableNameSchemaMapping[tableName].IsReplicaIdentityFull
+						if isFullReplica {
+							if err := addRecordWithKey(model.TableWithPkey{}, rec); err != nil {
 								return err
 							}
-							req.ConsumedOffset.Store(int64(clientXLogPos))
+						} else {
+							tablePkeyVal, err := model.RecToTablePKey(req.TableNameSchemaMapping, rec)
+							if err != nil {
+								return err
+							}
+
+							latestRecord, ok, err := cdcRecordsStorage.Get(tablePkeyVal)
+							if err != nil {
+								return err
+							}
+							if ok {
+								// iterate through unchanged toast cols and set them in new record
+								updatedCols := r.NewItems.UpdateIfNotExists(latestRecord.GetItems())
+								for _, col := range updatedCols {
+									delete(r.UnchangedToastColumns, col)
+								}
+							}
+							if err := addRecordWithKey(tablePkeyVal, rec); err != nil {
+								return err
+							}
 						}
-					} else if err := records.AddRecord(ctx, rec); err != nil {
-						return err
+
+					case *model.InsertRecord[Items]:
+						isFullReplica := req.TableNameSchemaMapping[tableName].IsReplicaIdentityFull
+						if isFullReplica {
+							if err := addRecordWithKey(model.TableWithPkey{}, rec); err != nil {
+								return err
+							}
+						} else {
+							tablePkeyVal, err := model.RecToTablePKey(req.TableNameSchemaMapping, rec)
+							if err != nil {
+								return err
+							}
+
+							if err := addRecordWithKey(tablePkeyVal, rec); err != nil {
+								return err
+							}
+						}
+					case *model.DeleteRecord[Items]:
+						isFullReplica := req.TableNameSchemaMapping[tableName].IsReplicaIdentityFull
+						if isFullReplica {
+							if err := addRecordWithKey(model.TableWithPkey{}, rec); err != nil {
+								return err
+							}
+						} else {
+							tablePkeyVal, err := model.RecToTablePKey(req.TableNameSchemaMapping, rec)
+							if err != nil {
+								return err
+							}
+
+							latestRecord, ok, err := cdcRecordsStorage.Get(tablePkeyVal)
+							if err != nil {
+								return err
+							}
+							if ok {
+								r.Items = latestRecord.GetItems()
+								if updateRecord, ok := latestRecord.(*model.UpdateRecord[Items]); ok {
+									r.UnchangedToastColumns = updateRecord.UnchangedToastColumns
+								}
+							} else {
+								// there is nothing to backfill the items in the delete record with,
+								// so don't update the row with this record
+								// add sentinel value to prevent update statements from selecting
+								r.UnchangedToastColumns = map[string]struct{}{
+									"_peerdb_not_backfilled_delete": {},
+								}
+							}
+
+							// A delete can only be followed by an INSERT, which does not need backfilling
+							// No need to store DeleteRecords in memory or disk.
+							if err := addRecordWithKey(model.TableWithPkey{}, rec); err != nil {
+								return err
+							}
+						}
+
+					case *model.RelationRecord[Items]:
+						tableSchemaDelta := r.TableSchemaDelta
+						if len(tableSchemaDelta.AddedColumns) > 0 {
+							logger.Info(fmt.Sprintf("Detected schema change for table %s, addedColumns: %v",
+								tableSchemaDelta.SrcTableName, tableSchemaDelta.AddedColumns))
+							records.AddSchemaDelta(req.TableNameMapping, tableSchemaDelta)
+						}
+
+					case *model.MessageRecord[Items]:
+						// if cdc store empty, we can move lsn,
+						// otherwise push to records so destination can ack once all previous messages processed
+						if cdcRecordsStorage.IsEmpty() {
+							if int64(clientXLogPos) > req.ConsumedOffset.Load() {
+								metadata := connmetadata.NewPostgresMetadataFromCatalog(logger, p.catalogPool)
+								if err := metadata.SetLastOffset(
+									ctx, req.FlowJobName, model.CdcCheckpoint{ID: int64(clientXLogPos)},
+								); err != nil {
+									return err
+								}
+								req.ConsumedOffset.Store(int64(clientXLogPos))
+							}
+						} else if err := records.AddRecord(ctx, rec); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -680,7 +672,7 @@ func processMessage[Items model.Items](
 	case *pglogrepl.CommitMessage:
 		// for a commit message, update the last checkpoint id for the record batch.
 		logger.Debug("CommitMessage", slog.Any("CommitLSN", msg.CommitLSN), slog.Any("TransactionEndLSN", msg.TransactionEndLSN))
-		batch.UpdateLatestCheckpoint(int64(msg.CommitLSN))
+		batch.UpdateLatestCheckpointID(int64(msg.CommitLSN))
 		p.commitLock = nil
 	case *pglogrepl.RelationMessage:
 		// treat all relation messages as corresponding to parent if partitioned.
@@ -706,7 +698,7 @@ func processMessage[Items model.Items](
 			slog.String("Prefix", msg.Prefix),
 			slog.String("LSN", msg.LSN.String()))
 		if !msg.Transactional {
-			batch.UpdateLatestCheckpoint(int64(msg.LSN))
+			batch.UpdateLatestCheckpointID(int64(msg.LSN))
 		}
 		return &model.MessageRecord[Items]{
 			BaseRecord: p.baseRecord(msg.LSN),

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -25,7 +25,7 @@ import (
 const (
 	mirrorJobsTableIdentifier = "peerdb_mirror_jobs"
 	createMirrorJobsTableSQL  = `CREATE TABLE IF NOT EXISTS %s.%s(mirror_job_name TEXT PRIMARY KEY,
-		lsn_offset BIGINT NOT NULL,sync_batch_id BIGINT NOT NULL,normalize_batch_id BIGINT NOT NULL)`
+		lsn_offset BIGINT NOT NULL,lsn_text TEXT NOT NULL,sync_batch_id BIGINT NOT NULL,normalize_batch_id BIGINT NOT NULL)`
 	rawTablePrefix    = "_peerdb_raw"
 	createSchemaSQL   = "CREATE SCHEMA IF NOT EXISTS %s"
 	createRawTableSQL = `CREATE TABLE IF NOT EXISTS %s.%s(_peerdb_uid uuid NOT NULL,
@@ -35,14 +35,15 @@ const (
 	createRawTableBatchIDIndexSQL  = "CREATE INDEX IF NOT EXISTS %s_batchid_idx ON %s.%s(_peerdb_batch_id)"
 	createRawTableDstTableIndexSQL = "CREATE INDEX IF NOT EXISTS %s_dst_table_idx ON %s.%s(_peerdb_destination_table_name)"
 
-	getLastOffsetSQL            = "SELECT lsn_offset FROM %s.%s WHERE mirror_job_name=$1"
-	setLastOffsetSQL            = "UPDATE %s.%s SET lsn_offset=GREATEST(lsn_offset, $1) WHERE mirror_job_name=$2"
+	getLastOffsetSQL            = "SELECT lsn_offset, lsn_text FROM %s.%s WHERE mirror_job_name=$1"
+	setLastOffsetSQL            = "UPDATE %s.%s SET lsn_offset=GREATEST(lsn_offset, $1), lsn_text = $2 WHERE mirror_job_name=$3"
 	getLastSyncBatchID_SQL      = "SELECT sync_batch_id FROM %s.%s WHERE mirror_job_name=$1"
 	getLastNormalizeBatchID_SQL = "SELECT normalize_batch_id FROM %s.%s WHERE mirror_job_name=$1"
 	createNormalizedTableSQL    = "CREATE TABLE IF NOT EXISTS %s(%s)"
 	checkTableExistsSQL         = "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname = $1 AND tablename = $2)"
-	upsertJobMetadataForSyncSQL = `INSERT INTO %s.%s AS j VALUES ($1,$2,$3,$4)
-	 ON CONFLICT(mirror_job_name) DO UPDATE SET lsn_offset=GREATEST(j.lsn_offset, EXCLUDED.lsn_offset), sync_batch_id=EXCLUDED.sync_batch_id`
+	upsertJobMetadataForSyncSQL = `INSERT INTO %s.%s AS j (mirror_job_name,lsn_offset,lsn_text,sync_batch_id,normalize_batch_id)
+		VALUES ($1,$2,$3,$4,0) ON CONFLICT(mirror_job_name) DO UPDATE SET lsn_offset=GREATEST(j.lsn_offset, EXCLUDED.lsn_offset),
+		lsn_text=EXCLUDED.lsn_text, sync_batch_id=EXCLUDED.sync_batch_id`
 	checkIfJobMetadataExistsSQL          = "SELECT COUNT(1)::TEXT::BOOL FROM %s.%s WHERE mirror_job_name=$1"
 	updateMetadataForNormalizeRecordsSQL = "UPDATE %s.%s SET normalize_batch_id=$1 WHERE mirror_job_name=$2"
 
@@ -550,12 +551,12 @@ func (c *PostgresConnector) MajorVersion(ctx context.Context) (shared.PGVersion,
 	return c.pgVersion, nil
 }
 
-func (c *PostgresConnector) updateSyncMetadata(ctx context.Context, flowJobName string, lastCP int64, syncBatchID int64,
+func (c *PostgresConnector) updateSyncMetadata(ctx context.Context, flowJobName string, lastCP model.CdcCheckpoint, syncBatchID int64,
 	syncRecordsTx pgx.Tx,
 ) error {
 	_, err := syncRecordsTx.Exec(ctx,
 		fmt.Sprintf(upsertJobMetadataForSyncSQL, c.metadataSchema, mirrorJobsTableIdentifier),
-		flowJobName, lastCP, syncBatchID, 0)
+		flowJobName, lastCP.ID, lastCP.Text, syncBatchID)
 	if err != nil {
 		return fmt.Errorf("failed to upsert flow job status: %w", err)
 	}

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1174,9 +1174,9 @@ func (c *PostgresConnector) SyncFlowCleanup(ctx context.Context, jobName string)
 		return fmt.Errorf("unable to check if job metadata exists: %w", err)
 	}
 	if mirrorJobsTableExists {
-		_, err = syncFlowCleanupTx.Exec(ctx,
-			fmt.Sprintf(deleteJobMetadataSQL, c.metadataSchema, mirrorJobsTableIdentifier), jobName)
-		if err != nil {
+		if _, err := syncFlowCleanupTx.Exec(ctx,
+			fmt.Sprintf(deleteJobMetadataSQL, c.metadataSchema, mirrorJobsTableIdentifier), jobName,
+		); err != nil {
 			return fmt.Errorf("unable to delete job metadata: %w", err)
 		}
 	}

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -274,15 +274,12 @@ func (c *PostgresConnector) ConnectionActive(ctx context.Context) error {
 }
 
 // NeedsSetupMetadataTables returns true if the metadata tables need to be set up.
-func (c *PostgresConnector) NeedsSetupMetadataTables(ctx context.Context) bool {
+func (c *PostgresConnector) NeedsSetupMetadataTables(ctx context.Context) (bool, error) {
 	result, err := c.tableExists(ctx, &utils.SchemaTable{
 		Schema: c.metadataSchema,
 		Table:  mirrorJobsTableIdentifier,
 	})
-	if err != nil {
-		return true
-	}
-	return !result
+	return !result, err
 }
 
 // SetupMetadataTables sets up the metadata tables.
@@ -302,27 +299,28 @@ func (c *PostgresConnector) SetupMetadataTables(ctx context.Context) error {
 }
 
 // GetLastOffset returns the last synced offset for a job.
-func (c *PostgresConnector) GetLastOffset(ctx context.Context, jobName string) (int64, error) {
-	var result pgtype.Int8
-	err := c.conn.QueryRow(ctx, fmt.Sprintf(getLastOffsetSQL, c.metadataSchema, mirrorJobsTableIdentifier), jobName).Scan(&result)
-	if err != nil {
+func (c *PostgresConnector) GetLastOffset(ctx context.Context, jobName string) (model.CdcCheckpoint, error) {
+	var result model.CdcCheckpoint
+	if err := c.conn.QueryRow(
+		ctx, fmt.Sprintf(getLastOffsetSQL, c.metadataSchema, mirrorJobsTableIdentifier), jobName,
+	).Scan(&result.ID, &result.Text); err != nil {
 		if err == pgx.ErrNoRows {
 			c.logger.Info("No row found, returning nil")
-			return 0, nil
+			return result, nil
 		}
-		return 0, fmt.Errorf("error while reading result row: %w", err)
+		return result, fmt.Errorf("error while reading result row: %w", err)
 	}
 
-	if result.Int64 == 0 {
+	if result.ID == 0 && result.Text == "" {
 		c.logger.Warn("Assuming zero offset means no sync has happened")
 	}
-	return result.Int64, nil
+	return result, nil
 }
 
 // SetLastOffset updates the last synced offset for a job.
-func (c *PostgresConnector) SetLastOffset(ctx context.Context, jobName string, lastOffset int64) error {
+func (c *PostgresConnector) SetLastOffset(ctx context.Context, jobName string, lastOffset model.CdcCheckpoint) error {
 	_, err := c.conn.
-		Exec(ctx, fmt.Sprintf(setLastOffsetSQL, c.metadataSchema, mirrorJobsTableIdentifier), lastOffset, jobName)
+		Exec(ctx, fmt.Sprintf(setLastOffsetSQL, c.metadataSchema, mirrorJobsTableIdentifier), lastOffset.ID, lastOffset.Text, jobName)
 	if err != nil {
 		return fmt.Errorf("error setting last offset for job %s: %w", jobName, err)
 	}
@@ -360,7 +358,7 @@ func pullCore[Items model.Items](
 	defer func() {
 		req.RecordStream.Close()
 		if c.replState != nil {
-			c.replState.Offset = req.RecordStream.GetLastCheckpoint()
+			c.replState.Offset = req.RecordStream.GetLastCheckpoint().ID
 		}
 	}()
 
@@ -405,7 +403,7 @@ func pullCore[Items model.Items](
 		return fmt.Errorf("error getting child to parent relid map: %w", err)
 	}
 
-	if err := c.MaybeStartReplication(ctx, slotName, publicationName, req.LastOffset, pgVersion); err != nil {
+	if err := c.MaybeStartReplication(ctx, slotName, publicationName, req.LastOffset.ID, pgVersion); err != nil {
 		// in case of Aurora error ERROR: replication slots cannot be used on RO (Read Only) node (SQLSTATE 55000)
 		if shared.IsSQLStateError(err, pgerrcode.ObjectNotInPrerequisiteState) &&
 			strings.Contains(err.Error(), "replication slots cannot be used on RO (Read Only) node") {
@@ -445,10 +443,11 @@ func pullCore[Items model.Items](
 	return nil
 }
 
-func (c *PostgresConnector) UpdateReplStateLastOffset(lastOffset int64) {
+func (c *PostgresConnector) UpdateReplStateLastOffset(_ context.Context, lastOffset model.CdcCheckpoint) error {
 	if c.replState != nil {
-		c.replState.LastOffset.Store(lastOffset)
+		c.replState.LastOffset.Store(lastOffset.ID)
 	}
+	return nil
 }
 
 func (c *PostgresConnector) SyncRecords(ctx context.Context, req *model.SyncRecordsRequest[model.RecordItems]) (*model.SyncResponse, error) {
@@ -581,27 +580,24 @@ func syncRecordsCore[Items model.Items](
 
 	// updating metadata with new offset and syncBatchID
 	lastCP := req.Records.GetLastCheckpoint()
-	err = c.updateSyncMetadata(ctx, req.FlowJobName, lastCP, req.SyncBatchID, syncRecordsTx)
-	if err != nil {
+	if err := c.updateSyncMetadata(ctx, req.FlowJobName, lastCP, req.SyncBatchID, syncRecordsTx); err != nil {
 		return nil, err
 	}
 	// transaction commits
-	err = syncRecordsTx.Commit(ctx)
-	if err != nil {
+	if err := syncRecordsTx.Commit(ctx); err != nil {
 		return nil, err
 	}
 
-	err = c.ReplayTableSchemaDeltas(ctx, req.Env, req.FlowJobName, req.Records.SchemaDeltas)
-	if err != nil {
+	if err := c.ReplayTableSchemaDeltas(ctx, req.Env, req.FlowJobName, req.Records.SchemaDeltas); err != nil {
 		return nil, fmt.Errorf("failed to sync schema changes: %w", err)
 	}
 
 	return &model.SyncResponse{
-		LastSyncedCheckpointID: lastCP,
-		NumRecordsSynced:       numRecords,
-		CurrentSyncBatchID:     req.SyncBatchID,
-		TableNameRowsMapping:   tableNameRowsMapping,
-		TableSchemaDeltas:      req.Records.SchemaDeltas,
+		LastSyncedCheckpoint: lastCP,
+		NumRecordsSynced:     numRecords,
+		CurrentSyncBatchID:   req.SyncBatchID,
+		TableNameRowsMapping: tableNameRowsMapping,
+		TableSchemaDeltas:    req.Records.SchemaDeltas,
 	}, nil
 }
 

--- a/flow/connectors/pubsub/pubsub.go
+++ b/flow/connectors/pubsub/pubsub.go
@@ -295,7 +295,7 @@ func (c *PubSubConnector) SyncRecords(ctx context.Context, req *model.SyncRecord
 			case <-ticker.C:
 				lastSeen := lastSeenLSN.Load()
 				if lastSeen > req.ConsumedOffset.Load() {
-					if err := c.SetLastOffset(ctx, req.FlowJobName, lastSeen); err != nil {
+					if err := c.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{ID: lastSeen}); err != nil {
 						c.logger.Warn("[pubsub] SetLastOffset error", slog.Any("error", err))
 					} else {
 						shared.AtomicInt64Max(req.ConsumedOffset, lastSeen)
@@ -378,10 +378,10 @@ Loop:
 	}
 
 	return &model.SyncResponse{
-		CurrentSyncBatchID:     req.SyncBatchID,
-		LastSyncedCheckpointID: lastCheckpoint,
-		NumRecordsSynced:       numRecords.Load(),
-		TableNameRowsMapping:   tableNameRowsMapping,
-		TableSchemaDeltas:      req.Records.SchemaDeltas,
+		CurrentSyncBatchID:   req.SyncBatchID,
+		LastSyncedCheckpoint: lastCheckpoint,
+		NumRecordsSynced:     numRecords.Load(),
+		TableNameRowsMapping: tableNameRowsMapping,
+		TableSchemaDeltas:    req.Records.SchemaDeltas,
 	}, nil
 }

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -111,10 +111,10 @@ func (c *S3Connector) SyncRecords(ctx context.Context, req *model.SyncRecordsReq
 	}
 
 	return &model.SyncResponse{
-		LastSyncedCheckpointID: lastCheckpoint,
-		NumRecordsSynced:       int64(numRecords),
-		TableNameRowsMapping:   tableNameRowsMapping,
-		TableSchemaDeltas:      req.Records.SchemaDeltas,
+		LastSyncedCheckpoint: lastCheckpoint,
+		NumRecordsSynced:     int64(numRecords),
+		TableNameRowsMapping: tableNameRowsMapping,
+		TableSchemaDeltas:    req.Records.SchemaDeltas,
 	}, nil
 }
 

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -423,7 +423,7 @@ func (c *SnowflakeConnector) SyncRecords(ctx context.Context, req *model.SyncRec
 		return nil, err
 	}
 
-	if err := c.FinishBatch(ctx, req.FlowJobName, req.SyncBatchID, res.LastSyncedCheckpointID); err != nil {
+	if err := c.FinishBatch(ctx, req.FlowJobName, req.SyncBatchID, res.LastSyncedCheckpoint); err != nil {
 		return nil, err
 	}
 
@@ -466,11 +466,11 @@ func (c *SnowflakeConnector) syncRecordsViaAvro(
 	}
 
 	return &model.SyncResponse{
-		LastSyncedCheckpointID: req.Records.GetLastCheckpoint(),
-		NumRecordsSynced:       int64(numRecords),
-		CurrentSyncBatchID:     syncBatchID,
-		TableNameRowsMapping:   tableNameRowsMapping,
-		TableSchemaDeltas:      req.Records.SchemaDeltas,
+		LastSyncedCheckpoint: req.Records.GetLastCheckpoint(),
+		NumRecordsSynced:     int64(numRecords),
+		CurrentSyncBatchID:   syncBatchID,
+		TableNameRowsMapping: tableNameRowsMapping,
+		TableSchemaDeltas:    req.Records.SchemaDeltas,
 	}, nil
 }
 

--- a/flow/connectors/utils/monitoring/monitoring.go
+++ b/flow/connectors/utils/monitoring/monitoring.go
@@ -79,11 +79,11 @@ func UpdateNumRowsAndEndLSNForCDCBatch(
 	flowJobName string,
 	batchID int64,
 	numRows uint32,
-	batchEndLSN int64,
+	batchEndCheckpoint model.CdcCheckpoint,
 ) error {
 	if _, err := pool.Exec(ctx,
-		"UPDATE peerdb_stats.cdc_batches SET rows_in_batch=$1,batch_end_lsn=$2 WHERE flow_name=$3 AND batch_id=$4",
-		numRows, uint64(batchEndLSN), flowJobName, batchID,
+		"UPDATE peerdb_stats.cdc_batches SET rows_in_batch=$1,batch_end_lsn=$2,batch_end_lsn_text=$3 WHERE flow_name=$4 AND batch_id=$5",
+		numRows, uint64(batchEndCheckpoint.ID), batchEndCheckpoint.Text, flowJobName, batchID,
 	); err != nil {
 		return fmt.Errorf("error while updating batch in cdc_batch: %w", err)
 	}

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -76,7 +76,7 @@ type PullRecordsRequest[T Items] struct {
 	// override replication slot name
 	OverrideReplicationSlotName string
 	// LastOffset is the latest LSN that was synced.
-	LastOffset int64
+	LastOffset CdcCheckpoint
 	// MaxBatchSize is the max number of records to fetch.
 	MaxBatchSize uint32
 	// IdleTimeout is the timeout to wait for new records.
@@ -163,8 +163,8 @@ type SyncResponse struct {
 	TableNameRowsMapping map[string]*RecordTypeCounts
 	// to be carried to parent workflow
 	TableSchemaDeltas []*protos.TableSchemaDelta
-	// LastSyncedCheckpointID is the last ID that was synced.
-	LastSyncedCheckpointID int64
+	// LastSyncedCheckpoint is the last state (eg LSN, GTID) that was synced.
+	LastSyncedCheckpoint CdcCheckpoint
 	// NumRecordsSynced is the number of records that were synced.
 	NumRecordsSynced   int64
 	CurrentSyncBatchID int64

--- a/flow/pua/stream_adapter.go
+++ b/flow/pua/stream_adapter.go
@@ -76,7 +76,9 @@ func AttachToCdcStream(
 			}
 		}
 		outstream.SchemaDeltas = stream.SchemaDeltas
-		outstream.UpdateLatestCheckpoint(stream.GetLastCheckpoint())
+		lastCP := stream.GetLastCheckpoint()
+		outstream.UpdateLatestCheckpointID(lastCP.ID)
+		outstream.UpdateLatestCheckpointText(lastCP.Text)
 		outstream.Close()
 	}()
 	return outstream

--- a/nexus/catalog/migrations/V42__mysql_metadata.sql
+++ b/nexus/catalog/migrations/V42__mysql_metadata.sql
@@ -1,0 +1,3 @@
+ALTER TABLE metadata_last_sync_state ADD COLUMN IF NOT EXISTS last_text text NOT NULL DEFAULT '';
+ALTER TABLE peerdb_stats.cdc_batches ADD COLUMN IF NOT EXISTS batch_end_lsn_text text NOT NULL DEFAULT '';
+


### PR DESCRIPTION
for pg we currently use destination instead of catalog. mysql->pg will use catalog. therefore metadata tables on destination pg can ignore this change, avoiding issues upgrading existing pgpg setups

also update connector interfaces a bit

split out from #2395