### PR TITLE
sync flow: explicitly cancel & wait on cancellation before finishing

### DIFF
--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -257,6 +257,7 @@ func processTableRemovals(
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval: 1 * time.Minute,
 		},
+		WaitForCancellation: true,
 	})
 	alterPublicationRemovedTablesFuture := workflow.ExecuteActivity(
 		removeTablesCtx,

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -238,6 +238,7 @@ func (q *QRepFlowExecution) startChildWorkflow(
 			MaximumAttempts: 20,
 		},
 		TypedSearchAttributes: shared.NewSearchAttributes(q.config.FlowJobName),
+		WaitForCancellation:   true,
 	})
 
 	return workflow.ExecuteChildWorkflow(partFlowCtx, QRepPartitionWorkflow, q.config, partitions, q.runUUID)
@@ -323,6 +324,7 @@ func (q *QRepFlowExecution) waitForNewRows(
 	ctx = workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		ParentClosePolicy:     enums.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
 		TypedSearchAttributes: shared.NewSearchAttributes(q.config.FlowJobName),
+		WaitForCancellation:   true,
 	})
 	future := workflow.ExecuteChildWorkflow(ctx, QRepWaitForNewRowsWorkflow, q.config, lastPartition)
 


### PR DESCRIPTION
this avoids activity living on past ContinueAsNew, which was causing races