### PR TITLE
ClickHouse: Support for special characters in column names

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -375,23 +375,23 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				case "Date32", "Nullable(Date32)":
 					projection.WriteString(fmt.Sprintf(
 						"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'),6)) AS `%s`,",
-						colName, dstColName,
+						strings.ReplaceAll(colName, "'", "''"), dstColName,
 					))
 					if enablePrimaryUpdate {
 						projectionUpdate.WriteString(fmt.Sprintf(
 							"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, '%s'),6)) AS `%s`,",
-							colName, dstColName,
+							strings.ReplaceAll(colName, "'", "''"), dstColName,
 						))
 					}
 				case "DateTime64(6)", "Nullable(DateTime64(6))":
 					projection.WriteString(fmt.Sprintf(
 						"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'),6) AS `%s`,",
-						colName, dstColName,
+						strings.ReplaceAll(colName, "'", "''"), dstColName,
 					))
 					if enablePrimaryUpdate {
 						projectionUpdate.WriteString(fmt.Sprintf(
 							"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, '%s'),6) AS `%s`,",
-							colName, dstColName,
+							strings.ReplaceAll(colName, "'", "''"), dstColName,
 						))
 					}
 				default:
@@ -405,21 +405,21 @@ func (c *ClickHouseConnector) NormalizeRecords(
 						case internal.BinaryFormatRaw:
 							projection.WriteString(fmt.Sprintf(
 								"base64Decode(JSONExtractString(_peerdb_data, '%s')) AS `%s`,",
-								colName, dstColName,
+								strings.ReplaceAll(colName, "'", "''"), dstColName,
 							))
 							if enablePrimaryUpdate {
 								projectionUpdate.WriteString(fmt.Sprintf(
 									"base64Decode(JSONExtractString(_peerdb_match_data, '%s')) AS `%s`,",
-									colName, dstColName,
+									strings.ReplaceAll(colName, "'", "''"), dstColName,
 								))
 							}
 						case internal.BinaryFormatHex:
 							projection.WriteString(fmt.Sprintf("hex(base64Decode(JSONExtractString(_peerdb_data, '%s'))) AS `%s`,",
-								colName, dstColName))
+								strings.ReplaceAll(colName, "'", "''"), dstColName))
 							if enablePrimaryUpdate {
 								projectionUpdate.WriteString(fmt.Sprintf(
 									"hex(base64Decode(JSONExtractString(_peerdb_match_data, '%s'))) AS `%s`,",
-									colName, dstColName,
+									strings.ReplaceAll(colName, "'", "''"), dstColName,
 								))
 							}
 						}
