### PR TITLE
feat: add context propagator and use it to enrich metrics with flow metadata

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1114,7 +1114,7 @@ func (a *FlowableActivity) GetFlowMetadata(
 	flowName string,
 	sourceName string,
 	destinationName string,
-) (*shared.FlowMetadata, error) {
+) (*protos.FlowContextMetadata, error) {
 	logger := log.With(activity.GetLogger(ctx), slog.String(string(shared.FlowNameKey), flowName))
 	peerTypes, err := connectors.LoadPeerTypes(ctx, a.CatalogPool, []string{sourceName, destinationName})
 	if err != nil {
@@ -1124,13 +1124,13 @@ func (a *FlowableActivity) GetFlowMetadata(
 	logger.Info("loaded peer types for flow", slog.String("flowName", flowName),
 		slog.String("sourceName", sourceName), slog.String("destinationName", destinationName),
 		slog.Any("peerTypes", peerTypes))
-	return &shared.FlowMetadata{
+	return &protos.FlowContextMetadata{
 		FlowName: flowName,
-		Source: shared.PeerMetadata{
+		Source: &protos.PeerContextMetadata{
 			Name: sourceName,
 			Type: peerTypes[sourceName],
 		},
-		Destination: shared.PeerMetadata{
+		Destination: &protos.PeerContextMetadata{
 			Name: destinationName,
 			Type: peerTypes[destinationName],
 		},

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -378,9 +378,7 @@ func (a *FlowableActivity) SyncFlow(
 				slog.Int64("totalRecordsSynced", totalRecordsSynced.Load()))
 			if a.OtelManager != nil {
 				a.OtelManager.Metrics.RecordsSyncedGauge.Record(ctx, syncResponse.NumRecordsSynced, metric.WithAttributeSet(attribute.NewSet(
-					attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
 					attribute.String(otel_metrics.BatchIdKey, strconv.FormatInt(syncResponse.CurrentSyncBatchID, 10)),
-					attribute.String(otel_metrics.SourcePeerType, fmt.Sprintf("%T", srcConn)),
 				)))
 			}
 			if options.NumberOfSyncs > 0 && currentSyncFlowNum.Load() >= options.NumberOfSyncs {
@@ -1109,4 +1107,28 @@ func (a *FlowableActivity) RemoveFlowEntryFromCatalog(ctx context.Context, flowN
 	}
 
 	return nil
+}
+
+func (a *FlowableActivity) GetFlowMetadata(ctx context.Context, flowName string, sourceName string,
+	destinationName string) (*shared.FlowMetadata, error) {
+	logger := log.With(activity.GetLogger(ctx), slog.String(string(shared.FlowNameKey), flowName))
+	peerTypes, err := connectors.LoadPeerTypes(ctx, a.CatalogPool, []string{sourceName, destinationName})
+	if err != nil {
+		a.Alerter.LogFlowError(ctx, flowName, err)
+		return nil, err
+	}
+	logger.Info("loaded peer types for flow", slog.String("flowName", flowName),
+		slog.String("sourceName", sourceName), slog.String("destinationName", destinationName),
+		slog.Any("peerTypes", peerTypes))
+	return &shared.FlowMetadata{
+		FlowName: flowName,
+		Source: shared.PeerMetadata{
+			Name: sourceName,
+			Type: peerTypes[sourceName],
+		},
+		Destination: shared.PeerMetadata{
+			Name: destinationName,
+			Type: peerTypes[destinationName],
+		},
+	}, nil
 }

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1109,8 +1109,12 @@ func (a *FlowableActivity) RemoveFlowEntryFromCatalog(ctx context.Context, flowN
 	return nil
 }
 
-func (a *FlowableActivity) GetFlowMetadata(ctx context.Context, flowName string, sourceName string,
-	destinationName string) (*shared.FlowMetadata, error) {
+func (a *FlowableActivity) GetFlowMetadata(
+	ctx context.Context,
+	flowName string,
+	sourceName string,
+	destinationName string,
+) (*shared.FlowMetadata, error) {
 	logger := log.With(activity.GetLogger(ctx), slog.String(string(shared.FlowNameKey), flowName))
 	peerTypes, err := connectors.LoadPeerTypes(ctx, a.CatalogPool, []string{sourceName, destinationName})
 	if err != nil {

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -230,14 +230,12 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	}
 
 	var res *model.SyncResponse
-	var dstConnType string
 	errGroup.Go(func() error {
 		dstConn, err := connectors.GetByNameAs[TSync](ctx, config.Env, a.CatalogPool, config.DestinationName)
 		if err != nil {
 			return fmt.Errorf("failed to recreate destination connector: %w", err)
 		}
 		defer connectors.CloseConnector(ctx, dstConn)
-		dstConnType = fmt.Sprintf("%T", dstConn)
 
 		syncBatchID, err := dstConn.GetLastSyncBatchID(errCtx, flowName)
 		if err != nil {

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -323,11 +323,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	a.Alerter.LogFlowInfo(ctx, flowName, pushedRecordsWithCount)
 
 	if a.OtelManager != nil {
-		a.OtelManager.Metrics.CurrentBatchIdGauge.Record(ctx, res.CurrentSyncBatchID, metric.WithAttributeSet(attribute.NewSet(
-			attribute.String(otel_metrics.FlowNameKey, flowName),
-			attribute.String(otel_metrics.SourcePeerType, fmt.Sprintf("%T", srcConn)),
-			attribute.String(otel_metrics.DestinationPeerType, dstConnType),
-		)))
+		a.OtelManager.Metrics.CurrentBatchIdGauge.Record(ctx, res.CurrentSyncBatchID)
 	}
 
 	syncState.Store(shared.Ptr("updating schema"))

--- a/flow/cmd/snapshot_worker.go
+++ b/flow/cmd/snapshot_worker.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"go.temporal.io/sdk/client"
 	temporalotel "go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/worker"
@@ -32,7 +33,7 @@ func SnapshotWorkerMain(opts *SnapshotWorkerOptions) (*WorkerSetupResponse, erro
 		Namespace: opts.TemporalNamespace,
 		Logger:    slog.New(shared.NewSlogHandler(slog.NewJSONHandler(os.Stdout, nil))),
 		ContextPropagators: []workflow.ContextPropagator{
-			shared.NewContextPropagator[*shared.FlowMetadata](shared.FlowMetadataKey),
+			shared.NewContextPropagator[*protos.FlowContextMetadata](shared.FlowMetadataKey),
 		},
 	}
 

--- a/flow/cmd/snapshot_worker.go
+++ b/flow/cmd/snapshot_worker.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"go.temporal.io/sdk/client"
 	temporalotel "go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/worker"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/activities"
 	"github.com/PeerDB-io/peerdb/flow/alerting"
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/peerdbenv"
 	"github.com/PeerDB-io/peerdb/flow/shared"

--- a/flow/cmd/snapshot_worker.go
+++ b/flow/cmd/snapshot_worker.go
@@ -10,6 +10,7 @@ import (
 	"go.temporal.io/sdk/client"
 	temporalotel "go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
 
 	"github.com/PeerDB-io/peerdb/flow/activities"
 	"github.com/PeerDB-io/peerdb/flow/alerting"
@@ -30,6 +31,9 @@ func SnapshotWorkerMain(opts *SnapshotWorkerOptions) (*WorkerSetupResponse, erro
 		HostPort:  opts.TemporalHostPort,
 		Namespace: opts.TemporalNamespace,
 		Logger:    slog.New(shared.NewSlogHandler(slog.NewJSONHandler(os.Stdout, nil))),
+		ContextPropagators: []workflow.ContextPropagator{
+			shared.NewContextPropagator[*shared.FlowMetadata](shared.FlowMetadataKey),
+		},
 	}
 
 	if opts.EnableOtelMetrics {

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/grafana/pyroscope-go"
 	"go.temporal.io/sdk/client"
 	temporalotel "go.temporal.io/sdk/contrib/opentelemetry"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/activities"
 	"github.com/PeerDB-io/peerdb/flow/alerting"
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/peerdbenv"
 	"github.com/PeerDB-io/peerdb/flow/shared"

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/grafana/pyroscope-go"
 	"go.temporal.io/sdk/client"
 	temporalotel "go.temporal.io/sdk/contrib/opentelemetry"
@@ -101,7 +102,7 @@ func WorkerSetup(opts *WorkerSetupOptions) (*WorkerSetupResponse, error) {
 		Namespace: opts.TemporalNamespace,
 		Logger:    slog.New(shared.NewSlogHandler(slog.NewJSONHandler(os.Stdout, nil))),
 		ContextPropagators: []workflow.ContextPropagator{
-			shared.NewContextPropagator[*shared.FlowMetadata](shared.FlowMetadataKey),
+			shared.NewContextPropagator[*protos.FlowContextMetadata](shared.FlowMetadataKey),
 		},
 	}
 	if opts.EnableOtelMetrics {

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/sdk/client"
 	temporalotel "go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
 
 	"github.com/PeerDB-io/peerdb/flow/activities"
 	"github.com/PeerDB-io/peerdb/flow/alerting"
@@ -99,6 +100,9 @@ func WorkerSetup(opts *WorkerSetupOptions) (*WorkerSetupResponse, error) {
 		HostPort:  opts.TemporalHostPort,
 		Namespace: opts.TemporalNamespace,
 		Logger:    slog.New(shared.NewSlogHandler(slog.NewJSONHandler(os.Stdout, nil))),
+		ContextPropagators: []workflow.ContextPropagator{
+			shared.NewContextPropagator[*shared.FlowMetadata](shared.FlowMetadataKey),
+		},
 	}
 	if opts.EnableOtelMetrics {
 		metricsProvider, metricsErr := otel_metrics.SetupTemporalMetricsProvider("flow-worker")

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -15,8 +15,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lib/pq/oid"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 	"go.temporal.io/sdk/activity"
 
 	connmetadata "github.com/PeerDB-io/peerdb/flow/connectors/external_metadata"
@@ -473,10 +471,7 @@ func PullCdcRecords[Items model.Items](
 			return shared.LogError(logger, fmt.Errorf("received Postgres WAL error: %+v", msg))
 		case *pgproto3.CopyData:
 			if p.otelManager != nil {
-				p.otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(msg.Data)), metric.WithAttributeSet(attribute.NewSet(
-					attribute.String(otel_metrics.FlowNameKey, req.FlowJobName),
-					attribute.String(otel_metrics.SourcePeerType, fmt.Sprintf("%T", p)),
-				)))
+				p.otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(msg.Data)))
 			}
 			switch msg.Data[0] {
 			case pglogrepl.PrimaryKeepaliveMessageByteID:

--- a/flow/otel_metrics/attributes.go
+++ b/flow/otel_metrics/attributes.go
@@ -11,6 +11,8 @@ const (
 	BatchIdKey          = "batchId"
 	SourcePeerType      = "sourcePeerType"
 	DestinationPeerType = "destinationPeerType"
+	SourcePeerName      = "sourcePeerName"
+	DestinationPeerName = "destinationPeerName"
 )
 
 const (

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/PeerDB-io/peerdb/flow/shared"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -113,7 +113,7 @@ func buildFlowMetadataAttributes(flowMetadata *protos.FlowContextMetadata) metri
 }
 
 type ContextAwareInt64SyncGauge struct {
-	Int64SyncGauge
+	metric.Int64Gauge
 }
 
 func (a *ContextAwareInt64SyncGauge) Record(ctx context.Context, value int64, options ...metric.RecordOption) {
@@ -121,11 +121,11 @@ func (a *ContextAwareInt64SyncGauge) Record(ctx context.Context, value int64, op
 	if flowMetadata != nil {
 		options = append(options, buildFlowMetadataAttributes(flowMetadata))
 	}
-	a.Int64SyncGauge.Record(ctx, value, options...)
+	a.Int64Gauge.Record(ctx, value, options...)
 }
 
 type ContextAwareFloat64SyncGauge struct {
-	Float64SyncGauge
+	metric.Float64Gauge
 }
 
 func (a *ContextAwareFloat64SyncGauge) Record(ctx context.Context, value float64, options ...metric.RecordOption) {
@@ -133,7 +133,7 @@ func (a *ContextAwareFloat64SyncGauge) Record(ctx context.Context, value float64
 	if flowMetadata != nil {
 		options = append(options, buildFlowMetadataAttributes(flowMetadata))
 	}
-	a.Float64SyncGauge.Record(ctx, value, options...)
+	a.Float64Gauge.Record(ctx, value, options...)
 }
 
 type ContextAwareInt64Counter struct {
@@ -161,7 +161,7 @@ func ContextAwareInt64Gauge(meter metric.Meter, name string, opts ...metric.Int6
 	if err != nil {
 		return nil, err
 	}
-	return &ContextAwareInt64SyncGauge{Int64SyncGauge: *gauge.(*Int64SyncGauge)}, nil
+	return &ContextAwareInt64SyncGauge{Int64Gauge: gauge}, nil
 }
 
 func Float64Gauge(meter metric.Meter, name string, opts ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
@@ -177,7 +177,7 @@ func ContextAwareFloat64Gauge(meter metric.Meter, name string, opts ...metric.Fl
 	if err != nil {
 		return nil, err
 	}
-	return &ContextAwareFloat64SyncGauge{Float64SyncGauge: *gauge.(*Float64SyncGauge)}, nil
+	return &ContextAwareFloat64SyncGauge{Float64Gauge: gauge}, nil
 }
 
 func NewContextAwareInt64Counter(meter metric.Meter, name string, opts ...metric.Int64CounterOption) (metric.Int64Counter, error) {

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/PeerDB-io/peerdb/flow/shared"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
@@ -99,6 +100,50 @@ func NewFloat64SyncGauge(meter metric.Meter, gaugeName string, opts ...metric.Fl
 	return &Float64SyncGauge{syncGauge: syncGauge}, nil
 }
 
+func buildFlowMetadataAttributes(flowMetadata *shared.FlowMetadata) metric.MeasurementOption {
+	return metric.WithAttributeSet(attribute.NewSet(
+		attribute.String(FlowNameKey, flowMetadata.FlowName),
+		attribute.String(SourcePeerType, flowMetadata.Source.Type.String()),
+		attribute.String(DestinationPeerType, flowMetadata.Destination.Type.String()),
+	))
+}
+
+type ContextAwareInt64SyncGauge struct {
+	Int64SyncGauge
+}
+
+func (a *ContextAwareInt64SyncGauge) Record(ctx context.Context, value int64, options ...metric.RecordOption) {
+	flowMetadata := shared.GetFlowMetadata(ctx)
+	if flowMetadata != nil {
+		options = append(options, buildFlowMetadataAttributes(flowMetadata))
+	}
+	a.Int64SyncGauge.Record(ctx, value, options...)
+}
+
+type ContextAwareFloat64SyncGauge struct {
+	Float64SyncGauge
+}
+
+func (a *ContextAwareFloat64SyncGauge) Record(ctx context.Context, value float64, options ...metric.RecordOption) {
+	flowMetadata := shared.GetFlowMetadata(ctx)
+	if flowMetadata != nil {
+		options = append(options, buildFlowMetadataAttributes(flowMetadata))
+	}
+	a.Float64SyncGauge.Record(ctx, value, options...)
+}
+
+type ContextAwareInt64Counter struct {
+	metric.Int64Counter
+}
+
+func (a *ContextAwareInt64Counter) Add(ctx context.Context, value int64, options ...metric.AddOption) {
+	flowMetadata := shared.GetFlowMetadata(ctx)
+	if flowMetadata != nil {
+		options = append(options, buildFlowMetadataAttributes(flowMetadata))
+	}
+	a.Int64Counter.Add(ctx, value, options...)
+}
+
 func Int64Gauge(meter metric.Meter, name string, opts ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
 	gaugeConfig := metric.NewInt64GaugeConfig(opts...)
 	return NewInt64SyncGauge(meter, name,
@@ -107,10 +152,39 @@ func Int64Gauge(meter metric.Meter, name string, opts ...metric.Int64GaugeOption
 	)
 }
 
+func ContextAwareInt64Gauge(meter metric.Meter, name string, opts ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
+	gauge, err := Int64Gauge(meter, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &ContextAwareInt64SyncGauge{Int64SyncGauge: *gauge.(*Int64SyncGauge)}, nil
+}
+
 func Float64Gauge(meter metric.Meter, name string, opts ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
 	gaugeConfig := metric.NewFloat64GaugeConfig(opts...)
 	return NewFloat64SyncGauge(meter, name,
 		metric.WithDescription(gaugeConfig.Description()),
 		metric.WithUnit(gaugeConfig.Unit()),
 	)
+}
+
+func ContextAwareFloat64Gauge(meter metric.Meter, name string, opts ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
+	gauge, err := Float64Gauge(meter, name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &ContextAwareFloat64SyncGauge{Float64SyncGauge: *gauge.(*Float64SyncGauge)}, nil
+}
+
+func NewContextAwareInt64Counter(meter metric.Meter, name string, opts ...metric.Int64CounterOption) (metric.Int64Counter, error) {
+	counterConfig := metric.NewInt64CounterConfig(opts...)
+	counter, err := meter.Int64Counter(name,
+		metric.WithDescription(counterConfig.Description()),
+		metric.WithUnit(counterConfig.Unit()),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ContextAwareInt64Counter{Int64Counter: counter}, nil
 }

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/PeerDB-io/peerdb/flow/shared"
-
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
 type ObservationMapValue[V comparable] struct {
@@ -101,7 +102,7 @@ func NewFloat64SyncGauge(meter metric.Meter, gaugeName string, opts ...metric.Fl
 	return &Float64SyncGauge{syncGauge: syncGauge}, nil
 }
 
-func buildFlowMetadataAttributes(flowMetadata *shared.FlowMetadata) metric.MeasurementOption {
+func buildFlowMetadataAttributes(flowMetadata *protos.FlowContextMetadata) metric.MeasurementOption {
 	return metric.WithAttributeSet(attribute.NewSet(
 		attribute.String(FlowNameKey, flowMetadata.FlowName),
 		attribute.String(SourcePeerType, flowMetadata.Source.Type.String()),

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -107,6 +107,8 @@ func buildFlowMetadataAttributes(flowMetadata *protos.FlowContextMetadata) metri
 		attribute.String(FlowNameKey, flowMetadata.FlowName),
 		attribute.String(SourcePeerType, flowMetadata.Source.Type.String()),
 		attribute.String(DestinationPeerType, flowMetadata.Destination.Type.String()),
+		attribute.String(SourcePeerName, flowMetadata.Source.Name),
+		attribute.String(DestinationPeerName, flowMetadata.Destination.Name),
 	))
 }
 

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -117,16 +117,16 @@ func getOrInitMetric[M any, O any](
 
 func (om *OtelManager) GetOrInitInt64Gauge(name string, opts ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
 	// Once fixed, replace first argument below with metric.Meter.Int64Gauge
-	return getOrInitMetric(Int64Gauge, om.Meter, om.Int64GaugesCache, name, opts...)
+	return getOrInitMetric(ContextAwareInt64Gauge, om.Meter, om.Int64GaugesCache, name, opts...)
 }
 
 func (om *OtelManager) GetOrInitFloat64Gauge(name string, opts ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
 	// Once fixed, replace first argument below with metric.Meter.Float64Gauge
-	return getOrInitMetric(Float64Gauge, om.Meter, om.Float64GaugesCache, name, opts...)
+	return getOrInitMetric(ContextAwareFloat64Gauge, om.Meter, om.Float64GaugesCache, name, opts...)
 }
 
 func (om *OtelManager) GetOrInitInt64Counter(name string, opts ...metric.Int64CounterOption) (metric.Int64Counter, error) {
-	return getOrInitMetric(metric.Meter.Int64Counter, om.Meter, om.Int64CountersCache, name, opts...)
+	return getOrInitMetric(NewContextAwareInt64Counter, om.Meter, om.Int64CountersCache, name, opts...)
 }
 
 func (om *OtelManager) setupMetrics() error {

--- a/flow/shared/context.go
+++ b/flow/shared/context.go
@@ -1,0 +1,83 @@
+package shared
+
+import (
+	"context"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	FlowMetadataKey = "x-peerdb-flow-metadata"
+)
+
+type FlowMetadata struct {
+	FlowName    string
+	Source      PeerMetadata
+	Destination PeerMetadata
+}
+
+type PeerMetadata struct {
+	Name string
+	Type protos.DBType
+}
+
+func GetFlowMetadata(ctx context.Context) *FlowMetadata {
+	if metadata, ok := ctx.Value(FlowMetadataKey).(*FlowMetadata); ok {
+		return metadata
+	}
+	return nil
+}
+
+type ContextPropagator[V any] struct {
+	Key string
+}
+
+func NewContextPropagator[V any](key string) workflow.ContextPropagator {
+	return &ContextPropagator[V]{Key: key}
+}
+
+func (c *ContextPropagator[V]) Inject(ctx context.Context, writer workflow.HeaderWriter) error {
+	value := ctx.Value(c.Key)
+	payload, err := converter.GetDefaultDataConverter().ToPayload(value)
+	if err != nil {
+		return err
+	}
+	writer.Set(c.Key, payload)
+	return nil
+}
+
+func (c *ContextPropagator[V]) Extract(ctx context.Context, reader workflow.HeaderReader) (context.Context, error) {
+	if payload, ok := reader.Get(c.Key); ok {
+		var value V
+		if err := converter.GetDefaultDataConverter().FromPayload(payload, &value); err != nil {
+			return ctx, nil
+		}
+		ctx = context.WithValue(ctx, c.Key, value)
+	}
+
+	return ctx, nil
+}
+
+func (c *ContextPropagator[V]) InjectFromWorkflow(ctx workflow.Context, writer workflow.HeaderWriter) error {
+	value := ctx.Value(c.Key)
+	payload, err := converter.GetDefaultDataConverter().ToPayload(value)
+	if err != nil {
+		return err
+	}
+	writer.Set(c.Key, payload)
+	return nil
+}
+
+func (c *ContextPropagator[V]) ExtractToWorkflow(ctx workflow.Context, reader workflow.HeaderReader) (workflow.Context, error) {
+	if payload, ok := reader.Get(c.Key); ok {
+		var value V
+		if err := converter.GetDefaultDataConverter().FromPayload(payload, &value); err != nil {
+			return ctx, nil
+		}
+		ctx = workflow.WithValue(ctx, c.Key, value)
+	}
+
+	return ctx, nil
+}

--- a/flow/shared/context.go
+++ b/flow/shared/context.go
@@ -8,8 +8,14 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+type TemporalContextKey string
+
+func (k TemporalContextKey) HeaderKey() string {
+	return string(k)
+}
+
 const (
-	FlowMetadataKey = "x-peerdb-flow-metadata"
+	FlowMetadataKey TemporalContextKey = "x-peerdb-flow-metadata"
 )
 
 type FlowMetadata struct {
@@ -31,7 +37,7 @@ func GetFlowMetadata(ctx context.Context) *FlowMetadata {
 }
 
 type ContextPropagator[V any] struct {
-	Key string
+	Key TemporalContextKey
 }
 
 func NewContextPropagator[V any](key string) workflow.ContextPropagator {
@@ -44,12 +50,12 @@ func (c *ContextPropagator[V]) Inject(ctx context.Context, writer workflow.Heade
 	if err != nil {
 		return err
 	}
-	writer.Set(c.Key, payload)
+	writer.Set(c.Key.HeaderKey(), payload)
 	return nil
 }
 
 func (c *ContextPropagator[V]) Extract(ctx context.Context, reader workflow.HeaderReader) (context.Context, error) {
-	if payload, ok := reader.Get(c.Key); ok {
+	if payload, ok := reader.Get(c.Key.HeaderKey()); ok {
 		var value V
 		if err := converter.GetDefaultDataConverter().FromPayload(payload, &value); err != nil {
 			return ctx, nil
@@ -66,12 +72,12 @@ func (c *ContextPropagator[V]) InjectFromWorkflow(ctx workflow.Context, writer w
 	if err != nil {
 		return err
 	}
-	writer.Set(c.Key, payload)
+	writer.Set(c.Key.HeaderKey(), payload)
 	return nil
 }
 
 func (c *ContextPropagator[V]) ExtractToWorkflow(ctx workflow.Context, reader workflow.HeaderReader) (workflow.Context, error) {
-	if payload, ok := reader.Get(c.Key); ok {
+	if payload, ok := reader.Get(c.Key.HeaderKey()); ok {
 		var value V
 		if err := converter.GetDefaultDataConverter().FromPayload(payload, &value); err != nil {
 			return ctx, nil

--- a/flow/shared/context.go
+++ b/flow/shared/context.go
@@ -3,10 +3,10 @@ package shared
 import (
 	"context"
 
-	"github.com/PeerDB-io/peerdb/flow/generated/protos"
-
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/workflow"
+	
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 )
 
 type TemporalContextKey string

--- a/flow/shared/context.go
+++ b/flow/shared/context.go
@@ -5,7 +5,7 @@ import (
 
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/workflow"
-	
+
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 )
 
@@ -19,19 +19,13 @@ const (
 	FlowMetadataKey TemporalContextKey = "x-peerdb-flow-metadata"
 )
 
-type FlowMetadata struct {
-	FlowName    string
-	Source      PeerMetadata
-	Destination PeerMetadata
-}
-
 type PeerMetadata struct {
 	Name string
 	Type protos.DBType
 }
 
-func GetFlowMetadata(ctx context.Context) *FlowMetadata {
-	if metadata, ok := ctx.Value(FlowMetadataKey).(*FlowMetadata); ok {
+func GetFlowMetadata(ctx context.Context) *protos.FlowContextMetadata {
+	if metadata, ok := ctx.Value(FlowMetadataKey).(*protos.FlowContextMetadata); ok {
 		return metadata
 	}
 	return nil

--- a/flow/shared/context.go
+++ b/flow/shared/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/workflow"
 )

--- a/flow/shared/context.go
+++ b/flow/shared/context.go
@@ -40,7 +40,7 @@ type ContextPropagator[V any] struct {
 	Key TemporalContextKey
 }
 
-func NewContextPropagator[V any](key string) workflow.ContextPropagator {
+func NewContextPropagator[V any](key TemporalContextKey) workflow.ContextPropagator {
 	return &ContextPropagator[V]{Key: key}
 }
 

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -52,18 +52,6 @@ func NewCDCFlowWorkflowState(cfg *protos.FlowConnectionConfigs) *CDCFlowWorkflow
 	}
 }
 
-func GetSideEffect[T any](ctx workflow.Context, f func(workflow.Context) T) T {
-	sideEffect := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
-		return f(ctx)
-	})
-
-	var result T
-	if err := sideEffect.Get(&result); err != nil {
-		panic(err)
-	}
-	return result
-}
-
 func GetUUID(ctx workflow.Context) string {
 	return GetSideEffect(ctx, func(_ workflow.Context) string {
 		return uuid.New().String()
@@ -373,11 +361,11 @@ func CDCFlowWorkflow(
 
 	originalRunID := workflow.GetInfo(ctx).OriginalRunID
 
-	newCtx, err := GetFlowMetadataContext(ctx, cfg.FlowJobName, cfg.SourceName, cfg.DestinationName)
+	var err error
+	ctx, err = GetFlowMetadataContext(ctx, cfg.FlowJobName, cfg.SourceName, cfg.DestinationName)
 	if err != nil {
 		return state, fmt.Errorf("failed to get flow metadata context: %w", err)
 	}
-	ctx = newCtx
 
 	// we cannot skip SetupFlow if SnapshotFlow did not complete in cases where Resync is enabled
 	// because Resync modifies TableMappings before Setup and also before Snapshot
@@ -573,16 +561,4 @@ func CDCFlowWorkflow(
 			return state, workflow.NewContinueAsNewError(ctx, CDCFlowWorkflow, cfg, state)
 		}
 	}
-}
-
-func GetFlowMetadataContext(ctx workflow.Context, flowJobName string, sourceName string, destinationName string) (workflow.Context, error) {
-	metadataCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
-		StartToCloseTimeout: 10 * time.Second,
-	})
-	getMetadataFuture := workflow.ExecuteLocalActivity(metadataCtx, flowable.GetFlowMetadata, flowJobName, sourceName, destinationName)
-	var metadata *protos.FlowContextMetadata
-	if err := getMetadataFuture.Get(metadataCtx, &metadata); err != nil {
-		return nil, err
-	}
-	return workflow.WithValue(ctx, shared.FlowMetadataKey, metadata), nil
 }

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -373,12 +373,12 @@ func CDCFlowWorkflow(
 
 	originalRunID := workflow.GetInfo(ctx).OriginalRunID
 
-	getMetadataCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+	metadataCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 1 * time.Minute,
 	})
-	getMetadataFuture := workflow.ExecuteActivity(getMetadataCtx, flowable.GetFlowMetadata, cfg.FlowJobName, cfg.SourceName, cfg.DestinationName)
+	getMetadataFuture := workflow.ExecuteActivity(metadataCtx, flowable.GetFlowMetadata, cfg.FlowJobName, cfg.SourceName, cfg.DestinationName)
 	var metadata *shared.FlowMetadata
-	if err := getMetadataFuture.Get(getMetadataCtx, &metadata); err != nil {
+	if err := getMetadataFuture.Get(metadataCtx, &metadata); err != nil {
 		return state, fmt.Errorf("failed to get flow metadata: %w", err)
 	}
 	ctx = workflow.WithValue(ctx, shared.FlowMetadataKey, metadata)

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -86,12 +86,12 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 	ctx = workflow.WithValue(ctx, shared.FlowNameKey, input.FlowJobName)
 	workflow.GetLogger(ctx).Info("performing cleanup for flow",
 		slog.String(string(shared.FlowNameKey), input.FlowJobName))
-	newCtx, err := GetFlowMetadataContext(ctx,
+	var err error
+	ctx, err = GetFlowMetadataContext(ctx,
 		input.FlowJobName, input.FlowConnectionConfigs.SourceName, input.FlowConnectionConfigs.DestinationName)
 	if err != nil {
 		return fmt.Errorf("failed to get flow metadata context: %w", err)
 	}
-	ctx = newCtx
 	if input.FlowConnectionConfigs != nil {
 		if input.DropFlowStats {
 			dropStatsCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -86,7 +86,8 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 	ctx = workflow.WithValue(ctx, shared.FlowNameKey, input.FlowJobName)
 	workflow.GetLogger(ctx).Info("performing cleanup for flow",
 		slog.String(string(shared.FlowNameKey), input.FlowJobName))
-	newCtx, err := GetFlowMetadataContext(ctx, input.FlowJobName, input.FlowConnectionConfigs.SourceName, input.FlowConnectionConfigs.DestinationName)
+	newCtx, err := GetFlowMetadataContext(ctx,
+		input.FlowJobName, input.FlowConnectionConfigs.SourceName, input.FlowConnectionConfigs.DestinationName)
 	if err != nil {
 		return fmt.Errorf("failed to get flow metadata context: %w", err)
 	}

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -2,6 +2,7 @@ package peerflow
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -85,7 +86,11 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 	ctx = workflow.WithValue(ctx, shared.FlowNameKey, input.FlowJobName)
 	workflow.GetLogger(ctx).Info("performing cleanup for flow",
 		slog.String(string(shared.FlowNameKey), input.FlowJobName))
-
+	newCtx, err := GetFlowMetadataContext(ctx, input.FlowJobName, input.FlowConnectionConfigs.SourceName, input.FlowConnectionConfigs.DestinationName)
+	if err != nil {
+		return fmt.Errorf("failed to get flow metadata context: %w", err)
+	}
+	ctx = newCtx
 	if input.FlowConnectionConfigs != nil {
 		if input.DropFlowStats {
 			dropStatsCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{

--- a/flow/workflows/util.go
+++ b/flow/workflows/util.go
@@ -1,0 +1,34 @@
+package peerflow
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/shared"
+)
+
+func GetSideEffect[T any](ctx workflow.Context, f func(workflow.Context) T) T {
+	sideEffect := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
+		return f(ctx)
+	})
+
+	var result T
+	if err := sideEffect.Get(&result); err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func GetFlowMetadataContext(ctx workflow.Context, flowJobName string, sourceName string, destinationName string) (workflow.Context, error) {
+	metadataCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+	})
+	getMetadataFuture := workflow.ExecuteLocalActivity(metadataCtx, flowable.GetFlowMetadata, flowJobName, sourceName, destinationName)
+	var metadata *protos.FlowContextMetadata
+	if err := getMetadataFuture.Get(metadataCtx, &metadata); err != nil {
+		return nil, err
+	}
+	return workflow.WithValue(ctx, shared.FlowMetadataKey, metadata), nil
+}

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -488,3 +488,14 @@ message MaintenanceMirror {
 message MaintenanceMirrors {
   repeated MaintenanceMirror mirrors = 1;
 }
+
+message PeerContextMetadata {
+  string name = 1;
+  peerdb_peers.DBType type = 2;
+}
+
+message FlowContextMetadata{
+  string flow_name = 1;
+  PeerContextMetadata source = 2;
+  PeerContextMetadata destination = 3;
+}


### PR DESCRIPTION
The context is propagated as temporal headers:
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/444f8b4d-e909-4b2e-aa3a-03fe0a1ac71e" />


Metrics automatically have the desired attributes:
<img width="879" alt="image" src="https://github.com/user-attachments/assets/5dddb50a-52cb-470d-bde2-2bf963deca66" />


