### PR TITLE
Extend API test for resync

### DIFF
--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -2,6 +2,7 @@ package e2e_api
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"slices"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/e2e"
@@ -64,6 +66,78 @@ func (s Suite) Connector() *connpostgres.PostgresConnector {
 
 func (s Suite) DestinationTable(table string) string {
 	return table
+}
+
+// checkMetadataLastSyncStateValues checks the values of sync_batch_id and normalize_batch_id
+// in the metadata_last_sync_state table
+func (s Suite) checkMetadataLastSyncStateValues(
+	env e2e.WorkflowRun,
+	flowConnConfig *protos.FlowConnectionConfigs,
+	reason string,
+	expectedSyncBatchId int64,
+	expectedNormalizeBatchId int64,
+) {
+	e2e.EnvWaitFor(s.t, env, 5*time.Minute, "sync flow check: "+reason, func() bool {
+		var syncBatchID pgtype.Int8
+		queryErr := s.pg.PostgresConnector.Conn().QueryRow(
+			s.t.Context(),
+			"select sync_batch_id from metadata_last_sync_state where job_name = $1",
+			flowConnConfig.FlowJobName,
+		).Scan(&syncBatchID)
+		if queryErr != nil {
+			return false
+		}
+		return syncBatchID.Valid && (syncBatchID.Int64 == expectedSyncBatchId)
+	})
+
+	e2e.EnvWaitFor(s.t, env, 5*time.Minute, "normalize flow check: "+reason, func() bool {
+		var normalizeBatchID pgtype.Int8
+		queryErr := s.pg.PostgresConnector.Conn().QueryRow(
+			s.t.Context(),
+			"select normalize_batch_id from metadata_last_sync_state where job_name = $1",
+			flowConnConfig.FlowJobName,
+		).Scan(&normalizeBatchID)
+		if queryErr != nil {
+			return false
+		}
+		return normalizeBatchID.Valid && (normalizeBatchID.Int64 == expectedNormalizeBatchId)
+	})
+}
+
+func (s Suite) waitForActiveSlotForPostgresMirror(env e2e.WorkflowRun, conn *pgx.Conn, mirrorName string) {
+	slotName := "peerflow_slot_" + mirrorName
+	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "waiting for replication to become active", func() bool {
+		var active pgtype.Bool
+		err := conn.QueryRow(s.t.Context(),
+			`SELECT active FROM pg_replication_slots WHERE slot_name = $1`, slotName).Scan(&active)
+		if err != nil {
+			return false
+		}
+		return active.Valid && active.Bool
+	})
+}
+
+// checkCatalogTableMapping checks the table mappings in the catalog for a given flow
+func (s Suite) checkCatalogTableMapping(
+	ctx context.Context,
+	conn *pgx.Conn,
+	flowName string,
+	expectedSourceTableNames []string,
+) {
+	var configBytes sql.RawBytes
+	err := conn.QueryRow(ctx,
+		"SELECT config_proto FROM flows WHERE name = $1", flowName).Scan(&configBytes)
+	require.NoError(s.t, err)
+
+	var config protos.FlowConnectionConfigs
+	err = proto.Unmarshal(configBytes, &config)
+	require.NoError(s.t, err)
+	require.Len(s.t, config.TableMappings, len(expectedSourceTableNames))
+	sourceTableNames := make([]string, len(config.TableMappings))
+	for i, tableMapping := range config.TableMappings {
+		sourceTableNames[i] = tableMapping.SourceTableIdentifier
+	}
+	require.ElementsMatch(s.t, expectedSourceTableNames, sourceTableNames)
 }
 
 func testApi[TSource e2e.SuiteSource](
@@ -445,7 +519,7 @@ func (s Suite) TestDropCompleted() {
 	})
 }
 
