### PR TITLE
mysql: min version tls 1.2

### DIFF
--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -123,7 +123,7 @@ func (c *MySqlConnector) connect(ctx context.Context) (*client.Conn, error) {
 		argF := []client.Option{func(conn *client.Conn) error {
 			conn.SetCapability(mysql.CLIENT_COMPRESS)
 			if !c.config.DisableTls {
-				tlsSetting := &tls.Config{MinVersion: tls.VersionTLS13, ServerName: c.config.Host}
+				tlsSetting := &tls.Config{MinVersion: tls.VersionTLS12, ServerName: c.config.Host}
 				if c.config.RootCa != nil {
 					caPool := x509.NewCertPool()
 					if !caPool.AppendCertsFromPEM([]byte(*c.config.RootCa)) {


### PR DESCRIPTION
I tried, but GCP MySQL 8.0 doesn't support tls 1.3