### PR TITLE
maria ci: fix heisenbug

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -165,7 +165,6 @@ func (c *MySqlConnector) SetupReplication(
 			return model.SetupReplicationResult{}, fmt.Errorf("[mysql] SetupReplication failed to GetMasterGTIDSet: %w", err)
 		}
 		lastOffsetText = set.String()
-		c.logger.Info("QQQQs", slog.String("xid", lastOffsetText))
 	} else {
 		pos, err := c.GetMasterPos(ctx)
 		if err != nil {
@@ -364,21 +363,6 @@ func (c *MySqlConnector) PullRecords(
 			req.RecordStream.UpdateLatestCheckpointText(fmt.Sprintf("!f:%s,%x", pos.Name, pos.Pos))
 		}
 
-		if gset != nil {
-			switch ev := event.Event.(type) {
-			case *replication.XIDEvent:
-				c.logger.Info("QQQQx", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.String("gset", gset.String()),
-					slog.String("xid", ev.GSet.String()), slog.Bool("inTx", inTx))
-			case *replication.QueryEvent:
-				c.logger.Info("QQQQy", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.String("gset", gset.String()),
-					slog.String("xid", ev.GSet.String()), slog.Bool("inTx", inTx))
-			case *replication.RowsEvent:
-				sourceTableName := string(ev.Table.Schema) + "." + string(ev.Table.Table)
-				c.logger.Info("QQQQr", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.String("gset", gset.String()),
-					slog.String("tble", sourceTableName), slog.Bool("inTx", inTx))
-			}
-		}
-
 		switch ev := event.Event.(type) {
 		case *replication.XIDEvent:
 			if gset != nil {
@@ -565,9 +549,6 @@ func (c *MySqlConnector) PullRecords(
 				}
 			}
 		}
-	}
-	if gset != nil {
-		c.logger.Info("QQQQa", slog.String("gset", gset.String()))
 	}
 	return nil
 }

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -337,6 +337,12 @@ func (c *MySqlConnector) PullRecords(
 	for inTx || recordCount < req.MaxBatchSize {
 		getCtx := ctx
 		if !inTx {
+			if err := timeoutCtx.Err(); err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					return nil
+				}
+				return err
+			}
 			getCtx = timeoutCtx
 		}
 		event, err := mystream.GetEvent(getCtx)

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -165,6 +165,7 @@ func (c *MySqlConnector) SetupReplication(
 			return model.SetupReplicationResult{}, fmt.Errorf("[mysql] SetupReplication failed to GetMasterGTIDSet: %w", err)
 		}
 		lastOffsetText = set.String()
+		c.logger.Info("QQQQs", slog.String("xid", lastOffsetText))
 	} else {
 		pos, err := c.GetMasterPos(ctx)
 		if err != nil {
@@ -362,7 +363,20 @@ func (c *MySqlConnector) PullRecords(
 			req.RecordStream.UpdateLatestCheckpointText(fmt.Sprintf("!f:%s,%x", pos.Name, pos.Pos))
 		}
 
-		c.logger.Info("QQQQ", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.Any("event", event.Event))
+		if gset != nil {
+			switch ev := event.Event.(type) {
+			case *replication.XIDEvent:
+				c.logger.Info("QQQQx", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.String("gset", gset.String()),
+					slog.String("xid", ev.GSet.String()))
+			case *replication.QueryEvent:
+				c.logger.Info("QQQQy", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.String("gset", gset.String()),
+					slog.String("xid", ev.GSet.String()))
+			case *replication.RowsEvent:
+				sourceTableName := string(ev.Table.Schema) + "." + string(ev.Table.Table)
+				c.logger.Info("QQQQr", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.String("gset", gset.String()),
+					slog.String("tble", sourceTableName))
+			}
+		}
 
 		switch ev := event.Event.(type) {
 		case *replication.XIDEvent:

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -356,6 +356,8 @@ func (c *MySqlConnector) PullRecords(
 			req.RecordStream.UpdateLatestCheckpointText(fmt.Sprintf("!f:%s,%x", pos.Name, pos.Pos))
 		}
 
+		c.logger.Info("QQQQ", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.Any("event", event.Event))
+
 		switch ev := event.Event.(type) {
 		case *replication.XIDEvent:
 			if gset != nil {

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -367,14 +367,14 @@ func (c *MySqlConnector) PullRecords(
 			switch ev := event.Event.(type) {
 			case *replication.XIDEvent:
 				c.logger.Info("QQQQx", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.String("gset", gset.String()),
-					slog.String("xid", ev.GSet.String()))
+					slog.String("xid", ev.GSet.String()), slog.Bool("inTx", inTx))
 			case *replication.QueryEvent:
 				c.logger.Info("QQQQy", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.String("gset", gset.String()),
-					slog.String("xid", ev.GSet.String()))
+					slog.String("xid", ev.GSet.String()), slog.Bool("inTx", inTx))
 			case *replication.RowsEvent:
 				sourceTableName := string(ev.Table.Schema) + "." + string(ev.Table.Table)
 				c.logger.Info("QQQQr", slog.String("type", fmt.Sprintf("%T", event.Event)), slog.String("gset", gset.String()),
-					slog.String("tble", sourceTableName))
+					slog.String("tble", sourceTableName), slog.Bool("inTx", inTx))
 			}
 		}
 
@@ -564,6 +564,9 @@ func (c *MySqlConnector) PullRecords(
 				}
 			}
 		}
