### PR TITLE
MaintainTx: Add heartbeat routine

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -957,6 +957,11 @@ func (a *FlowableActivity) ReplicateXminPartition(ctx context.Context,
 	partition *protos.QRepPartition,
 	runUUID string,
 ) (int64, error) {
+	shutdown := heartbeatRoutine(ctx, func() string {
+		return "syncing xmin"
+	})
+	defer shutdown()
+
 	switch config.System {
 	case protos.TypeSystem_Q:
 		stream := model.NewQRecordStream(shared.FetchAndChannelSize)

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -507,11 +507,6 @@ func replicateXminPartition[TRead any, TWrite any, TSync connectors.QRepSyncConn
 	) (int, int64, error),
 	syncRecords func(TSync, context.Context, *protos.QRepConfig, *protos.QRepPartition, TRead) (int, error),
 ) (int64, error) {
-	shutdown := heartbeatRoutine(ctx, func() string {
-		return "syncing xmin"
-	})
-	defer shutdown()
-
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
 	logger := activity.GetLogger(ctx)
 	logger.Info("replicating xmin")

--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -98,6 +98,10 @@ func (a *SnapshotActivity) SetupReplication(
 }
 
 func (a *SnapshotActivity) MaintainTx(ctx context.Context, sessionID string, peer string) error {
+	shutdown := heartbeatRoutine(ctx, func() string {
+		return "maintaining transaction snapshot"
+	})
+	defer shutdown()
 	conn, err := connectors.GetByNameAs[connectors.CDCPullConnector](ctx, nil, a.CatalogPool, peer)
 	if err != nil {
 		return err

--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -127,12 +127,7 @@ func (a *SnapshotActivity) MaintainTx(ctx context.Context, sessionID string, pee
 	logger := activity.GetLogger(ctx)
 	start := time.Now()
 	for {
-		msg := fmt.Sprintf("maintaining export snapshot transaction %s", time.Since(start).Round(time.Second))
-		logger.Info(msg)
-		// this function relies on context cancellation to exit
-		// context is not explicitly cancelled, but workflow exit triggers an implicit cancel
-		// from activity.RecordBeat
-		activity.RecordHeartbeat(ctx, msg)
+		logger.Info("maintaining export snapshot transaction", slog.Int64("seconds", int64(time.Since(start).Round(time.Second)/time.Second)))
 		if ctx.Err() != nil {
 			a.SnapshotStatesMutex.Lock()
 			delete(a.TxSnapshotStates, sessionID)


### PR DESCRIPTION
There are some operations before the activity heartbeat loop we have in place in this activity that can take a while. We thus need a top level heartbeat routine 