### PR TITLE
return error on invalid enum/set value

### DIFF
--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -395,15 +395,21 @@ func QValueFromMysqlRowEvent(
 			var set []string
 			for val != 0 {
 				idx := bits.TrailingZeros64(uint64(val))
-				set = append(set, sets[idx])
-				val ^= int64(1) << idx
+				if idx < len(sets) {
+					set = append(set, sets[idx])
+					val ^= int64(1) << idx
+				} else {
+					return nil, fmt.Errorf("set value out of range %d", idx)
+				}
 			}
 			return qvalue.QValueString{Val: strings.Join(set, ",")}, nil
 		case qvalue.QValueKindEnum: // enum
 			if val == 0 {
 				return qvalue.QValueEnum{Val: ""}, nil
-			} else {
+			} else if int(val)-1 < len(enums) {
 				return qvalue.QValueEnum{Val: enums[int(val)-1]}, nil
+			} else {
+				return nil, fmt.Errorf("enum value out of range %d", val)
 			}
 		}
 	case float32:


### PR DESCRIPTION
should only happen with schema desynchronization, but avoids panic