### PR TITLE
nexus: aws-lc-rs

### DIFF
--- a/nexus/Cargo.lock
+++ b/nexus/Cargo.lock
@@ -274,6 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -2931,6 +2932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c84e671791f3a354f265e55e400be8bb4b6262c1ec04fac4289e710ccf22ab43"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -2941,7 +2943,6 @@ dependencies = [
  "md5",
  "postgres-types",
  "rand 0.8.5",
- "ring",
  "rust_decimal",
  "stringprep",
  "thiserror 2.0.12",
@@ -3604,7 +3605,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3813,7 +3814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3825,7 +3826,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3897,7 +3898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4818,6 +4819,12 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -5046,7 +5053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -34,5 +34,5 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 pgwire = { version = "0.28", default-features = false, features = [
   "scram",
-  "server-api-ring",
+  "server-api-aws-lc-rs",
 ] }

--- a/nexus/peer-mysql/Cargo.toml
+++ b/nexus/peer-mysql/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono.workspace = true
 futures = { version = "0.3.28", features = ["executor"] }
-mysql_async = { version = "0.35", default-features = false, features = ["minimal-rust", "rust_decimal", "chrono", "rustls-tls", "ring"] }
+mysql_async = { version = "0.35", default-features = false, features = ["minimal-rust", "rust_decimal", "chrono", "rustls-tls", "aws-lc-rs"] }
 peer-ast = { path = "../peer-ast" }
 peer-cursor = { path = "../peer-cursor" }
 peer-connections = { path = "../peer-connections" }

--- a/nexus/postgres-connection/Cargo.toml
+++ b/nexus/postgres-connection/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 anyhow = "1"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 pt = { path = "../pt" }
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 ssh2.workspace = true
 tokio.workspace = true
 tokio-postgres = "0.7.2"

--- a/nexus/postgres-connection/src/lib.rs
+++ b/nexus/postgres-connection/src/lib.rs
@@ -33,7 +33,7 @@ impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
             message,
             cert,
             dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
         )
     }
 
@@ -47,12 +47,12 @@ impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
             message,
             cert,
             dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        rustls::crypto::ring::default_provider()
+        rustls::crypto::aws_lc_rs::default_provider()
             .signature_verification_algorithms
             .supported_schemes()
     }
@@ -156,7 +156,7 @@ pub async fn connect_postgres(
     } else {
         let connection_string = get_pg_connection_string(config);
 
-        let mut tls_config = ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+        let mut tls_config = ClientConfig::builder_with_provider(Arc::new(rustls::crypto::aws_lc_rs::default_provider()))
             .with_protocol_versions(&[&rustls::version::TLS13])?
             .with_root_certificates(RootCertStore::empty())
             .with_no_client_auth();


### PR DESCRIPTION
with #2712 we've added aws-lc-rs to our dependencies

ring recently lost some confidence with https://github.com/briansmith/ring/discussions/2414

switch to using aws-lc-rs ourselves. ring remains a downstream dependency