### PR TITLE
remove ureq

### DIFF
--- a/nexus/Cargo.lock
+++ b/nexus/Cargo.lock
@@ -967,9 +967,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
 dependencies = [
  "cc",
 ]
@@ -985,35 +985,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "indexmap 2.7.1",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1242,15 +1213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,15 +1235,6 @@ name = "elf"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "env_filter"
@@ -1548,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71393ecc86efbf00e4ca13953979ba8b94cfe549a4b74cc26d8b62f4d8feac2b"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2221,12 +2174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
-name = "litrs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,7 +2730,6 @@ dependencies = [
  "sqlparser",
  "tokio",
  "tracing",
- "ureq",
  "value",
 ]
 
@@ -3371,7 +3317,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
- "getrandom 0.3.0",
+ "getrandom 0.3.1",
  "zerocopy 0.8.14",
 ]
 
@@ -4743,9 +4689,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-normalization"
@@ -4779,42 +4725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b35e5241ee2cad3940e69c78b28b3600bec9c57146bce26b3eb888869b987d4"
-dependencies = [
- "base64 0.22.1",
- "cc",
- "cookie_store",
- "encoding_rs",
- "flate2",
- "log",
- "once_cell",
- "percent-encoding",
- "rustls 0.23.21",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "ureq-proto",
- "utf-8",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b930c6bd0de6a824c1bc380378a00f8f437f5da0a441740510a3dc4d02bd677e"
-dependencies = [
- "base64 0.22.1",
- "http 1.2.0",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4830,12 +4740,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -5222,9 +5126,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
 ]

--- a/nexus/peer-snowflake/Cargo.toml
+++ b/nexus/peer-snowflake/Cargo.toml
@@ -27,5 +27,4 @@ sha2 = "0.10"
 sqlparser.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-ureq = { version = "3", features = ["json", "charset"] }
 value = { path = "../value" }

--- a/nexus/peer-snowflake/src/stream.rs
+++ b/nexus/peer-snowflake/src/stream.rs
@@ -39,6 +39,7 @@ pub(crate) enum SnowflakeDataType {
     Variant,
 }
 
+#[derive(Clone)]
 pub struct SnowflakeSchema {
     schema: Schema,
 }
@@ -82,13 +83,17 @@ impl SnowflakeSchema {
 }
 
 pub struct SnowflakeRecordStream {
+    schema: SnowflakeSchema,
+    stream: Pin<Box<dyn Stream<Item = PgWireResult<Record>> + Send + Sync>>,
+}
+
+pub struct SnowflakeRecordStreamInner {
     result_set: ResultSet,
     partition_index: usize,
     partition_number: usize,
-    schema: SnowflakeSchema,
-    auth: SnowflakeAuth,
-
     endpoint_url: String,
+    auth: SnowflakeAuth,
+    schema: SnowflakeSchema,
 }
 
 impl SnowflakeRecordStream {
@@ -98,19 +103,26 @@ impl SnowflakeRecordStream {
         partition_number: usize,
         endpoint_url: String,
         auth: SnowflakeAuth,
-    ) -> Self {
-        let sf_schema = SnowflakeSchema::from_result_set(&result_set);
+    ) -> SnowflakeRecordStream {
+        let schema = SnowflakeSchema::from_result_set(&result_set);
 
-        Self {
+        let inner = SnowflakeRecordStreamInner {
             result_set,
-            schema: sf_schema,
             partition_index,
             partition_number,
             endpoint_url,
             auth,
-        }
-    }
+            schema: schema.clone(),
+        };
+        let stream = futures::stream::unfold(inner, |mut inner| async {
+            inner.advance().await.map(|val| (val, inner))
+        });
 
+        Self { schema, stream: Box::pin(stream) }
+    }
+}
+
+impl SnowflakeRecordStreamInner {
     pub fn convert_result_set_item(&mut self) -> anyhow::Result<Record> {
         let mut row_values = Vec::new();
 
@@ -202,7 +214,7 @@ impl SnowflakeRecordStream {
         })
     }
 
-    fn advance_partition(&mut self) -> anyhow::Result<bool> {
+    async fn advance_partition(&mut self) -> anyhow::Result<bool> {
         if (self.partition_number + 1) == self.result_set.resultSetMetaData.partitionInfo.len() {
             return Ok(false);
         }
@@ -213,14 +225,13 @@ impl SnowflakeRecordStream {
         let statement_handle = self.result_set.statementHandle.clone();
         let url = self.endpoint_url.clone();
         println!("Secret: {:#?}", secret);
-        let response: PartitionResult = ureq::get(format!("{}/{}", url, statement_handle))
-            .query("partition", partition_number.to_string())
+        let response = reqwest::Client::new().get(format!("{}/{}", url, statement_handle))
+            .query(&[("partition", partition_number.to_string())])
             .header("Authorization", format!("Bearer {}", secret))
             .header("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
             .header("user-agent", "ureq")
-            .call()?
-            .body_mut()
-            .read_json()
+            .send().await?
+            .json::<PartitionResult>().await
             .map_err(|_| anyhow::anyhow!("get_partition failed"))?;
         println!("Response: {:#?}", response.data);
 
@@ -228,24 +239,27 @@ impl SnowflakeRecordStream {
         Ok(true)
     }
 
-    fn advance(&mut self) -> anyhow::Result<bool> {
-        Ok((self.partition_index < self.result_set.data.len()) || self.advance_partition()?)
+    async fn advance(&mut self) -> Option<PgWireResult<Record>> {
+        let next = self.partition_index < self.result_set.data.len() || {
+            match self.advance_partition().await {
+                Ok(val) => val,
+                Err(err) => return Some(Err(PgWireError::ApiError(err.into()))),
+            }
+        };
+        if next {
+            let record = self.convert_result_set_item();
+            Some(record.map_err(|e| PgWireError::ApiError(e.into())))
+        } else {
+            None
+        }
     }
 }
 
 impl Stream for SnowflakeRecordStream {
     type Item = PgWireResult<Record>;
 
-    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.advance() {
-            Ok(true) => {
-                let record = self.convert_result_set_item();
-                let result = record.map_err(|e| PgWireError::ApiError(e.into()));
-                Poll::Ready(Some(result))
-            }
-            Ok(false) => Poll::Ready(None),
-            Err(err) => Poll::Ready(Some(Err(PgWireError::ApiError(err.into())))),
-        }
+    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Stream::poll_next(self.stream.as_mut(), ctx)
     }
 }
 


### PR DESCRIPTION
ureq-proto released a breaking change in 2.0.6 which broke our build

ureq used because of reddit: https://old.reddit.com/r/rust/comments/f39ueb/how_to_use_reqwest_without_async/fhiyw6n

instead use futures::unfold to properly implement async streams with an async http client,
as a bonus we replace our dependency on ureq with our existing dependency on reqwest