### PR TITLE
mysql: map specific types same as their more generic type

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -431,7 +431,8 @@ func (c *MySqlConnector) PullRecords(
 							if fd == nil {
 								continue
 							}
-							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val, enumMap[idx], setMap[idx])
+							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], enumMap[idx], setMap[idx],
+								qvalue.QValueKind(fd.Type), val)
 							if err != nil {
 								return err
 							}
@@ -464,7 +465,8 @@ func (c *MySqlConnector) PullRecords(
 							if fd == nil {
 								continue
 							}
-							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val, enumMap[idx], setMap[idx])
+							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], enumMap[idx], setMap[idx],
+								qvalue.QValueKind(fd.Type), val)
 							if err != nil {
 								return err
 							}
@@ -477,7 +479,8 @@ func (c *MySqlConnector) PullRecords(
 							if fd == nil {
 								continue
 							}
-							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val, enumMap[idx], setMap[idx])
+							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], enumMap[idx], setMap[idx],
+								qvalue.QValueKind(fd.Type), val)
 							if err != nil {
 								return err
 							}
@@ -511,7 +514,8 @@ func (c *MySqlConnector) PullRecords(
 							if fd == nil {
 								continue
 							}
-							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val, enumMap[idx], setMap[idx])
+							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], enumMap[idx], setMap[idx],
+								qvalue.QValueKind(fd.Type), val)
 							if err != nil {
 								return err
 							}

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -395,6 +395,8 @@ func (c *MySqlConnector) PullRecords(
 			schema := req.TableNameSchemaMapping[destinationTableName]
 			if schema != nil {
 				inTx = true
+				enumMap := ev.Table.EnumStrValueMap()
+				setMap := ev.Table.SetStrValueMap()
 				getFd := func(idx int) *protos.FieldDescription {
 					if ev.Table.ColumnName != nil {
 						unsafeName := shared.UnsafeFastReadOnlyBytesToString(ev.Table.ColumnName[idx])
@@ -429,7 +431,7 @@ func (c *MySqlConnector) PullRecords(
 							if fd == nil {
 								continue
 							}
-							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val)
+							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val, enumMap[idx], setMap[idx])
 							if err != nil {
 								return err
 							}
@@ -462,7 +464,7 @@ func (c *MySqlConnector) PullRecords(
 							if fd == nil {
 								continue
 							}
-							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val)
+							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val, enumMap[idx], setMap[idx])
 							if err != nil {
 								return err
 							}
@@ -475,7 +477,7 @@ func (c *MySqlConnector) PullRecords(
 							if fd == nil {
 								continue
 							}
-							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val)
+							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val, enumMap[idx], setMap[idx])
 							if err != nil {
 								return err
 							}
@@ -509,7 +511,7 @@ func (c *MySqlConnector) PullRecords(
 							if fd == nil {
 								continue
 							}
-							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val)
+							val, err := QValueFromMysqlRowEvent(ev.Table.ColumnType[idx], qvalue.QValueKind(fd.Type), val, enumMap[idx], setMap[idx])
 							if err != nil {
 								return err
 							}

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -102,11 +102,13 @@ func qkindFromMysql(field *mysql.Field) (qvalue.QValueKind, error) {
 func qkindFromMysqlColumnType(ct string) (qvalue.QValueKind, error) {
 	ct, isUnsigned := strings.CutSuffix(ct, " unsigned")
 	ct, param, _ := strings.Cut(ct, "(")
-	switch ct {
+	switch strings.ToLower(ct) {
 	case "json":
 		return qvalue.QValueKindJSON, nil
-	case "char", "varchar", "text", "enum", "set", "tinytext", "mediumtext", "longtext":
+	case "char", "varchar", "text", "set", "tinytext", "mediumtext", "longtext":
 		return qvalue.QValueKindString, nil
+	case "enum":
+		return qvalue.QValueKindEnum, nil
 	case "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob":
 		return qvalue.QValueKindBytes, nil
 	case "date":
@@ -151,7 +153,6 @@ func qkindFromMysqlColumnType(ct string) (qvalue.QValueKind, error) {
 		}
 	case "vector":
 		return qvalue.QValueKindArrayFloat32, nil
-
 	case "geometry", "point", "polygon", "linestring", "multipoint", "multipolygon", "geomcollection":
 		return qvalue.QValueKindGeometry, nil
 	default:

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -113,9 +113,7 @@ func qkindFromMysqlColumnType(ct string) (qvalue.QValueKind, error) {
 		return qvalue.QValueKindDate, nil
 	case "time":
 		return qvalue.QValueKindTime, nil
-	case "datetime":
-		return qvalue.QValueKindTimestamp, nil
-	case "timestamp":
+	case "datetime", "timestamp":
 		return qvalue.QValueKindTimestamp, nil
 	case "decimal", "numeric":
 		return qvalue.QValueKindNumeric, nil

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -105,9 +105,9 @@ func qkindFromMysqlColumnType(ct string) (qvalue.QValueKind, error) {
 	switch ct {
 	case "json":
 		return qvalue.QValueKindJSON, nil
-	case "char", "varchar", "text", "enum", "set":
+	case "char", "varchar", "text", "enum", "set", "tinytext", "mediumtext", "longtext":
 		return qvalue.QValueKindString, nil
-	case "binary", "varbinary", "blob":
+	case "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob":
 		return qvalue.QValueKindBytes, nil
 	case "date":
 		return qvalue.QValueKindDate, nil
@@ -154,7 +154,7 @@ func qkindFromMysqlColumnType(ct string) (qvalue.QValueKind, error) {
 	case "vector":
 		return qvalue.QValueKindArrayFloat32, nil
 
-	case "geometry":
+	case "geometry", "point", "polygon", "linestring", "multipoint", "multipolygon", "geomcollection":
 		return qvalue.QValueKindGeometry, nil
 	default:
 		return qvalue.QValueKind(""), fmt.Errorf("unknown mysql type %s", ct)

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -3,6 +3,7 @@ package connmysql
 import (
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 	"math"
 	"slices"
 	"strings"
@@ -353,8 +354,8 @@ func QValueFromMysqlFieldValue(qkind qvalue.QValueKind, fv mysql.FieldValue) (qv
 }
 
 func QValueFromMysqlRowEvent(
-	mytype byte, qkind qvalue.QValueKind, val any,
-	enums []string, sets []string,
+	mytype byte, enums []string, sets []string,
+	qkind qvalue.QValueKind, val any,
 ) (qvalue.QValue, error) {
 	// See go-mysql row_event.go for mapping
 	switch val := val.(type) {
@@ -391,8 +392,10 @@ func QValueFromMysqlRowEvent(
 		case qvalue.QValueKindInt64:
 			return qvalue.QValueInt64{Val: val}, nil
 		case qvalue.QValueKindString: // set
+			slog.Warn("QQQset", slog.Any("sets", sets), slog.Int64("val", val))
 			return qvalue.QValueString{Val: sets[int(val)]}, nil
 		case qvalue.QValueKindEnum: // enum
+			slog.Warn("QQQenum", slog.Any("enums", enums), slog.Int64("val", val))
 			return qvalue.QValueEnum{Val: enums[int(val)]}, nil
 		}
 	case float32:

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -400,7 +400,11 @@ func QValueFromMysqlRowEvent(
 			}
 			return qvalue.QValueString{Val: strings.Join(set, ",")}, nil
 		case qvalue.QValueKindEnum: // enum
-			return qvalue.QValueEnum{Val: enums[int(val)]}, nil
+			if val == 0 {
+				return qvalue.QValueEnum{Val: ""}, nil
+			} else {
+				return qvalue.QValueEnum{Val: enums[int(val)-1]}, nil
+			}
 		}
 	case float32:
 		return qvalue.QValueFloat32{Val: val}, nil

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -355,6 +355,59 @@ func (s ClickHouseSuite) Test_MySQL_Bit() {
 	e2e.RequireEnvCanceled(s.t, env)
 }
 
+func (s ClickHouseSuite) Test_MySQL_Blobs() {
+	if _, ok := s.source.(*e2e.MySqlSource); !ok {
+		s.t.Skip("only applies to mysql")
+	}
+
+	srcTableName := "test_blobs"
+	srcFullName := s.attachSchemaSuffix("test_blobs")
+	quotedSrcFullName := "\"" + strings.ReplaceAll(srcFullName, ".", "\".\"") + "\""
+	dstTableName := "test_blobs_dst"
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id SERIAL PRIMARY KEY,
+			"key" TEXT NOT NULL,
+			tb tinyblob NOT NULL,
+			mb mediumblob NOT NULL,
+			lb longblob NOT NULL,
+			bi binary(6),
+			vb varbinary(100) NOT NULL,
+			tt tinytext NOT NULL,
+			mt mediumtext NOT NULL,
+			lt longtext NOT NULL,
+			ch char(4),
+			vc varchar(100) NOT NULL
+		);
+	`, quotedSrcFullName)))
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s ("key",tb,mb,lb,bi,vb,tt,mt,lt,ch,vc) VALUES
+		('init','tinyblob','mediumblob','longblob','binary','varbinary','tinytext','mediumtext','longtext','char','varchar')`, quotedSrcFullName)))
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix(srcTableName),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+
+	tc := e2e.NewTemporalClient(s.t)
+	env := e2e.ExecutePeerflow(s.t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,\"key\",tb,mb,lb,vb,tt,mt,lt,vc")
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s ("key",tb,mb,lb,bi,vb,tt,mt,lt,ch,vc) VALUES
+		('cdc','tinyblob','mediumblob','longblob','binary','varbinary','tinytext','mediumtext','longtext','char','varchar')`, quotedSrcFullName)))
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,\"key\",tb,mb,lb,vb,tt,mt,lt,vc")
+
+	env.Cancel(s.t.Context())
+	e2e.RequireEnvCanceled(s.t, env)
+}
+
 func (s ClickHouseSuite) Test_MySQL_Vector() {
 	if mysource, ok := s.source.(*e2e.MySqlSource); !ok || mysource.Config.Flavor != protos.MySqlFlavor_MYSQL_MYSQL {
 		s.t.Skip("only applies to mysql")

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -430,7 +430,7 @@ func (s ClickHouseSuite) Test_MySQL_Enum() {
 	`, quotedSrcFullName)))
 
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s ("key",e,s) VALUES
-		('init','b''s','a,b')`, quotedSrcFullName)))
+		('init','b''s','a,b'),('init','','')`, quotedSrcFullName)))
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
 		FlowJobName:      s.attachSuffix(srcTableName),
@@ -447,7 +447,7 @@ func (s ClickHouseSuite) Test_MySQL_Enum() {
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,\"key\",e,s")
 
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s ("key",e,s) VALUES
-		('cdc','b''s','a,b')`, quotedSrcFullName)))
+		('cdc','b''s','a,b'),('cdc','','')`, quotedSrcFullName)))
 
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,\"key\",e,s")
 


### PR DESCRIPTION
overlooked some types:
* tinytext
* mediumtext
* longtext
* tinyblob
* mediumblob
* longblob
* specific geometry types

also enum/sets got lost, as in qrep they're sent as text, but in cdc they're int64 & we have to do some lookups