### PR TITLE
Edit peer button: separate peer type fetch

### DIFF
--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -116,6 +116,22 @@ func (h *FlowRequestHandler) GetPeerInfo(
 	}, nil
 }
 
+func (h *FlowRequestHandler) GetPeerType(
+	ctx context.Context,
+	req *protos.PeerInfoRequest,
+) (*protos.PeerTypeResponse, error) {
+	ctx, cancelCtx := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelCtx()
+	peer, err := connectors.LoadPeer(ctx, h.pool, req.PeerName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &protos.PeerTypeResponse{
+		PeerType: peer.Type.String(),
+	}, nil
+}
+
 func (h *FlowRequestHandler) ListPeers(
 	ctx context.Context,
 	req *protos.ListPeersRequest,

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -192,6 +192,10 @@ message PeerInfoResponse {
   string version = 2;
 }
 
+message PeerTypeResponse {
+  string peer_type = 1;
+}
+
 message PeerListItem {
   string name = 1;
   peerdb_peers.DBType type = 2;
@@ -634,6 +638,12 @@ service FlowService {
   rpc GetPeerInfo(PeerInfoRequest) returns (PeerInfoResponse) {
     option (google.api.http) = {
       get : "/v1/peers/info/{peer_name}"
+    };
+  }
+
+  rpc GetPeerType(PeerInfoRequest) returns (PeerTypeResponse) {
+    option (google.api.http) = {
+      get : "/v1/peers/type/{peer_name}"
     };
   }
   rpc ListPeers(ListPeersRequest) returns (ListPeersResponse) {

--- a/ui/components/PeerInfo.tsx
+++ b/ui/components/PeerInfo.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { DBType } from '@/grpc_generated/peers';
 import { PeerInfoResponse, PeerTypeResponse } from '@/grpc_generated/route';
 import { Button } from '@/lib/Button';
 import { Dialog, DialogClose } from '@/lib/Dialog';
@@ -34,19 +33,17 @@ export const PeerInfo = ({ peerName }: { peerName: string }) => {
   );
 };
 
-const EditPeerButton = ({
-  peerName,
-}: {
-  peerName: string;
-}) => {
-
+const EditPeerButton = ({ peerName }: { peerName: string }) => {
   const getPeerType = async (peerName: string): Promise<string> => {
-    const peerTypeRes:PeerTypeResponse = await fetch(`/api/v1/peers/type/${peerName}`, {
-      cache: 'no-store',
-    }).then((res) => res.json());
+    const peerTypeRes: PeerTypeResponse = await fetch(
+      `/api/v1/peers/type/${peerName}`,
+      {
+        cache: 'no-store',
+      }
+    ).then((res) => res.json());
     const peerType = peerTypeRes.peerType;
     return peerType;
-  }
+  };
 
   const [peerType, setPeerType] = useState<string>();
   useEffect(() => {

--- a/ui/components/PeerInfo.tsx
+++ b/ui/components/PeerInfo.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { DBType } from '@/grpc_generated/peers';
-import { PeerInfoResponse } from '@/grpc_generated/route';
+import { PeerInfoResponse, PeerTypeResponse } from '@/grpc_generated/route';
 import { Button } from '@/lib/Button';
 import { Dialog, DialogClose } from '@/lib/Dialog';
 import { Icon } from '@/lib/Icon';
@@ -28,7 +28,7 @@ export const PeerInfo = ({ peerName }: { peerName: string }) => {
 
   return (
     <div style={{ display: 'flex', alignItems: 'center' }}>
-      <EditPeerButton peerName={peerName} peerType={info?.peer?.type} />
+      <EditPeerButton peerName={peerName} />
       <PeerConfigDialog peerInfo={info} />
     </div>
   );
@@ -36,14 +36,22 @@ export const PeerInfo = ({ peerName }: { peerName: string }) => {
 
 const EditPeerButton = ({
   peerName,
-  peerType,
 }: {
   peerName: string;
-  peerType?: DBType;
 }) => {
-  if (peerType === undefined || !(peerType in DBType)) {
-    return null;
+
+  const getPeerType = async (peerName: string): Promise<string> => {
+    const peerTypeRes:PeerTypeResponse = await fetch(`/api/v1/peers/type/${peerName}`, {
+      cache: 'no-store',
+    }).then((res) => res.json());
+    const peerType = peerTypeRes.peerType;
+    return peerType;
   }
+
+  const [peerType, setPeerType] = useState<string>();
+  useEffect(() => {
+    getPeerType(peerName).then((type) => setPeerType(type));
+  }, [peerName]);
 
   return (
     <Button


### PR DESCRIPTION
As mentioned here: https://github.com/PeerDB-io/peerdb/pull/2361, we would want the rendering of the edit button to not have to go through the hoops of getting version, connecting to the data stores etc

Functionally tested
