### PR TITLE
feat(maintenance): add signal to skip snapshot for specific flows

### DIFF
--- a/flow/activities/maintenance_activity.go
+++ b/flow/activities/maintenance_activity.go
@@ -64,7 +64,10 @@ func (a *MaintenanceActivity) getMirrorStatus(ctx context.Context, mirror *proto
 	return internal.GetWorkflowStatus(ctx, a.TemporalClient, mirror.WorkflowId)
 }
 
-func (a *MaintenanceActivity) WaitForRunningSnapshots(ctx context.Context, skippedFlows map[string]struct{}) (*protos.MaintenanceMirrors, error) {
+func (a *MaintenanceActivity) WaitForRunningSnapshots(
+	ctx context.Context,
+	skippedFlows map[string]struct{},
+) (*protos.MaintenanceMirrors, error) {
 	mirrors, err := a.GetAllMirrors(ctx)
 	if err != nil {
 		return &protos.MaintenanceMirrors{}, err

--- a/flow/model/signals.go
+++ b/flow/model/signals.go
@@ -130,6 +130,10 @@ var CDCDynamicPropertiesSignal = TypedSignal[*protos.CDCFlowConfigUpdate]{
 	Name: "cdc-dynamic-properties",
 }
 
+var StartMaintenanceSignal = TypedSignal[*protos.StartMaintenanceSignal]{
+	Name: "start-maintenance-signal",
+}
+
 func SleepFuture(ctx workflow.Context, d time.Duration) workflow.Future {
 	f, set := workflow.NewFuture(ctx)
 	workflow.Go(ctx, func(ctx workflow.Context) {

--- a/flow/workflows/maintenance_flow.go
+++ b/flow/workflows/maintenance_flow.go
@@ -80,6 +80,7 @@ func startMaintenance(ctx workflow.Context, logger log.Logger) (*protos.StartMai
 	maintenanceSelector := workflow.NewNamedSelector(ctx, "MaintenanceLoop")
 	skippedFlows := make(map[string]struct{})
 	cancelCurrentChild := func() {}
+	maintenanceSelector.AddReceive(ctx.Done(), func(_ workflow.ReceiveChannel, _ bool) {})
 
 	signalChan.AddToSelector(maintenanceSelector, func(maintenanceSignal *protos.StartMaintenanceSignal, _ bool) {
 		logger.Info("Received StartMaintenance Signal", slog.Any("signal", maintenanceSignal))

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -477,6 +477,10 @@ message StartMaintenanceFlowOutput {
   string version = 1;
 }
 
+message StartMaintenanceSignal {
+  repeated string skipped_snapshot_wait_flows = 1;
+}
+
 message EndMaintenanceFlowInput {
 }
 


### PR DESCRIPTION
ref #2259 

To bypass maintenance for long running failing initial loads, we had to disable sync and maintenance in chart, and then remember to enable it in chart later when upgrading the next time.

This also caused laziness to skip upgrading altogether

This PR adds a new signal which can be used to bypass initial load checks for specified flows:
```json
{
  "skipped_snapshot_wait_flows": [
    "failing_flow_name_here"
  ]
}
```

