### PR TITLE
mysql: SignalAsEmpty/SignalAsNotEmpty

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -276,6 +276,13 @@ func (c *MySqlConnector) PullRecords(
 	defer cancelTimeout()
 
 	var recordCount uint32
+	defer func() {
+		if recordCount == 0 {
+			req.RecordStream.SignalAsEmpty()
+		}
+		c.logger.Info(fmt.Sprintf("[finished] PullRecords streamed %d records", recordCount))
+	}()
+
 	for recordCount < req.MaxBatchSize {
 		event, err := mystream.GetEvent(timeoutCtx)
 		if err != nil {
@@ -361,6 +368,9 @@ func (c *MySqlConnector) PullRecords(
 						}); err != nil {
 							return err
 						}
+						if recordCount == 1 {
+							req.RecordStream.SignalAsNotEmpty()
+						}
 					}
 				case replication.UPDATE_ROWS_EVENTv1, replication.UPDATE_ROWS_EVENTv2, replication.MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1:
 					for idx := 0; idx < len(ev.Rows); idx += 2 {
@@ -404,6 +414,9 @@ func (c *MySqlConnector) PullRecords(
 						}); err != nil {
 							return err
 						}
+						if recordCount == 1 {
+							req.RecordStream.SignalAsNotEmpty()
+						}
 					}
 				case replication.DELETE_ROWS_EVENTv1, replication.DELETE_ROWS_EVENTv2, replication.MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1:
 					for idx, row := range ev.Rows {
@@ -434,6 +447,9 @@ func (c *MySqlConnector) PullRecords(
 							UnchangedToastColumns: unchangedToastColumns,
 						}); err != nil {
 							return err
+						}
+						if recordCount == 1 {
+							req.RecordStream.SignalAsNotEmpty()
 						}
 					}
 				default:

--- a/flow/model/cdc_stream.go
+++ b/flow/model/cdc_stream.go
@@ -89,8 +89,10 @@ func (r *CDCStream[T]) SignalAsNotEmpty() {
 }
 
 func (r *CDCStream[T]) WaitAndCheckEmpty() bool {
-	isEmpty := <-r.emptySignal
-	return isEmpty
+	// if ok is false Close was called before SignalAsEmpty or SignalAsNotEmpty were called,
+	// such a scenario is best treated as stream being empty
+	isEmpty, ok := <-r.emptySignal
+	return isEmpty || !ok
 }
 
 func (r *CDCStream[T]) Close() {


### PR DESCRIPTION
more conservative approach to bring over postgres/cdc.go logic relative to #2506

kind of surprised cdc worked without this

*edit: so it worked before because closing the record stream would close the channel which would give the receiver the default value `false` for `isEmpty`*