### PR TITLE
fix: limit partition count to 1000 for temporal platform

### DIFF
--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -127,8 +127,11 @@ func (c *PostgresConnector) getNumRowsPartitions(
 
 	// Calculate the number of partitions
 	adjustedPartitions := shared.AdjustNumPartitions(totalRows.Int64, numRowsPerPartition)
-	c.logger.Info(fmt.Sprintf("total rows: %d, desired num rows per partition: %d, adjusted num partitions: %d, adjusted num rows per partition: %d",
-		totalRows.Int64, numRowsPerPartition, adjustedPartitions.AdjustedNumPartitions, adjustedPartitions.AdjustedNumRowsPerPartition))
+	c.logger.Info("partition adjustment details",
+		slog.Int64("totalRows", totalRows.Int64),
+		slog.Int64("desiredNumRowsPerPartition", numRowsPerPartition),
+		slog.Int64("adjustedNumPartitions", adjustedPartitions.AdjustedNumPartitions),
+		slog.Int64("adjustedNumRowsPerPartition", adjustedPartitions.AdjustedNumRowsPerPartition))
 
 	// Query to get partitions using window functions
 	var rows pgx.Rows

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -126,9 +126,9 @@ func (c *PostgresConnector) getNumRowsPartitions(
 	}
 
 	// Calculate the number of partitions
-	numPartitions := shared.DivCeil(totalRows.Int64, numRowsPerPartition)
-	c.logger.Info(fmt.Sprintf("total rows: %d, num partitions: %d, num rows per partition: %d",
-		totalRows.Int64, numPartitions, numRowsPerPartition))
+	adjustedPartitions := shared.AdjustNumPartitions(totalRows.Int64, numRowsPerPartition)
+	c.logger.Info(fmt.Sprintf("total rows: %d, desired num rows per partition: %d, adjusted num partitions: %d, adjusted num rows per partition: %d",
+		totalRows.Int64, numRowsPerPartition, adjustedPartitions.AdjustedNumPartitions, adjustedPartitions.AdjustedNumRowsPerPartition))
 
 	// Query to get partitions using window functions
 	var rows pgx.Rows
@@ -141,7 +141,7 @@ func (c *PostgresConnector) getNumRowsPartitions(
 			) subquery
 			GROUP BY bucket
 			ORDER BY start`,
-			numPartitions,
+			adjustedPartitions.AdjustedNumPartitions,
 			quotedWatermarkColumn,
 			parsedWatermarkTable.String(),
 		)
@@ -155,7 +155,7 @@ func (c *PostgresConnector) getNumRowsPartitions(
 			) subquery
 			GROUP BY bucket
 			ORDER BY start`,
-			numPartitions,
+			adjustedPartitions.AdjustedNumPartitions,
 			quotedWatermarkColumn,
 			parsedWatermarkTable.String(),
 		)

--- a/flow/shared/math.go
+++ b/flow/shared/math.go
@@ -1,7 +1,64 @@
 package shared
 
-import "golang.org/x/exp/constraints"
+import (
+	"math"
+
+	"golang.org/x/exp/constraints"
+)
 
 func DivCeil[T constraints.Integer](x, y T) T {
 	return (x + y - 1) / y
+}
+
+// AdjustedPartitions represents the adjusted partitioning parameters
+type AdjustedPartitions struct {
+	AdjustedNumPartitions       int64
+	AdjustedNumRowsPerPartition int64
+}
+
+// AdjustNumPartitions takes the total number of rows and the desired number of rows per partition,
+// and returns the adjusted number of partitions and rows per partition so that the partition count does not exceed 1000.
+// It does so by increasing the rows-per-partition by a power-of-10 multiplier when necessary.
+func AdjustNumPartitions(totalRows, desiredRowsPerPartition int64) AdjustedPartitions {
+	const maxPartitions = 1000
+
+	// Calculate the initial number of partitions.
+	desiredPartitions := DivCeil(totalRows, desiredRowsPerPartition)
+
+	// If the initial partition count is within the allowed limit, return it.
+	if desiredPartitions <= maxPartitions {
+		return AdjustedPartitions{
+			AdjustedNumPartitions:       desiredPartitions,
+			AdjustedNumRowsPerPartition: desiredRowsPerPartition,
+		}
+	}
+
+	// Determine the multiplier needed. We require:
+	//   totalRows / (desiredRowsPerPartition * multiplier) <= maxPartitions
+	// Rearranging:
+	//   multiplier >= totalRows / (desiredRowsPerPartition * maxPartitions)
+	ratio := float64(totalRows) / (float64(desiredRowsPerPartition) * float64(maxPartitions))
+
+	// Compute the smallest power-of-10 multiplier that is at least the ratio.
+	exponent := math.Ceil(math.Log10(ratio))
+	multiplier := int64(math.Pow(10, exponent))
+
+	// Adjust the rows per partition.
+	adjustedRowsPerPartition := desiredRowsPerPartition * multiplier
+
+	// Recalculate the number of partitions using the adjusted rows per partition.
+	adjustedPartitions := DivCeil(totalRows, adjustedRowsPerPartition)
+
+	// If, for any reason, the adjusted partition count is still over the maximum,
+	// cap it at maxPartitions.
+	if adjustedPartitions > maxPartitions {
+		adjustedPartitions = maxPartitions
+		// Recalculate rows per partition based on maxPartitions
+		adjustedRowsPerPartition = DivCeil(totalRows, maxPartitions)
+	}
+
+	return AdjustedPartitions{
+		AdjustedNumPartitions:       adjustedPartitions,
+		AdjustedNumRowsPerPartition: adjustedRowsPerPartition,
+	}
 }

