### PR TITLE
Formalize how we handle table inheritance for partitioned tables

### DIFF
--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -500,8 +501,8 @@ func (s Generic) Test_Partitioned_Table_Without_Publish_Via_Partition_Root() {
 	}
 	conn := pgSource.PostgresConnector
 
-	srcTable := "test_partition"
-	dstTable := "test_partition_dst"
+	srcTable := "test_partition_noroot"
+	dstTable := "test_partition_noroot_dst"
 	srcSchemaTable := e2e.AttachSchema(s, srcTable)
 	srcPublicationName := fmt.Sprintf("%s_%s_pub", srcTable, s.Suffix())
 
@@ -521,12 +522,89 @@ func (s Generic) Test_Partitioned_Table_Without_Publish_Via_Partition_Root() {
 			CREATE TABLE %[1]s_2024q3
 				PARTITION OF %[1]s
 				FOR VALUES FROM ('2024-07-01') TO ('2024-10-01');
-			CREATE PUBLICATION %[2]s FOR TABLE %[1]s_2024q1, %[1]s_2024q2, %[1]s_2024q3;
-	`, srcSchemaTable, srcPublicationName))
+			CREATE PUBLICATION %[2]s FOR TABLES IN SCHEMA %[3]s;
+	`, srcSchemaTable, srcPublicationName, e2e.Schema(s)))
 	require.NoError(t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
-		FlowJobName:   e2e.AddSuffix(s, "test_partition"),
+		FlowJobName:   e2e.AddSuffix(s, "test_partition_noroot"),
+		TableMappings: e2e.TableMappings(s, srcTable, dstTable),
+		Destination:   s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.PublicationName = srcPublicationName
+	flowConnConfig.IdleTimeoutSeconds = 60
+
+	tc := e2e.NewTemporalClient(t)
+	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+
+	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
+	// add a partition to the source table after CDC is running to test if
+	// the partition is picked up by the flow.
+	go func() {
+		time.Sleep(15 * time.Second)
+		_, err := conn.Conn().Exec(t.Context(), fmt.Sprintf(`
+		CREATE TABLE %[1]s_2024q4
+			PARTITION OF %[1]s
+			FOR VALUES FROM ('2024-10-01') TO ('2025-01-01');`, srcSchemaTable))
+		e2e.EnvNoError(t, env, err)
+		_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(`
+		INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-11-01');
+		INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-12-01');
+		INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2025-01-01');`,
+			srcSchemaTable))
+		e2e.EnvNoError(t, env, err)
+	}()
+	// insert 10 rows into the source table
+	for i := range 10 {
+		testName := fmt.Sprintf("test_name_%d", i)
+		_, err := conn.Conn().Exec(t.Context(),
+			fmt.Sprintf(`INSERT INTO %s(name, created_at) VALUES ($1, '2024-%d-01')`,
+				srcSchemaTable, max(1, i)), testName)
+		e2e.EnvNoError(t, env, err)
+	}
+	t.Log("Inserted 13 rows into the source table")
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "normalizing 13 rows", srcTable, dstTable, `id,name,created_at`)
+	env.Cancel(t.Context())
+	e2e.RequireEnvCanceled(t, env)
+}
+
+func (s Generic) Test_Inheritance_Table_Without_Dynamic_Setting() {
+	t := s.T()
+
+	pgSource, ok := s.Source().(*e2e.PostgresSource)
+	if !ok {
+		t.Skip("test only applies to postgres")
+	}
+	conn := pgSource.PostgresConnector
+
+	srcTable := "test_inheritance"
+	dstTable := "test_inheritance_dst"
+	srcSchemaTable := e2e.AttachSchema(s, srcTable)
+	srcPublicationName := fmt.Sprintf("%s_%s_pub", srcTable, s.Suffix())
+
+	_, err := conn.Conn().Exec(t.Context(), fmt.Sprintf(`
+			CREATE TABLE %[1]s(
+				id SERIAL NOT NULL,
+				name TEXT,
+				created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now(),
+				PRIMARY KEY (created_at, id)
+			);
+			CREATE TABLE %[1]s_child1() INHERITS (%[1]s);
+			CREATE TABLE %[1]s_child2() INHERITS (%[1]s);
+			CREATE PUBLICATION %[2]s FOR TABLES IN SCHEMA %[3]s;
+	`, srcSchemaTable, srcPublicationName, e2e.Schema(s)))
+	require.NoError(t, err)
+	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(`
+	INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-11-01');
+	INSERT INTO %[1]s_child1(name, created_at) VALUES ('test_name', '2024-12-01');
+	INSERT INTO %[1]s_child2(name, created_at) VALUES ('test_name', '2025-01-01');`,
+		srcSchemaTable))
+	require.NoError(t, err)
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:   e2e.AddSuffix(s, "test_inheritance"),
 		TableMappings: e2e.TableMappings(s, srcTable, dstTable),
 		Destination:   s.Peer().Name,
 	}
