### PR TITLE
generic sql: remove unused methods

### DIFF
--- a/flow/e2e/snowflake/snowflake_helper.go
+++ b/flow/e2e/snowflake/snowflake_helper.go
@@ -116,10 +116,6 @@ func (s *SnowflakeTestHelper) ExecuteAndProcessQuery(ctx context.Context, query 
 	return s.testClient.ExecuteAndProcessQuery(ctx, query)
 }
 
-func (s *SnowflakeTestHelper) CreateTable(ctx context.Context, tableName string, schema *qvalue.QRecordSchema) error {
-	return s.testClient.CreateTable(ctx, schema, s.testSchemaName, tableName)
-}
-
 // runs a query that returns an int result
 func (s *SnowflakeTestHelper) RunIntQuery(ctx context.Context, query string) (int, error) {
 	rows, err := s.testClient.ExecuteAndProcessQuery(ctx, query)


### PR DESCRIPTION
generic sql code only used by sqlserver & snowflake,
ideally this would be entirely removed & consumers would directly use sqlx.DB

but for now keeping clean up simple