### PR TITLE
applySchemaDeltas: add missing env wiring

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -88,6 +88,7 @@ func (a *FlowableActivity) applySchemaDeltas(
 			TableMappings: options.TableMappings,
 			FlowName:      config.FlowJobName,
 			System:        config.System,
+			Env:           config.Env,
 		}); err != nil {
 			return a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to execute schema update at source: %w", err))
 		}

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -1012,19 +1012,7 @@ func (s ClickHouseSuite) Test_Nullable_Schema_Change() {
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`ALTER TABLE %s ADD COLUMN c2 INT`, srcFullName)))
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s (c1,c2) VALUES (1,null)`, srcFullName)))
 
-	e2e.EnvWaitFor(s.t, env, 4*time.Minute, "new column", func() bool {
-		ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
-		if err != nil {
-			return false
-		}
-		rows, err := ch.Query(s.t.Context(), "select c2 from "+dstTableName)
-		if err != nil {
-			return false
-		}
-		defer rows.Close()
-
-		return rows.ColumnTypes()[0].Nullable()
-	})
+	e2e.EnvWaitForEqualTables(env, s, "new column", tableName, "id,c1,c2")
 
 	env.Cancel(s.t.Context())
 	e2e.RequireEnvCanceled(s.t, env)


### PR DESCRIPTION
When a column addition occurs, at the end we update the schema of the table in the table_schema_mapping table in catalog in `applySchemaDeltas`

We currently are not passing the `Env` map to `applySchemaDeltas`, and `Env` contains nullable_enabled information. If the nullable setting is set to true, then after this column addition, it would be reset to false, causing data inconsistencies

This PR adds this wiring