@@ -537,17 +615,15 @@ func (s Generic) Test_Partitioned_Table_Without_Publish_Via_Partition_Root() {
 	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
-	// insert 10 rows into the source table
-	for i := range 10 {
-		testName := fmt.Sprintf("test_name_%d", i)
-		_, err := conn.Conn().Exec(t.Context(),
-			fmt.Sprintf(`INSERT INTO %s(name, created_at) VALUES ($1, '2024-%d-01')`,
-				srcSchemaTable, max(1, i)), testName)
-		e2e.EnvNoError(t, env, err)
-	}
-	t.Log("Inserted 10 rows into the source table")
+	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(`
+	INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-11-01');
+	INSERT INTO %[1]s_child1(name, created_at) VALUES ('test_name', '2024-12-01');
+	INSERT INTO %[1]s_child2(name, created_at) VALUES ('test_name', '2025-01-01');`,
+		srcSchemaTable))
+	e2e.EnvNoError(t, env, err)
+	t.Log("Inserted 3 rows into the source table during CDC")
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "normalizing 10 rows", srcTable, dstTable, `id,name,created_at`)
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "only 1 row should be present", srcTable, dstTable, `id,name,created_at`)
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
 }

--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -604,6 +604,7 @@ func (s Generic) Test_Inheritance_Table_Without_Dynamic_Setting() {
 	}
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
 	flowConnConfig.PublicationName = srcPublicationName
+	flowConnConfig.Env = map[string]string{"PEERDB_POSTGRES_CDC_HANDLE_INHERITANCE_FOR_NON_PARTITIONED_TABLES": "false"}
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
@@ -662,7 +663,6 @@ func (s Generic) Test_Inheritance_Table_With_Dynamic_Setting() {
 	}
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
 	flowConnConfig.PublicationName = srcPublicationName
-	flowConnConfig.Env = map[string]string{"PEERDB_POSTGRES_CDC_HANDLE_INHERITANCE_FOR_NON_PARTITIONED_TABLES": "true"}
 	flowConnConfig.IdleTimeoutSeconds = 60
 	flowConnConfig.DoInitialSnapshot = true
 

--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -520,8 +520,8 @@ func (s Generic) Test_Partitioned_Table_Without_Publish_Via_Partition_Root() {
 			CREATE TABLE %[1]s_2024q3
 				PARTITION OF %[1]s
 				FOR VALUES FROM ('2024-07-01') TO ('2024-10-01');
-			CREATE PUBLICATION %[1]s_pub FOR TABLE %[1]s_2024q1, %[1]s_2024q2, %[1]s_2024q3;
-	`, srcSchemaTable))
+			CREATE PUBLICATION %[2]s_pub FOR TABLE %[1]s_2024q1, %[1]s_2024q2, %[1]s_2024q3;
+	`, srcSchemaTable, srcTable))
 	require.NoError(t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
@@ -530,7 +530,7 @@ func (s Generic) Test_Partitioned_Table_Without_Publish_Via_Partition_Root() {
 		Destination:   s.Peer().Name,
 	}
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
-	flowConnConfig.PublicationName = fmt.Sprintf("%s_pub", srcSchemaTable)
+	flowConnConfig.PublicationName = srcTable + "_pub"
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)

--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -664,6 +664,7 @@ func (s Generic) Test_Inheritance_Table_With_Dynamic_Setting() {
 	flowConnConfig.PublicationName = srcPublicationName
 	flowConnConfig.Env = map[string]string{"PEERDB_POSTGRES_CDC_HANDLE_INHERITANCE_FOR_NON_PARTITIONED_TABLES": "true"}
 	flowConnConfig.IdleTimeoutSeconds = 60
+	flowConnConfig.DoInitialSnapshot = true
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
@@ -689,7 +690,8 @@ func (s Generic) Test_Inheritance_Table_With_Dynamic_Setting() {
 	e2e.EnvNoError(t, env, err)
 	t.Log("Inserted 3 rows into the source table during CDC")
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "rows from parent and 3 child tables should be present", srcTable, dstTable, `id,name,created_at`)
+	e2e.EnvWaitForEqualTablesWithNames(env, s,
+		"rows from parent and 3 child tables should be present", srcTable, dstTable, `id,name,created_at`)
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
 }

