### PR TITLE
e2e: run heartbeat workflow explicitly

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,7 @@ ignore:
   - "flow/e2e/eventhub"
   - "flow/middleware"
   - "flow/shared/aws_common"
+  - "flow/shared/telemetry/sns_message_sender.go"
 
 component_management:
   individual_components:

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,7 @@ ignore:
   - "flow/connectors/postgres/sanitize"
   - "flow/connectors/pubsub"
   - "flow/connectors/snowflake"
+  - "flow/e2e/eventhub"
   - "flow/middleware"
   - "flow/shared/aws_common"
 

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -556,10 +556,9 @@ func (a *FlowableActivity) ReplicateQRepPartitions(ctx context.Context,
 	}
 
 	numPartitions := len(partitions.Partitions)
+	logger.Info("replicating partitions for batch",
+		slog.Int64("batchID", int64(partitions.BatchId)), slog.Int("partitions", numPartitions))
 
-	logger.Info(fmt.Sprintf("replicating partitions for batch %d - size: %d",
-		partitions.BatchId, numPartitions),
-	)
 	for _, p := range partitions.Partitions {
 		logger.Info(fmt.Sprintf("batch-%d - replicating partition - %s", partitions.BatchId, p.PartitionId))
 		var err error

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -565,6 +565,15 @@ func (s Suite) TestCustomSync() {
 		return tag.Key == "k" && tag.Value == "v"
 	}))
 
+	// test list mirrors
+	listResponse, err := s.ListMirrors(s.t.Context(), &protos.ListMirrorsRequest{})
+	require.NoError(s.t, err)
+	sourcePeer := s.Source().GeneratePeer(s.t)
+	require.True(s.t, slices.ContainsFunc(listResponse.Mirrors, func(mirror *protos.ListMirrorsItem) bool {
+		return mirror.WorkflowId == env.GetID() && mirror.SourceName == sourcePeer.Name &&
+			mirror.SourceType == sourcePeer.Type && mirror.IsCdc
+	}))
+
 	_, err = s.CustomSyncFlow(s.t.Context(), &protos.CreateCustomSyncRequest{FlowJobName: flowConnConfig.FlowJobName, NumberOfSyncs: 1})
 	require.ErrorContains(s.t, err, "is not paused")
 

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -47,6 +47,14 @@ func (s PeerFlowE2ETestSuitePG) checkPeerdbColumns(dstSchemaQualified string, ro
 	return nil
 }
 
+func (s PeerFlowE2ETestSuitePG) TestHeartbeat() {
+	// general testing of heartbeat workflow, not pg specific
+	require.NotNil(s.t, e2e.GeneratePostgresPeer(s.t))
+	tc := e2e.NewTemporalClient(s.t)
+	env := e2e.ExecuteWorkflow(s.t.Context(), tc, shared.PeerFlowTaskQueue, peerflow.HeartbeatFlowWorkflow)
+	e2e.EnvWaitForFinished(s.t, env, 5*time.Minute)
+}
+
 func (s PeerFlowE2ETestSuitePG) Test_Geospatial_PG() {
 	srcTableName := s.attachSchemaSuffix("test_geospatial_pg")
 	dstTableName := s.attachSchemaSuffix("test_geospatial_pg_dst")

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -44,8 +44,7 @@ func (s PeerFlowE2ETestSuitePG) comparePGTables(srcSchemaQualified, dstSchemaQua
 func (s PeerFlowE2ETestSuitePG) checkEnums(srcSchemaQualified, dstSchemaQualified string) error {
 	var exists pgtype.Bool
 	query := fmt.Sprintf("SELECT EXISTS (SELECT 1 FROM %s src "+
-		"WHERE NOT EXISTS ("+
-		"SELECT 1 FROM %s dst "+
+		"WHERE NOT EXISTS (SELECT 1 FROM %s dst "+
 		"WHERE src.my_mood::text = dst.my_mood::text)) LIMIT 1;", srcSchemaQualified,
 		dstSchemaQualified)
 	if err := s.Conn().QueryRow(s.t.Context(), query).Scan(&exists); err != nil {
@@ -201,8 +200,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Complete_QRep_Flow_Multi_Insert_PG() {
 	e2e.EnvWaitForFinished(s.t, env, 3*time.Minute)
 	require.NoError(s.t, env.Error(s.t.Context()))
 
-	err = s.comparePGTables(srcSchemaQualified, dstSchemaQualified, "*")
-	require.NoError(s.t, err)
+	require.NoError(s.t, s.comparePGTables(srcSchemaQualified, dstSchemaQualified, "*"))
 }
 
 func (s PeerFlowE2ETestSuitePG) Test_PG_TypeSystemQRep() {

--- a/flow/shared/math.go
+++ b/flow/shared/math.go
@@ -19,7 +19,7 @@ type AdjustedPartitions struct {
 // AdjustNumPartitions takes the total number of rows and the desired number of rows per partition,
 // and returns the adjusted number of partitions and rows per partition so that the partition count does not exceed 1000.
 // It does so by increasing the rows-per-partition by a power-of-10 multiplier when necessary.
-func AdjustNumPartitions(totalRows, desiredRowsPerPartition int64) AdjustedPartitions {
+func AdjustNumPartitions(totalRows int64, desiredRowsPerPartition int64) AdjustedPartitions {
 	const maxPartitions = 1000
 
 	// Calculate the initial number of partitions.


### PR DESCRIPTION
avoids flaky coverage percentage based on whether scheduled task fired during CI or not