### PR TITLE
feat: add additional non-proto metadata and move flowOperation

### DIFF
--- a/flow/internal/context.go
+++ b/flow/internal/context.go
@@ -37,10 +37,8 @@ func GetFlowMetadata(ctx context.Context) *protos.FlowContextMetadata {
 }
 
 func GetAdditionalMetadata(ctx context.Context) AdditionalContextMetadata {
-	if metadata, ok := ctx.Value(AdditionalMetadataKey).(AdditionalContextMetadata); ok {
-		return metadata
-	}
-	return AdditionalContextMetadata{}
+	metadata, _ := ctx.Value(AdditionalMetadataKey).(AdditionalContextMetadata)
+	return metadata
 }
 
 func WithOperationContext(ctx context.Context, operation protos.FlowOperation) context.Context {

--- a/flow/internal/context.go
+++ b/flow/internal/context.go
@@ -46,7 +46,7 @@ func GetAdditionalMetadata(ctx context.Context) AdditionalContextMetadata {
 func WithOperationContext(ctx context.Context, operation protos.FlowOperation) context.Context {
 	currentMetadata := GetAdditionalMetadata(ctx)
 	currentMetadata.Operation = operation
-	return context.WithValue(ctx, FlowMetadataKey, currentMetadata)
+	return context.WithValue(ctx, AdditionalMetadataKey, currentMetadata)
 }
 
 type ContextPropagator[V any] struct {

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -114,9 +114,13 @@ func buildContextualAttributes(ctx context.Context) metric.MeasurementOption {
 			attribute.String(DestinationPeerName, flowMetadata.Destination.Name),
 			attribute.Stringer(FlowStatusKey, flowMetadata.Status),
 			attribute.Bool(IsFlowResyncKey, flowMetadata.IsResync),
-			attribute.Stringer(FlowOperationKey, flowMetadata.Operation),
 		)
 	}
+	additionalMetadata := internal.GetAdditionalMetadata(ctx)
+	attributes = append(attributes,
+		attribute.Stringer(FlowOperationKey, additionalMetadata.Operation),
+	)
+
 	if activity.IsActivity(ctx) {
 		activityInfo := activity.GetInfo(ctx)
 		attributes = append(attributes,

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -514,11 +514,16 @@ enum FlowOperation {
   FLOW_OPERATION_NORMALIZE = 2;
 }
 
+// FlowContextMetadata has contextual information of a flow and is universal at the flow level, it cannot be different for children context
+// it is referenced via pointer
 message FlowContextMetadata{
   string flow_name = 1;
   PeerContextMetadata source = 2;
   PeerContextMetadata destination = 3;
   FlowStatus status = 4;
   bool is_resync = 5;
-  FlowOperation operation = 6;
+}
+
+message AdditionalContextMetadata{
+  FlowOperation operation = 1;
 }


### PR DESCRIPTION
FlowContextMetadata is currently global and any change in child/parent will propagate to everywhere within the flow

This adds a secondary AdditionalContext which is passed by copy instead and any `context.WithValue` for it will apply only to the newly created contexts


Eg: Operation depends on the child context and is not global, the lifecycle of operation is that context itself