@@ -429,12 +429,12 @@ func (c *ClickHouseConnector) NormalizeRecords(
 					if projection.Len() == projLen {
 						projection.WriteString(fmt.Sprintf(
 							"JSONExtract(_peerdb_data, '%s', '%s') AS `%s`,",
-							colName, clickHouseType, dstColName,
+							strings.ReplaceAll(colName, "'", "''"), clickHouseType, dstColName,
 						))
 						if enablePrimaryUpdate {
 							projectionUpdate.WriteString(fmt.Sprintf(
 								"JSONExtract(_peerdb_match_data, '%s', '%s') AS `%s`,",
-								colName, clickHouseType, dstColName,
+								strings.ReplaceAll(colName, "'", "''"), clickHouseType, dstColName,
 							))
 						}
 					}

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -18,6 +18,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
+	peerdb_clickhouse "github.com/PeerDB-io/peerdb/flow/shared/clickhouse"
 )
 
 const (
@@ -375,23 +376,23 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				case "Date32", "Nullable(Date32)":
 					projection.WriteString(fmt.Sprintf(
 						"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'),6)) AS `%s`,",
-						strings.ReplaceAll(colName, "'", "''"), dstColName,
+						peerdb_clickhouse.EscapeStr(colName), dstColName,
 					))
 					if enablePrimaryUpdate {
 						projectionUpdate.WriteString(fmt.Sprintf(
 							"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, '%s'),6)) AS `%s`,",
-							strings.ReplaceAll(colName, "'", "''"), dstColName,
+							peerdb_clickhouse.EscapeStr(colName), dstColName,
 						))
 					}
 				case "DateTime64(6)", "Nullable(DateTime64(6))":
 					projection.WriteString(fmt.Sprintf(
 						"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, '%s'),6) AS `%s`,",
-						strings.ReplaceAll(colName, "'", "''"), dstColName,
+						peerdb_clickhouse.EscapeStr(colName), dstColName,
 					))
 					if enablePrimaryUpdate {
 						projectionUpdate.WriteString(fmt.Sprintf(
 							"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, '%s'),6) AS `%s`,",
-							strings.ReplaceAll(colName, "'", "''"), dstColName,
+							peerdb_clickhouse.EscapeStr(colName), dstColName,
 						))
 					}
 				default:
@@ -405,21 +406,21 @@ func (c *ClickHouseConnector) NormalizeRecords(
 						case internal.BinaryFormatRaw:
 							projection.WriteString(fmt.Sprintf(
 								"base64Decode(JSONExtractString(_peerdb_data, '%s')) AS `%s`,",
-								strings.ReplaceAll(colName, "'", "''"), dstColName,
+								peerdb_clickhouse.EscapeStr(colName), dstColName,
 							))
 							if enablePrimaryUpdate {
 								projectionUpdate.WriteString(fmt.Sprintf(
 									"base64Decode(JSONExtractString(_peerdb_match_data, '%s')) AS `%s`,",
-									strings.ReplaceAll(colName, "'", "''"), dstColName,
+									peerdb_clickhouse.EscapeStr(colName), dstColName,
 								))
 							}
 						case internal.BinaryFormatHex:
 							projection.WriteString(fmt.Sprintf("hex(base64Decode(JSONExtractString(_peerdb_data, '%s'))) AS `%s`,",
-								strings.ReplaceAll(colName, "'", "''"), dstColName))
+								peerdb_clickhouse.EscapeStr(colName), dstColName))
 							if enablePrimaryUpdate {
 								projectionUpdate.WriteString(fmt.Sprintf(
 									"hex(base64Decode(JSONExtractString(_peerdb_match_data, '%s'))) AS `%s`,",
-									strings.ReplaceAll(colName, "'", "''"), dstColName,
+									peerdb_clickhouse.EscapeStr(colName), dstColName,
 								))
 							}
 						}
