### PR TITLE
Fix chunking with enabled primary key updates

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -278,6 +278,13 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		slog.Int64("EndBatchID", req.SyncBatchID),
 		slog.Int("connections", parallelNormalize))
 
+	numParts, err := peerdbenv.PeerDBClickHouseNormalizationChunkingParts(ctx, req.Env)
+	if err != nil {
+		c.logger.Warn("failed to get chunking parts, proceeding without chunking", slog.Any("error", err))
+		numParts = 1
+	}
+	numParts = max(numParts, 1)
+
 	queries := make(chan string)
 	rawTbl := c.getRawTableName(req.FlowJobName)
 
@@ -302,17 +309,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 					slog.Int64("normalizeBatchId", normBatchID),
 					slog.String("query", query))
 
-				numParts, err := peerdbenv.PeerDBClickHouseNormalizationChunkingParts(ctx, req.Env)
-				if err != nil {
-					c.logger.Warn("failed to get chunking parts, proceeding without chunking", slog.Any("error", err))
-				} else if numParts > 1 {
-					for i := range numParts {
-						partitionedQuery := fmt.Sprintf("%s AND cityHash64(_peerdb_uid) %% %d = %d", query, numParts, i)
-						if err := c.execWithLogging(ctx, partitionedQuery); err != nil {
-							return fmt.Errorf("error while inserting into normalized table: %w", err)
-						}
-					}
-				} else if err := chConn.Exec(errCtx, query); err != nil {
+				if err := chConn.Exec(errCtx, query); err != nil {
 					return fmt.Errorf("error while inserting into normalized table: %w", err)
 				}
 			}
