### PR TITLE
Raise HeartbeatTimeout to 5m

### DIFF
--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -455,7 +455,7 @@ func CDCFlowWorkflow(
 
 			renameTablesCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 				StartToCloseTimeout: 12 * time.Hour,
-				HeartbeatTimeout:    time.Minute,
+				HeartbeatTimeout:    5 * time.Minute,
 				RetryPolicy: &temporal.RetryPolicy{
 					InitialInterval: 1 * time.Minute,
 				},
@@ -481,7 +481,7 @@ func CDCFlowWorkflow(
 	var finished bool
 	syncCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 365 * 24 * time.Hour,
-		HeartbeatTimeout:    time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 		WaitForCancellation: true,
 		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
 	})

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -90,7 +90,7 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 		if input.DropFlowStats {
 			dropStatsCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 				StartToCloseTimeout: 2 * time.Minute,
-				HeartbeatTimeout:    1 * time.Minute,
+				HeartbeatTimeout:    5 * time.Minute,
 				RetryPolicy: &temporal.RetryPolicy{
 					InitialInterval: 1 * time.Minute,
 				},

--- a/flow/workflows/maintenance_flow.go
+++ b/flow/workflows/maintenance_flow.go
@@ -78,7 +78,7 @@ func startMaintenance(ctx workflow.Context, logger log.Logger) (*protos.StartMai
 
 	snapshotWaitCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 24 * time.Hour,
-		HeartbeatTimeout:    1 * time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 	})
 	waitSnapshotsFuture := workflow.ExecuteActivity(snapshotWaitCtx,
 		maintenance.WaitForRunningSnapshots,
@@ -141,7 +141,7 @@ func pauseAndGetRunningMirrors(
 ) (*protos.MaintenanceMirrors, error) {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 24 * time.Hour,
-		HeartbeatTimeout:    1 * time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 	})
 	selector := workflow.NewSelector(ctx)
 	runningMirrors := make([]bool, len(mirrorsList.Mirrors))
@@ -206,7 +206,7 @@ func EndMaintenanceWorkflow(ctx workflow.Context, input *protos.EndMaintenanceFl
 func endMaintenance(ctx workflow.Context, logger log.Logger) (*protos.EndMaintenanceFlowOutput, error) {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 24 * time.Hour,
-		HeartbeatTimeout:    1 * time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 	})
 
 	mirrorsList, err := resumeBackedUpMirrors(ctx, logger)
@@ -285,7 +285,7 @@ func runBackgroundAlerter(ctx workflow.Context) workflow.CancelFunc {
 	activityCtx, cancelActivity := workflow.WithCancel(ctx)
 	alerterCtx := workflow.WithActivityOptions(activityCtx, workflow.ActivityOptions{
 		StartToCloseTimeout: 24 * time.Hour,
-		HeartbeatTimeout:    1 * time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 	})
 	workflow.ExecuteActivity(alerterCtx, maintenance.BackgroundAlerter)
 	return cancelActivity

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -177,7 +177,7 @@ func (q *QRepFlowExecution) getPartitions(
 
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 72 * time.Hour,
-		HeartbeatTimeout:    time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,
 			BackoffCoefficient:     2.,
@@ -289,7 +289,7 @@ func (q *QRepFlowExecution) consolidatePartitions(ctx workflow.Context) error {
 	// only an operation for Snowflake currently.
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 24 * time.Hour,
-		HeartbeatTimeout:    time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,
 			BackoffCoefficient:     2.,
@@ -353,7 +353,7 @@ func (q *QRepFlowExecution) handleTableCreationForResync(ctx workflow.Context, s
 		renamedTableIdentifier := q.config.DestinationTableIdentifier + "_peerdb_resync"
 		createTablesFromExistingCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 			StartToCloseTimeout: 10 * time.Minute,
-			HeartbeatTimeout:    time.Minute,
+			HeartbeatTimeout:    5 * time.Minute,
 			RetryPolicy: &temporal.RetryPolicy{
 				InitialInterval:        time.Minute,
 				BackoffCoefficient:     2.,
@@ -399,7 +399,7 @@ func (q *QRepFlowExecution) handleTableRenameForResync(ctx workflow.Context, sta
 
 		renameTablesCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 			StartToCloseTimeout: 30 * time.Minute,
-			HeartbeatTimeout:    time.Minute,
+			HeartbeatTimeout:    5 * time.Minute,
 			RetryPolicy: &temporal.RetryPolicy{
 				InitialInterval:        time.Minute,
 				BackoffCoefficient:     2.,
@@ -441,7 +441,7 @@ func QRepWaitForNewRowsWorkflow(ctx workflow.Context, config *protos.QRepConfig,
 
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 16 * 365 * 24 * time.Hour, // 16 years
-		HeartbeatTimeout:    time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,
 			BackoffCoefficient:     2.,

--- a/flow/workflows/setup_flow.go
+++ b/flow/workflows/setup_flow.go
@@ -184,7 +184,7 @@ func (s *SetupFlowExecution) setupNormalizedTables(
 
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 1 * time.Hour,
-		HeartbeatTimeout:    time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval: 1 * time.Minute,
 		},

--- a/flow/workflows/xmin_flow.go
+++ b/flow/workflows/xmin_flow.go
@@ -73,7 +73,7 @@ func XminFlowWorkflow(
 	var lastPartition int64
 	replicateXminPartitionCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 24 * 5 * time.Hour,
-		HeartbeatTimeout:    time.Minute,
+		HeartbeatTimeout:    5 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval: 1 * time.Minute,
 		},


### PR DESCRIPTION
Despite sending heartbeats every 15s, we're seeing heartbeats regularly take almost 1m to register

When that latency exceeds 1m it causes activity failure. Avoid that