### PR TITLE
[dropflow] move metadata_last_sync_state cleanup to last activity

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1197,7 +1197,7 @@ func (a *FlowableActivity) RemoveFlowDetailsFromCatalog(ctx context.Context, flo
 		slog.String(string(shared.FlowNameKey), flowName))
 	tx, err := a.CatalogPool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction to remove flow entries from catalog: %w", err)
+		return fmt.Errorf("failed to begin transaction to remove flow details from catalog: %w", err)
 	}
 	defer shared.RollbackTx(tx, logger)
 
@@ -1221,7 +1221,7 @@ func (a *FlowableActivity) RemoveFlowDetailsFromCatalog(ctx context.Context, flo
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("failed to commit transaction to remove flow entries from catalog: %w", err)
+		return fmt.Errorf("failed to commit transaction to remove flow details from catalog: %w", err)
 	}
 
 	return nil

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1217,7 +1217,7 @@ func (a *FlowableActivity) RemoveFlowDetailsFromCatalog(ctx context.Context, flo
 	}
 
 	if _, err := tx.Exec(ctx, connmetadata.GetSyncFlowCleanupQuery(), flowName); err != nil {
-		return fmt.Errorf(" unable to clear metadata for flow cleanup: %w", err)
+		return fmt.Errorf("unable to clear metadata for flow cleanup: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -94,7 +94,9 @@ func (a *FlowableActivity) CheckMetadataTables(
 
 	// this should have been done by DropFlowDestination
 	// but edge case due to late context cancellation
-	if err := conn.SyncFlowCleanup(ctx, config.FlowName); err != nil {
+	logger := log.With(internal.LoggerFromCtx(ctx), slog.String(string(shared.FlowNameKey), config.FlowName))
+	metadata := connmetadata.NewPostgresMetadataFromCatalog(logger, a.CatalogPool)
+	if err := metadata.SyncFlowCleanup(ctx, config.FlowName); err != nil {
 		return nil, a.Alerter.LogFlowError(ctx, config.FlowName, fmt.Errorf("failed to clean up destination before mirror setup: %w", err))
 	}
 

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1217,7 +1217,7 @@ func (a *FlowableActivity) RemoveFlowDetailsFromCatalog(ctx context.Context, flo
 	}
 
 	if _, err := tx.Exec(ctx, connmetadata.GetSyncFlowCleanupQuery(), flowName); err != nil {
-		return fmt.Errorf("[snowflake drop mirror] unable to clear metadata for sync flow cleanup: %w", err)
+		return fmt.Errorf(" unable to clear metadata for flow cleanup: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1192,7 +1192,7 @@ func (a *FlowableActivity) RemoveTablesFromCatalog(
 	return err
 }
 
-func (a *FlowableActivity) RemoveFlowEntryFromCatalog(ctx context.Context, flowName string) error {
+func (a *FlowableActivity) RemoveFlowDetailsFromCatalog(ctx context.Context, flowName string) error {
 	logger := log.With(internal.LoggerFromCtx(ctx),
 		slog.String(string(shared.FlowNameKey), flowName))
 	tx, err := a.CatalogPool.Begin(ctx)
@@ -1214,6 +1214,10 @@ func (a *FlowableActivity) RemoveFlowEntryFromCatalog(ctx context.Context, flowN
 	} else {
 		logger.Info("flow entries removed from catalog",
 			slog.Int("rowsAffected", int(ct.RowsAffected())))
+	}
+
+	if _, err := tx.Exec(ctx, connmetadata.GetSyncFlowCleanupQuery(), flowName); err != nil {
+		return fmt.Errorf("[snowflake drop mirror] unable to clear metadata for sync flow cleanup: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -92,14 +92,6 @@ func (a *FlowableActivity) CheckMetadataTables(
 	}
 	defer connectors.CloseConnector(ctx, conn)
 
-	// this should have been done by DropFlowDestination
-	// but edge case due to late context cancellation
-	logger := log.With(internal.LoggerFromCtx(ctx), slog.String(string(shared.FlowNameKey), config.FlowName))
-	metadata := connmetadata.NewPostgresMetadataFromCatalog(logger, a.CatalogPool)
-	if err := metadata.SyncFlowCleanup(ctx, config.FlowName); err != nil {
-		return nil, a.Alerter.LogFlowError(ctx, config.FlowName, fmt.Errorf("failed to clean up destination before mirror setup: %w", err))
-	}
-
 	needsSetup, err := conn.NeedsSetupMetadataTables(ctx)
 	if err != nil {
 		return nil, err

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -740,12 +740,11 @@ func (c *BigQueryConnector) SyncFlowCleanup(ctx context.Context, jobName string)
 	dataset := c.client.DatasetInProject(c.projectID, c.datasetID)
 	rawTableHandle := dataset.Table(c.getRawTableName(jobName))
 	// check if exists, then delete
-	_, err := rawTableHandle.Metadata(ctx)
-	if err == nil {
-		c.logger.Info("deleting raw table", slog.String("table", rawTableHandle.FullyQualifiedName()))
+	if _, err := rawTableHandle.Metadata(ctx); err == nil {
+		c.logger.Info("[bigquery] deleting raw table", slog.String("table", rawTableHandle.FullyQualifiedName()))
 		deleteErr := rawTableHandle.Delete(ctx)
 		if deleteErr != nil {
-			return fmt.Errorf("failed to delete raw table: %w", deleteErr)
+			return fmt.Errorf("[bigquery] failed to delete raw table: %w", deleteErr)
 		}
 	}
 

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -737,15 +737,10 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 }
 
 func (c *BigQueryConnector) SyncFlowCleanup(ctx context.Context, jobName string) error {
-	err := c.PostgresMetadata.SyncFlowCleanup(ctx, jobName)
-	if err != nil {
-		return fmt.Errorf("unable to clear metadata for sync flow cleanup: %w", err)
-	}
-
 	dataset := c.client.DatasetInProject(c.projectID, c.datasetID)
 	rawTableHandle := dataset.Table(c.getRawTableName(jobName))
 	// check if exists, then delete
-	_, err = rawTableHandle.Metadata(ctx)
+	_, err := rawTableHandle.Metadata(ctx)
 	if err == nil {
 		c.logger.Info("deleting raw table", slog.String("table", rawTableHandle.FullyQualifiedName()))
 		deleteErr := rawTableHandle.Delete(ctx)

--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -222,11 +222,6 @@ func (c *ClickHouseConnector) RenameTables(
 }
 
 func (c *ClickHouseConnector) SyncFlowCleanup(ctx context.Context, jobName string) error {
-	if err := c.PostgresMetadata.SyncFlowCleanup(ctx, jobName); err != nil {
-		return fmt.Errorf("[clickhouse] unable to clear metadata for sync flow cleanup: %w", err)
-	}
-	c.logger.Info("successfully cleared metadata for flow " + jobName)
-
 	// delete raw table if exists
 	rawTableIdentifier := c.getRawTableName(jobName)
 	if err := c.execWithLogging(ctx, fmt.Sprintf(dropTableIfExistsSQL, rawTableIdentifier)); err != nil {

--- a/flow/connectors/external_metadata/store.go
+++ b/flow/connectors/external_metadata/store.go
@@ -215,10 +215,14 @@ func (p *PostgresMetadata) IsQRepPartitionSynced(ctx context.Context, req *proto
 	return exists, nil
 }
 
+func GetSyncFlowCleanupQuery() string {
+	return fmt.Sprintf(`
+		DELETE FROM %s WHERE job_name = $1
+	`, lastSyncStateTableName)
+}
+
 func (p *PostgresMetadata) SyncFlowCleanup(ctx context.Context, jobName string) error {
-	if _, err := p.pool.Exec(ctx,
-		`DELETE FROM `+lastSyncStateTableName+` WHERE job_name = $1`, jobName,
-	); err != nil {
+	if _, err := p.pool.Exec(ctx, GetSyncFlowCleanupQuery(), jobName); err != nil {
 		return err
 	}
 

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1258,9 +1258,12 @@ func (c *PostgresConnector) SyncFlowCleanup(ctx context.Context, jobName string)
 		return fmt.Errorf("unable to drop raw table: %w", err)
 	}
 
-	mirrorJobsTableExists, err := c.jobMetadataExists(ctx, jobName)
+	mirrorJobsTableExists, err := c.tableExists(ctx, &utils.SchemaTable{
+		Schema: c.metadataSchema,
+		Table:  mirrorJobsTableIdentifier,
+	})
 	if err != nil {
-		return fmt.Errorf("unable to check if job metadata exists: %w", err)
+		return fmt.Errorf("unable to check if job metadata table exists: %w", err)
 	}
 	if mirrorJobsTableExists {
 		if _, err := syncFlowCleanupTx.Exec(ctx,

--- a/flow/connectors/snowflake/qrep.go
+++ b/flow/connectors/snowflake/qrep.go
@@ -72,13 +72,9 @@ func (c *SnowflakeConnector) getTableSchema(ctx context.Context, tableName strin
 func (c *SnowflakeConnector) SetupQRepMetadataTables(ctx context.Context, config *protos.QRepConfig) error {
 	ctx = c.withMirrorNameQueryTag(ctx, config.FlowJobName)
 
-	var schemaExists sql.NullBool
-	err := c.QueryRowContext(ctx, checkIfSchemaExistsSQL, c.rawSchema).Scan(&schemaExists)
-	if err != nil {
+	if schemaExists, err := c.checkIfRawSchemaExists(ctx); err != nil {
 		return fmt.Errorf("error while checking if schema %s for raw table exists: %w", c.rawSchema, err)
-	}
-
-	if !schemaExists.Valid || !schemaExists.Bool {
+	} else if !schemaExists {
 		_, err := c.execWithLogging(ctx, fmt.Sprintf(createSchemaSQL, c.rawSchema))
 		if err != nil {
 			return err

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -65,8 +65,6 @@ const (
 
 	checkIfTableExistsSQL = `SELECT TO_BOOLEAN(COUNT(1)) FROM INFORMATION_SCHEMA.TABLES
 	 WHERE TABLE_SCHEMA=? and TABLE_NAME=?`
-	checkIfSchemaExistsSQL = `SELECT TO_BOOLEAN(COUNT(1)) FROM INFORMATION_SCHEMA.SCHEMATA
-	 WHERE SCHEMA_NAME=?`
 	dropTableIfExistsSQL = "DROP TABLE IF EXISTS %s.%s"
 )
 
@@ -98,12 +96,12 @@ type UnchangedToastColumnResult struct {
 }
 
 func (c *SnowflakeConnector) ValidateCheck(ctx context.Context) error {
-	schemaName := c.rawSchema
 	// check if schema exists
-	var schemaExists sql.NullBool
-	if err := c.QueryRowContext(ctx, checkIfSchemaExistsSQL, schemaName).Scan(&schemaExists); err != nil {
+	schemaExists, err := c.checkIfRawSchemaExists(ctx)
+	if err != nil {
 		return fmt.Errorf("error while checking if schema exists: %w", err)
 	}
+	schemaName := c.rawSchema
 
 	dummyTable := "PEERDB_DUMMY_TABLE_" + shared.RandomString(4)
 
@@ -120,7 +118,7 @@ func (c *SnowflakeConnector) ValidateCheck(ctx context.Context) error {
 		}
 	}()
 
-	if !schemaExists.Valid || !schemaExists.Bool {
+	if !schemaExists {
 		// create schema
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf(createSchemaSQL, schemaName)); err != nil {
 			return fmt.Errorf("failed to create schema %s: %w", schemaName, err)
@@ -581,13 +579,9 @@ func (c *SnowflakeConnector) mergeTablesForBatch(
 func (c *SnowflakeConnector) CreateRawTable(ctx context.Context, req *protos.CreateRawTableInput) (*protos.CreateRawTableOutput, error) {
 	ctx = c.withMirrorNameQueryTag(ctx, req.FlowJobName)
 
-	var schemaExists sql.NullBool
-	err := c.QueryRowContext(ctx, checkIfSchemaExistsSQL, c.rawSchema).Scan(&schemaExists)
-	if err != nil {
+	if schemaExists, err := c.checkIfRawSchemaExists(ctx); err != nil {
 		return nil, fmt.Errorf("error while checking if schema %s for raw table exists: %w", c.rawSchema, err)
-	}
-
-	if !schemaExists.Valid || !schemaExists.Bool {
+	} else if !schemaExists {
 		_, err := c.execWithLogging(ctx, fmt.Sprintf(createSchemaSQL, c.rawSchema))
 		if err != nil {
 			return nil, err
@@ -596,15 +590,14 @@ func (c *SnowflakeConnector) CreateRawTable(ctx context.Context, req *protos.Cre
 	// there is no easy way to check if a table has the same schema in Snowflake,
 	// so just executing the CREATE TABLE IF NOT EXISTS blindly.
 	rawTableIdentifier := getRawTableIdentifier(req.FlowJobName)
-	_, err = c.execWithLogging(ctx,
-		fmt.Sprintf(createRawTableSQL, c.rawSchema, rawTableIdentifier))
-	if err != nil {
+
+	if _, err := c.execWithLogging(ctx,
+		fmt.Sprintf(createRawTableSQL, c.rawSchema, rawTableIdentifier)); err != nil {
 		return nil, fmt.Errorf("unable to create raw table: %w", err)
 	}
 
 	stage := c.getStageNameForJob(req.FlowJobName)
-	err = c.createStage(ctx, stage, &protos.QRepConfig{})
-	if err != nil {
+	if err := c.createStage(ctx, stage, &protos.QRepConfig{}); err != nil {
 		return nil, err
 	}
 
@@ -626,6 +619,15 @@ func (c *SnowflakeConnector) SyncFlowCleanup(ctx context.Context, jobName string
 	}
 
 	return nil
+}
+
+func (c *SnowflakeConnector) checkIfRawSchemaExists(ctx context.Context) (bool, error) {
+	var result pgtype.Bool
+	if err := c.QueryRowContext(ctx, `SELECT TO_BOOLEAN(COUNT(1)) FROM INFORMATION_SCHEMA.SCHEMATA
+	 WHERE SCHEMA_NAME=?`, c.rawSchema).Scan(&result); err != nil {
+		return false, fmt.Errorf("error while checking if schema %s exists: %w", c.rawSchema, err)
+	}
+	return result.Valid && result.Bool, nil
 }
 
 func (c *SnowflakeConnector) checkIfTableExists(

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -618,13 +618,10 @@ func (c *SnowflakeConnector) SyncFlowCleanup(ctx context.Context, jobName string
 
 	// delete raw table if exists
 	rawTableIdentifier := getRawTableIdentifier(jobName)
-	_, err := c.execWithLogging(ctx, fmt.Sprintf(dropTableIfExistsSQL, c.rawSchema, rawTableIdentifier))
-	if err != nil {
-		return fmt.Errorf("[snowflake drop mirror] unable to drop raw table: %w", err)
+	if _, err := c.execWithLogging(ctx, fmt.Sprintf(dropTableIfExistsSQL, c.rawSchema, rawTableIdentifier)); err != nil {
+		return fmt.Errorf("[snowflake] unable to drop raw table: %w", err)
 	}
-
-	err = c.dropStage(ctx, "", jobName)
-	if err != nil {
+	if err := c.dropStage(ctx, "", jobName); err != nil {
 		return err
 	}
 

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -615,14 +615,10 @@ func (c *SnowflakeConnector) CreateRawTable(ctx context.Context, req *protos.Cre
 
 func (c *SnowflakeConnector) SyncFlowCleanup(ctx context.Context, jobName string) error {
 	ctx = c.withMirrorNameQueryTag(ctx, jobName)
-	err := c.PostgresMetadata.SyncFlowCleanup(ctx, jobName)
-	if err != nil {
-		return fmt.Errorf("[snowflake drop mirror] unable to clear metadata for sync flow cleanup: %w", err)
-	}
 
 	// delete raw table if exists
 	rawTableIdentifier := getRawTableIdentifier(jobName)
-	_, err = c.execWithLogging(ctx, fmt.Sprintf(dropTableIfExistsSQL, c.rawSchema, rawTableIdentifier))
+	_, err := c.execWithLogging(ctx, fmt.Sprintf(dropTableIfExistsSQL, c.rawSchema, rawTableIdentifier))
 	if err != nil {
 		return fmt.Errorf("[snowflake drop mirror] unable to drop raw table: %w", err)
 	}

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -212,7 +212,6 @@ func processTableAdditions(
 	additionalTablesUUID := GetUUID(ctx)
 	childAdditionalTablesCDCFlowID := GetChildWorkflowID("additional-cdc-flow", cfg.FlowJobName, additionalTablesUUID)
 	additionalTablesCfg := proto.CloneOf(cfg)
-	additionalTablesCfg.FlowJobName = fmt.Sprintf("%s-%s", cfg.FlowJobName, additionalTablesUUID)
 	additionalTablesCfg.DoInitialSnapshot = true
 	additionalTablesCfg.InitialSnapshotOnly = true
 	additionalTablesCfg.TableMappings = flowConfigUpdate.AdditionalTables

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -212,6 +212,7 @@ func processTableAdditions(
 	additionalTablesUUID := GetUUID(ctx)
 	childAdditionalTablesCDCFlowID := GetChildWorkflowID("additional-cdc-flow", cfg.FlowJobName, additionalTablesUUID)
 	additionalTablesCfg := proto.CloneOf(cfg)
+	additionalTablesCfg.FlowJobName = fmt.Sprintf("%s-%s", cfg.FlowJobName, additionalTablesUUID)
 	additionalTablesCfg.DoInitialSnapshot = true
 	additionalTablesCfg.InitialSnapshotOnly = true
 	additionalTablesCfg.TableMappings = flowConfigUpdate.AdditionalTables

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -208,7 +208,7 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 			},
 		})
 		if err := workflow.ExecuteActivity(
-			removeFlowEntriesCtx, flowable.RemoveFlowEntryFromCatalog, input.FlowJobName,
+			removeFlowEntriesCtx, flowable.RemoveFlowDetailsFromCatalog, input.FlowJobName,
 		).Get(ctx, nil); err != nil {
 			workflow.GetLogger(ctx).Error("failed to remove flow entries from catalog", slog.Any("error", err))
 			return err

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -210,7 +210,7 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 		if err := workflow.ExecuteActivity(
 			removeFlowEntriesCtx, flowable.RemoveFlowDetailsFromCatalog, input.FlowJobName,
 		).Get(ctx, nil); err != nil {
-			workflow.GetLogger(ctx).Error("failed to remove flow entries from catalog", slog.Any("error", err))
+			workflow.GetLogger(ctx).Error("failed to remove flow details from catalog", slog.Any("error", err))
 			return err
 		}
 	}


### PR DESCRIPTION
This is to avoid race conditions where `metadata_last_sync_state` is removed by `DropFlowDestination` BEFORE `DropFlowSource` is able to cancel the goroutine that may insert data into the table.

If we hit this race condition during a resync, batchIDs and offsets being from an older mirror can cause many subtle issues and potential data inconsistency