### PR TITLE
cdc/qrep workflows: continue as new after setting state to completed

### DIFF
--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -324,6 +324,10 @@ func CDCFlowWorkflow(
 		return state, fmt.Errorf("failed to set `%s` query handler: %w", shared.FlowStatusQuery, err)
 	}
 
+	if state.CurrentFlowStatus == protos.FlowStatus_STATUS_COMPLETED {
+		return state, nil
+	}
+
 	mirrorNameSearch := shared.NewSearchAttributes(cfg.FlowJobName)
 
 	if state.ActiveSignal == model.PauseSignal {
@@ -463,15 +467,14 @@ func CDCFlowWorkflow(
 			}
 		}
 
-		logger.Info("executed setup flow and snapshot flow")
 		// if initial_copy_only is opted for, we end the flow here.
 		if cfg.InitialSnapshotOnly {
 			logger.Info("initial snapshot only, ending flow")
 			state.CurrentFlowStatus = protos.FlowStatus_STATUS_COMPLETED
-			return state, nil
+		} else {
+			logger.Info("executed setup flow and snapshot flow, start running")
+			state.CurrentFlowStatus = protos.FlowStatus_STATUS_RUNNING
 		}
-
-		state.CurrentFlowStatus = protos.FlowStatus_STATUS_RUNNING
 		return state, workflow.NewContinueAsNewError(ctx, CDCFlowWorkflow, cfg, state)
 	}
 

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -506,6 +506,10 @@ func QRepFlowWorkflow(
 		return state, err
 	}
 
+	if state.CurrentFlowStatus == protos.FlowStatus_STATUS_COMPLETED {
+		return state, nil
+	}
+
 	signalChan := model.FlowSignal.GetSignalChannel(ctx)
 	q := newQRepFlowExecution(ctx, config, originalRunID)
 
@@ -578,9 +582,9 @@ func QRepFlowWorkflow(
 		}
 
 		if config.InitialCopyOnly {
-			state.CurrentFlowStatus = protos.FlowStatus_STATUS_COMPLETED
 			q.logger.Info("initial copy completed for peer flow")
-			return state, nil
+			state.CurrentFlowStatus = protos.FlowStatus_STATUS_COMPLETED
+			return state, workflow.NewContinueAsNewError(ctx, QRepFlowWorkflow, config, state)
 		}
 
 		if err := q.handleTableRenameForResync(ctx, state); err != nil {


### PR DESCRIPTION
then `return state, nil` at start after setting up queries

old mirrors which had completed were running into non-determinism errors when queried,
as once completed they can't go through pause/resume for migrations