### PR TITLE
feat(classifier): add ACCESS_ENTITY_NOT_FOUND with condition as recoverable

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -34,6 +34,8 @@ var (
 	ClickHouseDecimalParsingRe = regexp.MustCompile(
 		`Cannot parse type Decimal\(\d+, \d+\), expected non-empty binary data with size equal to or less than \d+, got \d+`,
 	)
+	// ID(a14c2a1c-edcd-5fcb-73be-bd04e09fccb7) not found in user directories
+	ClickHouseNotFoundInUserDirsRe    = regexp.MustCompile("ID\\([a-z0-9-]+\\) not found in user directories")
 	PostgresPublicationDoesNotExistRe = regexp.MustCompile(`publication ".*?" does not exist`)
 	PostgresWalSegmentRemovedRe       = regexp.MustCompile(`requested WAL segment \w+ has already been removed`)
 )
@@ -275,6 +277,10 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		case chproto.ErrCannotParseUUID, chproto.ErrValueIsOutOfRangeOfDataType: // https://github.com/ClickHouse/ClickHouse/pull/78540
 			if ClickHouseDecimalParsingRe.MatchString(chException.Message) {
 				return ErrorUnsupportedDatatype, chErrorInfo
+			}
+		case 492: // `ACCESS_ENTITY_NOT_FOUND` TBD via https://github.com/ClickHouse/ch-go/pull/1058
+			if ClickHouseNotFoundInUserDirsRe.MatchString(chException.Message) {
+				return ErrorRetryRecoverable, chErrorInfo
 			}
 		case chproto.ErrIllegalTypeOfArgument:
 			var qrepSyncError *exceptions.QRepSyncError

--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -35,7 +35,7 @@ var (
 		`Cannot parse type Decimal\(\d+, \d+\), expected non-empty binary data with size equal to or less than \d+, got \d+`,
 	)
 	// ID(a14c2a1c-edcd-5fcb-73be-bd04e09fccb7) not found in user directories
-	ClickHouseNotFoundInUserDirsRe    = regexp.MustCompile("ID\\([a-z0-9-]+\\) not found in user directories")
+	ClickHouseNotFoundInUserDirsRe    = regexp.MustCompile(`ID\([a-z0-9-]+\) not found in user directories`)
 	PostgresPublicationDoesNotExistRe = regexp.MustCompile(`publication ".*?" does not exist`)
 	PostgresWalSegmentRemovedRe       = regexp.MustCompile(`requested WAL segment \w+ has already been removed`)
 )

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -123,3 +123,17 @@ func TestAuroraInternalWALErrorShouldBeRecoverable(t *testing.T) {
 		Code:   pgerrcode.InternalError,
 	}, errInfo, "Unexpected error info")
 }
+
+func TestClickHouseAccessEntityNotFoundErrorShouldBeRecoverable(t *testing.T) {
+	// Simulate a ClickHouse access entity not found error
+	err := &clickhouse.Exception{
+		Code:    492,
+		Message: "ID(a14c2a1c-edcd-5fcb-73be-bd04e09fccb7) not found in user directories",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), exceptions.NewQRepSyncError(fmt.Errorf("error in WAL: %w", err), "", ""))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceClickHouse,
+		Code:   "492",
+	}, errInfo, "Unexpected error info")
+}


### PR DESCRIPTION
When droppping a pipe during initial load it can take some time for the workflow to get cancelled. During this time the insert queries fail with errros like: `ID(a14c2a1c-edcd-5fcb-73be-bd04e09fccb7) not found in user directories`.

For now classifying as recoverable because if seen for a longer duration we should be alerted


ref https://github.com/ClickHouse/ch-go/pull/1058 for adding the new error code