### PR TITLE
feat(record-slot-size): increase frequency to 2 mins

### DIFF
--- a/flow/workflows/scheduled_flows.go
+++ b/flow/workflows/scheduled_flows.go
@@ -55,7 +55,7 @@ func GlobalScheduleManagerWorkflow(ctx workflow.Context) error {
 
 	slotSizeCtx := withCronOptions(ctx,
 		"record-slot-size-"+info.OriginalRunID,
-		"*/5 * * * *")
+		"*/2 * * * *")
 	workflow.ExecuteChildWorkflow(slotSizeCtx, RecordSlotSizeWorkflow)
 
 	ctx.Done().Receive(ctx, nil)


### PR DESCRIPTION
Alerting tools like Prometheus have a staleness range of 5 mins, so we need to push metrics with a finer granularity