@@ -321,156 +318,144 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	}
 
 	for _, tbl := range destinationTableNames {
-		// SELECT projection FROM raw_table WHERE _peerdb_batch_id > normalize_batch_id AND _peerdb_batch_id <= sync_batch_id
-		selectQuery := strings.Builder{}
-		selectQuery.WriteString("SELECT ")
+		for numPart := range numParts {
+			// SELECT projection FROM raw_table WHERE _peerdb_batch_id > normalize_batch_id AND _peerdb_batch_id <= sync_batch_id
+			selectQuery := strings.Builder{}
+			selectQuery.WriteString("SELECT ")
 
-		colSelector := strings.Builder{}
-		colSelector.WriteRune('(')
+			colSelector := strings.Builder{}
+			colSelector.WriteRune('(')
 
-		schema := req.TableNameSchemaMapping[tbl]
+			schema := req.TableNameSchemaMapping[tbl]
 
-		var tableMapping *protos.TableMapping
-		for _, tm := range req.TableMappings {
-			if tm.DestinationTableIdentifier == tbl {
-				tableMapping = tm
-				break
+			var tableMapping *protos.TableMapping
+			for _, tm := range req.TableMappings {
+				if tm.DestinationTableIdentifier == tbl {
+					tableMapping = tm
+					break
+				}
 			}
-		}
 
-		projection := strings.Builder{}
-		projectionUpdate := strings.Builder{}
+			projection := strings.Builder{}
+			projectionUpdate := strings.Builder{}
 
-		for _, column := range schema.Columns {
-			colName := column.Name
-			dstColName := colName
-			colType := qvalue.QValueKind(column.Type)
+			for _, column := range schema.Columns {
+				colName := column.Name
+				dstColName := colName
+				colType := qvalue.QValueKind(column.Type)
 
-			var clickHouseType string
-			var columnNullableEnabled bool
-			if tableMapping != nil {
-				for _, col := range tableMapping.Columns {
-					if col.SourceName == colName {
-						if col.DestinationName != "" {
-							dstColName = col.DestinationName
+				var clickHouseType string
+				var columnNullableEnabled bool
+				if tableMapping != nil {
+					for _, col := range tableMapping.Columns {
+						if col.SourceName == colName {
+							if col.DestinationName != "" {
+								dstColName = col.DestinationName
+							}
+							if col.DestinationType != "" {
+								// TODO can we restrict this to avoid injection?
+								clickHouseType = col.DestinationType
+							}
+							columnNullableEnabled = col.NullableEnabled
+							break
 						}
-						if col.DestinationType != "" {
-							// TODO can we restrict this to avoid injection?
-							clickHouseType = col.DestinationType
-						}
-						columnNullableEnabled = col.NullableEnabled
-						break
 					}
 				}
-			}
 
-			colSelector.WriteString(fmt.Sprintf("`%s`,", dstColName))
-			if clickHouseType == "" {
-				var err error
-				clickHouseType, err = colType.ToDWHColumnType(ctx, req.Env, protos.DBType_CLICKHOUSE, column)
-				if err != nil {
-					close(queries)
-					return model.NormalizeResponse{}, fmt.Errorf("error while converting column type to clickhouse type: %w", err)
-				}
-
-				if (schema.NullableEnabled || columnNullableEnabled) && column.Nullable && !colType.IsArray() {
-					clickHouseType = fmt.Sprintf("Nullable(%s)", clickHouseType)
-				}
-			}
-
-			switch clickHouseType {
-			case "Date32", "Nullable(Date32)":
-				projection.WriteString(fmt.Sprintf(
-					"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'),6)) AS `%s`,",
-					colName, dstColName,
-				))
-				if enablePrimaryUpdate {
-					projectionUpdate.WriteString(fmt.Sprintf(
-						"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, '%s'),6)) AS `%s`,",
-						colName, dstColName,
-					))
-				}
-			case "DateTime64(6)", "Nullable(DateTime64(6))":
-				projection.WriteString(fmt.Sprintf(
-					"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'),6) AS `%s`,",
-					colName, dstColName,
-				))
-				if enablePrimaryUpdate {
-					projectionUpdate.WriteString(fmt.Sprintf(
-						"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, '%s'),6) AS `%s`,",
-						colName, dstColName,
-					))
-				}
-			default:
-				projLen := projection.Len()
-				if colType == qvalue.QValueKindBytes {
-					format, err := peerdbenv.PeerDBBinaryFormat(ctx, req.Env)
+				colSelector.WriteString(fmt.Sprintf("`%s`,", dstColName))
+				if clickHouseType == "" {
+					var err error
+					clickHouseType, err = colType.ToDWHColumnType(ctx, req.Env, protos.DBType_CLICKHOUSE, column)
 					if err != nil {
-						return model.NormalizeResponse{}, err
+						close(queries)
+						return model.NormalizeResponse{}, fmt.Errorf("error while converting column type to clickhouse type: %w", err)
 					}
-					switch format {
-					case peerdbenv.BinaryFormatRaw:
-						projection.WriteString(fmt.Sprintf("base64Decode(JSONExtractString(_peerdb_data, '%s')) AS `%s`,", colName, dstColName))
-						if enablePrimaryUpdate {
-							projectionUpdate.WriteString(fmt.Sprintf(
-								"base64Decode(JSONExtractString(_peerdb_match_data, '%s')) AS `%s`,",
-								colName, dstColName,
-							))
-						}
-					case peerdbenv.BinaryFormatHex:
-						projection.WriteString(fmt.Sprintf("hex(base64Decode(JSONExtractString(_peerdb_data, '%s'))) AS `%s`,",
-							colName, dstColName))
-						if enablePrimaryUpdate {
-							projectionUpdate.WriteString(fmt.Sprintf(
-								"hex(base64Decode(JSONExtractString(_peerdb_match_data, '%s'))) AS `%s`,",
-								colName, dstColName,
-							))
-						}
+
+					if (schema.NullableEnabled || columnNullableEnabled) && column.Nullable && !colType.IsArray() {
+						clickHouseType = fmt.Sprintf("Nullable(%s)", clickHouseType)
 					}
 				}
 
-				// proceed with default logic if logic above didn't add any sql
-				if projection.Len() == projLen {
-					projection.WriteString(fmt.Sprintf("JSONExtract(_peerdb_data, '%s', '%s') AS `%s`,", colName, clickHouseType, dstColName))
+				switch clickHouseType {
+				case "Date32", "Nullable(Date32)":
+					projection.WriteString(fmt.Sprintf(
+						"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'),6)) AS `%s`,",
+						colName, dstColName,
+					))
 					if enablePrimaryUpdate {
 						projectionUpdate.WriteString(fmt.Sprintf(
-							"JSONExtract(_peerdb_match_data, '%s', '%s') AS `%s`,",
+							"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, '%s'),6)) AS `%s`,",
+							colName, dstColName,
+						))
+					}
+				case "DateTime64(6)", "Nullable(DateTime64(6))":
+					projection.WriteString(fmt.Sprintf(
+						"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'),6) AS `%s`,",
+						colName, dstColName,
+					))
+					if enablePrimaryUpdate {
+						projectionUpdate.WriteString(fmt.Sprintf(
+							"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, '%s'),6) AS `%s`,",
+							colName, dstColName,
+						))
+					}
+				default:
+					projLen := projection.Len()
+					if colType == qvalue.QValueKindBytes {
+						format, err := peerdbenv.PeerDBBinaryFormat(ctx, req.Env)
+						if err != nil {
+							return model.NormalizeResponse{}, err
+						}
+						switch format {
+						case peerdbenv.BinaryFormatRaw:
+							projection.WriteString(fmt.Sprintf(
+								"base64Decode(JSONExtractString(_peerdb_data, '%s')) AS `%s`,",
+								colName, dstColName,
+							))
+							if enablePrimaryUpdate {
+								projectionUpdate.WriteString(fmt.Sprintf(
+									"base64Decode(JSONExtractString(_peerdb_match_data, '%s')) AS `%s`,",
+									colName, dstColName,
+								))
+							}
+						case peerdbenv.BinaryFormatHex:
+							projection.WriteString(fmt.Sprintf("hex(base64Decode(JSONExtractString(_peerdb_data, '%s'))) AS `%s`,",
+								colName, dstColName))
+							if enablePrimaryUpdate {
+								projectionUpdate.WriteString(fmt.Sprintf(
+									"hex(base64Decode(JSONExtractString(_peerdb_match_data, '%s'))) AS `%s`,",
+									colName, dstColName,
+								))
+							}
+						}
+					}
+
+					// proceed with default logic if logic above didn't add any sql
+					if projection.Len() == projLen {
+						projection.WriteString(fmt.Sprintf(
+							"JSONExtract(_peerdb_data, '%s', '%s') AS `%s`,",
 							colName, clickHouseType, dstColName,
 						))
+						if enablePrimaryUpdate {
+							projectionUpdate.WriteString(fmt.Sprintf(
+								"JSONExtract(_peerdb_match_data, '%s', '%s') AS `%s`,",
+								colName, clickHouseType, dstColName,
+							))
+						}
 					}
 				}
 			}
-		}
 
-		// add _peerdb_sign as _peerdb_record_type / 2
-		projection.WriteString(fmt.Sprintf("intDiv(_peerdb_record_type, 2) AS `%s`,", signColName))
-		colSelector.WriteString(fmt.Sprintf("`%s`,", signColName))
+			// add _peerdb_sign as _peerdb_record_type / 2
+			projection.WriteString(fmt.Sprintf("intDiv(_peerdb_record_type, 2) AS `%s`,", signColName))
+			colSelector.WriteString(fmt.Sprintf("`%s`,", signColName))
 
-		// add _peerdb_timestamp as _peerdb_version
-		projection.WriteString(fmt.Sprintf("_peerdb_timestamp AS `%s`", versionColName))
-		colSelector.WriteString(versionColName)
-		colSelector.WriteString(") ")
+			// add _peerdb_timestamp as _peerdb_version
+			projection.WriteString(fmt.Sprintf("_peerdb_timestamp AS `%s`", versionColName))
+			colSelector.WriteString(versionColName)
+			colSelector.WriteString(") ")
 
-		selectQuery.WriteString(projection.String())
-		selectQuery.WriteString(" FROM ")
-		selectQuery.WriteString(rawTbl)
-		selectQuery.WriteString(" WHERE _peerdb_batch_id > ")
-		selectQuery.WriteString(strconv.FormatInt(normBatchID, 10))
-		selectQuery.WriteString(" AND _peerdb_batch_id <= ")
-		selectQuery.WriteString(strconv.FormatInt(req.SyncBatchID, 10))
-		selectQuery.WriteString(" AND _peerdb_destination_table_name = '")
-		selectQuery.WriteString(tbl)
-		selectQuery.WriteString("'")
-
-		if enablePrimaryUpdate {
-			// projectionUpdate generates delete on previous record, so _peerdb_record_type is filled in as 2
-			projectionUpdate.WriteString(fmt.Sprintf("1 AS `%s`,", signColName))
-			// decrement timestamp by 1 so delete is ordered before latest data,
-			// could be same if deletion records were only generated when ordering updated
-			projectionUpdate.WriteString(fmt.Sprintf("_peerdb_timestamp - 1 AS `%s`", versionColName))
-
-			selectQuery.WriteString("UNION ALL SELECT ")
-			selectQuery.WriteString(projectionUpdate.String())
+			selectQuery.WriteString(projection.String())
 			selectQuery.WriteString(" FROM ")
 			selectQuery.WriteString(rawTbl)
 			selectQuery.WriteString(" WHERE _peerdb_batch_id > ")
@@ -479,24 +464,50 @@ func (c *ClickHouseConnector) NormalizeRecords(
 			selectQuery.WriteString(strconv.FormatInt(req.SyncBatchID, 10))
 			selectQuery.WriteString(" AND _peerdb_destination_table_name = '")
 			selectQuery.WriteString(tbl)
-			selectQuery.WriteString("' AND _peerdb_record_type = 1")
-		}
+			selectQuery.WriteString("'")
+			if numParts > 1 {
+				selectQuery.WriteString(fmt.Sprintf(" AND cityHash64(_peerdb_uid) %% %d = %d", numParts, numPart))
+			}
 
-		insertIntoSelectQuery := strings.Builder{}
-		insertIntoSelectQuery.WriteString("INSERT INTO `")
-		insertIntoSelectQuery.WriteString(tbl)
-		insertIntoSelectQuery.WriteString("` ")
-		insertIntoSelectQuery.WriteString(colSelector.String())
-		insertIntoSelectQuery.WriteString(selectQuery.String())
+			if enablePrimaryUpdate {
+				// projectionUpdate generates delete on previous record, so _peerdb_record_type is filled in as 2
+				projectionUpdate.WriteString(fmt.Sprintf("1 AS `%s`,", signColName))
+				// decrement timestamp by 1 so delete is ordered before latest data,
+				// could be same if deletion records were only generated when ordering updated
+				projectionUpdate.WriteString(fmt.Sprintf("_peerdb_timestamp - 1 AS `%s`", versionColName))
 
-		select {
-		case queries <- insertIntoSelectQuery.String():
-		case <-errCtx.Done():
-			close(queries)
-			c.logger.Error("[clickhouse] context canceled while normalizing",
-				slog.Any("error", errCtx.Err()),
-				slog.Any("cause", context.Cause(errCtx)))
-			return model.NormalizeResponse{}, context.Cause(errCtx)
+				selectQuery.WriteString("UNION ALL SELECT ")
+				selectQuery.WriteString(projectionUpdate.String())
+				selectQuery.WriteString(" FROM ")
+				selectQuery.WriteString(rawTbl)
+				selectQuery.WriteString(" WHERE _peerdb_batch_id > ")
+				selectQuery.WriteString(strconv.FormatInt(normBatchID, 10))
+				selectQuery.WriteString(" AND _peerdb_batch_id <= ")
+				selectQuery.WriteString(strconv.FormatInt(req.SyncBatchID, 10))
+				selectQuery.WriteString(" AND _peerdb_destination_table_name = '")
+				selectQuery.WriteString(tbl)
+				selectQuery.WriteString("' AND _peerdb_record_type = 1")
+				if numParts > 1 {
+					selectQuery.WriteString(fmt.Sprintf(" AND cityHash64(_peerdb_uid) %% %d = %d", numParts, numPart))
+				}
+			}
+
+			insertIntoSelectQuery := strings.Builder{}
+			insertIntoSelectQuery.WriteString("INSERT INTO `")
+			insertIntoSelectQuery.WriteString(tbl)
+			insertIntoSelectQuery.WriteString("` ")
+			insertIntoSelectQuery.WriteString(colSelector.String())
+			insertIntoSelectQuery.WriteString(selectQuery.String())
+
+			select {
+			case queries <- insertIntoSelectQuery.String():
+			case <-errCtx.Done():
+				close(queries)
+				c.logger.Error("[clickhouse] context canceled while normalizing",
+					slog.Any("error", errCtx.Err()),
+					slog.Any("cause", context.Cause(errCtx)))
+				return model.NormalizeResponse{}, context.Cause(errCtx)
+			}
 		}
 	}
 	close(queries)

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -476,7 +476,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				// could be same if deletion records were only generated when ordering updated
 				projectionUpdate.WriteString(fmt.Sprintf("_peerdb_timestamp - 1 AS `%s`", versionColName))
 
-				selectQuery.WriteString("UNION ALL SELECT ")
+				selectQuery.WriteString(" UNION ALL SELECT ")
 				selectQuery.WriteString(projectionUpdate.String())
 				selectQuery.WriteString(" FROM ")
 				selectQuery.WriteString(rawTbl)

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -384,6 +384,43 @@ func (s ClickHouseSuite) Test_Update_PKey_Env_Enabled() {
 	e2e.RequireEnvCanceled(s.t, env)
 }
 
+func (s ClickHouseSuite) Test_Chunking_Normalize() {
+	srcTableName := "test_update_pkey_chunking_enabled"
+	srcFullName := s.attachSchemaSuffix("test_update_pkey_chunking_enabled")
+	dstTableName := "test_update_pkey_chunking_enabled_dst"
+
+	require.NoError(s.t, s.source.Exec(fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id INT PRIMARY KEY,
+			"key" TEXT NOT NULL
+		);
+	`, srcFullName)))
+
+	require.NoError(s.t, s.source.Exec(fmt.Sprintf(`INSERT INTO %s (id,"key") VALUES (1,'init'),(2,'two'),(3,'tri'),(4,'cry')`, srcFullName)))
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("clickhouse_pkey_update_chunking_enabled"),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.Env = map[string]string{"PEERDB_CLICKHOUSE_ENABLE_PRIMARY_UPDATE": "true", "PEERDB_CLICKHOUSE_NORMALIZATION_PARTS": "3"}
+
+	tc := e2e.NewTemporalClient(s.t)
+	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,\"key\"")
+
+	require.NoError(s.t, s.source.Exec(fmt.Sprintf(`UPDATE %s SET id=id+10, "key"='update'||id`, srcFullName)))
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,\"key\"")
+
+	env.Cancel()
+	e2e.RequireEnvCanceled(s.t, env)
+}
+
 func (s ClickHouseSuite) Test_Replident_Full_Unchanged_TOAST_Updates() {
 	srcTableName := "test_replident_full_toast"
 	srcFullName := s.attachSchemaSuffix("test_replident_full_toast")


### PR DESCRIPTION
Appending to end of query broke with UNION ALL introduced when using primary key updates

This method also works better with setting to run inserts in parallel, where chunks will be distributed to these inserts,
which can speed up single table mirrors