### PR TITLE
Add API test for adding a table before a resync

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -379,6 +379,7 @@ func (h *FlowRequestHandler) FlowStateChange(
 			} else if !isCDC {
 				return nil, errors.New("resync is only supported for CDC mirrors")
 			} else {
+				slog.Info("resync requested for cdc flow", logs)
 				// getting config before dropping the flow since the flow entry is deleted unconditionally
 				config, err := h.getFlowConfigFromCatalog(ctx, req.FlowJobName)
 				if err != nil {

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -531,7 +531,9 @@ func (s Suite) TestAddTableBeforeResync() {
 	e2e.EnvWaitFor(s.t, newEnv, 3*time.Minute, "sync flow done after resync", func() bool {
 		var syncBatchID pgtype.Int8
 		queryErr := s.pg.PostgresConnector.Conn().QueryRow(
-			s.t.Context(), "select sync_batch_id from metadata_last_sync_state where job_name = $1", flowConnConfig.FlowJobName,
+			s.t.Context(),
+			"select sync_batch_id from metadata_last_sync_state where job_name = $1",
+			flowConnConfig.FlowJobName,
 		).Scan(&syncBatchID)
 		if queryErr != nil {
 			return false
@@ -541,7 +543,9 @@ func (s Suite) TestAddTableBeforeResync() {
 	e2e.EnvWaitFor(s.t, newEnv, 3*time.Minute, "normalize flow done after resync", func() bool {
 		var normalizeBatchID pgtype.Int8
 		queryErr := s.pg.PostgresConnector.Conn().QueryRow(
-			s.t.Context(), "select normalize_batch_id from metadata_last_sync_state where job_name = $1", flowConnConfig.FlowJobName,
+			s.t.Context(),
+			"select normalize_batch_id from metadata_last_sync_state where job_name = $1",
+			flowConnConfig.FlowJobName,
 		).Scan(&normalizeBatchID)
 		if queryErr != nil {
 			return false

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -468,7 +468,7 @@ func (s Suite) TestAddTableBeforeResync() {
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 	e2e.EnvWaitForFinished(s.t, env, 3*time.Minute)
 	e2e.RequireEqualTables(s.ch, "original", "id,val")
-	s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
 		FlowJobName:        flowConnConfig.FlowJobName,
 		RequestedFlowState: protos.FlowStatus_STATUS_RUNNING,
 		FlowConfigUpdate: &protos.FlowConfigUpdate{
@@ -484,6 +484,7 @@ func (s Suite) TestAddTableBeforeResync() {
 			},
 		},
 	})
+	require.NoError(s.t, err)
 	e2e.RequireEqualTables(s.ch, "added", "id,val")
 
 	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -527,7 +527,8 @@ func (s Suite) TestAddTableBeforeResync() {
 	})
 
 	// Test CDC
-	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf("INSERT INTO %s(id, val) values (3,'cdc_after_resync')", e2e.AttachSchema(s, "added"))))
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s(id, val) values (3,'cdc_after_resync')", e2e.AttachSchema(s, "added"))))
 	e2e.EnvWaitFor(s.t, newEnv, 3*time.Minute, "sync flow done after resync", func() bool {
 		var syncBatchID pgtype.Int8
 		queryErr := s.pg.PostgresConnector.Conn().QueryRow(

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -541,7 +541,7 @@ func (s Suite) TestAddTableBeforeResync() {
 		}
 		return syncBatchID.Valid && (syncBatchID.Int64 == 1)
 	})
-	e2e.EnvWaitFor(s.t, newEnv, 3*time.Minute, "normalize flow done after resync", func() bool {
+	e2e.EnvWaitFor(s.t, newEnv, 5*time.Minute, "normalize flow done after resync", func() bool {
 		var normalizeBatchID pgtype.Int8
 		queryErr := s.pg.PostgresConnector.Conn().QueryRow(
 			s.t.Context(),


### PR DESCRIPTION
This PR adds a test to check if resync picks up added tables and they are well and truly part of the CDC pipeline. 
It is a follow-up of #2917 