### PR TITLE
Support ClickHouse having extra columns compared to source for initial load

### DIFF
--- a/flow/connectors/clickhouse/qrep.go
+++ b/flow/connectors/clickhouse/qrep.go
@@ -33,15 +33,11 @@ func (c *ClickHouseConnector) SyncQRepRecords(
 		slog.String("destinationTable", destTable),
 	)
 
-	tblSchema, err := c.getTableSchema(ctx, destTable)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get schema of table %s: %w", destTable, err)
-	}
-	c.logger.Info("Called QRep sync function and obtained table schema", flowLog)
+	c.logger.Info("Called QRep sync function", flowLog)
 
 	avroSync := NewClickHouseAvroSyncMethod(config, c)
 
-	return avroSync.SyncQRepRecords(ctx, config, partition, tblSchema, stream)
+	return avroSync.SyncQRepRecords(ctx, config, partition, stream)
 }
 
 func (c *ClickHouseConnector) getTableSchema(ctx context.Context, tableName string) ([]driver.ColumnType, error) {

--- a/flow/connectors/clickhouse/qrep.go
+++ b/flow/connectors/clickhouse/qrep.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
@@ -38,17 +37,6 @@ func (c *ClickHouseConnector) SyncQRepRecords(
 	avroSync := NewClickHouseAvroSyncMethod(config, c)
 
 	return avroSync.SyncQRepRecords(ctx, config, partition, stream)
-}
-
-func (c *ClickHouseConnector) getTableSchema(ctx context.Context, tableName string) ([]driver.ColumnType, error) {
-	queryString := fmt.Sprintf("SELECT * FROM `%s` LIMIT 0", tableName)
-	rows, err := c.query(ctx, queryString)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute query: %w", err)
-	}
-	defer rows.Close()
-
-	return rows.ColumnTypes(), nil
 }
 
 func (c *ClickHouseConnector) ConsolidateQRepPartitions(_ context.Context, config *protos.QRepConfig) error {

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -146,6 +146,11 @@ func (s *ClickHouseAvroSyncMethod) SyncQRepRecords(
 	selectedColumnNames := make([]string, 0, len(schema.Fields))
 	insertedColumnNames := make([]string, 0, len(schema.Fields))
 	for _, colName := range schema.GetColumnNames() {
+		for _, excludedColumn := range config.Exclude {
+			if colName == excludedColumn {
+				continue
+			}
+		}
 		avroColName, ok := columnNameAvroFieldMap[colName]
 		if !ok {
 			s.logger.Error("destination column not found in avro schema",

--- a/flow/e2e/clickhouse/clickhouse.go
+++ b/flow/e2e/clickhouse/clickhouse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -1262,6 +1262,9 @@ func (s ClickHouseSuite) Test_Extra_CH_Columns() {
 		{Name: "id", Type: "Int32"},
 		{Name: "key", Type: "String"},
 		{Name: "updatedAt", Type: "String"},
+		{Name: "_peerdb_is_deleted", Type: "Int8"},
+		{Name: "_peerdb_synced_at", Type: "DateTime"},
+		{Name: "_peerdb_version", Type: "Int64"},
 	}, "id"),
 	)
 

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -216,6 +216,7 @@ func (s *SnapshotFlowExecution) cloneTable(
 		Script:                     s.config.Script,
 		Env:                        s.config.Env,
 		ParentMirrorName:           flowName,
+		Exclude:                    mapping.Exclude,
 	}
 
 	boundSelector.SpawnChild(childCtx, QRepFlowWorkflow, nil, config, nil)

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -317,6 +317,7 @@ message QRepConfig {
   map<string, string> env = 24;
 
   string parent_mirror_name = 25;
+  repeated string exclude = 26;
 }
 
 message QRepPartition {

--- a/ui/app/mirrors/create/helpers/common.ts
+++ b/ui/app/mirrors/create/helpers/common.ts
@@ -69,4 +69,5 @@ export const blankQRepSetting: QRepConfig = {
   system: TypeSystem.Q,
   env: {},
   parentMirrorName: '',
+  exclude: [],
 };


### PR DESCRIPTION
Currently to construct the column selectors for the Insert into Select to ClickHouse in initial load, we get the columns from ClickHouse. 
This results in initial load failing if there is an extra column on target vs source. 

The reason we were using the CH schema and not the source schema here was so that column exclusion was automatically taken care of. But this caused an unideal situation where we support source having extra columns for initial load and ClickHouse having extra columns for CDC normalize.

This PR re-wires things to make initial load use the source schema and gives it column exclusion info