### PR TITLE
Spin up individual workflow job for each table

### DIFF
--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -232,10 +232,7 @@ func processTableAdditions(
 		if err := childAdditionalTablesCDCFlowFuture.Get(childAdditionalTablesCDCFlowCtx, &res); err != nil {
 			return err
 		}
-		// gotta accumulate the results of the map
-		for xId, xStr := range res.SyncFlowOptions.SrcTableIdNameMapping {
-			accumlatedSrcTableIdNameMapping[xId] = xStr
-		}
+		maps.Copy(accumlatedSrcTableIdNameMapping, res.SyncFlowOptions.SrcTableIdNameMapping)
 	}
 
 	maps.Copy(state.SyncFlowOptions.SrcTableIdNameMapping, accumlatedSrcTableIdNameMapping)


### PR DESCRIPTION
We're looking to sync a fairly large number of tables (~50k) and adding them in batches. The table creation is done sequentially and this ends up taking a very large amount of time. Additionally, it seems that everytime a new table is added the presence of _all_ tables is checked - something that can be optimised.


Let me know if the suggestion makes sense.

Thank you!