### PR TITLE
nexus: consistent binary serialization

### DIFF
--- a/nexus/Cargo.lock
+++ b/nexus/Cargo.lock
@@ -4782,7 +4782,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
- "hex",
  "pgwire",
  "postgres",
  "postgres-inet",

--- a/nexus/value/Cargo.toml
+++ b/nexus/value/Cargo.toml
@@ -11,7 +11,6 @@ bytes = "1.1"
 chrono.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-hex = "0.4"
 pgwire.workspace = true
 postgres = { version = "0.19", features = ["with-chrono-0_4"] }
 postgres-inet = "0.19.0"

--- a/nexus/value/src/array.rs
+++ b/nexus/value/src/array.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 
+use base64::prelude::{Engine as _, BASE64_STANDARD};
 use bytes::{BufMut, Bytes, BytesMut};
 use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 use pgwire::types::ToSqlText;
@@ -88,12 +89,12 @@ impl ArrayValue {
             ),
             ArrayValue::Binary(arr) => serde_json::Value::Array(
                 arr.iter()
-                    .map(|v| serde_json::Value::String(hex::encode(v)))
+                    .map(|v| serde_json::Value::String(BASE64_STANDARD.encode(v)))
                     .collect(),
             ),
             ArrayValue::VarBinary(arr) => serde_json::Value::Array(
                 arr.iter()
-                    .map(|v| serde_json::Value::String(hex::encode(v)))
+                    .map(|v| serde_json::Value::String(BASE64_STANDARD.encode(v)))
                     .collect(),
             ),
             ArrayValue::Uuid(arr) => serde_json::Value::Array(


### PR DESCRIPTION
bytes are encoded as base64, but then hex for arrays of bytes

always serialize to json as base64