### PR TITLE
mysql column exclusion

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -327,8 +327,23 @@ func (c *MySqlConnector) PullRecords(
 		case *replication.RowsEvent:
 			sourceTableName := string(ev.Table.Schema) + "." + string(ev.Table.Table) // TODO this is fragile
 			destinationTableName := req.TableNameMapping[sourceTableName].Name
+			exclusion := req.TableNameMapping[sourceTableName].Exclude
 			schema := req.TableNameSchemaMapping[destinationTableName]
 			if schema != nil {
+				getFd := func(idx int) *protos.FieldDescription {
+					if ev.Table.ColumnName != nil {
+						name := shared.UnsafeFastReadOnlyBytesToString(ev.Table.ColumnName[idx])
+						if _, excluded := exclusion[name]; !excluded {
+							for _, col := range schema.Columns {
+								if col.Name == name {
+									return col
+								}
+							}
+						}
+						return nil
+					}
+					return schema.Columns[idx]
+				}
 				switch event.Header.EventType {
 				case replication.WRITE_ROWS_EVENTv0, replication.UPDATE_ROWS_EVENTv0, replication.DELETE_ROWS_EVENTv0:
 					return errors.New("mysql v0 replication protocol not supported")
@@ -336,7 +351,10 @@ func (c *MySqlConnector) PullRecords(
 					for _, row := range ev.Rows {
 						items := model.NewRecordItems(len(row))
 						for idx, val := range row {
-							fd := schema.Columns[idx]
+							fd := getFd(idx)
+							if fd == nil {
+								continue
+							}
 							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val)
 							if err != nil {
 								return err
@@ -370,7 +388,10 @@ func (c *MySqlConnector) PullRecords(
 						oldRow := ev.Rows[idx]
 						oldItems := model.NewRecordItems(len(oldRow))
 						for idx, val := range oldRow {
-							fd := schema.Columns[idx]
+							fd := getFd(idx)
+							if fd == nil {
+								continue
+							}
 							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val)
 							if err != nil {
 								return err
@@ -380,7 +401,10 @@ func (c *MySqlConnector) PullRecords(
 						newRow := ev.Rows[idx+1]
 						newItems := model.NewRecordItems(len(newRow))
 						for idx, val := range ev.Rows[idx+1] {
-							fd := schema.Columns[idx]
+							fd := getFd(idx)
+							if fd == nil {
+								continue
+							}
 							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val)
 							if err != nil {
 								return err
@@ -415,7 +439,10 @@ func (c *MySqlConnector) PullRecords(
 
 						items := model.NewRecordItems(len(row))
 						for idx, val := range row {
-							fd := schema.Columns[idx]
+							fd := getFd(idx)
+							if fd == nil {
+								continue
+							}
 							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val)
 							if err != nil {
 								return err

--- a/flow/e2e/bigquery/peer_flow_bq_test.go
+++ b/flow/e2e/bigquery/peer_flow_bq_test.go
@@ -405,7 +405,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Types_BQ() {
 	/* test inserting various types*/
 	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 		INSERT INTO %s SELECT 2,2,b'1',b'101',
-		true,random_bytea(32),'s','test','1.1.10.2'::cidr,
+		true,random_bytes(32),'s','test','1.1.10.2'::cidr,
 		CURRENT_DATE,1.23,1.234,'10.0.0.0/32'::inet,1,
 		'5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds'::interval,
 		'{"sai":-8.02139037433155}'::json,'{"sai":1}'::jsonb,'08:00:2b:01:02:03'::macaddr,

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -975,5 +975,5 @@ func (s ClickHouseSuite) Test_Column_Exclusion() {
 	for _, field := range rows.Schema.Fields {
 		require.NotEqual(s.t, "c2", field.Name)
 	}
-	require.Len(s.t, rows.Schema.Fields, 5)
+	require.Len(s.t, rows.Schema.Fields, 6)
 }

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -914,15 +914,14 @@ func (s ClickHouseSuite) Test_Column_Exclusion() {
 			id SERIAL PRIMARY KEY,
 			c1 INT,
 			c2 INT,
-			t TEXT,
-			t2 TEXT
+			t TEXT
 		);
 	`, srcFullName)))
 
 	// insert 5 rows into the source table
 	for i := range 5 {
 		require.NoError(s.t, s.source.Exec(fmt.Sprintf(
-			`INSERT INTO %[1]s(c1,c2,t,t2) VALUES (%[2]d, %[2]d,'test_value_%[2]d',random_bytes(100))`,
+			`INSERT INTO %[1]s(c1,c2,t) VALUES (%[2]d,%[2]d,'test_value_%[2]d')`,
 			srcFullName, i,
 		)))
 	}
@@ -951,16 +950,16 @@ func (s ClickHouseSuite) Test_Column_Exclusion() {
 	// insert 5 rows into the source table
 	for i := range 5 {
 		e2e.EnvNoError(s.t, env, s.source.Exec(fmt.Sprintf(
-			`INSERT INTO %[1]s(c1,c2,t,t2) VALUES (%[2]d, %[2]d,'test_value_%[2]d',random_bytes(100))`,
+			`INSERT INTO %[1]s(c1,c2,t) VALUES (%[2]d,%[2]d,'test_value_%[2]d')`,
 			srcFullName, i,
 		)))
 	}
 
-	e2e.EnvWaitForEqualTables(env, s, "normalize table", tableName, "id,c1,t,t2")
+	e2e.EnvWaitForEqualTables(env, s, "normalize table", tableName, "id,c1,t")
 	e2e.EnvNoError(s.t, env, s.source.Exec(
 		fmt.Sprintf(`UPDATE %s SET c1=c1+1 WHERE MOD(c2,2)=1`, srcFullName)))
 	e2e.EnvNoError(s.t, env, s.source.Exec(fmt.Sprintf(`DELETE FROM %s WHERE MOD(c2,2)=0`, srcFullName)))
-	e2e.EnvWaitForEqualTables(env, s, "normalize update/delete", tableName, "id,c1,t,t2")
+	e2e.EnvWaitForEqualTables(env, s, "normalize update/delete", tableName, "id,c1,t")
 
 	env.Cancel()
 

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -763,7 +763,7 @@ func (s ClickHouseSuite) Test_Types_CH() {
 		c39 TXID_SNAPSHOT,c40 UUID,c42 INT[], c43 FLOAT[], c44 TEXT[], c45 mood, c46 HSTORE,
 		c47 DATE[], c48 TIMESTAMPTZ[], c49 TIMESTAMP[], c50 BOOLEAN[], c51 SMALLINT[]);
 		INSERT INTO %[1]s SELECT 2,2,b'1',b'101',
-		true,random_bytea(32),'s','test','1.1.10.2'::cidr,
+		true,random_bytes(32),'s','test','1.1.10.2'::cidr,
 		CURRENT_DATE,1.23,1.234,'10.0.0.0/32'::inet,1,
 		'5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds'::interval,
 		'{"sai":-8.02139037433155}'::json,'{"sai":1}'::jsonb,'08:00:2b:01:02:03'::macaddr,
@@ -800,7 +800,7 @@ func (s ClickHouseSuite) Test_Types_CH() {
 
 	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 		INSERT INTO %s SELECT 3,2,b'1',b'101',
-		true,random_bytea(32),'s','test','1.1.10.2'::cidr,
+		true,random_bytes(32),'s','test','1.1.10.2'::cidr,
 		CURRENT_DATE,1.23,1.234,'10.0.0.0/32'::inet,1,
 		'5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds'::interval,
 		'{"sai":-8.02139037433155}'::json,'{"sai":1}'::jsonb,'08:00:2b:01:02:03'::macaddr,
@@ -827,7 +827,7 @@ func (s ClickHouseSuite) Test_Types_CH() {
 		UPDATE %[1]s SET c1=3,c32='testery' WHERE id=2;
 		UPDATE %[1]s SET c33=now(),c34=now(),c35=now()::TIME,c36=now()::TIMETZ WHERE id=3;
 		INSERT INTO %[1]s SELECT 4,2,b'1',b'101',
-		true,random_bytea(32),'s','test','1.1.10.2'::cidr,
+		true,random_bytes(32),'s','test','1.1.10.2'::cidr,
 		CURRENT_DATE,1.23,1.234,'10.0.0.0/32'::inet,1,
 		'5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds'::interval,
 		'{"sai":-8.02139037433155}'::json,'{"sai":1}'::jsonb,'08:00:2b:01:02:03'::macaddr,
@@ -922,7 +922,7 @@ func (s ClickHouseSuite) Test_Column_Exclusion() {
 	// insert 5 rows into the source table
 	for i := range 5 {
 		require.NoError(s.t, s.source.Exec(fmt.Sprintf(
-			`INSERT INTO %[1]s(c1,c2,t,t2) VALUES (%[2]d, %[2]d,'test_value_%[2]d',random_string(100))`,
+			`INSERT INTO %[1]s(c1,c2,t,t2) VALUES (%[2]d, %[2]d,'test_value_%[2]d',random_bytes(100))`,
 			srcFullName, i,
 		)))
 	}
@@ -951,7 +951,7 @@ func (s ClickHouseSuite) Test_Column_Exclusion() {
 	// insert 5 rows into the source table
 	for i := range 5 {
 		e2e.EnvNoError(s.t, env, s.source.Exec(fmt.Sprintf(
-			`INSERT INTO %[1]s(c1,c2,t,t2) VALUES (%[2]d, %[2]d,'test_value_%[2]d',random_string(100))`,
+			`INSERT INTO %[1]s(c1,c2,t,t2) VALUES (%[2]d, %[2]d,'test_value_%[2]d',random_bytes(100))`,
 			srcFullName, i,
 		)))
 	}

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -903,6 +903,10 @@ func (s ClickHouseSuite) Test_UnsignedMySQL() {
 }
 
 func (s ClickHouseSuite) Test_Column_Exclusion() {
+	if mySource, ok := s.source.(*e2e.MySqlSource); ok && mySource.IsMaria {
+		s.t.Skip("skip maria, testing minimal row metadata on maria")
+	}
+
 	tc := e2e.NewTemporalClient(s.t)
 
 	tableName := "test_exclude_ch"

--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -15,7 +15,7 @@ import (
 
 type MySqlSource struct {
 	*connmysql.MySqlConnector
-	isMaria bool
+	IsMaria bool
 }
 
 var mysqlConfig = &protos.MySqlConfig{
@@ -80,7 +80,14 @@ func setupMyCore(t *testing.T, suffix string, isMaria bool) (*MySqlSource, error
 		return nil, err
 	}
 
-	return &MySqlSource{MySqlConnector: connector}, nil
+	if !isMaria {
+		if _, err := connector.Execute(context.Background(), "set global binlog_row_metadata=full"); err != nil {
+			connector.Close()
+			return nil, err
+		}
+	}
+
+	return &MySqlSource{MySqlConnector: connector, IsMaria: isMaria}, nil
 }
 
 func (s *MySqlSource) Connector() connectors.Connector {
@@ -100,7 +107,7 @@ func (s *MySqlSource) Teardown(t *testing.T, suffix string) {
 func (s *MySqlSource) GeneratePeer(t *testing.T) *protos.Peer {
 	t.Helper()
 	config := mysqlConfig
-	if s.isMaria {
+	if s.IsMaria {
 		config = mariaConfig
 	}
 

--- a/flow/e2e/pg.go
+++ b/flow/e2e/pg.go
@@ -82,7 +82,7 @@ func setupPostgresSchema(t *testing.T, conn *pgx.Conn, suffix string) error {
 			SELECT string_agg(substring('0123456789bcdefghijkmnpqrstvwxyz',
 			round(random() * 32)::integer, 1), '') FROM generate_series(1, $1);
 		$$ language sql;
-		CREATE OR REPLACE FUNCTION random_bytea(bytea_length integer)
+		CREATE OR REPLACE FUNCTION random_bytes(bytea_length integer)
 		RETURNS bytea AS $body$
 			SELECT decode(string_agg(lpad(to_hex(width_bucket(random(), 0, 1, 256)-1),2,'0'), ''), 'hex')
 			FROM generate_series(1, $1);

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -481,7 +481,7 @@ func (s PeerFlowE2ETestSuiteSF) Test_Types_SF() {
 	/* test inserting various types*/
 	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
 	INSERT INTO %s SELECT 2,2,b'1',b'101',
-	true,random_bytea(32),'s','test','1.1.10.2'::cidr,
+	true,random_bytes(32),'s','test','1.1.10.2'::cidr,
 	CURRENT_DATE,1.23,1.234,'192.168.1.5'::inet,1,
 	'5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds'::interval,
 	'{"sai":1}'::json,'{"sai":1}'::jsonb,'08:00:2b:01:02:03'::macaddr,

--- a/flow/e2e/snowflake/peer_flow_sf_test.go
+++ b/flow/e2e/snowflake/peer_flow_sf_test.go
@@ -811,9 +811,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Column_Exclusion() {
 	// insert 10 rows into the source table
 	for i := range 10 {
 		testValue := fmt.Sprintf("test_value_%d", i)
-		_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-			INSERT INTO %s(c2,t,t2) VALUES ($1,$2,random_string(100))
-		`, srcTableName), i, testValue)
+		_, err := s.Conn().Exec(context.Background(),
+			fmt.Sprintf(`INSERT INTO %s(c2,t,t2) VALUES ($1,$2,random_string(100))`, srcTableName), i, testValue)
 		e2e.EnvNoError(s.t, env, err)
 	}
 	s.t.Log("Inserted 10 rows into the source table")
@@ -877,16 +876,13 @@ func (s PeerFlowE2ETestSuiteSF) Test_Soft_Delete_Basic() {
 	env := e2e.ExecutePeerflow(tc, peerflow.CDCFlowWorkflow, config, nil)
 	e2e.SetupCDCFlowStatusQuery(s.t, env, config)
 
-	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-			INSERT INTO %s(c1,c2,t) VALUES (1,2,random_string(9000))`, srcTableName))
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`INSERT INTO %s(c1,c2,t) VALUES (1,2,random_string(9000))`, srcTableName))
 	e2e.EnvNoError(s.t, env, err)
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "normalize row", tableName, dstName, "id,c1,c2,t")
-	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-			UPDATE %s SET c1=c1+4 WHERE id=1`, srcTableName))
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`UPDATE %s SET c1=c1+4 WHERE id=1`, srcTableName))
 	e2e.EnvNoError(s.t, env, err)
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "normalize update", tableName, dstName, "id,c1,c2,t")
-	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-			DELETE FROM %s WHERE id=1`, srcTableName))
+	_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`DELETE FROM %s WHERE id=1`, srcTableName))
 	e2e.EnvNoError(s.t, env, err)
 	e2e.EnvWaitForEqualTablesWithNames(
 		env,
@@ -1216,9 +1212,8 @@ func (s PeerFlowE2ETestSuiteSF) Test_Column_Exclusion_With_Schema_Changes() {
 	// insert 10 rows into the source table
 	for i := range 10 {
 		testValue := fmt.Sprintf("test_value_%d", i)
-		_, err = s.Conn().Exec(context.Background(), fmt.Sprintf(`
-			INSERT INTO %s(c2,t) VALUES ($1,$2)
-		`, srcTableName), i, testValue)
+		_, err = s.Conn().Exec(context.Background(),
+			fmt.Sprintf(`INSERT INTO %s(c2,t) VALUES ($1,$2)`, srcTableName), i, testValue)
 		e2e.EnvNoError(s.t, env, err)
 	}
 	s.t.Log("Inserted 10 rows into the source table")


### PR DESCRIPTION
also tests column exclusion with mysql as source

fails, added some logic which requires `binlog_row_metadata = full`

could put column number in table schema info to remap cdc column index to schema column index

should raise error if we detect we're going to panic