--- a/flow/shared/math_test.go
+++ b/flow/shared/math_test.go
@@ -1,0 +1,130 @@
+package shared
+
+import (
+	"testing"
+)
+
+func TestAdjustNumPartitions(t *testing.T) {
+	tests := []struct {
+		name                     string
+		totalRows                int64
+		desiredRowsPerPartition  int64
+		expectedPartitions       int64
+		expectedRowsPerPartition int64
+	}{
+		{
+			name:                    "No adjustment needed",
+			totalRows:               1000,
+			desiredRowsPerPartition: 150,
+			// partitions = ceil(1000 / 150) = 7, which is <= 1000.
+			expectedPartitions:       7,
+			expectedRowsPerPartition: 150,
+		},
+		{
+			name:                    "At exactly limit",
+			totalRows:               1000,
+			desiredRowsPerPartition: 1,
+			// partitions = 1000, no adjustment needed.
+			expectedPartitions:       1000,
+			expectedRowsPerPartition: 1,
+		},
+		{
+			name:                    "Small totalRows",
+			totalRows:               50,
+			desiredRowsPerPartition: 1,
+			// partitions = 50 (cannot exceed totalRows).
+			expectedPartitions:       50,
+			expectedRowsPerPartition: 1,
+		},
+		{
+			name:                    "Moderate adjustment",
+			totalRows:               100000,
+			desiredRowsPerPartition: 50,
+			// initial partitions = ceil(100000 / 50) = 2000, which is > 1000.
+			// ratio = 100000 / (50 * 1000) = 2,
+			// multiplier = 10^ceil(log10(2)) = 10,
+			// adjustedRowsPerPartition = 50 * 10 = 500,
+			// adjusted partitions = ceil(100000 / 500) = 200.
+			expectedPartitions:       200,
+			expectedRowsPerPartition: 500,
+		},
+		{
+			name:                    "Large totalRows exactly max",
+			totalRows:               1000000000, // 1e9
+			desiredRowsPerPartition: 100000,
+			// initial partitions = 1e9 / 100000 = 10000.
+			// ratio = 1e9 / (100000 * 1000) = 10,
+			// multiplier = 10^ceil(log10(10)) = 10,
+			// adjustedRowsPerPartition = 100000 * 10 = 1e6,
+			// adjusted partitions = 1e9 / 1e6 = 1000.
+			expectedPartitions:       1000,
+			expectedRowsPerPartition: 1000000,
+		},
+		{
+			name:                    "Large totalRows with multiplier",
+			totalRows:               1000000000, // 1e9
+			desiredRowsPerPartition: 50000,
+			// initial partitions = 1e9 / 50000 = 20000.
+			// ratio = 1e9 / (50000 * 1000) = 20,
+			// multiplier = 10^ceil(log10(20)) = 100,
+			// adjustedRowsPerPartition = 50000 * 100 = 5e6,
+			// adjusted partitions = 1e9 / 5e6 = 200.
+			expectedPartitions:       200,
+			expectedRowsPerPartition: 5000000,
+		},
+		{
+			name:                    "Moderate values",
+			totalRows:               500000,
+			desiredRowsPerPartition: 250,
+			// initial partitions = ceil(500000 / 250) = 2000.
+			// ratio = 500000 / (250 * 1000) = 2,
+			// multiplier = 10,
+			// adjustedRowsPerPartition = 250 * 10 = 2500,
+			// adjusted partitions = ceil(500000 / 2500) = 200.
+			expectedPartitions:       200,
+			expectedRowsPerPartition: 2500,
+		},
+		{
+			name:                    "Exact division yields no adjustment",
+			totalRows:               120000,
+			desiredRowsPerPartition: 150,
+			// initial partitions = 120000 / 150 = 800 exactly.
+			expectedPartitions:       800,
+			expectedRowsPerPartition: 150,
+		},
+		{
+			name:                    "Non exact division with high desired",
+			totalRows:               987654321,
+			desiredRowsPerPartition: 80001,
+			// initial partitions = ceil(987654321 / 80001) ≈ 12346.
+			// ratio = 987654321 / (80001 * 1000) ≈ 12.345,
+			// multiplier = 10^ceil(log10(12.345)) = 100,
+			// adjustedRowsPerPartition = 80001 * 100,
+			// adjusted partitions = ceil(987654321 / 8000100) ≈ 124.
+			expectedPartitions:       124,
+			expectedRowsPerPartition: 8000100,
+		},
+		{
+			name:                    "Desired rows per partition greater than totalRows",
+			totalRows:               100,
+			desiredRowsPerPartition: 150,
+			// initial partitions = ceil(100/150) = 1, which is valid.
+			expectedPartitions:       1,
+			expectedRowsPerPartition: 150,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AdjustNumPartitions(tc.totalRows, tc.desiredRowsPerPartition)
+			if got.AdjustedNumPartitions != tc.expectedPartitions {
+				t.Errorf("AdjustNumPartitions(totalRows=%d, desiredRowsPerPartition=%d).AdjustedNumPartitions = %d; want %d",
+					tc.totalRows, tc.desiredRowsPerPartition, got.AdjustedNumPartitions, tc.expectedPartitions)
+			}
+			if got.AdjustedNumRowsPerPartition != tc.expectedRowsPerPartition {
+				t.Errorf("AdjustNumPartitions(totalRows=%d, desiredRowsPerPartition=%d).AdjustedNumRowsPerPartition = %d; want %d",
+					tc.totalRows, tc.desiredRowsPerPartition, got.AdjustedNumRowsPerPartition, tc.expectedRowsPerPartition)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adjusts partition calculation to ensure count stays under 1000 by increasing rows per partition when needed. This prevents hitting Temporal platform limits.