@@ -429,12 +430,12 @@ func (c *ClickHouseConnector) NormalizeRecords(
 					if projection.Len() == projLen {
 						projection.WriteString(fmt.Sprintf(
 							"JSONExtract(_peerdb_data, '%s', '%s') AS `%s`,",
-							strings.ReplaceAll(colName, "'", "''"), clickHouseType, dstColName,
+							peerdb_clickhouse.EscapeStr(colName), clickHouseType, dstColName,
 						))
 						if enablePrimaryUpdate {
 							projectionUpdate.WriteString(fmt.Sprintf(
 								"JSONExtract(_peerdb_match_data, '%s', '%s') AS `%s`,",
-								strings.ReplaceAll(colName, "'", "''"), clickHouseType, dstColName,
+								peerdb_clickhouse.EscapeStr(colName), clickHouseType, dstColName,
 							))
 						}
 					}

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -161,7 +161,7 @@ func (s *ClickHouseAvroSyncMethod) SyncQRepRecords(
 		sessionTokenPart = fmt.Sprintf(", '%s'", creds.AWS.SessionToken)
 	}
 
-	hashColName := dstTableSchema[0].Name()
+	hashColName := columnNameAvroFieldMap[dstTableSchema[0].Name()]
 	numParts, err := internal.PeerDBClickHouseInitialLoadPartsPerPartition(ctx, s.config.Env)
 	if err != nil {
 		s.logger.Warn("failed to get chunking parts, proceeding without chunking", slog.Any("error", err))

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -76,7 +76,7 @@ func (s *ClickHouseAvroSyncMethod) SyncRecords(
 	s.logger.Info("sync function called and schema acquired",
 		slog.String("dstTable", dstTableName))
 
-	avroSchema, err := s.getAvroSchema(ctx, env, dstTableName, schema)
+	avroSchema, err := s.getAvroSchema(ctx, env, dstTableName, schema, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -116,7 +116,8 @@ func (s *ClickHouseAvroSyncMethod) SyncQRepRecords(
 		return 0, err
 	}
 
-	avroSchema, err := s.getAvroSchema(ctx, config.Env, dstTableName, schema)
+	columnNameAvroFieldMap := model.ConstructColumnNameAvroFieldMap(schema.Fields)
+	avroSchema, err := s.getAvroSchema(ctx, config.Env, dstTableName, schema, columnNameAvroFieldMap)
 	if err != nil {
 		return 0, err
 	}
@@ -139,7 +140,8 @@ func (s *ClickHouseAvroSyncMethod) SyncQRepRecords(
 	endpoint := s.credsProvider.Provider.GetEndpointURL()
 	region := s.credsProvider.Provider.GetRegion()
 	avroFileUrl := utils.FileURLForS3Service(endpoint, region, s3o.Bucket, avroFile.FilePath)
-	selector := make([]string, 0, len(dstTableSchema))
+	selectedColumnNames := make([]string, 0, len(dstTableSchema))
+	insertedColumnNames := make([]string, 0, len(dstTableSchema))
 	for _, col := range dstTableSchema {
 		colName := col.Name()
 		if strings.EqualFold(colName, config.SoftDeleteColName) ||
@@ -149,10 +151,11 @@ func (s *ClickHouseAvroSyncMethod) SyncQRepRecords(
 			continue
 		}
 
-		selector = append(selector, "`"+colName+"`")
+		selectedColumnNames = append(selectedColumnNames, "`"+columnNameAvroFieldMap[colName]+"`")
+		insertedColumnNames = append(insertedColumnNames, "`"+colName+"`")
 	}
-	selectorStr := strings.Join(selector, ",")
-
+	selectorStr := strings.Join(selectedColumnNames, ",")
+	insertedStr := strings.Join(insertedColumnNames, ",")
 	sessionTokenPart := ""
 	if creds.AWS.SessionToken != "" {
 		sessionTokenPart = fmt.Sprintf(", '%s'", creds.AWS.SessionToken)
@@ -173,7 +176,7 @@ func (s *ClickHouseAvroSyncMethod) SyncQRepRecords(
 		}
 		query := fmt.Sprintf(
 			"INSERT INTO `%s`(%s) SELECT %s FROM s3('%s','%s','%s'%s, 'Avro')%s SETTINGS throw_on_max_partitions_per_insert_block = 0",
-			config.DestinationTableIdentifier, selectorStr, selectorStr, avroFileUrl,
+			config.DestinationTableIdentifier, insertedStr, selectorStr, avroFileUrl,
 			creds.AWS.AccessKeyID, creds.AWS.SecretAccessKey, sessionTokenPart, whereClause)
 		s.logger.Info("inserting part",
 			slog.String("query", query),
@@ -202,8 +205,9 @@ func (s *ClickHouseAvroSyncMethod) getAvroSchema(
 	env map[string]string,
 	dstTableName string,
 	schema qvalue.QRecordSchema,
+	avroNameMap map[string]string,
 ) (*model.QRecordAvroSchemaDefinition, error) {
-	avroSchema, err := model.GetAvroSchemaDefinition(ctx, env, dstTableName, schema, protos.DBType_CLICKHOUSE)
+	avroSchema, err := model.GetAvroSchemaDefinition(ctx, env, dstTableName, schema, protos.DBType_CLICKHOUSE, avroNameMap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to define Avro schema: %w", err)
 	}

--- a/flow/connectors/s3/qrep.go
+++ b/flow/connectors/s3/qrep.go
@@ -42,7 +42,8 @@ func getAvroSchema(
 	dstTableName string,
 	schema qvalue.QRecordSchema,
 ) (*model.QRecordAvroSchemaDefinition, error) {
-	avroSchema, err := model.GetAvroSchemaDefinition(ctx, env, dstTableName, schema, protos.DBType_S3)
+	// TODO: Support avro-incompatible column names
+	avroSchema, err := model.GetAvroSchemaDefinition(ctx, env, dstTableName, schema, protos.DBType_S3, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to define Avro schema: %w", err)
 	}

--- a/flow/connectors/snowflake/avro_file_writer_test.go
+++ b/flow/connectors/snowflake/avro_file_writer_test.go
@@ -143,7 +143,7 @@ func TestWriteRecordsToAvroFileHappyPath(t *testing.T) {
 	// Define sample data
 	records, schema := generateRecords(t, true, 10, false)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE)
+	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)
@@ -170,7 +170,7 @@ func TestWriteRecordsToZstdAvroFileHappyPath(t *testing.T) {
 	// Define sample data
 	records, schema := generateRecords(t, true, 10, false)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE)
+	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)
@@ -197,7 +197,7 @@ func TestWriteRecordsToDeflateAvroFileHappyPath(t *testing.T) {
 	// Define sample data
 	records, schema := generateRecords(t, true, 10, false)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE)
+	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)
@@ -223,7 +223,7 @@ func TestWriteRecordsToAvroFileNonNull(t *testing.T) {
 
 	records, schema := generateRecords(t, false, 10, false)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE)
+	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)
@@ -250,7 +250,7 @@ func TestWriteRecordsToAvroFileAllNulls(t *testing.T) {
 	// Define sample data
 	records, schema := generateRecords(t, true, 10, true)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE)
+	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)

--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -203,7 +203,8 @@ func (s *SnowflakeAvroSyncHandler) getAvroSchema(
 	dstTableName string,
 	schema qvalue.QRecordSchema,
 ) (*model.QRecordAvroSchemaDefinition, error) {
-	avroSchema, err := model.GetAvroSchemaDefinition(ctx, env, dstTableName, schema, protos.DBType_SNOWFLAKE)
+	// TODO: Support avroNameMap for avro-incompatible column name support
+	avroSchema, err := model.GetAvroSchemaDefinition(ctx, env, dstTableName, schema, protos.DBType_SNOWFLAKE, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to define Avro schema: %w", err)
 	}

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -1084,15 +1084,20 @@ func (s ClickHouseSuite) Test_Unprivileged_Postgres_Columns() {
 		CREATE TABLE IF NOT EXISTS %s (
 			id SERIAL PRIMARY KEY,
 			key TEXT NOT NULL,
-			"se'cret" TEXT
+			"se'cret" TEXT,
+			"spacey column" TEXT,
+			"#sync_me!" BOOLEAN,
+			"2birds1stone" INT
 		);
 	`, srcFullName))
 	require.NoError(s.t, err)
 
-	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s (key, "se'cret") VALUES ('init_initial_load', 'secret')`, srcFullName))
+	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
+	INSERT INTO %s (key, "se'cret", "spacey column", "#sync_me!", "2birds1stone") 
+	VALUES ('init_initial_load', 'secret', 'neptune', 'true', 509 )`, srcFullName))
 	require.NoError(s.t, err)
 
-	err = e2e.RevokePermissionForTableColumns(s.t.Context(), s.Conn(), srcFullName, []string{"id", "key"})
+	err = e2e.RevokePermissionForTableColumns(s.t.Context(), s.Conn(), srcFullName, []string{"id", "key", "spacey column", "#sync_me!", "2birds1stone"})
 	require.NoError(s.t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
@@ -1111,10 +1116,15 @@ func (s ClickHouseSuite) Test_Unprivileged_Postgres_Columns() {
 	env := e2e.ExecutePeerflow(s.t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,key")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,key,\"spacey column\",\"#sync_me!\",\"2birds1stone\"")
 	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s (key, "se'cret") VALUES ('init_cdc', 'secret')`, srcFullName))
 	require.NoError(s.t, err)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,key")
+	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
+	INSERT INTO %s (key, "se'cret", "spacey column", "#sync_me!", "2birds1stone") 
+	VALUES ('init_initial_load', 'secret', 'pluto', 'false', 123324 )`, srcFullName))
+
+	require.NoError(s.t, err)
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,key,\"spacey column\",\"#sync_me!\",\"2birds1stone\"")
 	env.Cancel(s.t.Context())
 	e2e.RequireEnvCanceled(s.t, env)
 }

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -1098,7 +1098,8 @@ func (s ClickHouseSuite) Test_Unprivileged_Postgres_Columns() {
 	VALUES ('init_initial_load', 'secret', 'neptune', 'true', 509, "abcd")`, srcFullName))
 	require.NoError(s.t, err)
 
