### PR TITLE
fix(alerting): remove explicit flowName to prevent collision

### DIFF
--- a/flow/alerting/alerting.go
+++ b/flow/alerting/alerting.go
@@ -485,7 +485,6 @@ func (a *Alerter) LogFlowError(ctx context.Context, flowName string, inErr error
 		a.sendTelemetryMessage(ctx, logger, flowName, errorWithStack, telemetry.ERROR, tags...)
 	}
 	errorAttributeSet := metric.WithAttributeSet(attribute.NewSet(
-		attribute.String(otel_metrics.FlowNameKey, flowName),
 		attribute.Stringer(otel_metrics.ErrorClassKey, errorClass),
 		attribute.Stringer(otel_metrics.ErrorActionKey, errorClass.ErrorAction()),
 		attribute.Stringer(otel_metrics.ErrorSourceKey, errInfo.Source),


### PR DESCRIPTION
When flowName is passed explicitly, it overrides the contextial flowName in output metric. This causes initial load mirrors overriding the contextual flowName as `clone_mirror_` and further causing it to be screwed up. Now the error metric will always have the parent flowName (mirror name) via the context