### PR TITLE
initial load: base clone workflow id on source, not destination

### DIFF
--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -142,8 +142,7 @@ func (s *ClickHouseAvroSyncMethod) SyncQRepRecords(
 	selector := make([]string, 0, len(dstTableSchema))
 	for _, col := range dstTableSchema {
 		colName := col.Name()
-		if strings.EqualFold(colName, config.SoftDeleteColName) ||
-			strings.EqualFold(colName, signColName) ||
+		if strings.EqualFold(colName, signColName) ||
 			strings.EqualFold(colName, config.SyncedAtColName) ||
 			strings.EqualFold(colName, versionColName) {
 			continue

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -106,7 +106,7 @@ func (s *SnapshotFlowExecution) cloneTable(
 	dstName := mapping.DestinationTableIdentifier
 	originalRunID := workflow.GetInfo(ctx).OriginalRunID
 
-	childWorkflowID := fmt.Sprintf("clone_%s_%s_%s", flowName, dstName, originalRunID)
+	childWorkflowID := fmt.Sprintf("clone_%s_%s_%s", flowName, srcName, originalRunID)
 	childWorkflowID = shared.ReplaceIllegalCharactersWithUnderscores(childWorkflowID)
 
 	s.logger.Info(fmt.Sprintf("Obtained child id %s for source table %s and destination table %s",


### PR DESCRIPTION
This avoids issues when setting multiple tables in a mirror to output to same table

This is incomplete, but a start

Also remove a soft delete reference since CH doesn't do soft deletion like that