--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -549,9 +549,9 @@ func (s Generic) Test_Partitioned_Table_Without_Publish_Via_Partition_Root() {
 			FOR VALUES FROM ('2024-10-01') TO ('2025-01-01');`, srcSchemaTable))
 		e2e.EnvNoError(t, env, err)
 		_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(`
+		INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-10-01');
 		INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-11-01');
-		INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-12-01');
-		INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2025-01-01');`,
+		INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-12-01');`,
 			srcSchemaTable))
 		e2e.EnvNoError(t, env, err)
 	}()
@@ -597,9 +597,9 @@ func (s Generic) Test_Inheritance_Table_Without_Dynamic_Setting() {
 	`, srcSchemaTable, srcPublicationName, e2e.Schema(s)))
 	require.NoError(t, err)
 	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(`
-	INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-11-01');
-	INSERT INTO %[1]s_child1(name, created_at) VALUES ('test_name', '2024-12-01');
-	INSERT INTO %[1]s_child2(name, created_at) VALUES ('test_name', '2025-01-01');`,
+	INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-01-01');
+	INSERT INTO %[1]s_child1(name, created_at) VALUES ('test_name', '2024-02-01');
+	INSERT INTO %[1]s_child2(name, created_at) VALUES ('test_name', '2024-03-01');`,
 		srcSchemaTable))
 	require.NoError(t, err)
 