-	err = e2e.RevokePermissionForTableColumns(s.t.Context(), s.Conn(), srcFullName, []string{"id", "key", "spacey column", "#sync_me!", "2birds1stone", "quo'te"})
+	err = e2e.RevokePermissionForTableColumns(s.t.Context(), s.Conn(), srcFullName,
+		[]string{"id", "key", "spacey column", "#sync_me!", "2birds1stone", "quo'te"})
 	require.NoError(s.t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
@@ -1123,7 +1124,8 @@ func (s ClickHouseSuite) Test_Unprivileged_Postgres_Columns() {
 	VALUES ('cdc1', 'secret', 'pluto', 'false', 123324, "lwkfj")`, srcFullName))
 
 	require.NoError(s.t, err)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,key,\"spacey column\",\"#sync_me!\",\"2birds1stone\",\"quo'te\"")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName,
+		"id,key,\"spacey column\",\"#sync_me!\",\"2birds1stone\",\"quo'te\"")
 	env.Cancel(s.t.Context())
 	e2e.RequireEnvCanceled(s.t, env)
 }

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -1118,7 +1118,8 @@ func (s ClickHouseSuite) Test_Unprivileged_Postgres_Columns() {
 	env := e2e.ExecutePeerflow(s.t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,key,\"spacey column\",\"#sync_me!\",\"2birds1stone\",\"quo'te\"")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName,
+		"id,key,\"spacey column\",\"#sync_me!\",\"2birds1stone\",\"quo'te\"")
 	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
 	INSERT INTO %s (key, "se'cret", "spacey column", "#sync_me!", "2birds1stone","quo'te") 
 	VALUES ('cdc1', 'secret', 'pluto', 'false', 123324, 'lwkfj')`, srcFullName))

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -1095,7 +1095,7 @@ func (s ClickHouseSuite) Test_Unprivileged_Postgres_Columns() {
 
 	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
 	INSERT INTO %s (key, "se'cret", "spacey column", "#sync_me!", "2birds1stone", "quo'te") 
-	VALUES ('init_initial_load', 'secret', 'neptune', 'true', 509, "abcd")`, srcFullName))
+	VALUES ('init_initial_load', 'secret', 'neptune', 'true', 509, 'abcd')`, srcFullName))
 	require.NoError(s.t, err)
 
 	err = e2e.RevokePermissionForTableColumns(s.t.Context(), s.Conn(), srcFullName,
@@ -1121,7 +1121,7 @@ func (s ClickHouseSuite) Test_Unprivileged_Postgres_Columns() {
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,key,\"spacey column\",\"#sync_me!\",\"2birds1stone\",\"quo'te\"")
 	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
 	INSERT INTO %s (key, "se'cret", "spacey column", "#sync_me!", "2birds1stone","quo'te") 
-	VALUES ('cdc1', 'secret', 'pluto', 'false', 123324, "lwkfj")`, srcFullName))
+	VALUES ('cdc1', 'secret', 'pluto', 'false', 123324, 'lwkfj')`, srcFullName))
 
 	require.NoError(s.t, err)
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName,

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -69,6 +70,24 @@ func TruncateOrLogNumeric(num decimal.Decimal, precision int16, scale int16, tar
 		}
 	}
 	return num, nil
