### PR TITLE
[postgres] validate hsfeedback on standby

### DIFF
--- a/flow/connectors/postgres/validate.go
+++ b/flow/connectors/postgres/validate.go
@@ -165,13 +165,22 @@ func (c *PostgresConnector) CheckReplicationPermissions(ctx context.Context, use
 	if err != nil {
 		return fmt.Errorf("failed to get server version: %w", err)
 	}
-	if serverVersion < shared.POSTGRES_16 {
-		var recoveryRes bool
-		if err := c.conn.QueryRow(ctx, "SELECT pg_is_in_recovery()").Scan(&recoveryRes); err != nil {
-			return fmt.Errorf("failed to check if Postgres is in recovery: %w", err)
-		}
-		if recoveryRes {
+
+	var recoveryRes bool
+	if err := c.conn.QueryRow(ctx, "SELECT pg_is_in_recovery()").Scan(&recoveryRes); err != nil {
+		return fmt.Errorf("failed to check if Postgres is in recovery: %w", err)
+	}
+	if recoveryRes {
+		if serverVersion < shared.POSTGRES_16 {
 			return errors.New("cannot create replication slots on a standby server with version <16")
+		}
+
+		var hsFeedbackRes bool
+		if err := c.conn.QueryRow(ctx, "SELECT setting FROM pg_settings WHERE name='hot_standby_feedback'").Scan(&hsFeedbackRes); err != nil {
+			return fmt.Errorf("failed to check hot_standby_feedback: %w", err)
+		}
+		if !hsFeedbackRes {
+			return errors.New("hot_standby_feedback setting must be enabled on standby servers")
 		}
 	}
 


### PR DESCRIPTION
without this setting on a standby, replication slots can be invalidated due to `conflict with recovery`
so explicitly checking for this