### PR TITLE
TLS 1.3

### DIFF
--- a/flow/cmd/maintenance.go
+++ b/flow/cmd/maintenance.go
@@ -145,9 +145,7 @@ func skipStartMaintenanceIfNeeded(ctx context.Context, args *MaintenanceCLIParam
 			return false, errors.New("flow address is required when skipping based on API")
 		}
 		slog.Info("Constructing flow client")
-		transportCredentials := credentials.NewTLS(&tls.Config{
-			MinVersion: tls.VersionTLS12,
-		})
+		transportCredentials := credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS13})
 		if !args.FlowTlsEnabled {
 			transportCredentials = insecure.NewCredentials()
 		}

--- a/flow/connectors/elasticsearch/elasticsearch.go
+++ b/flow/connectors/elasticsearch/elasticsearch.go
@@ -46,9 +46,7 @@ func NewElasticsearchConnector(ctx context.Context,
 		Addresses: config.Addresses,
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: 4,
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS13,
-			},
+			TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS13},
 		},
 	}
 	if config.AuthType == protos.ElasticsearchAuthType_BASIC {

--- a/flow/connectors/kafka/kafka.go
+++ b/flow/connectors/kafka/kafka.go
@@ -75,7 +75,7 @@ func NewKafkaConnector(
 		kgo.WithLogger(kgoLogger(logger)),
 	)
 	if !config.DisableTls {
-		optionalOpts = append(optionalOpts, kgo.DialTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12}))
+		optionalOpts = append(optionalOpts, kgo.DialTLSConfig(&tls.Config{MinVersion: tls.VersionTLS13}))
 	}
 	switch config.Partitioner {
 	case "LeastBackup":


### PR DESCRIPTION
Talked with KG, he went TLS 1.2 on maintenance for no particular reason

Kafka we had 1.2 because Confluent didn't support 1.3 at the time. They now support 1.3