+}
+
+// ConvertToAvroCompatibleName converts a column name to a field name that is compatible with Avro.
+func ConvertToAvroCompatibleName(columnName string) string {
+	// Avro field names must:
+	// start with [A-Za-z_]
+	// subsequently contain only [A-Za-z0-9_]
+	if columnName == "" {
+		return "_"
+	}
+	// Ensure the first character is a letter or underscore
+	if columnName[0] >= '0' && columnName[0] <= '9' {
+		columnName = "_" + columnName
+	}
+	// Replace invalid characters with _
+	re := regexp.MustCompile(`[^A-Za-z0-9_]`)
+	columnName = re.ReplaceAllString(columnName, "_")
+	return columnName
 }
 
 // GetAvroSchemaFromQValueKind returns the Avro schema for a given QValueKind.

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -21,6 +21,8 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
+var re = regexp.MustCompile(`[^A-Za-z0-9_]`)
+
 type AvroSchemaField struct {
 	Name        string `json:"name"`
 	Type        any    `json:"type"`
@@ -84,8 +86,8 @@ func ConvertToAvroCompatibleName(columnName string) string {
 	if columnName[0] >= '0' && columnName[0] <= '9' {
 		columnName = "_" + columnName
 	}
+
 	// Replace invalid characters with _
-	re := regexp.MustCompile(`[^A-Za-z0-9_]`)
 	columnName = re.ReplaceAllString(columnName, "_")
 	return columnName
 }

--- a/flow/model/qvalue/avro_converter_test.go
+++ b/flow/model/qvalue/avro_converter_test.go
@@ -3,8 +3,9 @@ package qvalue_test
 import (
 	"testing"
 
-	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
 )
 
 func TestColumnNameAvroFieldConvert(t *testing.T) {

--- a/flow/model/qvalue/avro_converter_test.go
+++ b/flow/model/qvalue/avro_converter_test.go
@@ -1,0 +1,66 @@
+package qvalue_test
+
+import (
+	"testing"
+
+	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColumnNameAvroFieldConvert(t *testing.T) {
+	testColumnNames := []string{
+		"valid_column",             // Already valid
+		"ColumnWithCaps",           // Mixed case
+		"column-name",              // Hyphen should be replaced with _
+		"column.name",              // Dot should be replaced with _
+		"column@name",              // Special character should be replaced with _
+		"!invalid_start",           // Invalid start character
+		"123numericStart",          // Starts with a number, should be prefixed with _
+		"UPPER_CASE_COLUMN",        // Already valid
+		"column name",              // Space should be replaced with _
+		"column$name",              // Special character should be replaced with _
+		"column#name",              // Special character should be replaced with _
+		"column&name",              // Special character should be replaced with _
+		"123",                      // Fully numeric, should be prefixed with _
+		"_already_valid",           // Already valid
+		"column__name",             // Already valid with underscores
+		"table.column",             // Dotted name (common in queries), should be replaced with _
+		"column-name-with-hyphens", // Multiple hyphens
+		" spaces  in  name ",       // Multiple spaces should be replaced
+		"trailing_",                // Should remain unchanged
+		"__leading_underscores",    // Already valid, should remain
+		"CAPS-WITH-HYPHEN",         // Hyphen should be replaced with _
+		"",                         // Empty input, should return "_"
+	}
+
+	expectedColumnNames := []string{
+		"valid_column",
+		"ColumnWithCaps",
+		"column_name",
+		"column_name",
+		"column_name",
+		"_invalid_start",
+		"_123numericStart",
+		"UPPER_CASE_COLUMN",
+		"column_name",
+		"column_name",
+		"column_name",
+		"column_name",
+		"_123",
+		"_already_valid",
+		"column__name",
+		"table_column",
+		"column_name_with_hyphens",
+		"_spaces__in__name_",
+		"trailing_",
+		"__leading_underscores",
+		"CAPS_WITH_HYPHEN",
+		"_",
+	}
+
+	for i, columnName := range testColumnNames {
+		t.Run(columnName, func(t *testing.T) {
+			assert.Equal(t, expectedColumnNames[i], qvalue.ConvertToAvroCompatibleName(columnName))
+		})
+	}
+}

--- a/flow/shared/clickhouse/escape.go
+++ b/flow/shared/clickhouse/escape.go
@@ -2,18 +2,19 @@ package clickhouse
 
 import "strings"
 
-const BS = '\\'
-const mustEscape = "\t\n`'\\"
+const (
+	BS         = '\\'
+	mustEscape = "\t\n`'\\"
+)
 
 func EscapeStr(value string) string {
-	result := ""
-
+	var result strings.Builder
 	for _, c := range value {
 		if strings.ContainsRune(mustEscape, c) {
-			result += string(BS)
+			result.WriteRune(BS)
 		}
-		result += string(c)
+		result.WriteRune(c)
 	}
 
-	return result
+	return result.String()
 }

--- a/flow/shared/clickhouse/escape.go
+++ b/flow/shared/clickhouse/escape.go
@@ -1,7 +1,7 @@
 package clickhouse
 
 const BS = '\\'
-const mustEscape = "\t\n`'\\" // String constant instead of slice
+const mustEscape = "\t\n`'\\"
 
 func EscapeStr(value string) string {
 	result := ""

--- a/flow/shared/clickhouse/escape.go
+++ b/flow/shared/clickhouse/escape.go
@@ -1,5 +1,7 @@
 package clickhouse
 
+import "strings"
+
 const BS = '\\'
 const mustEscape = "\t\n`'\\"
 
@@ -7,20 +9,11 @@ func EscapeStr(value string) string {
 	result := ""
 
 	for _, c := range value {
-		if containsRune(mustEscape, c) {
+		if strings.ContainsRune(mustEscape, c) {
 			result += string(BS)
 		}
 		result += string(c)
 	}
 
 	return result
-}
-
-func containsRune(s string, r rune) bool {
-	for _, c := range s {
-		if c == r {
-			return true
-		}
-	}
-	return false
 }

--- a/flow/shared/clickhouse/escape.go
+++ b/flow/shared/clickhouse/escape.go
@@ -1,0 +1,26 @@
+package clickhouse
+
+const BS = '\\'
+const mustEscape = "\t\n`'\\" // String constant instead of slice
+
+func EscapeStr(value string) string {
+	result := ""
+
+	for _, c := range value {
+		if containsRune(mustEscape, c) {
+			result += string(BS)
+		}
+		result += string(c)
+	}
+
+	return result
+}
+
+func containsRune(s string, r rune) bool {
+	for _, c := range s {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Avro requires alphanumeric + underscore field names. However Postgres column names do not have the same restriction.

- This PR introduces a map of column names to an Avro compatible encoding of the same. Violating characters are replaced by underscore and the resulting string is suffixed with a serial number.
- This is utilized only for the initial load Avro loading since for CDC the columns will be that of our raw table columns.
- This PR only implements this support for ClickHouse target peers
- It also supports these columns for our normalize inserts by escaping the single quotes in column name argument of the JSONExtract* functions
- Functionally tested and the unprivileged columns E2E test has been adapted to include more columns to test this PR

Fixes #2701 