### PR TITLE
be more precise about ignoring temporal application errors

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -276,7 +276,8 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	syncStartTime := time.Now()
 	if err := errGroup.Wait(); err != nil {
 		// don't log flow error for "replState changed" and "slot is already active"
-		if !(temporal.IsApplicationError(err) || shared.IsSQLStateError(err, pgerrcode.ObjectInUse)) {
+		var applicationError *temporal.ApplicationError
+		if !((errors.As(err, &applicationError) && applicationError.Type() == "desync") || shared.IsSQLStateError(err, pgerrcode.ObjectInUse)) {
 			_ = a.Alerter.LogFlowError(ctx, flowName, err)
 		}
 		if temporal.IsApplicationError(err) {


### PR DESCRIPTION
postgres connector errors with disconnect typed errors when it detects misconfiguration,
these errors should be propagated to alerting