### PR TITLE
ClickHouse: use retryable exec for normalise insert

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -278,7 +278,6 @@ func (c *ClickHouseConnector) exec(ctx context.Context, query string, args ...an
 	return chvalidate.Exec(ctx, c.logger, c.database, query, args...)
 }
 
-//nolint:unparam
 func (c *ClickHouseConnector) execWithConnection(ctx context.Context, conn clickhouse.Conn, query string, args ...any) error {
 	return chvalidate.Exec(ctx, c.logger, conn, query, args...)
 }

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -278,6 +278,11 @@ func (c *ClickHouseConnector) exec(ctx context.Context, query string, args ...an
 	return chvalidate.Exec(ctx, c.logger, c.database, query, args...)
 }
 
+//nolint:unparam
+func (c *ClickHouseConnector) execWithConnection(ctx context.Context, conn clickhouse.Conn, query string, args ...any) error {
+	return chvalidate.Exec(ctx, c.logger, conn, query, args...)
+}
+
 func (c *ClickHouseConnector) query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
 	return chvalidate.Query(ctx, c.logger, c.database, query, args...)
 }

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -304,7 +304,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 					slog.Int64("normalizeBatchId", normBatchID),
 					slog.String("query", query))
 
-				if err := chConn.Exec(errCtx, query); err != nil {
+				if err := c.execWithConnection(ctx, chConn, query); err != nil {
 					return fmt.Errorf("error while inserting into normalized table: %w", err)
 				}
 			}


### PR DESCRIPTION
Seems like we have facility to detect some retryable error codes when inserting into clickhouse, allowing us to retry on the spot rather than having normalise as a whole retry

Related [comment](https://github.com/PeerDB-io/peerdb/pull/2662#discussion_r1983113366)