### PR TITLE
added e2e test for cutoff bug in schema change handling

### DIFF
--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -388,18 +388,10 @@ func (s Generic) Test_Schema_Changes_Cutoff_Bug() {
 	srcTableName2 := e2e.AttachSchema(s, srcTable2)
 	dstTableName2 := s.DestinationTable(dstTable2)
 
-	require.NoError(t, s.Source().Exec(t.Context(), fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %[1]s (
-			id SERIAL PRIMARY KEY,
-			c1 BIGINT
-		);
-		CREATE TABLE IF NOT EXISTS %[2]s (
-			id SERIAL PRIMARY KEY,
-			c1 BIGINT
-		);
-		INSERT INTO %[1]s(c1) VALUES(1);
-		INSERT INTO %[2]s(c1) VALUES(1);
-	`, srcTableName1, srcTableName2)))
+	require.NoError(t, s.Source().Exec(t.Context(),
+		fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id SERIAL PRIMARY KEY, c1 BIGINT)", srcTableName1)))
+	require.NoError(t, s.Source().Exec(t.Context(),
+		fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id SERIAL PRIMARY KEY, c1 BIGINT)", srcTableName2)))
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
 		FlowJobName:   e2e.AddSuffix(s, srcTable1),
@@ -413,12 +405,10 @@ func (s Generic) Test_Schema_Changes_Cutoff_Bug() {
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
-	e2e.EnvNoError(t, env, s.Source().Exec(t.Context(), fmt.Sprintf(
-		`INSERT INTO %[2]s(c1) VALUES(2);
-		ALTER TABLE %[1]s ADD COLUMN c2 BIGINT;
-		ALTER TABLE %[2]s ADD COLUMN c2 BIGINT;
-		INSERT INTO %[1]s(c1, c2) VALUES(2, 2);`,
-		srcTableName1, srcTableName2)))
+	e2e.EnvNoError(t, env, s.Source().Exec(t.Context(), fmt.Sprintf(`INSERT INTO %s(c1) VALUES(2)`, srcTableName2)))
+	e2e.EnvNoError(t, env, s.Source().Exec(t.Context(), fmt.Sprintf(`ALTER TABLE %s ADD COLUMN c2 BIGINT`, srcTableName1)))
+	e2e.EnvNoError(t, env, s.Source().Exec(t.Context(), fmt.Sprintf(`ALTER TABLE %s ADD COLUMN c2 BIGINT`, srcTableName2)))
+	e2e.EnvNoError(t, env, s.Source().Exec(t.Context(), fmt.Sprintf(`INSERT INTO %s(c1,c2) VALUES(2,2)`, srcTableName1)))
 
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "table1 added column", srcTable1, dstTable1, "id,c1,coalesce(c2,0) c2")
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "table2 not added column", srcTable2, dstTable2, "id,c1")
@@ -484,10 +474,8 @@ func (s Generic) Test_Schema_Changes_Cutoff_Bug() {
 	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema1, output[dstTableName1]))
 	e2e.EnvTrue(t, env, e2e.CompareTableSchemas(expectedTableSchema2, output[dstTableName2]))
 
-	e2e.EnvNoError(t, env, s.Source().Exec(t.Context(), fmt.Sprintf(
-		`INSERT INTO %[1]s(c1,c2) VALUES (3, 3);
-		INSERT INTO %[2]s(c1,c2) VALUES (2, 2);`,
-		srcTableName1, srcTableName2)))
+	e2e.EnvNoError(t, env, s.Source().Exec(t.Context(), fmt.Sprintf(`INSERT INTO %s(c1,c2) VALUES (3, 3)`, srcTableName1)))
+	e2e.EnvNoError(t, env, s.Source().Exec(t.Context(), fmt.Sprintf(`INSERT INTO %s(c1,c2) VALUES (2, 2)`, srcTableName2)))
 
 	// verify we got our two rows, if schema did not match up it will error.
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "table1 added column", srcTable1, dstTable1, "id,c1,coalesce(c2,0) c2")

--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -124,10 +124,6 @@ func (s Generic) Test_Simple_Flow() {
 func (s Generic) Test_Simple_Schema_Changes() {
 	t := s.T()
 
-	if _, ok := s.Source().(*e2e.MySqlSource); ok {
-		t.Skip("mysql connector does not support schema changes yet")
-	}
-
 	destinationSchemaConnector, ok := s.DestinationConnector().(connectors.GetTableSchemaConnector)
 	if !ok {
 		t.Skip("skipping test because destination connector does not implement GetTableSchemaConnector")
@@ -377,10 +373,6 @@ func (s Generic) Test_Partitioned_Table() {
 
 func (s Generic) Test_Schema_Changes_Cutoff_Bug() {
 	t := s.T()
-
-	if _, ok := s.Source().(*e2e.MySqlSource); ok {
-		t.Skip("mysql connector does not support schema changes yet")
-	}
 
 	destinationSchemaConnector, ok := s.DestinationConnector().(connectors.GetTableSchemaConnector)
 	if !ok {


### PR DESCRIPTION
schema change replay has a bug where in some edge cases, we blindly update the schema of a Postgres table and save it to catalog before we receive the `RelationMessage` from Postgres that would help us detect and apply the change on the destination

The root cause of this was in a function `applySchemaDeltas` we refreshed the schemas of *all* tables in catalog instead of the ones we saw changes for, so consider the following sequence of events

1. receive changes for table t2
2. schema change: add column for table t1
3. schema change: add column for table t2
4. receive changes for table t1 with new column
5. receive changes for table t2 with new column

If the current batch ends between 4 and 5. Postgres sends `RelationMessage` for t1 with the new column so we are able to add the column on destination, but not for t2 since we haven't seen changes with the new schema yet.

But the aforementioned function fetches the updated schema for t2 as well, and normalizes start failing because we're using a schema we haven't reconciled with the destination yet. This is non recoverable since even after we receive the `RelationMessage` for t2; we match it with the schema from catalog and see no differences to apply.

This test should fail atm, fixes in progress at #2717 and #2721.