### PR TITLE
PEERDB_SKIP_EXPORT_SNAPSHOT

### DIFF
--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -97,7 +97,7 @@ func (a *SnapshotActivity) SetupReplication(
 	}, nil
 }
 
-func (a *SnapshotActivity) MaintainTx(ctx context.Context, sessionID string, peer string) error {
+func (a *SnapshotActivity) MaintainTx(ctx context.Context, sessionID string, peer string, env map[string]string) error {
 	shutdown := heartbeatRoutine(ctx, func() string {
 		return "maintaining transaction snapshot"
 	})
@@ -108,7 +108,7 @@ func (a *SnapshotActivity) MaintainTx(ctx context.Context, sessionID string, pee
 	}
 	defer connectors.CloseConnector(ctx, conn)
 
-	exportSnapshotOutput, tx, err := conn.ExportTxSnapshot(ctx)
+	exportSnapshotOutput, tx, err := conn.ExportTxSnapshot(ctx, env)
 	if err != nil {
 		return err
 	}

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -82,7 +82,7 @@ type CDCPullConnectorCore interface {
 
 	// For InitialSnapshotOnly correctness without replication slot
 	// `any` is for returning transaction if necessary
-	ExportTxSnapshot(context.Context) (*protos.ExportTxSnapshotOutput, any, error)
+	ExportTxSnapshot(context.Context, map[string]string) (*protos.ExportTxSnapshotOutput, any, error)
 
 	// `any` from ExportSnapshot passed here when done, allowing transaction to commit
 	FinishExport(any) error

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -135,7 +135,7 @@ func (c *MySqlConnector) EnsurePullability(
 	return nil, nil
 }
 
-func (c *MySqlConnector) ExportTxSnapshot(context.Context) (*protos.ExportTxSnapshotOutput, any, error) {
+func (c *MySqlConnector) ExportTxSnapshot(context.Context, map[string]string) (*protos.ExportTxSnapshotOutput, any, error) {
 	// https://dev.mysql.com/doc/refman/8.4/en/replication-howto-masterstatus.html
 	return nil, nil, nil
 }

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -367,6 +367,7 @@ func (c *PostgresConnector) createSlotAndPublication(
 	publication string,
 	tableNameMapping map[string]model.NameAndExclude,
 	doInitialCopy bool,
+	skipSnapshotExport bool,
 ) (model.SetupReplicationResult, error) {
 	// iterate through source tables and create publication,
 	// expecting tablenames to be schema qualified
@@ -421,6 +422,15 @@ func (c *PostgresConnector) createSlotAndPublication(
 		}
 
 		c.logger.Info(fmt.Sprintf("Created replication slot '%s'", slot))
+		if skipSnapshotExport {
+			conn.Close(ctx)
+			return model.SetupReplicationResult{
+				Conn:             nil,
+				SlotName:         res.SlotName,
+				SnapshotName:     "",
+				SupportsTIDScans: pgversion >= shared.POSTGRES_13,
+			}, nil
+		}
 		return model.SetupReplicationResult{
 			Conn:             conn,
 			SlotName:         res.SlotName,

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1094,7 +1094,22 @@ func (c *PostgresConnector) EnsurePullability(
 	return &protos.EnsurePullabilityBatchOutput{TableIdentifierMapping: tableIdentifierMapping}, nil
 }
 
-func (c *PostgresConnector) ExportTxSnapshot(ctx context.Context) (*protos.ExportTxSnapshotOutput, any, error) {
+func (c *PostgresConnector) ExportTxSnapshot(ctx context.Context, env map[string]string) (*protos.ExportTxSnapshotOutput, any, error) {
+	pgversion, err := c.MajorVersion(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("[export-snapshot] error getting PG version: %w", err)
+	}
+
+	skipSnapshotExport, err := internal.PeerDBSkipSnapshotExport(ctx, env)
+	if err != nil {
+		c.logger.Error("failed to check PEERDB_SKIP_SNAPSHOT_EXPORT, proceeding with export snapshot", slog.Any("error", err))
+	} else if skipSnapshotExport {
+		return &protos.ExportTxSnapshotOutput{
+			SnapshotName:     "",
+			SupportsTidScans: pgversion >= shared.POSTGRES_13,
+		}, nil, err
+	}
+
 	var snapshotName string
 	tx, err := c.conn.Begin(ctx)
 	if err != nil {
@@ -1115,11 +1130,6 @@ func (c *PostgresConnector) ExportTxSnapshot(ctx context.Context) (*protos.Expor
 		return nil, nil, fmt.Errorf("[export-snapshot] error setting lock_timeout: %w", err)
 	}
 
-	pgversion, err := c.MajorVersion(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("[export-snapshot] error getting PG version: %w", err)
-	}
-
 	if err := tx.QueryRow(ctx, "SELECT pg_export_snapshot()").Scan(&snapshotName); err != nil {
 		return nil, nil, err
 	}
@@ -1133,6 +1143,9 @@ func (c *PostgresConnector) ExportTxSnapshot(ctx context.Context) (*protos.Expor
 }
 
 func (c *PostgresConnector) FinishExport(tx any) error {
+	if tx == nil {
+		return nil
+	}
 	pgtx := tx.(pgx.Tx)
 	timeout, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -271,6 +271,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
+	{
+		Name:             "PEERDB_SKIP_SNAPSHOT_EXPORT",
+		Description:      "This avoids initial load failing due to connectivity drops, but risks data consistency unless precautions are taken",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
+		TargetForSetting: protos.DynconfTarget_ALL,
+	},
 }
 
 var DynamicIndex = func() map[string]int {
@@ -546,4 +554,8 @@ func PeerDBClickHouseNormalizationParts(ctx context.Context, env map[string]stri
 
 func PeerDBClickHouseInitialLoadPartsPerPartition(ctx context.Context, env map[string]string) (uint64, error) {
 	return dynamicConfUnsigned[uint64](ctx, env, "PEERDB_CLICKHOUSE_INITIAL_LOAD_PARTS_PER_PARTITION")
+}
+
+func PeerDBSkipSnapshotExport(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_SKIP_SNAPSHOT_EXPORT")
 }

--- a/flow/shared/postgres.go
+++ b/flow/shared/postgres.go
@@ -70,8 +70,7 @@ func RegisterHStore(ctx context.Context, conn *pgx.Conn) error {
 
 func GetMajorVersion(ctx context.Context, conn *pgx.Conn) (PGVersion, error) {
 	var version int32
-	err := conn.QueryRow(ctx, "SELECT current_setting('server_version_num')::INTEGER").Scan(&version)
-	if err != nil {
+	if err := conn.QueryRow(ctx, "SELECT current_setting('server_version_num')::INTEGER").Scan(&version); err != nil {
 		return 0, fmt.Errorf("failed to get server version: %w", err)
 	}
 

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -229,11 +229,9 @@ func (s *SnapshotFlowExecution) cloneTables(
 	maxParallelClones int,
 ) error {
 	if snapshotType == SNAPSHOT_TYPE_SLOT {
-		s.logger.Info(fmt.Sprintf("cloning tables for slot name %s and snapshotName %s",
-			slotName, snapshotName))
+		s.logger.Info("cloning tables for slot", slog.String("slot", slotName), slog.String("snapshot", snapshotName))
 	} else if snapshotType == SNAPSHOT_TYPE_TX {
-		s.logger.Info("cloning tables in txn snapshot mode with snapshotName " +
-			snapshotName)
+		s.logger.Info("cloning tables in tx snapshot mode", slog.String("snapshot", snapshotName))
 	}
 
 	boundSelector := shared.NewBoundSelector(ctx, "CloneTablesSelector", maxParallelClones)
@@ -354,6 +352,7 @@ func SnapshotFlowWorkflow(
 			snapshot.MaintainTx,
 			sessionInfo.SessionID,
 			config.SourceName,
+			config.Env,
 		)
 
 		fExportSnapshot := workflow.ExecuteActivity(

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -57,6 +57,7 @@ func (s *SnapshotFlowExecution) setupReplication(
 		DoInitialSnapshot:           s.config.DoInitialSnapshot,
 		ExistingPublicationName:     s.config.PublicationName,
 		ExistingReplicationSlotName: s.config.ReplicationSlotName,
+		Env:                         s.config.Env,
 	}
 
 	res := &protos.SetupReplicationOutput{}

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -140,6 +140,7 @@ message EnsurePullabilityBatchOutput {
 message SetupReplicationInput {
   string flow_job_name = 2;
   map<string, string> table_name_mapping = 3;
+  map<string, string> env = 4;
 
   // replicate to destination using ctid
   bool do_initial_snapshot = 5;


### PR DESCRIPTION
This avoids keeping a long running connection during initial load, preventing connection drops from breaking initial load