### PR TITLE
don't verify hostname for ip hosts, add root ca field to pg

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -352,6 +352,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				// could not read from reorderbuffer spill file: Bad file descriptor
 				return ErrorRetryRecoverable, errorInfo
 			}
+			//nolint:lll
 			// &{Severity:ERROR SeverityUnlocalized:ERROR Code:XX000 Message:requested WAL segment 000000010001337F0000002E has already been removed}
 			if pgWalErr.Msg.Code == pgerrcode.InternalError && PostgresWalSegmentRemovedRe.MatchString(pgWalErr.Msg.Message) {
 				return ErrorRetryRecoverable, errorInfo

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -65,7 +65,7 @@ func ParseConfig(connectionString string, pgConfig *protos.PostgresConfig) (*pgx
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse connection string: %w", err)
 	}
-	if !pgConfig.DisableTls && pgConfig.RootCa != nil {
+	if pgConfig.RootCa != nil {
 		caPool := x509.NewCertPool()
 		if !caPool.AppendCertsFromPEM([]byte(*pgConfig.RootCa)) {
 			return nil, errors.New("failed to parse provided root CA")

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -64,7 +64,7 @@ func ParseConfig(connectionString string, pgConfig *protos.PostgresConfig) (*pgx
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse connection string: %w", err)
 	}
-	if pgConfig.RootCa != nil {
+	if !pgConfig.DisableTls && pgConfig.RootCa != nil {
 		caPool := x509.NewCertPool()
 		if !caPool.AppendCertsFromPEM([]byte(*pgConfig.RootCa)) {
 			return nil, errors.New("failed to parse provided root CA")

--- a/flow/connectors/postgres/ssh_wrapped_conn.go
+++ b/flow/connectors/postgres/ssh_wrapped_conn.go
@@ -32,7 +32,7 @@ func NewPostgresConnFromPostgresConfig(
 	}
 	connectionString := internal.GetPGConnectionString(pgConfig, flowName)
 
-	connConfig, err := pgx.ParseConfig(connectionString)
+	connConfig, err := ParseConfig(connectionString, pgConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/flow/internal/catalog.go
+++ b/flow/internal/catalog.go
@@ -49,6 +49,6 @@ func GetCatalogPostgresConfigFromEnv(ctx context.Context) *protos.PostgresConfig
 		User:       PeerDBCatalogUser(),
 		Password:   PeerDBCatalogPassword(ctx),
 		Database:   PeerDBCatalogDatabase(),
-		DisableTls: PeerDBCatalogDisableTls(),
+		RequireTls: PeerDBCatalogRequireTls(),
 	}
 }

--- a/flow/internal/catalog.go
+++ b/flow/internal/catalog.go
@@ -44,10 +44,11 @@ func GetCatalogConnectionStringFromEnv(ctx context.Context) string {
 
 func GetCatalogPostgresConfigFromEnv(ctx context.Context) *protos.PostgresConfig {
 	return &protos.PostgresConfig{
-		Host:     PeerDBCatalogHost(),
-		Port:     uint32(PeerDBCatalogPort()),
-		User:     PeerDBCatalogUser(),
-		Password: PeerDBCatalogPassword(ctx),
-		Database: PeerDBCatalogDatabase(),
+		Host:       PeerDBCatalogHost(),
+		Port:       uint32(PeerDBCatalogPort()),
+		User:       PeerDBCatalogUser(),
+		Password:   PeerDBCatalogPassword(ctx),
+		Database:   PeerDBCatalogDatabase(),
+		DisableTls: PeerDBCatalogDisableTls(),
 	}
 }

--- a/flow/internal/config.go
+++ b/flow/internal/config.go
@@ -83,8 +83,8 @@ func PeerDBCatalogDatabase() string {
 	return GetEnvString("PEERDB_CATALOG_DATABASE", "")
 }
 
-func PeerDBCatalogDisableTls() bool {
-	return getEnvConvert("PEERDB_CATALOG_DISABLE_TLS", true, strconv.ParseBool)
+func PeerDBCatalogRequireTls() bool {
+	return getEnvConvert("PEERDB_CATALOG_REQUIRE_TLS", false, strconv.ParseBool)
 }
 
 // PEERDB_TELEMETRY_AWS_SNS_TOPIC_ARN

--- a/flow/internal/config.go
+++ b/flow/internal/config.go
@@ -83,6 +83,10 @@ func PeerDBCatalogDatabase() string {
 	return GetEnvString("PEERDB_CATALOG_DATABASE", "")
 }
 
+func PeerDBCatalogDisableTls() bool {
+	return getEnvConvert("PEERDB_CATALOG_DISABLE_TLS", true, strconv.ParseBool)
+}
+
 // PEERDB_TELEMETRY_AWS_SNS_TOPIC_ARN
 func PeerDBTelemetryAWSSNSTopicArn() string {
 	return GetEnvString("PEERDB_TELEMETRY_AWS_SNS_TOPIC_ARN", "")

--- a/flow/internal/postgres.go
+++ b/flow/internal/postgres.go
@@ -30,6 +30,9 @@ func GetPGConnectionString(pgConfig *protos.PostgresConfig, flowName string) str
 		pgConfig.Database,
 		applicationName,
 	)
+	if !pgConfig.DisableTls {
+		connString += "&sslmode=require"
+	}
 	return connString
 }
 

--- a/flow/internal/postgres.go
+++ b/flow/internal/postgres.go
@@ -30,7 +30,7 @@ func GetPGConnectionString(pgConfig *protos.PostgresConfig, flowName string) str
 		pgConfig.Database,
 		applicationName,
 	)
-	if !pgConfig.DisableTls {
+	if pgConfig.RequireTls {
 		connString += "&sslmode=require"
 	}
 	return connString

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -699,6 +699,10 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                 metadata_schema: opts.get("metadata_schema").map(|s| s.to_string()),
                 ssh_config: ssh_fields,
                 root_ca: opts.get("root_ca").map(|s| s.to_string()),
+                disable_tls: opts
+                    .get("disable_tls")
+                    .map(|s| s.parse::<bool>().unwrap_or_default())
+                    .unwrap_or_default(),
             };
 
             Config::PostgresConfig(postgres_config)

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -699,8 +699,8 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                 metadata_schema: opts.get("metadata_schema").map(|s| s.to_string()),
                 ssh_config: ssh_fields,
                 root_ca: opts.get("root_ca").map(|s| s.to_string()),
-                disable_tls: opts
-                    .get("disable_tls")
+                require_tls: opts
+                    .get("require_tls")
                     .map(|s| s.parse::<bool>().unwrap_or_default())
                     .unwrap_or_default(),
             };

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -698,6 +698,7 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .to_string(),
                 metadata_schema: opts.get("metadata_schema").map(|s| s.to_string()),
                 ssh_config: ssh_fields,
+                root_ca: opts.get("root_ca").map(|s| s.to_string()),
             };
 
             Config::PostgresConfig(postgres_config)

--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -92,6 +92,7 @@ impl CatalogConfig<'_> {
             metadata_schema: Some("".to_string()),
             ssh_config: None,
             root_ca: None,
+            disable_tls: true,
         }
     }
 

--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -92,7 +92,7 @@ impl CatalogConfig<'_> {
             metadata_schema: Some("".to_string()),
             ssh_config: None,
             root_ca: None,
-            disable_tls: true,
+            require_tls: false,
         }
     }
 

