### PR TITLE
MySQL Mirror: set max execution time

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -586,6 +586,7 @@ func (a *FlowableActivity) ReplicateQRepPartitions(ctx context.Context,
 		}
 
 		if err != nil {
+			logger.Error("failed to replicate partition", slog.Any("error", err))
 			return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 		}
 	}

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -182,6 +182,10 @@ func (c *MySqlConnector) connect(ctx context.Context) (*client.Conn, error) {
 		if _, err := conn.Execute("SET sql_mode = 'ANSI,NO_BACKSLASH_ESCAPES'"); err != nil {
 			return nil, fmt.Errorf("failed to set sql_mode to ANSI: %w", err)
 		}
+		// set max_execution_time to unlimited
+		if _, err := conn.Execute("SET SESSION MAX_EXECUTION_TIME=0;"); err != nil {
+			return nil, fmt.Errorf("failed to set max_execution_time to 0: %w", err)
+		}
 	}
 	return conn, nil
 }


### PR DESCRIPTION
MySQL has a setting - `max_execution_time` - after which queries are cancelled, including ours

This PR sets this setting to unlimited at a session level when connecting to MySQL