### PR TITLE
feat(classifier): mark statement timeout related errors as recoverable

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -242,6 +242,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorNotifyConnectivity, pgErrorInfo
 		case pgerrcode.OutOfMemory:
 			return ErrorNotifyOOMSource, pgErrorInfo
+		case pgerrcode.QueryCanceled:
+			return ErrorRetryRecoverable, pgErrorInfo
 		}
 	}
 

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -139,7 +139,7 @@ func TestClickHouseAccessEntityNotFoundErrorShouldBeRecoverable(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
-func TestPotgresQueryCancelledErrorShouldBeRecoverable(t *testing.T) {
+func TestPostgresQueryCancelledErrorShouldBeRecoverable(t *testing.T) {
 	connectionString := internal.GetCatalogConnectionStringFromEnv(t.Context())
 	config, err := pgx.ParseConfig(connectionString)
 	require.NoError(t, err)

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 )
 
@@ -135,5 +136,23 @@ func TestClickHouseAccessEntityNotFoundErrorShouldBeRecoverable(t *testing.T) {
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceClickHouse,
 		Code:   "492",
+	}, errInfo, "Unexpected error info")
+}
+
+func TestPotgresQueryCancelledErrorShouldBeRecoverable(t *testing.T) {
+	connectionString := internal.GetCatalogConnectionStringFromEnv(t.Context())
+	config, err := pgx.ParseConfig(connectionString)
+	require.NoError(t, err)
+	config.Config.RuntimeParams["statement_timeout"] = "1500"
+	connectConfig, err := pgx.ConnectConfig(t.Context(), config)
+	defer connectConfig.Close(t.Context())
+	require.NoError(t, err)
+	_, err = connectConfig.Exec(t.Context(), "SELECT pg_sleep(2)")
+
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed querying: %w", err))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.QueryCanceled,
 	}, errInfo, "Unexpected error info")
 }

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -145,8 +145,8 @@ func TestPostgresQueryCancelledErrorShouldBeRecoverable(t *testing.T) {
 	require.NoError(t, err)
 	config.Config.RuntimeParams["statement_timeout"] = "1500"
 	connectConfig, err := pgx.ConnectConfig(t.Context(), config)
-	defer connectConfig.Close(t.Context())
 	require.NoError(t, err)
+	defer connectConfig.Close(t.Context())
 	_, err = connectConfig.Exec(t.Context(), "SELECT pg_sleep(2)")
 
 	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed querying: %w", err))


### PR DESCRIPTION
fixes #2915