@@ -616,9 +616,9 @@ func (s Generic) Test_Inheritance_Table_Without_Dynamic_Setting() {
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
 	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(`
-	INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2024-11-01');
-	INSERT INTO %[1]s_child1(name, created_at) VALUES ('test_name', '2024-12-01');
-	INSERT INTO %[1]s_child2(name, created_at) VALUES ('test_name', '2025-01-01');`,
+	INSERT INTO %[1]s(name, created_at) VALUES ('test_name', '2025-01-01');
+	INSERT INTO %[1]s_child1(name, created_at) VALUES ('test_name', '2025-02-01');
+	INSERT INTO %[1]s_child2(name, created_at) VALUES ('test_name', '2025-03-01');`,
 		srcSchemaTable))
 	e2e.EnvNoError(t, env, err)
 	t.Log("Inserted 3 rows into the source table during CDC")

--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -503,6 +503,7 @@ func (s Generic) Test_Partitioned_Table_Without_Publish_Via_Partition_Root() {
 	srcTable := "test_partition"
 	dstTable := "test_partition_dst"
 	srcSchemaTable := e2e.AttachSchema(s, srcTable)
+	srcPublicationName := fmt.Sprintf("%s_%s_pub", srcTable, s.Suffix())
 
 	_, err := conn.Conn().Exec(t.Context(), fmt.Sprintf(`
 			CREATE TABLE %[1]s(
@@ -520,8 +521,8 @@ func (s Generic) Test_Partitioned_Table_Without_Publish_Via_Partition_Root() {
 			CREATE TABLE %[1]s_2024q3
 				PARTITION OF %[1]s
 				FOR VALUES FROM ('2024-07-01') TO ('2024-10-01');
-			CREATE PUBLICATION %[2]s_pub FOR TABLE %[1]s_2024q1, %[1]s_2024q2, %[1]s_2024q3;
-	`, srcSchemaTable, srcTable))
+			CREATE PUBLICATION %[2]s FOR TABLE %[1]s_2024q1, %[1]s_2024q2, %[1]s_2024q3;
+	`, srcSchemaTable, srcPublicationName))
 	require.NoError(t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
@@ -530,7 +531,7 @@ func (s Generic) Test_Partitioned_Table_Without_Publish_Via_Partition_Root() {
 		Destination:   s.Peer().Name,
 	}
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
-	flowConnConfig.PublicationName = srcTable + "_pub"
+	flowConnConfig.PublicationName = srcPublicationName
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)

--- a/flow/e2e/pg.go
+++ b/flow/e2e/pg.go
@@ -205,6 +205,19 @@ func (s *PostgresSource) GetRows(ctx context.Context, suffix string, table strin
 	)
 }
 
+// to avoid fetching rows from "child" tables ala Postgres table inheritance
+func (s *PostgresSource) GetRowsOnly(ctx context.Context, suffix string, table string, cols string) (*model.QRecordBatch, error) {
+	pgQueryExecutor, err := s.PostgresConnector.NewQRepQueryExecutor(ctx, "testflow", "testpart")
+	if err != nil {
+		return nil, err
+	}
+
+	return pgQueryExecutor.ExecuteAndProcessQuery(
+		ctx,
+		fmt.Sprintf(`SELECT %s FROM ONLY e2e_test_%s.%s ORDER BY id`, cols, suffix, utils.QuoteIdentifier(table)),
+	)
+}
+
 func RevokePermissionForTableColumns(ctx context.Context, conn *pgx.Conn, tableIdentifier string, selectedColumns []string) error {
 	schemaTable, err := utils.ParseSchemaTable(tableIdentifier)
 	if err != nil {

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -59,6 +59,10 @@ type GenericSuite interface {
 	DestinationTable(table string) string
 }
 
+func Schema(s Suite) string {
+	return fmt.Sprintf("e2e_test_%s", s.Suffix())
+}
+
 func AttachSchema(s Suite, table string) string {
 	return fmt.Sprintf("e2e_test_%s.%s", s.Suffix(), table)
 }

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -60,7 +60,7 @@ type GenericSuite interface {
 }
 
 func Schema(s Suite) string {
-	return fmt.Sprintf("e2e_test_%s", s.Suffix())
+	return "e2e_test_" + s.Suffix()
 }
 
 func AttachSchema(s Suite, table string) string {

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -300,6 +300,15 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
+	{
+		Name: "PEERDB_POSTGRES_CDC_HANDLE_INHERITANCE_FOR_NON_PARTITIONED_TABLES",
+		Description: "For Postgres CDC: attempt to fetch/remap child tables for tables that aren't partitioned by Postgres." +
+			"Useful for tables that are partitioned by extensions",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_ALL,
+	},
 }
 
 var DynamicIndex = func() map[string]int {
@@ -587,4 +596,8 @@ func PeerDBSkipSnapshotExport(ctx context.Context, env map[string]string) (bool,
 
 func PeerDBSourceSchemaAsDestinationColumn(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_SOURCE_SCHEMA_AS_DESTINATION_COLUMN")
+}
+
+func PeerDBPostgresCDCHandleInheritanceForNonPartitionedTables(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_POSTGRES_CDC_HANDLE_INHERITANCE_FOR_NON_PARTITIONED_TABLES")
 }

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -303,7 +303,7 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 	{
 		Name: "PEERDB_POSTGRES_CDC_HANDLE_INHERITANCE_FOR_NON_PARTITIONED_TABLES",
 		Description: "For Postgres CDC: attempt to fetch/remap child tables for tables that aren't partitioned by Postgres." +
-			"Useful for tables that are partitioned by extensions",
+			"Useful for tables that are partitioned by extensions or table inheritance",
 		DefaultValue:     "false",
 		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -304,7 +304,7 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		Name: "PEERDB_POSTGRES_CDC_HANDLE_INHERITANCE_FOR_NON_PARTITIONED_TABLES",
 		Description: "For Postgres CDC: attempt to fetch/remap child tables for tables that aren't partitioned by Postgres." +
 			"Useful for tables that are partitioned by extensions or table inheritance",
-		DefaultValue:     "false",
+		DefaultValue:     "true",
 		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,


### PR DESCRIPTION
Most users of partitioned tables we've encountered so far use Postgres "native" partitioning, in which the parent table is marked with a special relation kind (`relkind`) of `p`. This is handled best by setting `publish_via_partition_root` on the publication (we create publications like this, users are encouraged to) but as a fallback for pre PG13 we also support "lookup" of child to parent tables and using that information to manually implement child-to-parent table mapping. We also recently made this lookup dynamic, so new partitions encountered after we start CDC should also be handled.

There is also the possibility of child tables for a regular table, either via extensions doing this or because Postgres supports [table inheritance](https://www.postgresql.org/docs/current/ddl-inherit.html). Here the feature of child-to-parent mapping may not be desired since there is a chance of the "child" tables having a different schema and also mapping all partitions to the same parent table may not be desired. The remapping for regular tables was the default behaviour since https://github.com/PeerDB-io/peerdb/pull/2323 but now we're making this opt-out, toggled via a dynamic configuration setting. It is opt-out because the case of extensions using it for partitioning is more prevalent than being used for table inheritance, which is a bit of a niche feature.

In all cases initial load will move data from all the child tables/partitions of a table, because `SELECT` by default selects these. There is syntax for only selecting from the parent table (`SELECT ... FROM ONLY t1`) but the use for this is limited.

Also adding e2e tests for these various cases.