+	}
+	if gset != nil {
+		c.logger.Info("QQQQa", slog.String("gset", gset.String()))
 	}
 	return nil
 }

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -338,6 +338,7 @@ func (c *MySqlConnector) PullRecords(
 	for inTx || recordCount < req.MaxBatchSize {
 		getCtx := ctx
 		if !inTx {
+			// don't gamble on closed timeoutCtx.Done() being prioritized over event backlog channel
 			if err := timeoutCtx.Err(); err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
 					return nil

--- a/flow/e2e/generic/generic_test.go
+++ b/flow/e2e/generic/generic_test.go
@@ -46,7 +46,7 @@ func TestGenericCH_PG(t *testing.T) {
 func TestGenericCH_MySQL(t *testing.T) {
 	e2eshared.RunSuite(t, SetupGenericSuite(e2e_clickhouse.SetupSuite(t, func(t *testing.T) (*e2e.MySqlSource, string, error) {
 		t.Helper()
-		suffix := "pgchg_" + strings.ToLower(shared.RandomString(8))
+		suffix := "mychg_" + strings.ToLower(shared.RandomString(8))
 		source, err := e2e.SetupMySQL(t, suffix)
 		return source, suffix, err
 	})))

--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -152,12 +152,8 @@ func (s *MySqlSource) GeneratePeer(t *testing.T) *protos.Peer {
 }
 
 func (s *MySqlSource) Exec(ctx context.Context, sql string) error {
-	if _, err := s.MySqlConnector.Execute(ctx, sql); err != nil {
-		return err
-	} else if _, err := s.MySqlConnector.Execute(ctx, "flush binary logs"); err != nil {
-		return err
-	}
-	return nil
+	_, err := s.MySqlConnector.Execute(ctx, sql)
+	return err
 }
 
 func (s *MySqlSource) GetRows(ctx context.Context, suffix string, table string, cols string) (*model.QRecordBatch, error) {

--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -111,6 +111,7 @@ func SetupMyCore(t *testing.T, suffix string, isMaria bool, replicationMechanism
 	} else {
 		for _, sql := range []string{
 			"set global binlog_format=row",
+			"set binlog_format=row",
 			"set global binlog_row_metadata=full",
 		} {
 			if _, err := connector.Execute(t.Context(), sql); err != nil {

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -151,16 +151,14 @@ func processCDCFlowConfigUpdate(
 	logger.Info("processing CDCFlowConfigUpdate", slog.Any("updatedState", flowConfigUpdate))
 
 	if tablesAreAdded {
-		err := processTableAdditions(ctx, logger, cfg, state, mirrorNameSearch)
-		if err != nil {
+		if err := processTableAdditions(ctx, logger, cfg, state, mirrorNameSearch); err != nil {
 			logger.Error("failed to process additional tables", slog.Any("error", err))
 			return err
 		}
 	}
 
 	if tablesAreRemoved {
-		err := processTableRemovals(ctx, logger, cfg, state)
-		if err != nil {
+		if err := processTableRemovals(ctx, logger, cfg, state); err != nil {
 			logger.Error("failed to process removed tables", slog.Any("error", err))
 			return err
 		}


### PR DESCRIPTION
ofc it doesn't fail when I'm trying to observe it fail in #2846..

https://dev.mysql.com/doc/refman/8.4/en/set-variable.html

> If you change a global system variable, the value is remembered and used to initialize the session value for new sessions until you change the variable to a different value or the server exits. The change is visible to any client that accesses the global value. However, the change affects the corresponding session value only for clients that connect after the change. **The global variable change does not affect the session value for any current client sessions (not even the session within which the global value change occurs).**