### PR TITLE
Remove consistency sleep and account for nil env

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"golang.org/x/sync/errgroup"
@@ -230,9 +229,6 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	ctx context.Context,
 	req *model.NormalizeRecordsRequest,
 ) (model.NormalizeResponse, error) {
-	// fix for potential consistency issues
-	time.Sleep(3 * time.Second)
-
 	normBatchID, err := c.GetLastNormalizeBatchID(ctx, req.FlowJobName)
 	if err != nil {
 		c.logger.Error("[clickhouse] error while getting last sync and normalize batch id", "error", err)

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -91,6 +91,9 @@ func processCDCFlowConfigUpdate(
 		state.SyncFlowOptions.NumberOfSyncs = 0
 	}
 	if flowConfigUpdate.UpdatedEnv != nil {
+		if cfg.Env == nil {
+			cfg.Env = make(map[string]string)
+		}
 		maps.Copy(cfg.Env, flowConfigUpdate.UpdatedEnv)
 	}
 


### PR DESCRIPTION
This PR fixes two issues:
1) Removes the 3 second sleep in NormalizeRecords in ClickHouse. This was a shot-in-the-dark measure to mitigate a data loss issue which we now know is fixed by specifying select_sequential_consistency in the case of non SMT tables.
2) In the case where `env` is not provided when creating a mirror, `cfg.Env` can be nil. When the mirror is edited and `updatedEnv` is passed, we get a `assignment to entry in nil map` error