-func (s Suite) TestAddTableBeforeResync() {
+func (s Suite) TestEditTablesBeforeResync() {
 	require.NoError(s.t, s.source.Exec(s.t.Context(),
 		fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", e2e.AttachSchema(s, "original"))))
 	require.NoError(s.t, s.source.Exec(s.t.Context(),
@@ -504,17 +578,54 @@ func (s Suite) TestAddTableBeforeResync() {
 		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RUNNING
 	})
 	e2e.RequireEqualTables(s.ch, "added", "id,val")
+	s.checkCatalogTableMapping(s.t.Context(), s.pg.PostgresConnector.Conn(), flowConnConfig.FlowJobName, []string{
+		e2e.AttachSchema(s, "added"),
+		e2e.AttachSchema(s, "original"),
+	})
+	// Test CDC
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s(id, val) values (2,'added_table_cdc')", e2e.AttachSchema(s, "added"))))
+	s.checkMetadataLastSyncStateValues(env, flowConnConfig, "cdc after add table", 1, 1)
+	e2e.RequireEqualTables(s.ch, "added", "id,val")
 
 	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
 		FlowJobName:        flowConnConfig.FlowJobName,
 		RequestedFlowState: protos.FlowStatus_STATUS_PAUSED,
 	})
 	require.NoError(s.t, err)
-	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "wait for pause", func() bool {
+	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "wait for pause for remove table", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_PAUSED
+	})
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_RUNNING,
+		FlowConfigUpdate: &protos.FlowConfigUpdate{
+			Update: &protos.FlowConfigUpdate_CdcFlowConfigUpdate{
+				CdcFlowConfigUpdate: &protos.CDCFlowConfigUpdate{
+					RemovedTables: []*protos.TableMapping{
+						{
+							SourceTableIdentifier:      e2e.AttachSchema(s, "original"),
+							DestinationTableIdentifier: "original",
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(s.t, err)
+
+	s.checkCatalogTableMapping(s.t.Context(), s.pg.PostgresConnector.Conn(), flowConnConfig.FlowJobName, []string{
+		e2e.AttachSchema(s, "added"),
+	})
+	if pgconn, ok := s.source.Connector().(*connpostgres.PostgresConnector); ok {
+		s.waitForActiveSlotForPostgresMirror(env, pgconn.Conn(), flowConnConfig.FlowJobName)
+	}
+
+	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "wait for pause after table removal", func() bool {
 		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_PAUSED
 	})
 	require.NoError(s.t, s.source.Exec(s.t.Context(),
-		fmt.Sprintf("INSERT INTO %s(id, val) values (2,'resync')", e2e.AttachSchema(s, "added"))))
+		fmt.Sprintf("INSERT INTO %s(id, val) values (3,'resync')", e2e.AttachSchema(s, "added"))))
 	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
 		FlowJobName:        flowConnConfig.FlowJobName,
 		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
@@ -528,33 +639,17 @@ func (s Suite) TestAddTableBeforeResync() {
 		return newEnv.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RUNNING
 	})
 
-	// Test CDC
+	// Removed table should not have been in the initial load
+	initialLoadClientFacingData, err := s.InitialLoadSummary(s.t.Context(), &protos.InitialLoadSummaryRequest{
+		ParentMirrorName: flowConnConfig.FlowJobName,
+	})
+	require.NoError(s.t, err)
+	require.True(s.t, len(initialLoadClientFacingData.TableSummaries) == 1)
+	require.Equal(s.t, initialLoadClientFacingData.TableSummaries[0].TableName, "added")
+	// Test resync CDC
 	require.NoError(s.t, s.source.Exec(s.t.Context(),
-		fmt.Sprintf("INSERT INTO %s(id, val) values (3,'cdc_after_resync')", e2e.AttachSchema(s, "added"))))
-	e2e.EnvWaitFor(s.t, newEnv, 3*time.Minute, "sync flow done after resync", func() bool {
-		var syncBatchID pgtype.Int8
-		queryErr := s.pg.PostgresConnector.Conn().QueryRow(
-			s.t.Context(),
-			"select sync_batch_id from metadata_last_sync_state where job_name = $1",
-			flowConnConfig.FlowJobName,
-		).Scan(&syncBatchID)
-		if queryErr != nil {
-			return false
-		}
-		return syncBatchID.Valid && (syncBatchID.Int64 == 1)
-	})
-	e2e.EnvWaitFor(s.t, newEnv, 5*time.Minute, "normalize flow done after resync", func() bool {
-		var normalizeBatchID pgtype.Int8
-		queryErr := s.pg.PostgresConnector.Conn().QueryRow(
-			s.t.Context(),
-			"select normalize_batch_id from metadata_last_sync_state where job_name = $1",
-			flowConnConfig.FlowJobName,
-		).Scan(&normalizeBatchID)
-		if queryErr != nil {
-			return false
-		}
-		return normalizeBatchID.Valid && (normalizeBatchID.Int64 == 1)
-	})
+		fmt.Sprintf("INSERT INTO %s(id, val) values (4,'cdc_after_resync')", e2e.AttachSchema(s, "added"))))
+	s.checkMetadataLastSyncStateValues(newEnv, flowConnConfig, "cdc after resync", 1, 1)
 	e2e.EnvWaitForEqualTables(newEnv, s.ch, "resync after normalize", "added", "id,val")
 	newEnv.Cancel(s.t.Context())
 	e2e.RequireEnvCanceled(s.t, newEnv)

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -690,7 +690,7 @@ func (s Suite) TestEditTablesBeforeResync() {
 		if len(initialLoadClientFacingDataAfterResync.TableSummaries) != 1 {
 			return false
 		}
-		if initialLoadClientFacingDataAfterResync.TableSummaries[0].TableName != "added" {
+		if initialLoadClientFacingDataAfterResync.TableSummaries[0].TableName != "added_resync" {
 			return false
 		}
 		return true

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -688,9 +688,11 @@ func (s Suite) TestEditTablesBeforeResync() {
 			return false
 		}
 		if len(initialLoadClientFacingDataAfterResync.TableSummaries) != 1 {
+			s.t.Log("inconsistent initial load data after resync: ", initialLoadClientFacingDataAfterResync)
 			return false
 		}
 		if initialLoadClientFacingDataAfterResync.TableSummaries[0].TableName != "added_resync" {
+			s.t.Log("inconsistent first table load after resync: ", initialLoadClientFacingDataAfterResync)
 			return false
 		}
 		return true

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -529,7 +529,7 @@ func (s Suite) TestEditTablesBeforeResync() {
 	require.NoError(s.t, s.source.Exec(s.t.Context(),
 		fmt.Sprintf("INSERT INTO %s(id, val) values (1,'first')", e2e.AttachSchema(s, "added"))))
 	connectionGen := e2e.FlowConnectionGenerationConfig{
-		FlowJobName:      "add_table_before_resync_" + s.suffix,
+		FlowJobName:      "edit_tables_before_resync_" + s.suffix,
 		TableNameMapping: map[string]string{e2e.AttachSchema(s, "original"): "original"},
 		Destination:      s.ch.Peer().Name,
 	}

--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -110,7 +110,7 @@ export default function EditMirror({ params: { mirrorId } }: EditMirrorProps) {
     setLoading(true);
     const req: FlowStateChangeRequest = {
       flowJobName: mirrorId,
-      requestedFlowState: FlowStatus.STATUS_UNKNOWN,
+      requestedFlowState: FlowStatus.STATUS_RUNNING,
       flowConfigUpdate: {
         cdcFlowConfigUpdate: { ...config, additionalTables, removedTables },
       },


### PR DESCRIPTION
## Overview
This PR extends the existing (now called) `TestEditTablesBeforeResync` test in `api_test.go`.
This test is meant to cover editing tables and resyncing after these table edits to see how the mirror behaves.

## Steps

The test can be divided into - setup, add table, remove table and resync. Relevant metadata checks are being done for the table edits.

### 1. Setup tables and running mirror
1. Create the first table called `original`.
2. Create the second table called `added`.
3. Insert a row into `original`.
4. Insert a row into `added`.
5. Create a mirror with only `original` in the table mapping.
6. Wait for initial load of this mirror with `original` to complete.
7. Check if equal tables for `original`.

### 2. Table addition
8. Pause the mirror.
9. Send a flow state change request to add the table - `added`.
10. Wait for `added` table's initial load to complete.
11. Wait for equal tables for `added`.
12. Check the table mapping in `config_proto` for this flow in catalog and verify that it has `original` and `added` and mirror is back to Running.
13. Check if initial load stats has 2 entries.
14. Insert a row into `added` in source.
15. Check if sync_batch_id and normalize_batch_id in `metadata_last_sync_state` table in catalog are set to expected values : 1 for both.

### 3. Table removal
16. Pause the mirror.
17. Send a flow state change request to remove the table - `original`.
18. Check if catalog's table mapping now only has the `added` table and mirror is back to Running.
19. In case of source peer being Postgres, check if the replication slot is active.

### 4. Resync
20. Pause the mirror.
21. Insert a row into the `added` table.
22. Send a flow state change request for resync.
23. Check if equal tables for `added`.
24. Check if mirror is back to Running.
25. Check if `InitialLoadSummary` which we call in UI - returns only the `added` table's initial load data.
26. Insert a row into `added`.
27. Check if sync_batch_id and normalize_batch_id in `metadata_last_sync_state` table in catalog are set to expected values : 1 for both.
28. Wait for equal tables for added.
29. Cancel the context.