### PR TITLE
primary key update: skip empty _peerdb_match_data rows

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -473,7 +473,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				selectQuery.WriteString(projectionUpdate.String())
 				selectQuery.WriteString(" FROM ")
 				selectQuery.WriteString(rawTbl)
-				selectQuery.WriteString(" WHERE _peerdb_batch_id > ")
+				selectQuery.WriteString(" WHERE _peerdb_match_data != '' && _peerdb_batch_id > ")
 				selectQuery.WriteString(strconv.FormatInt(normBatchID, 10))
 				selectQuery.WriteString(" AND _peerdb_batch_id <= ")
 				selectQuery.WriteString(strconv.FormatInt(req.SyncBatchID, 10))

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -473,7 +473,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				selectQuery.WriteString(projectionUpdate.String())
 				selectQuery.WriteString(" FROM ")
 				selectQuery.WriteString(rawTbl)
-				selectQuery.WriteString(" WHERE _peerdb_match_data != '' && _peerdb_batch_id > ")
+				selectQuery.WriteString(" WHERE _peerdb_match_data != '' AND _peerdb_batch_id > ")
 				selectQuery.WriteString(strconv.FormatInt(normBatchID, 10))
 				selectQuery.WriteString(" AND _peerdb_batch_id <= ")
 				selectQuery.WriteString(strconv.FormatInt(req.SyncBatchID, 10))


### PR DESCRIPTION
pg only sends old items when replica identity updated