### PR TITLE
Dropping ClickHouse mirrors: Cleanup avro stage catalog table

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -224,12 +224,20 @@ func (c *ClickHouseConnector) SyncFlowCleanup(ctx context.Context, jobName strin
 	if err := c.PostgresMetadata.SyncFlowCleanup(ctx, jobName); err != nil {
 		return fmt.Errorf("[clickhouse] unable to clear metadata for sync flow cleanup: %w", err)
 	}
+	c.logger.Info("successfully cleared metadata for flow " + jobName)
 
 	// delete raw table if exists
 	rawTableIdentifier := c.getRawTableName(jobName)
 	if err := c.execWithLogging(ctx, fmt.Sprintf(dropTableIfExistsSQL, rawTableIdentifier)); err != nil {
 		return fmt.Errorf("[clickhouse] unable to drop raw table: %w", err)
 	}
+	c.logger.Info("successfully dropped raw table " + rawTableIdentifier)
+
+	// clear avro stage for this flow
+	if err := DeleteAvroStageForFlow(ctx, jobName); err != nil {
+		return fmt.Errorf("[clickhouse] unable to clear avro stage: %w", err)
+	}
+	c.logger.Info("successfully cleared avro stage for flow " + jobName)
 
 	return nil
 }

--- a/flow/connectors/clickhouse/s3_stage.go
+++ b/flow/connectors/clickhouse/s3_stage.go
@@ -66,3 +66,20 @@ func GetAvroStage(ctx context.Context, flowJobName string, syncBatchID int64) (*
 
 	return &avroFile, nil
 }
+
+func DeleteAvroStageForFlow(ctx context.Context, flowJobName string) error {
+	conn, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get connection for clearing avro stage: %w", err)
+	}
+
+	if _, err := conn.Exec(ctx, `
+		DELETE FROM ch_s3_stage
+		WHERE flow_job_name = $1`,
+		flowJobName,
+	); err != nil {
+		return fmt.Errorf("failed to clear avro stage for flow %s: %w", flowJobName, err)
+	}
+
+	return nil
+}

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -1428,3 +1428,35 @@ func (s ClickHouseSuite) Test_SkipSnapshotExport() {
 	env.Cancel(s.t.Context())
 	e2e.RequireEnvCanceled(s.t, env)
 }
+
+func (s ClickHouseSuite) Test_Drop_Mirror() {
+	srcTableName := "test_drop_mirror"
+	srcFullName := s.attachSchemaSuffix("test_drop_mirror")
+	dstTableName := "test_drop_mirror"
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (id INT PRIMARY KEY, "key" TEXT NOT NULL)`, srcFullName)))
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s (id,"key") VALUES (1,'init')`, srcFullName)))
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("clickhouse_drop_mirror"),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+
+	tc := e2e.NewTemporalClient(s.t)
+	env := e2e.ExecutePeerflow(s.t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,\"key\"")
+
+	env = e2e.ExecuteWorkflow(s.t.Context(), tc, shared.PeerFlowTaskQueue, peerflow.DropFlowWorkflow, &protos.DropFlowInput{
+		FlowJobName:           flowConnConfig.FlowJobName,
+		DropFlowStats:         true,
+		FlowConnectionConfigs: flowConnConfig,
+	})
+	e2e.EnvWaitForFinished(s.t, env, 3*time.Minute)
+}


### PR DESCRIPTION
This PR deletes all avro file entries in the ch_avro_stage table in catalog for a mirror when that mirror is dropped.
Pending: 
Completing the E2E test