### PR TITLE
feat(flow-context): add current flowStatus and resync information

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1098,27 +1098,27 @@ func (a *FlowableActivity) RemoveFlowEntryFromCatalog(ctx context.Context, flowN
 
 func (a *FlowableActivity) GetFlowMetadata(
 	ctx context.Context,
-	flowName string,
-	sourceName string,
-	destinationName string,
+	input *protos.FlowContextMetadataInput,
 ) (*protos.FlowContextMetadata, error) {
-	logger := log.With(activity.GetLogger(ctx), slog.String(string(shared.FlowNameKey), flowName))
-	peerTypes, err := connectors.LoadPeerTypes(ctx, a.CatalogPool, []string{sourceName, destinationName})
+	logger := log.With(activity.GetLogger(ctx), slog.String(string(shared.FlowNameKey), input.FlowName))
+	peerTypes, err := connectors.LoadPeerTypes(ctx, a.CatalogPool, []string{input.SourceName, input.DestinationName})
 	if err != nil {
-		return nil, a.Alerter.LogFlowError(ctx, flowName, err)
+		return nil, a.Alerter.LogFlowError(ctx, input.FlowName, err)
 	}
-	logger.Info("loaded peer types for flow", slog.String("flowName", flowName),
-		slog.String("sourceName", sourceName), slog.String("destinationName", destinationName),
+	logger.Info("loaded peer types for flow", slog.String("flowName", input.FlowName),
+		slog.String("sourceName", input.SourceName), slog.String("destinationName", input.DestinationName),
 		slog.Any("peerTypes", peerTypes))
 	return &protos.FlowContextMetadata{
-		FlowName: flowName,
+		FlowName: input.FlowName,
 		Source: &protos.PeerContextMetadata{
-			Name: sourceName,
-			Type: peerTypes[sourceName],
+			Name: input.SourceName,
+			Type: peerTypes[input.SourceName],
 		},
 		Destination: &protos.PeerContextMetadata{
-			Name: destinationName,
-			Type: peerTypes[destinationName],
+			Name: input.DestinationName,
+			Type: peerTypes[input.DestinationName],
 		},
+		Status:   input.Status,
+		IsResync: input.IsResync,
 	}, nil
 }

--- a/flow/cmd/snapshot_worker.go
+++ b/flow/cmd/snapshot_worker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/activities"
 	"github.com/PeerDB-io/peerdb/flow/alerting"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/peerdbenv"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -33,7 +34,7 @@ func SnapshotWorkerMain(opts *SnapshotWorkerOptions) (*WorkerSetupResponse, erro
 		Namespace: opts.TemporalNamespace,
 		Logger:    slog.New(shared.NewSlogHandler(slog.NewJSONHandler(os.Stdout, nil))),
 		ContextPropagators: []workflow.ContextPropagator{
-			shared.NewContextPropagator[*protos.FlowContextMetadata](shared.FlowMetadataKey),
+			internal.NewContextPropagator[*protos.FlowContextMetadata](internal.FlowMetadataKey),
 		},
 	}
 

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/activities"
 	"github.com/PeerDB-io/peerdb/flow/alerting"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/peerdbenv"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -102,7 +103,7 @@ func WorkerSetup(opts *WorkerSetupOptions) (*WorkerSetupResponse, error) {
 		Namespace: opts.TemporalNamespace,
 		Logger:    slog.New(shared.NewSlogHandler(slog.NewJSONHandler(os.Stdout, nil))),
 		ContextPropagators: []workflow.ContextPropagator{
-			shared.NewContextPropagator[*protos.FlowContextMetadata](shared.FlowMetadataKey),
+			internal.NewContextPropagator[*protos.FlowContextMetadata](internal.FlowMetadataKey),
 		},
 	}
 	if opts.EnableOtelMetrics {

--- a/flow/internal/context.go
+++ b/flow/internal/context.go
@@ -1,4 +1,4 @@
-package shared
+package internal
 
 import (
 	"context"

--- a/flow/otel_metrics/attributes.go
+++ b/flow/otel_metrics/attributes.go
@@ -14,6 +14,8 @@ const (
 	DestinationPeerType = "destinationPeerType"
 	SourcePeerName      = "sourcePeerName"
 	DestinationPeerName = "destinationPeerName"
+	FlowStatusKey       = "flowStatus"
+	IsFlowResyncKey     = "isFlowResync"
 )
 
 const (

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -109,6 +109,8 @@ func buildFlowMetadataAttributes(flowMetadata *protos.FlowContextMetadata) metri
 		attribute.String(DestinationPeerType, flowMetadata.Destination.Type.String()),
 		attribute.String(SourcePeerName, flowMetadata.Source.Name),
 		attribute.String(DestinationPeerName, flowMetadata.Destination.Name),
+		attribute.String(FlowStatusKey, flowMetadata.Status.String()),
+		attribute.Bool(IsFlowResyncKey, flowMetadata.IsResync),
 	))
 }
 

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/metric/embedded"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
-	"github.com/PeerDB-io/peerdb/flow/shared"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 type ObservationMapValue[V comparable] struct {
@@ -119,7 +119,7 @@ type ContextAwareInt64SyncGauge struct {
 }
 
 func (a *ContextAwareInt64SyncGauge) Record(ctx context.Context, value int64, options ...metric.RecordOption) {
-	flowMetadata := shared.GetFlowMetadata(ctx)
+	flowMetadata := internal.GetFlowMetadata(ctx)
 	if flowMetadata != nil {
 		options = append(options, buildFlowMetadataAttributes(flowMetadata))
 	}
@@ -131,7 +131,7 @@ type ContextAwareFloat64SyncGauge struct {
 }
 
 func (a *ContextAwareFloat64SyncGauge) Record(ctx context.Context, value float64, options ...metric.RecordOption) {
-	flowMetadata := shared.GetFlowMetadata(ctx)
+	flowMetadata := internal.GetFlowMetadata(ctx)
 	if flowMetadata != nil {
 		options = append(options, buildFlowMetadataAttributes(flowMetadata))
 	}
@@ -143,7 +143,7 @@ type ContextAwareInt64Counter struct {
 }
 
 func (a *ContextAwareInt64Counter) Add(ctx context.Context, value int64, options ...metric.AddOption) {
-	flowMetadata := shared.GetFlowMetadata(ctx)
+	flowMetadata := internal.GetFlowMetadata(ctx)
 	if flowMetadata != nil {
 		options = append(options, buildFlowMetadataAttributes(flowMetadata))
 	}

--- a/flow/shared/context.go
+++ b/flow/shared/context.go
@@ -19,11 +19,6 @@ const (
 	FlowMetadataKey TemporalContextKey = "x-peerdb-flow-metadata"
 )
 
-type PeerMetadata struct {
-	Name string
-	Type protos.DBType
-}
-
 func GetFlowMetadata(ctx context.Context) *protos.FlowContextMetadata {
 	if metadata, ok := ctx.Value(FlowMetadataKey).(*protos.FlowContextMetadata); ok {
 		return metadata

--- a/flow/shared/logger.go
+++ b/flow/shared/logger.go
@@ -7,6 +7,8 @@ import (
 
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/log"
+
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 func LoggerFromCtx(ctx context.Context) log.Logger {
@@ -23,8 +25,8 @@ func LoggerFromCtx(ctx context.Context) log.Logger {
 		logger = log.With(logger, string(FlowNameKey), flowName)
 	}
 
-	if flowMetadata := GetFlowMetadata(ctx); flowMetadata != nil {
-		logger = log.With(logger, string(FlowMetadataKey), flowMetadata)
+	if flowMetadata := internal.GetFlowMetadata(ctx); flowMetadata != nil {
+		logger = log.With(logger, string(internal.FlowMetadataKey), flowMetadata)
 	}
 
 	return logger

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -369,7 +369,13 @@ func CDCFlowWorkflow(
 	originalRunID := workflow.GetInfo(ctx).OriginalRunID
 
 	var err error
-	ctx, err = GetFlowMetadataContext(ctx, cfg.FlowJobName, cfg.SourceName, cfg.DestinationName)
+	ctx, err = GetFlowMetadataContext(ctx, &protos.FlowContextMetadataInput{
+		FlowName:        cfg.FlowJobName,
+		SourceName:      cfg.SourceName,
+		DestinationName: cfg.DestinationName,
+		Status:          state.CurrentFlowStatus,
+		IsResync:        cfg.Resync,
+	})
 	if err != nil {
 		return state, fmt.Errorf("failed to get flow metadata context: %w", err)
 	}

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -106,8 +106,13 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 	workflow.GetLogger(ctx).Info("performing cleanup for flow",
 		slog.String(string(shared.FlowNameKey), input.FlowJobName))
 	var err error
-	ctx, err = GetFlowMetadataContext(ctx,
-		input.FlowJobName, input.FlowConnectionConfigs.SourceName, input.FlowConnectionConfigs.DestinationName)
+	ctx, err = GetFlowMetadataContext(ctx, &protos.FlowContextMetadataInput{
+		FlowName:        input.FlowJobName,
+		SourceName:      input.FlowConnectionConfigs.SourceName,
+		DestinationName: input.FlowConnectionConfigs.DestinationName,
+		Status:          protos.FlowStatus_STATUS_UNKNOWN,
+		IsResync:        false,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get flow metadata context: %w", err)
 	}

--- a/flow/workflows/util.go
+++ b/flow/workflows/util.go
@@ -6,7 +6,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
-	"github.com/PeerDB-io/peerdb/flow/shared"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 func GetSideEffect[T any](ctx workflow.Context, f func(workflow.Context) T) T {
@@ -33,5 +33,5 @@ func GetFlowMetadataContext(
 	if err := getMetadataFuture.Get(metadataCtx, &metadata); err != nil {
 		return nil, err
 	}
-	return workflow.WithValue(ctx, shared.FlowMetadataKey, metadata), nil
+	return workflow.WithValue(ctx, internal.FlowMetadataKey, metadata), nil
 }

--- a/flow/workflows/util.go
+++ b/flow/workflows/util.go
@@ -21,11 +21,14 @@ func GetSideEffect[T any](ctx workflow.Context, f func(workflow.Context) T) T {
 	return result
 }
 
-func GetFlowMetadataContext(ctx workflow.Context, flowJobName string, sourceName string, destinationName string) (workflow.Context, error) {
+func GetFlowMetadataContext(
+	ctx workflow.Context,
+	input *protos.FlowContextMetadataInput,
+) (workflow.Context, error) {
 	metadataCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
 		StartToCloseTimeout: 30 * time.Second,
 	})
-	getMetadataFuture := workflow.ExecuteLocalActivity(metadataCtx, flowable.GetFlowMetadata, flowJobName, sourceName, destinationName)
+	getMetadataFuture := workflow.ExecuteLocalActivity(metadataCtx, flowable.GetFlowMetadata, input)
 	var metadata *protos.FlowContextMetadata
 	if err := getMetadataFuture.Get(metadataCtx, &metadata); err != nil {
 		return nil, err

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -499,8 +499,18 @@ message PeerContextMetadata {
   peerdb_peers.DBType type = 2;
 }
 
+message FlowContextMetadataInput {
+  string flow_name = 1;
+  string source_name = 2;
+  string destination_name = 3;
+  FlowStatus status = 4;
+  bool is_resync = 5;
+}
+
 message FlowContextMetadata{
   string flow_name = 1;
   PeerContextMetadata source = 2;
   PeerContextMetadata destination = 3;
+  FlowStatus status = 4;
+  bool is_resync = 5;
 }


### PR DESCRIPTION
This can potentially resolve #2470

Maybe we should also set context in the child workflows, but should be fine for initial cases


### ⚠️  Warning

This PR will lead to non-determinism in completed mirrors for releases that were upgraded from v0.24.0 to v0.25.0 (releases upgraded from version < 0.24.0) should be ok

They can be fixed by rerunning the old completed workflow with 2nd input as completed and updating catalog entry to point to the new wf