### PR TITLE
[mysql] general fixes

### DIFF
--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -69,7 +69,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 	)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
-			return nil, errors.New("/validatecdc source peer does not support being a source peer")
+			return nil, errors.New("connector is not a supported source type")
 		}
 		err := fmt.Errorf("failed to create source connector: %w", err)
 		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -83,7 +83,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		h.alerter.LogNonFlowWarning(ctx, telemetry.CreateMirror, req.ConnectionConfigs.FlowJobName,
 			err.Error(),
 		)
-		return nil, err
+		return nil, fmt.Errorf("failed to validate source connector %s: %w", req.ConnectionConfigs.SourceName, err)
 	}
 
 	dstConn, err := connectors.GetByNameAs[connectors.MirrorDestinationValidationConnector](

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -136,7 +136,9 @@ func (c *MySqlConnector) connect(ctx context.Context) (*client.Conn, error) {
 	conn := c.conn.Load()
 	if conn == nil {
 		argF := []client.Option{func(conn *client.Conn) error {
-			conn.SetCapability(mysql.CLIENT_COMPRESS)
+			if c.config.Compression > 0 {
+				conn.SetCapability(mysql.CLIENT_COMPRESS)
+			}
 			if !c.config.DisableTls {
 				config, err := shared.CreateTlsConfig(tls.VersionTLS12, c.config.RootCa, c.config.Host, c.config.TlsHost)
 				if err != nil {

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -67,13 +67,7 @@ const (
 	 WHERE TABLE_SCHEMA=? and TABLE_NAME=?`
 	checkIfSchemaExistsSQL = `SELECT TO_BOOLEAN(COUNT(1)) FROM INFORMATION_SCHEMA.SCHEMATA
 	 WHERE SCHEMA_NAME=?`
-	getLastOffsetSQL            = "SELECT OFFSET FROM %s.%s WHERE MIRROR_JOB_NAME=?"
-	setLastOffsetSQL            = "UPDATE %s.%s SET OFFSET=GREATEST(OFFSET, ?) WHERE MIRROR_JOB_NAME=?"
-	getLastSyncBatchID_SQL      = "SELECT SYNC_BATCH_ID FROM %s.%s WHERE MIRROR_JOB_NAME=?"
-	getLastNormalizeBatchID_SQL = "SELECT NORMALIZE_BATCH_ID FROM %s.%s WHERE MIRROR_JOB_NAME=?"
-	dropTableIfExistsSQL        = "DROP TABLE IF EXISTS %s.%s"
-	deleteJobMetadataSQL        = "DELETE FROM %s.%s WHERE MIRROR_JOB_NAME=?"
-	dropSchemaIfExistsSQL       = "DROP SCHEMA IF EXISTS %s"
+	dropTableIfExistsSQL = "DROP TABLE IF EXISTS %s.%s"
 )
 
 type SnowflakeConnector struct {

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -297,11 +297,13 @@ func (s Suite) TestScripts() {
 	}
 }
 
-func (s Suite) TestMySQLBinlogValidation() {
+func (s Suite) TestMySQLRDSBinlogValidation() {
 	_, ok := s.source.(*e2e.MySqlSource)
 	if !ok {
 		s.t.Skip("only for MySQL")
 	}
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", e2e.AttachSchema(s, "valid"))))
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
 		FlowJobName:      "my_validation_" + s.suffix,

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -159,12 +159,21 @@ func (s *SnapshotFlowExecution) cloneTable(
 		from = strings.Join(quotedColumns, ",")
 	}
 
+	// usually MySQL supports double quotes with ANSI_QUOTES, but Vitess doesn't
+	// Vitess currently only supports initial load so change here is enough
+	srcTableEscaped := parsedSrcTable.String()
+	if dbtype, err := getPeerType(ctx, s.config.SourceName); err != nil {
+		return err
+	} else if dbtype == protos.DBType_MYSQL {
+		srcTableEscaped = parsedSrcTable.MySQL()
+	}
+
 	var query string
 	if mapping.PartitionKey == "" {
-		query = fmt.Sprintf("SELECT %s FROM %s", from, parsedSrcTable.String())
+		query = fmt.Sprintf("SELECT %s FROM %s", from, srcTableEscaped)
 	} else {
 		query = fmt.Sprintf("SELECT %s FROM %s WHERE %s BETWEEN {{.start}} AND {{.end}}",
-			from, parsedSrcTable.String(), mapping.PartitionKey)
+			from, srcTableEscaped, mapping.PartitionKey)
 	}
 
 	numWorkers := uint32(8)
@@ -180,13 +189,12 @@ func (s *SnapshotFlowExecution) cloneTable(
 	snapshotWriteMode := &protos.QRepWriteMode{
 		WriteType: protos.QRepWriteType_QREP_WRITE_MODE_APPEND,
 	}
+
 	// ensure document IDs are synchronized across initial load and CDC
 	// for the same document
-	dbtype, err := getPeerType(ctx, s.config.DestinationName)
-	if err != nil {
+	if dbtype, err := getPeerType(ctx, s.config.DestinationName); err != nil {
 		return err
-	}
-	if dbtype == protos.DBType_ELASTICSEARCH {
+	} else if dbtype == protos.DBType_ELASTICSEARCH {
 		if err := initTableSchema(); err != nil {
 			return err
 		}


### PR DESCRIPTION
1. MySQL connections were setting compression unconditionally, respect setting instead
2. remove unused Snowflake SQL
3. remove binlog/replication validation from peer creation so we can do initial load only mirrors for MySQL
4. make binlog/replication validation during mirror creation conditional on initial load only
5. change double quotes to backticks for statements we run on MySQL during initial load, brings us closer to supporting Vitess which can't handle ANSI_QUOTES