### PR TITLE
QRep Initial Copy Only: set status to completed

### DIFF
--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -578,6 +578,7 @@ func QRepFlowWorkflow(
 		}
 
 		if config.InitialCopyOnly {
+			state.CurrentFlowStatus = protos.FlowStatus_STATUS_COMPLETED
 			q.logger.Info("initial copy completed for peer flow")
 			return state, nil
 		}


### PR DESCRIPTION
Like we do in CDC, for QRep mirrors, set the status of the mirror to Completed when it is initial copy only and it completes