### PR TITLE
applySchemaUpdates: apply delta to existing schema instead of refreshing

### DIFF
--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -58,6 +58,7 @@ func (c *BigQueryConnector) replayTableSchemaDeltasQRep(
 	tableSchemaDelta := &protos.TableSchemaDelta{
 		SrcTableName: config.WatermarkTable,
 		DstTableName: config.DestinationTableIdentifier,
+		System:       config.System,
 	}
 
 	for _, col := range srcSchema.Fields {

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -910,16 +910,16 @@ func processRelationMessage[Items model.Items](
 	}
 
 	schemaDelta := &protos.TableSchemaDelta{
-		SrcTableName:    p.srcTableIDNameMapping[currRel.RelationID],
-		DstTableName:    p.tableNameMapping[p.srcTableIDNameMapping[currRel.RelationID]].Name,
-		AddedColumns:    nil,
-		System:          prevSchema.System,
-		NullableEnabled: prevSchema.NullableEnabled,
+		SrcTableName:          p.srcTableIDNameMapping[currRel.RelationID],
+		DstTableName:          p.tableNameMapping[p.srcTableIDNameMapping[currRel.RelationID]].Name,
+		AddedColumns:          nil,
+		System:                prevSchema.System,
+		NullableEnabled:       prevSchema.NullableEnabled,
+		IsReplicaIdentityFull: ReplicaIdentityType(currRel.ReplicaIdentity) == ReplicaIdentityFull,
 	}
 	for _, column := range currRel.Columns {
-		// not present in previous relation message, but in current one, so added.
-		if _, ok := prevRelMap[column.Name]; !ok {
-			// only add to delta if not excluded
+		if prevType, ok := prevRelMap[column.Name]; !ok {
+			// not present in previous relation message, but in current one, so added.
 			if _, ok := p.tableNameMapping[p.srcTableIDNameMapping[currRel.RelationID]].Exclude[column.Name]; !ok {
 				schemaDelta.AddedColumns = append(schemaDelta.AddedColumns, &protos.FieldDescription{
 					Name:         column.Name,
@@ -928,11 +928,10 @@ func processRelationMessage[Items model.Items](
 					Nullable:     column.Flags == 0, // pg does not send nullable info, only whether column is part of primary key
 				})
 			}
+		} else if prevType != currRelMap[column.Name] {
 			// present in previous and current relation messages, but data types have changed.
-			// so we add it to AddedColumns and DroppedColumns, knowing that we process DroppedColumns first.
-		} else if prevRelMap[column.Name] != currRelMap[column.Name] {
 			p.logger.Warn(fmt.Sprintf("Detected column %s with type changed from %s to %s in table %s, but not propagating",
-				column.Name, prevRelMap[column.Name], currRelMap[column.Name], schemaDelta.SrcTableName))
+				column.Name, prevType, currRelMap[column.Name], schemaDelta.SrcTableName))
 		}
 	}
 	for _, column := range prevSchema.Columns {
@@ -946,11 +945,10 @@ func processRelationMessage[Items model.Items](
 	p.relationMessageMapping[currRel.RelationID] = currRel
 	// only log audit if there is actionable delta
 	if len(schemaDelta.AddedColumns) > 0 {
-		rec := &model.RelationRecord[Items]{
+		return &model.RelationRecord[Items]{
 			BaseRecord:       p.baseRecord(lsn),
 			TableSchemaDelta: schemaDelta,
-		}
-		return rec, monitoring.AuditSchemaDelta(ctx, p.catalogPool.Pool, p.flowJobName, schemaDelta)
+		}, monitoring.AuditSchemaDelta(ctx, p.catalogPool.Pool, p.flowJobName, schemaDelta)
 	}
 	return nil, nil
 }

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -105,11 +105,10 @@ var ErrSlotAlreadyExists error = errors.New("slot already exists")
 // getRelIDForTable returns the relation ID for a table.
 func (c *PostgresConnector) getRelIDForTable(ctx context.Context, schemaTable *utils.SchemaTable) (uint32, error) {
 	var relID pgtype.Uint32
-	err := c.conn.QueryRow(ctx,
-		`SELECT c.oid FROM pg_class c JOIN pg_namespace n
-		 ON n.oid = c.relnamespace WHERE n.nspname=$1 AND c.relname=$2`,
-		schemaTable.Schema, schemaTable.Table).Scan(&relID)
-	if err != nil {
+	if err := c.conn.QueryRow(ctx,
+		"SELECT c.oid FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname=$1 AND c.relname=$2",
+		schemaTable.Schema, schemaTable.Table,
+	).Scan(&relID); err != nil {
 		return 0, fmt.Errorf("error getting relation ID for table %s: %w", schemaTable, err)
 	}
 

--- a/flow/internal/postgres.go
+++ b/flow/internal/postgres.go
@@ -59,7 +59,7 @@ func LoadTableSchemaFromCatalog(
 	tableName string,
 ) (*protos.TableSchema, error) {
 	var tableSchemaBytes []byte
-	if err := pool.Pool.QueryRow(
+	if err := pool.QueryRow(
 		ctx,
 		"select table_schema from table_schema_mapping where flow_name = $1 and table_name = $2",
 		flowName,

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -348,6 +348,7 @@ message TableSchemaDelta {
   repeated FieldDescription added_columns = 3;
   TypeSystem system = 4;
   bool nullable_enabled = 5;
+  bool is_replica_identity_full = 6;
 }
 
 message QRepFlowState {


### PR DESCRIPTION
avoids a race condition where schema is updated multiple times between time of relation message & application of relation message

TODO logging