### PR TITLE
fix(maintenance): skip for not found workflows if older than 90 days

### DIFF
--- a/flow/activities/maintenance_activity.go
+++ b/flow/activities/maintenance_activity.go
@@ -220,16 +220,17 @@ func (a *MaintenanceActivity) PauseMirrorIfRunning(ctx context.Context, mirror *
 				return false, wErr
 			}
 			logger.Info("Received response for ANY existing Workflows check", "len(executions)", len(response.Executions))
-			if len(response.Executions) != 0 {
-				foundWorkflowIds := make([]string, len(response.Executions))
-				for i, exec := range response.Executions {
-					logger.Info("Found existing CDCFlow", "workflowId", exec.GetExecution().GetWorkflowId())
-					foundWorkflowIds[i] = exec.GetExecution().GetWorkflowId()
-				}
-				logger.Warn("Found some existing CDCFlow, this is unexpected and should be investigated",
-					"foundWorkflows", foundWorkflowIds)
+			if len(response.Executions) == 0 {
+				logger.Warn("No existing workflows found, skipping pause")
 				return false, nil
 			}
+			foundWorkflowIds := make([]string, len(response.Executions))
+			for i, exec := range response.Executions {
+				logger.Info("Found existing CDCFlow", "workflowId", exec.GetExecution().GetWorkflowId())
+				foundWorkflowIds[i] = exec.GetExecution().GetWorkflowId()
+			}
+			logger.Warn("Found some existing CDCFlow, this is unexpected and should be investigated",
+				"foundWorkflows", foundWorkflowIds)
 		}
 		return false, err
 	}

--- a/flow/activities/maintenance_activity.go
+++ b/flow/activities/maintenance_activity.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -41,7 +42,7 @@ func (a *MaintenanceActivity) GetAllMirrors(ctx context.Context) (*protos.Mainte
 	rows, err := a.CatalogPool.Query(ctx, `
 	select distinct on(name)
 	  id, name, workflow_id,
-	  created_at, coalesce(query_string, '')='' is_cdc
+	  created_at, updated_at, coalesce(query_string, '')='' is_cdc
 	from flows
 	`)
 	if err != nil {
@@ -51,8 +52,10 @@ func (a *MaintenanceActivity) GetAllMirrors(ctx context.Context) (*protos.Mainte
 	maintenanceMirrorItems, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (*protos.MaintenanceMirror, error) {
 		var info protos.MaintenanceMirror
 		var createdAt time.Time
-		err := row.Scan(&info.MirrorId, &info.MirrorName, &info.WorkflowId, &createdAt, &info.IsCdc)
+		var updatedAt time.Time
+		err := row.Scan(&info.MirrorId, &info.MirrorName, &info.WorkflowId, &createdAt, &updatedAt, &info.IsCdc)
 		info.MirrorCreatedAt = timestamppb.New(createdAt)
+		info.MirrorUpdatedAt = timestamppb.New(updatedAt)
 		return &info, err
 	})
 	return &protos.MaintenanceMirrors{
@@ -200,6 +203,32 @@ func (a *MaintenanceActivity) PauseMirrorIfRunning(ctx context.Context, mirror *
 					logger.Warn("Mirror does not exist in flows table, skipping pause")
 					return false, nil
 				}
+			}
+		} else if errors.As(err, &notFoundErr) && regexp.MustCompile("workflow not found for ID: (.+)").MatchString(notFoundErr.Message) &&
+			// This is max temporal retention period, but this is mirror update time, not deletion time, so it is not accurate
+			mirror.MirrorUpdatedAt.AsTime().Before(time.Now().Add(-90*24*time.Hour)) &&
+			// We are in Temporal Cloud
+			internal.PeerDBTemporalEnableCertAuth() {
+			// workflow not found for ID: mirror_d1e3f532__8adb__4f79__9d00__01e44b6bcbfb-peerflow-27144d2c-06ce-4552-87e5-696b3a909702
+			logger.Warn("Workflow not found in Temporal Cloud and mirror update_at is older than 90 days, checking for existing workflows")
+			response, wErr := a.TemporalClient.ListWorkflow(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+				Query: fmt.Sprintf("`MirrorName`=\"%s\"",
+					mirror.MirrorName),
+			})
+			if wErr != nil {
+				logger.Error("Error checking for ANY existing Workflows", "error", wErr)
+				return false, wErr
+			}
+			logger.Info("Received response for ANY existing Workflows check", "len(executions)", len(response.Executions))
+			if len(response.Executions) != 0 {
+				foundWorkflowIds := make([]string, len(response.Executions))
+				for i, exec := range response.Executions {
+					logger.Info("Found existing CDCFlow", "workflowId", exec.GetExecution().GetWorkflowId())
+					foundWorkflowIds[i] = exec.GetExecution().GetWorkflowId()
+				}
+				logger.Warn("Found some existing CDCFlow, this is unexpected and should be investigated",
+					"foundWorkflows", foundWorkflowIds)
+				return false, nil
 			}
 		}
 		return false, err

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -494,6 +494,7 @@ message MaintenanceMirror {
   string workflow_id = 3;
   bool is_cdc = 4;
   google.protobuf.Timestamp mirror_created_at = 5;
+  google.protobuf.Timestamp mirror_updated_at = 6;
 }
 
 message MaintenanceMirrors {


### PR DESCRIPTION
resolves #2768 

If workflow does not exist in temporal, it probably means that it was dropped long back and the cancelled CDCFlowWorkflow is beyond its retention period. This PR aims to guess this and skip pausing for such mirrors