--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -91,6 +91,7 @@ impl CatalogConfig<'_> {
             database: self.database.to_string(),
             metadata_schema: Some("".to_string()),
             ssh_config: None,
+            root_ca: None,
         }
     }
 

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -80,6 +80,7 @@ message PostgresConfig {
   optional string metadata_schema = 7;
   optional SSHConfig ssh_config = 8;
   optional string root_ca = 9 [(peerdb_redacted) = true];
+  bool disable_tls = 10;
 }
 
 message EventHubConfig {

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -80,7 +80,7 @@ message PostgresConfig {
   optional string metadata_schema = 7;
   optional SSHConfig ssh_config = 8;
   optional string root_ca = 9 [(peerdb_redacted) = true];
-  bool disable_tls = 10;
+  bool require_tls = 10;
 }
 
 message EventHubConfig {

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -79,6 +79,7 @@ message PostgresConfig {
   // defaults to _peerdb_internal
   optional string metadata_schema = 7;
   optional SSHConfig ssh_config = 8;
+  optional string root_ca = 9 [(peerdb_redacted) = true];
 }
 
 message EventHubConfig {

--- a/ui/app/dto/PeersDTO.ts
+++ b/ui/app/dto/PeersDTO.ts
@@ -5,6 +5,7 @@ import {
   EventHubConfig,
   EventHubGroupConfig,
   KafkaConfig,
+  MySqlConfig,
   PostgresConfig,
   PubSubConfig,
   S3Config,
@@ -13,6 +14,7 @@ import {
 
 export type PeerConfig =
   | PostgresConfig
+  | MySqlConfig
   | SnowflakeConfig
   | BigqueryConfig
   | ClickhouseConfig

--- a/ui/app/peers/create/[peerType]/helpers/pg.ts
+++ b/ui/app/peers/create/[peerType]/helpers/pg.ts
@@ -46,11 +46,11 @@ export const postgresSetting: PeerSetting[] = [
       'https://www.postgresql.org/docs/current/sql-createdatabase.html',
   },
   {
-    label: 'Disable TLS?',
+    label: 'Require TLS?',
     stateHandler: (value, setter) =>
-      setter((curr) => ({ ...curr, disableTls: value as boolean })),
+      setter((curr) => ({ ...curr, requireTls: value as boolean })),
     type: 'switch',
-    tips: 'If you are using a non-TLS connection, check this box.',
+    tips: 'Use sslmode=require instead of sslmode=prefer',
     optional: true,
   },
   {
@@ -76,5 +76,5 @@ export const blankPostgresSetting: PostgresConfig = {
   user: '',
   password: '',
   database: '',
-  disableTls: false,
+  requireTls: false,
 };

--- a/ui/app/peers/create/[peerType]/helpers/pg.ts
+++ b/ui/app/peers/create/[peerType]/helpers/pg.ts
@@ -46,6 +46,14 @@ export const postgresSetting: PeerSetting[] = [
       'https://www.postgresql.org/docs/current/sql-createdatabase.html',
   },
   {
+    label: 'Disable TLS?',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, disableTls: value as boolean })),
+    type: 'switch',
+    tips: 'If you are using a non-TLS connection, check this box.',
+    optional: true,
+  },
+  {
     label: 'Root Certificate',
     stateHandler: (value, setter) => {
       if (!value) {
@@ -68,4 +76,5 @@ export const blankPostgresSetting: PostgresConfig = {
   user: '',
   password: '',
   database: '',
+  disableTls: false,
 };

--- a/ui/app/peers/create/[peerType]/helpers/pg.ts
+++ b/ui/app/peers/create/[peerType]/helpers/pg.ts
@@ -45,6 +45,21 @@ export const postgresSetting: PeerSetting[] = [
     helpfulLink:
       'https://www.postgresql.org/docs/current/sql-createdatabase.html',
   },
+  {
+    label: 'Root Certificate',
+    stateHandler: (value, setter) => {
+      if (!value) {
+        // remove key from state if empty
+        setter((curr) => {
+          delete (curr as PostgresConfig)['rootCa'];
+          return curr;
+        });
+      } else setter((curr) => ({ ...curr, rootCa: value as string }));
+    },
+    type: 'file',
+    optional: true,
+    tips: 'If not provided, host CA roots will be used.',
+  },
 ];
 
 export const blankPostgresSetting: PostgresConfig = {

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -95,6 +95,12 @@ export const pgSchema = z.object({
     .string()
     .max(100, 'Transaction snapshot too long (100 char limit)')
     .optional(),
+  rootCa: z
+    .string({
+      invalid_type_error: 'Root CA must be a string',
+    })
+    .optional()
+    .transform((e) => (e === '' ? undefined : e)),
   sshConfig: sshSchema,
 });
 export const mySchema = z.object({

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -95,7 +95,7 @@ export const pgSchema = z.object({
     .string()
     .max(100, 'Transaction snapshot too long (100 char limit)')
     .optional(),
-  disableTls: z.boolean(),
+  requireTls: z.boolean(),
   rootCa: z
     .string({
       invalid_type_error: 'Root CA must be a string',

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -95,6 +95,7 @@ export const pgSchema = z.object({
     .string()
     .max(100, 'Transaction snapshot too long (100 char limit)')
     .optional(),
+  disableTls: z.boolean(),
   rootCa: z
     .string({
       invalid_type_error: 'Root CA must be a string',

--- a/ui/components/PeerForms/ClickhouseConfig.tsx
+++ b/ui/components/PeerForms/ClickhouseConfig.tsx
@@ -42,9 +42,6 @@ export default function ClickHouseForm({ settings, setter }: ConfigProps) {
     }
   };
 
-  const handleSwitchChange = (val: string | boolean, setting: PeerSetting) => {
-    setting.stateHandler(val, setter);
-  };
   const handleTextFieldChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     setting: PeerSetting
@@ -82,8 +79,8 @@ export default function ClickHouseForm({ settings, setter }: ConfigProps) {
               action={
                 <div>
                   <Switch
-                    onCheckedChange={(state: boolean) =>
-                      handleSwitchChange(state, setting)
+                    onCheckedChange={(val: boolean) =>
+                      setting.stateHandler(val, setter)
                     }
                   />
                   {setting.tips && (
@@ -202,7 +199,7 @@ export default function ClickHouseForm({ settings, setter }: ConfigProps) {
                   <TextField
                     variant='simple'
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      handleSwitchChange(e.target.value, setting)
+                      setting.stateHandler(e.target.value, setter)
                     }
                     type={setting.type}
                     placeholder={setting.placeholder}

--- a/ui/components/PeerForms/MySqlForm.tsx
+++ b/ui/components/PeerForms/MySqlForm.tsx
@@ -28,10 +28,6 @@ export default function MySqlForm({ settings, setter }: ConfigProps) {
   const [showSSH, setShowSSH] = useState(false);
   const [sshConfig, setSSHConfig] = useState(blankSSHConfig);
 
-  const handleSwitchChange = (val: string | boolean, setting: PeerSetting) => {
-    setting.stateHandler(val, setter);
-  };
-
   const handleCa = (
     file: File,
     setFile: (value: string, setter: PeerSetter) => void
@@ -101,7 +97,7 @@ export default function MySqlForm({ settings, setter }: ConfigProps) {
   return (
     <>
       {settings.map((setting, id) => {
-        return setting.type == 'switch' ? (
+        return setting.type === 'switch' ? (
           <RowWithSwitch
             key={id}
             label={
@@ -122,8 +118,8 @@ export default function MySqlForm({ settings, setter }: ConfigProps) {
             action={
               <div>
                 <Switch
-                  onCheckedChange={(state: boolean) =>
-                    handleSwitchChange(state, setting)
+                  onCheckedChange={(val: boolean) =>
+                    setting.stateHandler(val, setter)
                   }
                 />
                 {setting.tips && (

--- a/ui/components/PeerForms/MySqlForm.tsx
+++ b/ui/components/PeerForms/MySqlForm.tsx
@@ -68,6 +68,7 @@ export default function MySqlForm({ settings, setter }: ConfigProps) {
       };
     }
   };
+
   const handleTextFieldChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     setting: PeerSetting

--- a/ui/components/PeerForms/PostgresForm.tsx
+++ b/ui/components/PeerForms/PostgresForm.tsx
@@ -9,7 +9,7 @@ import {
 import InfoPopover from '@/components/InfoPopover';
 import { SSHConfig } from '@/grpc_generated/peers';
 import { Label } from '@/lib/Label';
-import { RowWithTextField } from '@/lib/Layout';
+import { RowWithSwitch, RowWithTextField } from '@/lib/Layout';
 import { Switch } from '@/lib/Switch';
 import { TextField } from '@/lib/TextField';
 import { Tooltip } from '@/lib/Tooltip';
@@ -104,7 +104,38 @@ export default function PostgresForm({
   return (
     <>
       {settings.map((setting, id) => {
-        return (
+        return setting.type === 'switch' ? (
+          <RowWithSwitch
+            key={id}
+            label={
+              <Label>
+                {setting.label}{' '}
+                {!setting.optional && (
+                  <Tooltip
+                    style={{ width: '100%' }}
+                    content={'This is a required field.'}
+                  >
+                    <Label colorName='lowContrast' colorSet='destructive'>
+                      *
+                    </Label>
+                  </Tooltip>
+                )}
+              </Label>
+            }
+            action={
+              <div>
+                <Switch
+                  onCheckedChange={(val: boolean) =>
+                    setting.stateHandler(val, setter)
+                  }
+                />
+                {setting.tips && (
+                  <InfoPopover tips={setting.tips} link={setting.helpfulLink} />
+                )}
+              </div>
+            }
+          />
+        ) : (
           <RowWithTextField
             key={id}
             label={


### PR DESCRIPTION
pgx follows libpq's bad sslmode=prefer default

when root ca specified, behave like sslmode=verify-ca if host is IP, otherwise like sslmode=verify-full

include require tls option to behave like sslmode=require

https://github.com/golang/go/issues/21971

update pg & mysql to skip hostname verification when host is an IP address,
GCP instances have certs without CN/SAN, only relying on trusting root CA