### PR TITLE
ci: address mysql flakiness

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -371,6 +371,10 @@ func (c *MySqlConnector) PullRecords(
 				c.logger.Info("rotate", slog.String("name", pos.Name), slog.Uint64("pos", uint64(pos.Pos)))
 			}
 		case *replication.QueryEvent:
+			if gset != nil {
+				gset = ev.GSet
+				req.RecordStream.UpdateLatestCheckpointText(gset.String())
+			}
 			if mysqlParser == nil {
 				mysqlParser = parser.New()
 			}

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -354,8 +354,7 @@ func corePullQRepRecords(
 		return 0, 0, err
 	}
 
-	executor, err := c.NewQRepQueryExecutorSnapshot(ctx, config.SnapshotName, config.FlowJobName,
-		partition.PartitionId)
+	executor, err := c.NewQRepQueryExecutorSnapshot(ctx, config.SnapshotName, config.FlowJobName, partition.PartitionId)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to create query executor: %w", err)
 	}

--- a/flow/connectors/postgres/qrep_query_executor.go
+++ b/flow/connectors/postgres/qrep_query_executor.go
@@ -191,6 +191,21 @@ func (qe *QRepQueryExecutor) ExecuteAndProcessQuery(
 
 	select {
 	case <-errors:
+		if errorsError == nil {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-stream.SchemaChan():
+				schema, err := stream.Schema()
+				if err != nil {
+					return nil, err
+				}
+				return &model.QRecordBatch{
+					Schema:  schema,
+					Records: nil,
+				}, nil
+			}
+		}
 		return nil, errorsError
 	case <-stream.SchemaChan():
 		schema, err := stream.Schema()

--- a/flow/connectors/postgres/sink_q.go
+++ b/flow/connectors/postgres/sink_q.go
@@ -40,15 +40,14 @@ func (stream RecordStreamSink) ExecuteQueryWithTx(
 	cursorName := fmt.Sprintf("peerdb_cursor_%d", randomUint)
 	fetchSize := shared.FetchAndChannelSize
 	cursorQuery := fmt.Sprintf("DECLARE %s CURSOR FOR %s", cursorName, query)
-	qe.logger.Info(fmt.Sprintf("[pg_query_executor] executing cursor declaration for %v with args %v", cursorQuery, args))
 
 	if _, err := tx.Exec(ctx, cursorQuery, args...); err != nil {
 		qe.logger.Info("[pg_query_executor] failed to declare cursor",
-			slog.String("cursorQuery", cursorQuery), slog.Any("error", err))
+			slog.String("cursorQuery", cursorQuery), slog.Any("args", args), slog.Any("error", err))
 		return 0, 0, fmt.Errorf("[pg_query_executor] failed to declare cursor: %w", err)
+	} else {
+		qe.logger.Info("[pg_query_executor] declared cursor", slog.String("cursorQuery", cursorQuery), slog.Any("args", args))
 	}
-
-	qe.logger.Info(fmt.Sprintf("[pg_query_executor] declared cursor '%s' for query '%s'", cursorName, query))
 
 	var totalNumRows int64
 	var totalNumBytes int64
@@ -59,7 +58,7 @@ func (stream RecordStreamSink) ExecuteQueryWithTx(
 			return totalNumRows, totalNumBytes, err
 		}
 
-		qe.logger.Info(fmt.Sprintf("[pg_query_executor] fetched %d rows for query '%s'", numRows, query))
+		qe.logger.Info("[pg_query_executor] fetched rows", slog.Int64("rows", numRows), slog.String("query", query))
 		totalNumRows += numRows
 		totalNumBytes += numBytes
 

--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -152,8 +152,12 @@ func (s *MySqlSource) GeneratePeer(t *testing.T) *protos.Peer {
 }
 
 func (s *MySqlSource) Exec(ctx context.Context, sql string) error {
-	_, err := s.MySqlConnector.Execute(ctx, sql)
-	return err
+	if _, err := s.MySqlConnector.Execute(ctx, sql); err != nil {
+		return err
+	} else if _, err := s.MySqlConnector.Execute(ctx, "flush binary logs"); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *MySqlSource) GetRows(ctx context.Context, suffix string, table string, cols string) (*model.QRecordBatch, error) {


### PR DESCRIPTION
flush in an attempt to not have mysql sit on binlog
avoid segfault in query executor test (or any other code that assumes nil error must be non-nil query batch)
update gtidset on query event [based on canal](https://github.com/go-mysql-org/go-mysql/blob/417b93a01264f5e7b6e2d8700f4064be48394b68/canal/sync.go#L171)