### PR TITLE
Cleanup connpostgres usage outside connpostgres

### DIFF
--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors"
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
-	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 )
@@ -32,48 +30,6 @@ func redactProto(message proto.Message) {
 		}
 		return true
 	})
-}
-
-func (h *FlowRequestHandler) getPGPeerConfig(ctx context.Context, peerName string) (*protos.PostgresConfig, error) {
-	var encPeerOptions []byte
-	var encKeyID string
-	if err := h.pool.QueryRow(
-		ctx, "SELECT options, enc_key_id FROM peers WHERE name=$1 AND type=3", peerName,
-	).Scan(&encPeerOptions, &encKeyID); err != nil {
-		return nil, err
-	}
-
-	peerOptions, err := internal.Decrypt(ctx, encKeyID, encPeerOptions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load peer: %w", err)
-	}
-
-	var pgPeerConfig protos.PostgresConfig
-	if err := proto.Unmarshal(peerOptions, &pgPeerConfig); err != nil {
-		return nil, err
-	}
-	return &pgPeerConfig, nil
-}
-
-func (h *FlowRequestHandler) getConnForPGPeer(ctx context.Context, peerName string) (utils.SSHTunnel, *pgx.Conn, error) {
-	pgPeerConfig, err := h.getPGPeerConfig(ctx, peerName)
-	if err != nil {
-		return utils.SSHTunnel{}, nil, err
-	}
-
-	tunnel, err := utils.NewSSHTunnel(ctx, pgPeerConfig.SshConfig)
-	if err != nil {
-		slog.Error("Failed to create postgres pool", slog.Any("error", err))
-		return utils.SSHTunnel{}, nil, err
-	}
-
-	conn, err := connpostgres.NewPostgresConnFromPostgresConfig(ctx, pgPeerConfig, tunnel)
-	if err != nil {
-		tunnel.Close()
-		return utils.SSHTunnel{}, nil, err
-	}
-
-	return tunnel, conn, nil
 }
 
 func (h *FlowRequestHandler) GetPeerInfo(
@@ -220,17 +176,12 @@ func (h *FlowRequestHandler) GetSlotInfo(
 	ctx context.Context,
 	req *protos.PostgresPeerActivityInfoRequest,
 ) (*protos.PeerSlotResponse, error) {
-	pgConfig, err := h.getPGPeerConfig(ctx, req.PeerName)
-	if err != nil {
-		return nil, err
-	}
-
-	pgConnector, err := connpostgres.NewPostgresConnector(ctx, nil, pgConfig)
+	pgConnector, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, h.pool, req.PeerName)
 	if err != nil {
 		slog.Error("Failed to create postgres connector", slog.Any("error", err))
 		return nil, err
 	}
-	defer pgConnector.Close()
+	defer connectors.CloseConnector(ctx, pgConnector)
 
 	slotInfo, err := pgConnector.GetSlotInfo(ctx, "")
 	if err != nil {
@@ -286,16 +237,15 @@ func (h *FlowRequestHandler) GetStatInfo(
 	ctx context.Context,
 	req *protos.PostgresPeerActivityInfoRequest,
 ) (*protos.PeerStatResponse, error) {
-	tunnel, peerConn, err := h.getConnForPGPeer(ctx, req.PeerName)
+	peerConn, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, h.pool, req.PeerName)
 	if err != nil {
 		return nil, err
 	}
-	defer tunnel.Close()
-	defer peerConn.Close(ctx)
+	defer connectors.CloseConnector(ctx, peerConn)
 
-	peerUser := peerConn.Config().User
+	peerUser := peerConn.Config.User
 
-	rows, err := peerConn.Query(ctx, "SELECT pid, wait_event, wait_event_type, query_start::text, query,"+
+	rows, err := peerConn.Conn().Query(ctx, "SELECT pid, wait_event, wait_event_type, query_start::text, query,"+
 		"EXTRACT(epoch FROM(now()-query_start)) AS dur, state"+
 		" FROM pg_stat_activity WHERE "+
 		"usename=$1 AND application_name LIKE 'peerdb%';", peerUser)
@@ -368,14 +318,13 @@ func (h *FlowRequestHandler) GetPublications(
 	ctx context.Context,
 	req *protos.PostgresPeerActivityInfoRequest,
 ) (*protos.PeerPublicationsResponse, error) {
-	tunnel, peerConn, err := h.getConnForPGPeer(ctx, req.PeerName)
+	peerConn, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, h.pool, req.PeerName)
 	if err != nil {
 		return nil, err
 	}
-	defer tunnel.Close()
-	defer peerConn.Close(ctx)
+	defer connectors.CloseConnector(ctx, peerConn)
 
-	rows, err := peerConn.Query(ctx, "select pubname from pg_publication;")
+	rows, err := peerConn.Conn().Query(ctx, "select pubname from pg_publication;")
 	if err != nil {
 		slog.Info("failed to fetch publications", slog.Any("error", err))
 		return nil, err

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -3,13 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/PeerDB-io/peerdb/flow/connectors"
-	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
-	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/telemetry"
 )
 
@@ -43,22 +40,6 @@ func (h *FlowRequestHandler) ValidatePeer(
 		}, nil
 	}
 	defer conn.Close()
-
-	if req.Peer.Type == protos.DBType_POSTGRES {
-		pgversion, err := conn.(*connpostgres.PostgresConnector).MajorVersion(ctx)
-		if err != nil {
-			slog.Error("/peer/validate: pg version check", slog.Any("error", err))
-			return nil, err
-		}
-
-		if pgversion < shared.POSTGRES_12 {
-			return &protos.ValidatePeerResponse{
-				Status: protos.ValidatePeerStatus_INVALID,
-				Message: fmt.Sprintf("Postgres peer %s must be of PG12 or above. Current version: %d",
-					req.Peer.Name, pgversion),
-			}, nil
-		}
-	}
 
 	if validationConn, ok := conn.(connectors.ValidationConnector); ok {
 		if validErr := validationConn.ValidateCheck(ctx); validErr != nil {

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -565,6 +565,7 @@ var (
 	_ RawTableConnector = &connsnowflake.SnowflakeConnector{}
 	_ RawTableConnector = &connpostgres.PostgresConnector{}
 
+	_ ValidationConnector = &connpostgres.PostgresConnector{}
 	_ ValidationConnector = &connsnowflake.SnowflakeConnector{}
 	_ ValidationConnector = &connclickhouse.ClickHouseConnector{}
 	_ ValidationConnector = &connbigquery.BigQueryConnector{}

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -279,9 +279,9 @@ func (c *PostgresConnector) checkSlotAndPublication(ctx context.Context, slot st
 func getSlotInfo(ctx context.Context, conn *pgx.Conn, slotName string, database string) ([]*protos.SlotInfo, error) {
 	var whereClause string
 	if slotName != "" {
-		whereClause = "WHERE slot_name=" + QuoteLiteral(slotName)
+		whereClause = "WHERE slot_name=" + utils.QuoteLiteral(slotName)
 	} else {
-		whereClause = "WHERE database=" + QuoteLiteral(database)
+		whereClause = "WHERE database=" + utils.QuoteLiteral(database)
 	}
 
 	pgversion, err := shared.GetMajorVersion(ctx, conn)
@@ -332,7 +332,7 @@ func getSlotInfo(ctx context.Context, conn *pgx.Conn, slotName string, database 
 // If slotName input is empty, all slot info rows are returned - this is for UI.
 // Else, only the row pertaining to that slotName will be returned.
 func (c *PostgresConnector) GetSlotInfo(ctx context.Context, slotName string) ([]*protos.SlotInfo, error) {
-	return getSlotInfo(ctx, c.conn, slotName, c.config.Database)
+	return getSlotInfo(ctx, c.conn, slotName, c.Config.Database)
 }
 
 func (c *PostgresConnector) CreatePublication(
@@ -470,24 +470,24 @@ func generateCreateTableSQLForNormalizedTable(
 		}
 
 		createTableSQLArray = append(createTableSQLArray,
-			fmt.Sprintf("%s %s%s", QuoteIdentifier(column.Name), pgColumnType, notNull))
+			fmt.Sprintf("%s %s%s", utils.QuoteIdentifier(column.Name), pgColumnType, notNull))
 	}
 
 	if config.SoftDeleteColName != "" {
 		createTableSQLArray = append(createTableSQLArray,
-			QuoteIdentifier(config.SoftDeleteColName)+` BOOL DEFAULT FALSE`)
+			utils.QuoteIdentifier(config.SoftDeleteColName)+` BOOL DEFAULT FALSE`)
 	}
 
 	if config.SyncedAtColName != "" {
 		createTableSQLArray = append(createTableSQLArray,
-			QuoteIdentifier(config.SyncedAtColName)+` TIMESTAMP DEFAULT CURRENT_TIMESTAMP`)
+			utils.QuoteIdentifier(config.SyncedAtColName)+` TIMESTAMP DEFAULT CURRENT_TIMESTAMP`)
 	}
 
 	// add composite primary key to the table
 	if len(tableSchema.PrimaryKeyColumns) > 0 && !tableSchema.IsReplicaIdentityFull {
 		primaryKeyColsQuoted := make([]string, 0, len(tableSchema.PrimaryKeyColumns))
 		for _, primaryKeyCol := range tableSchema.PrimaryKeyColumns {
-			primaryKeyColsQuoted = append(primaryKeyColsQuoted, QuoteIdentifier(primaryKeyCol))
+			primaryKeyColsQuoted = append(primaryKeyColsQuoted, utils.QuoteIdentifier(primaryKeyCol))
 		}
 		createTableSQLArray = append(createTableSQLArray, fmt.Sprintf("PRIMARY KEY(%s)",
 			strings.Join(primaryKeyColsQuoted, ",")))

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -72,7 +72,7 @@ func (c *PostgresConnector) GetQRepPartitions(
 
 func (c *PostgresConnector) setTransactionSnapshot(ctx context.Context, tx pgx.Tx, snapshot string) error {
 	if snapshot != "" {
-		if _, err := tx.Exec(ctx, "SET TRANSACTION SNAPSHOT "+QuoteLiteral(snapshot)); err != nil {
+		if _, err := tx.Exec(ctx, "SET TRANSACTION SNAPSHOT "+utils.QuoteLiteral(snapshot)); err != nil {
 			return fmt.Errorf("failed to set transaction snapshot: %w", err)
 		}
 	}
@@ -87,7 +87,7 @@ func (c *PostgresConnector) getNumRowsPartitions(
 	last *protos.QRepPartition,
 ) ([]*protos.QRepPartition, error) {
 	numRowsPerPartition := int64(config.NumRowsPerPartition)
-	quotedWatermarkColumn := QuoteIdentifier(config.WatermarkColumn)
+	quotedWatermarkColumn := utils.QuoteIdentifier(config.WatermarkColumn)
 
 	whereClause := ""
 	if last != nil && last.Range != nil {
@@ -202,7 +202,7 @@ func (c *PostgresConnector) getMinMaxValues(
 	last *protos.QRepPartition,
 ) (interface{}, interface{}, error) {
 	var minValue, maxValue interface{}
-	quotedWatermarkColumn := QuoteIdentifier(config.WatermarkColumn)
+	quotedWatermarkColumn := utils.QuoteIdentifier(config.WatermarkColumn)
 
 	parsedWatermarkTable, err := utils.ParseSchemaTable(config.WatermarkTable)
 	if err != nil {
@@ -480,8 +480,8 @@ func syncQRepRecords(
 			updateSyncedAtStmt := fmt.Sprintf(
 				`UPDATE %s SET %s = CURRENT_TIMESTAMP WHERE %s IS NULL;`,
 				pgx.Identifier{dstTable.Schema, dstTable.Table}.Sanitize(),
-				QuoteIdentifier(syncedAtCol),
-				QuoteIdentifier(syncedAtCol),
+				utils.QuoteIdentifier(syncedAtCol),
+				utils.QuoteIdentifier(syncedAtCol),
 			)
 			_, err = tx.Exec(ctx, updateSyncedAtStmt)
 			if err != nil {
@@ -540,14 +540,14 @@ func syncQRepRecords(
 		selectStrArray := make([]string, 0, len(columnNames))
 		for _, col := range columnNames {
 			_, ok := upsertMatchCols[col]
-			quotedCol := QuoteIdentifier(col)
+			quotedCol := utils.QuoteIdentifier(col)
 			if !ok {
 				setClauseArray = append(setClauseArray, fmt.Sprintf(`%s = EXCLUDED.%s`, quotedCol, quotedCol))
 			}
 			selectStrArray = append(selectStrArray, quotedCol)
 		}
 		setClauseArray = append(setClauseArray,
-			QuoteIdentifier(syncedAtCol)+`= CURRENT_TIMESTAMP`)
+			utils.QuoteIdentifier(syncedAtCol)+`= CURRENT_TIMESTAMP`)
 		setClause := strings.Join(setClauseArray, ",")
 		selectSQL := strings.Join(selectStrArray, ",")
 
@@ -556,7 +556,7 @@ func syncQRepRecords(
 			`INSERT INTO %s (%s, %s) SELECT %s, CURRENT_TIMESTAMP FROM %s ON CONFLICT (%s) DO UPDATE SET %s;`,
 			dstTableIdentifier.Sanitize(),
 			selectSQL,
-			QuoteIdentifier(syncedAtCol),
+			utils.QuoteIdentifier(syncedAtCol),
 			selectSQL,
 			stagingTableIdentifier.Sanitize(),
 			strings.Join(writeMode.UpsertKeyColumns, ", "),

--- a/flow/connectors/postgres/qrep_partition_test.go
+++ b/flow/connectors/postgres/qrep_partition_test.go
@@ -168,7 +168,7 @@ func TestGetQRepPartitions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &PostgresConnector{
 				connStr: connStr,
-				config:  &protos.PostgresConfig{},
+				Config:  &protos.PostgresConfig{},
 				conn:    conn,
 				logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testGetQRepPartitions"))),
 			}

--- a/flow/connectors/postgres/sink_pg.go
+++ b/flow/connectors/postgres/sink_pg.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/postgres/sanitize"
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
@@ -55,7 +56,7 @@ func (p PgCopyWriter) ExecuteQueryWithTx(
 	defer shared.RollbackTx(tx, qe.logger)
 
 	if qe.snapshot != "" {
-		if _, err := tx.Exec(ctx, "SET TRANSACTION SNAPSHOT "+QuoteLiteral(qe.snapshot)); err != nil {
+		if _, err := tx.Exec(ctx, "SET TRANSACTION SNAPSHOT "+utils.QuoteLiteral(qe.snapshot)); err != nil {
 			qe.logger.Error("[pg_query_executor] failed to set snapshot",
 				slog.Any("error", err), slog.String("query", query))
 			return 0, fmt.Errorf("[pg_query_executor] failed to set snapshot: %w", err)
@@ -119,7 +120,7 @@ func (p PgCopyReader) CopyInto(ctx context.Context, c *PostgresConnector, tx pgx
 	}
 	quotedCols := make([]string, 0, len(cols))
 	for _, col := range cols {
-		quotedCols = append(quotedCols, QuoteIdentifier(col))
+		quotedCols = append(quotedCols, utils.QuoteIdentifier(col))
 	}
 	ct, err := tx.Conn().PgConn().CopyFrom(
 		ctx,

--- a/flow/connectors/postgres/sink_q.go
+++ b/flow/connectors/postgres/sink_q.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
@@ -26,7 +27,7 @@ func (stream RecordStreamSink) ExecuteQueryWithTx(
 	defer shared.RollbackTx(tx, qe.logger)
 
 	if qe.snapshot != "" {
-		if _, err := tx.Exec(ctx, "SET TRANSACTION SNAPSHOT "+QuoteLiteral(qe.snapshot)); err != nil {
+		if _, err := tx.Exec(ctx, "SET TRANSACTION SNAPSHOT "+utils.QuoteLiteral(qe.snapshot)); err != nil {
 			qe.logger.Error("[pg_query_executor] failed to set snapshot",
 				slog.Any("error", err), slog.String("query", query))
 			return 0, fmt.Errorf("[pg_query_executor] failed to set snapshot: %w", err)

--- a/flow/connectors/postgres/validate.go
+++ b/flow/connectors/postgres/validate.go
@@ -13,6 +13,18 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
+func (c *PostgresConnector) ValidateCheck(ctx context.Context) error {
+	pgversion, err := c.MajorVersion(ctx)
+	if err != nil {
+		return err
+	}
+
+	if pgversion < shared.POSTGRES_12 {
+		return fmt.Errorf("postgres must be of PG12 or above. Current version: %d", pgversion)
+	}
+	return nil
+}
+
 func (c *PostgresConnector) CheckSourceTables(ctx context.Context,
 	tableNames []*utils.SchemaTable, pubName string, noCDC bool,
 ) error {
@@ -25,9 +37,9 @@ func (c *PostgresConnector) CheckSourceTables(ctx context.Context,
 	for _, parsedTable := range tableNames {
 		var row pgx.Row
 		tableArr = append(tableArr, fmt.Sprintf(`(%s::text,%s::text)`,
-			QuoteLiteral(parsedTable.Schema), QuoteLiteral(parsedTable.Table)))
+			utils.QuoteLiteral(parsedTable.Schema), utils.QuoteLiteral(parsedTable.Table)))
 		if err := c.conn.QueryRow(ctx,
-			fmt.Sprintf("SELECT * FROM %s.%s LIMIT 0", QuoteIdentifier(parsedTable.Schema), QuoteIdentifier(parsedTable.Table)),
+			fmt.Sprintf("SELECT * FROM %s.%s LIMIT 0", utils.QuoteIdentifier(parsedTable.Schema), utils.QuoteIdentifier(parsedTable.Table)),
 		).Scan(&row); err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return err
 		}
@@ -66,7 +78,7 @@ func (c *PostgresConnector) CheckSourceTables(ctx context.Context,
 				if err := row.Scan(&schema, &table); err != nil {
 					return "", err
 				}
-				return fmt.Sprintf("%s.%s", QuoteIdentifier(schema), QuoteIdentifier(table)), nil
+				return fmt.Sprintf("%s.%s", utils.QuoteIdentifier(schema), utils.QuoteIdentifier(table)), nil
 			})
 			if err != nil {
 				return err
@@ -184,7 +196,7 @@ func (c *PostgresConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 		}
 
 		// Check permissions of postgres peer
-		if err := c.CheckReplicationPermissions(ctx, c.config.User); err != nil {
+		if err := c.CheckReplicationPermissions(ctx, c.Config.User); err != nil {
 			return fmt.Errorf("failed to check replication permissions: %v", err)
 		}
 	}
@@ -204,7 +216,7 @@ func (c *PostgresConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 		srcTableNames := make([]string, 0, len(sourceTables))
 		for _, srcTable := range sourceTables {
 			srcTableNames = append(srcTableNames, fmt.Sprintf(
-				`%s.%s`, QuoteIdentifier(srcTable.Schema), QuoteIdentifier(srcTable.Table),
+				`%s.%s`, utils.QuoteIdentifier(srcTable.Schema), utils.QuoteIdentifier(srcTable.Table),
 			))
 		}
 

--- a/flow/connectors/utils/escape.go
+++ b/flow/connectors/utils/escape.go
@@ -1,6 +1,6 @@
 // from https://github.com/lib/pq/blob/v1.10.9/conn.go#L1656
 
-package connpostgres
+package utils
 
 import "strings"
 

--- a/flow/connectors/utils/identifiers.go
+++ b/flow/connectors/utils/identifiers.go
@@ -6,10 +6,6 @@ import (
 	"unicode"
 )
 
-func QuoteIdentifier(identifier string) string {
-	return fmt.Sprintf(`"%s"`, identifier)
-}
-
 // SchemaTable is a table in a schema.
 type SchemaTable struct {
 	Schema string

--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors"
 	"github.com/PeerDB-io/peerdb/flow/connectors/mysql"
-	"github.com/PeerDB-io/peerdb/flow/connectors/postgres"
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
@@ -150,7 +150,7 @@ func (s *MySqlSource) Exec(ctx context.Context, sql string) error {
 func (s *MySqlSource) GetRows(ctx context.Context, suffix string, table string, cols string) (*model.QRecordBatch, error) {
 	rs, err := s.MySqlConnector.Execute(
 		ctx,
-		fmt.Sprintf(`SELECT %s FROM "e2e_test_%s".%s ORDER BY id`, cols, suffix, connpostgres.QuoteIdentifier(table)),
+		fmt.Sprintf(`SELECT %s FROM "e2e_test_%s".%s ORDER BY id`, cols, suffix, utils.QuoteIdentifier(table)),
 	)
 	if err != nil {
 		return nil, err

--- a/flow/e2e/pg.go
+++ b/flow/e2e/pg.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors"
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
@@ -199,6 +200,6 @@ func (s *PostgresSource) GetRows(ctx context.Context, suffix string, table strin
 
 	return pgQueryExecutor.ExecuteAndProcessQuery(
 		ctx,
-		fmt.Sprintf(`SELECT %s FROM e2e_test_%s.%s ORDER BY id`, cols, suffix, connpostgres.QuoteIdentifier(table)),
+		fmt.Sprintf(`SELECT %s FROM e2e_test_%s.%s ORDER BY id`, cols, suffix, utils.QuoteIdentifier(table)),
 	)
 }

--- a/flow/e2e/postgres/postgres.go
+++ b/flow/e2e/postgres/postgres.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors"
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/e2e"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
@@ -65,7 +66,7 @@ func (s PeerFlowE2ETestSuitePG) GetRows(table string, cols string) (*model.QReco
 
 	return pgQueryExecutor.ExecuteAndProcessQuery(
 		s.t.Context(),
-		fmt.Sprintf(`SELECT %s FROM e2e_test_%s.%s ORDER BY id`, cols, s.suffix, connpostgres.QuoteIdentifier(table)),
+		fmt.Sprintf(`SELECT %s FROM e2e_test_%s.%s ORDER BY id`, cols, s.suffix, utils.QuoteIdentifier(table)),
 	)
 }
 

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -12,7 +12,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/PeerDB-io/peerdb/flow/activities"
-	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
@@ -153,7 +152,7 @@ func (s *SnapshotFlowExecution) cloneTable(
 		quotedColumns := make([]string, 0, len(tableSchema.Columns))
 		for _, col := range tableSchema.Columns {
 			if !slices.Contains(mapping.Exclude, col.Name) {
-				quotedColumns = append(quotedColumns, connpostgres.QuoteIdentifier(col.Name))
+				quotedColumns = append(quotedColumns, utils.QuoteIdentifier(col.Name))
 			}
 		}
 		from = strings.Join(quotedColumns, ",")


### PR DESCRIPTION
1. move QuoteLiteral & QuoteIdentifier to connectors/utils. These functions are portable across ANSI SQL
2. implement ValidationConnector for PostgresConnector, remove specialized PG peer validation
3. replace getPGPeerConfig/getConnForPGPeer with connectors.GetByNameAs in cmd/peer_data