### PR TITLE
e2e api mirror validation

### DIFF
--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -60,9 +60,9 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 		if !cfg.Resync {
 			// for resync, we don't need to check the content or structure of the original tables;
 			// they'll anyways get swapped out with the _resync tables which we CREATE OR REPLACE
-			err = c.processTableComparison(dstTableName, processedMapping[dstTableName],
-				chTableColumnsMapping[dstTableName], peerDBColumns, tableMapping)
-			if err != nil {
+			if err := c.processTableComparison(dstTableName, processedMapping[dstTableName],
+				chTableColumnsMapping[dstTableName], peerDBColumns, tableMapping,
+			); err != nil {
 				return err
 			}
 		}

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -2,15 +2,20 @@ package e2e_api
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/PeerDB-io/peerdb/flow/connectors/postgres"
+	"github.com/PeerDB-io/peerdb/flow/e2e"
 	"github.com/PeerDB-io/peerdb/flow/e2eshared"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
+	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
 func NewClient(t *testing.T) protos.FlowServiceClient {
@@ -23,44 +28,97 @@ func NewClient(t *testing.T) protos.FlowServiceClient {
 
 type Suite struct {
 	protos.FlowServiceClient
-	*testing.T
+	t      *testing.T
+	pg     *e2e.PostgresSource
+	suffix string
 }
 
 func (s Suite) Teardown(ctx context.Context) {
+	s.pg.Teardown(s.t, ctx, s.suffix)
+}
+
+func (s Suite) T() *testing.T {
+	return s.t
+}
+
+func (s Suite) Suffix() string {
+	return s.suffix
+}
+
+func (s Suite) Source() e2e.SuiteSource {
+	return s.pg
+}
+
+func (s Suite) Connector() *connpostgres.PostgresConnector {
+	return s.pg.PostgresConnector
+}
+
+func (s Suite) DestinationTable(table string) string {
+	return table
 }
 
 func TestApi(t *testing.T) {
 	e2eshared.RunSuite(t, func(t *testing.T) Suite {
 		t.Helper()
-		return Suite{FlowServiceClient: NewClient(t), T: t}
+
+		suffix := "api_" + strings.ToLower(shared.RandomString(8))
+		pg, err := e2e.SetupPostgres(t, suffix)
+		require.NoError(t, err)
+		return Suite{
+			FlowServiceClient: NewClient(t),
+			t:                 t,
+			pg:                pg,
+			suffix:            suffix,
+		}
 	})
+}
+
+func (s Suite) TestGetVersion() {
+	response, err := s.GetVersion(s.t.Context(), &protos.PeerDBVersionRequest{})
+	require.NoError(s.t, err)
+	require.Equal(s.t, internal.PeerDBVersionShaShort(), response.Version)
 }
 
 func (s Suite) TestPostgresValidation_WrongPassword() {
-	config := internal.GetCatalogPostgresConfigFromEnv(s.Context())
+	config := internal.GetCatalogPostgresConfigFromEnv(s.t.Context())
 	config.Password = "wrong"
-	response, err := s.ValidatePeer(s.Context(), &protos.ValidatePeerRequest{
+	response, err := s.ValidatePeer(s.t.Context(), &protos.ValidatePeerRequest{
 		Peer: &protos.Peer{
 			Name:   "testfail",
 			Type:   protos.DBType_POSTGRES,
 			Config: &protos.Peer_PostgresConfig{PostgresConfig: config},
 		},
 	})
-	require.NoError(s.T, err)
-	require.NotNil(s.T, response)
-	require.Equal(s.T, protos.ValidatePeerStatus_INVALID, response.Status)
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+	require.Equal(s.t, protos.ValidatePeerStatus_INVALID, response.Status)
 }
 
 func (s Suite) TestPostgresValidation_Pass() {
-	config := internal.GetCatalogPostgresConfigFromEnv(s.Context())
-	response, err := s.ValidatePeer(s.Context(), &protos.ValidatePeerRequest{
+	config := internal.GetCatalogPostgresConfigFromEnv(s.t.Context())
+	response, err := s.ValidatePeer(s.t.Context(), &protos.ValidatePeerRequest{
 		Peer: &protos.Peer{
 			Name:   "testfail",
 			Type:   protos.DBType_POSTGRES,
 			Config: &protos.Peer_PostgresConfig{PostgresConfig: config},
 		},
 	})
-	require.NoError(s.T, err)
-	require.NotNil(s.T, response)
-	require.Equal(s.T, protos.ValidatePeerStatus_VALID, response.Status)
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+	require.Equal(s.t, protos.ValidatePeerStatus_VALID, response.Status)
+}
+
+func (s Suite) TestPostgresClickHouseMirrorValidation_Pass() {
+	require.NoError(s.t, s.pg.Exec(s.t.Context(),
+		fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", e2e.AttachSchema(s, "valid"))))
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      "ch_validation_%s" + s.suffix,
+		TableNameMapping: map[string]string{e2e.AttachSchema(s, "valid"): "valid"},
+		Destination:      e2e.GeneratePostgresPeer(s.t).Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	response, err := s.ValidateCDCMirror(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
 }


### PR DESCRIPTION
also remove unused BQ code, all BQ integers are int64