### PR TITLE
classify undefined object same as undefined table

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -194,6 +194,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			pgerrcode.InvalidPassword,
 			pgerrcode.InsufficientPrivilege,
 			pgerrcode.UndefinedTable,
+			pgerrcode.UndefinedObject,
 			pgerrcode.CannotConnectNow:
 			return ErrorNotifyConnectivity, pgErrorInfo
 		case pgerrcode.AdminShutdown:


### PR DESCRIPTION
can happen when publication does not exist