### PR TITLE
MySQL Validation: fix check of binlog expire logs seconds

### DIFF
--- a/flow/connectors/mysql/validate.go
+++ b/flow/connectors/mysql/validate.go
@@ -77,7 +77,7 @@ func (c *MySqlConnector) CheckBinlogSettings(ctx context.Context, requireRowMeta
 	row := rs.Values[0]
 
 	binlogExpireLogsSeconds := row[0].AsUint64()
-	if binlogExpireLogsSeconds < 86400 {
+	if binlogExpireLogsSeconds < 86400 && binlogExpireLogsSeconds != 0 {
 		c.logger.Warn("binlog_expire_logs_seconds should be at least 24 hours",
 			slog.Uint64("binlog_expire_logs_seconds", binlogExpireLogsSeconds))
 	}


### PR DESCRIPTION
This setting can be zero, in which case automatic purging of binlogs is turned off. This is fine for replication purposes