### PR TITLE
add frontend for fetching type conversion

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -464,7 +464,6 @@ func GetColumnsTypeConversion() (*protos.ColumnsTypeConversionResponse, error) {
 			Qkind:            string(qkind),
 			DestinationTypes: destTypes,
 		})
-
 	}
 	return &protos.ColumnsTypeConversionResponse{
 		Conversions: res,

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -456,3 +456,17 @@ func (c *ClickHouseConnector) GetTableSchema(
 
 	return res, nil
 }
+
+func GetColumnsTypeConversion() (*protos.ColumnsTypeConversionResponse, error) {
+	res := make([]*protos.ColumnsTypeConversion, 0)
+	for qkind, destTypes := range listSupportedTypeConversions() {
+		res = append(res, &protos.ColumnsTypeConversion{
+			Qkind:            string(qkind),
+			DestinationTypes: destTypes,
+		})
+
+	}
+	return &protos.ColumnsTypeConversionResponse{
+		Conversions: res,
+	}, nil
+}

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -456,16 +456,3 @@ func (c *ClickHouseConnector) GetTableSchema(
 
 	return res, nil
 }
-
-func GetColumnsTypeConversion() (*protos.ColumnsTypeConversionResponse, error) {
-	res := make([]*protos.ColumnsTypeConversion, 0)
-	for qkind, destTypes := range listSupportedTypeConversions() {
-		res = append(res, &protos.ColumnsTypeConversion{
-			Qkind:            string(qkind),
-			DestinationTypes: destTypes,
-		})
-	}
-	return &protos.ColumnsTypeConversionResponse{
-		Conversions: res,
-	}, nil
-}

--- a/ui/app/mirrors/create/cdc/customColumnType.tsx
+++ b/ui/app/mirrors/create/cdc/customColumnType.tsx
@@ -75,7 +75,7 @@ export default function CustomColumnType({
 
   const destinationTypeOptions = useCallback(
     (col: string): { value: string; label: string }[] => {
-      return destinationTypeMapping[col] || [];
+      return destinationTypeMapping[col] ?? [];
     },
     [destinationTypeMapping]
   );
@@ -100,7 +100,7 @@ export default function CustomColumnType({
                 tc.destinationTypes.map((type: string) => ({
                   value: type,
                   label: type,
-                })) || [];
+                })) ?? [];
               break;
             }
           }

--- a/ui/app/mirrors/create/cdc/customColumnType.tsx
+++ b/ui/app/mirrors/create/cdc/customColumnType.tsx
@@ -135,7 +135,7 @@ export default function CustomColumnType({
         );
       }
     },
-    [tableRow.source]
+    [tableRow.source, setRows]
   );
 
   const handleCreateColumn = useCallback(

--- a/ui/app/mirrors/create/cdc/customColumnType.tsx
+++ b/ui/app/mirrors/create/cdc/customColumnType.tsx
@@ -1,0 +1,336 @@
+'use client';
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import ReactSelect from 'react-select';
+
+import { TableMapRow } from '@/app/dto/MirrorsDTO';
+import SelectTheme from '@/app/styles/select';
+import { DBType } from '@/grpc_generated/peers';
+import { ColumnsItem } from '@/grpc_generated/route';
+import { Button } from '@/lib/Button';
+import { Checkbox } from '@/lib/Checkbox';
+import { Icon } from '@/lib/Icon';
+import { Label } from '@/lib/Label';
+import { RowWithCheckbox } from '@/lib/Layout';
+import { fetchAllTypeConversions } from '../handlers';
+import { engineOptionStyles } from './styles';
+interface CustomColumnTypeProps {
+  columns: ColumnsItem[];
+  tableRow: TableMapRow;
+  rows: TableMapRow[];
+  setRows: Dispatch<SetStateAction<TableMapRow[]>>;
+  peerType: DBType;
+}
+
+export default function CustomColumnType({
+  columns,
+  tableRow,
+  rows,
+  setRows,
+  peerType,
+}: CustomColumnTypeProps) {
+  const [useCustom, setUseCustom] = useState(false);
+  const [selectedColumnName, setSelectedColumnName] = useState<string>('');
+  const [destinationTypeMapping, setDestinationTypeMapping] = useState<
+    Record<string, { value: string; label: string }[]>
+  >({});
+
+  const customColumnTypeList = useMemo(() => {
+    const currentRow = rows.find((r) => r.source === tableRow.source);
+    if (!currentRow) return [];
+
+    return currentRow.columns
+      .filter((col) => col.destinationType)
+      .map((col) => ({
+        columnName: col.sourceName,
+        destinationType: col.destinationType,
+      }));
+  }, [rows, tableRow.source]);
+
+  const availableColumns = columns
+    .filter(
+      (column) =>
+        !customColumnTypeList.some(
+          (mapping) => mapping.columnName === column.name
+        )
+    )
+    .filter((column) => destinationTypeMapping[column.name] !== undefined);
+
+  const destinationTypeOptions = useCallback(
+    (col: string): { value: string; label: string }[] => {
+      return destinationTypeMapping[col] || [];
+    },
+    [destinationTypeMapping]
+  );
+
+  useEffect(() => {
+    const fetchTypeMappings = async () => {
+      if (!useCustom) return;
+
+      const columnNameToQvalueKind = columns.map((col) => [
+        col.name,
+        col.qkind,
+      ]) as [string, string][];
+
+      try {
+        const typeConversions = await fetchAllTypeConversions(peerType);
+        const columnNameToDestinationTypes = {} as Record<
+          string,
+          { value: string; label: string }[]
+        >;
+        for (const [columnName, qkind] of columnNameToQvalueKind) {
+          for (const tc of typeConversions) {
+            if (tc.qkind === qkind) {
+              columnNameToDestinationTypes[columnName] =
+                tc.destinationTypes.map((type: string) => ({
+                  value: type,
+                  label: type,
+                })) || [];
+              break;
+            }
+          }
+        }
+        setDestinationTypeMapping(columnNameToDestinationTypes);
+      } catch (error) {
+        console.error('Error fetching type conversions:', error);
+      }
+    };
+
+    fetchTypeMappings();
+    // TODO: there is a bug where `columns` is getting re-rendered excessively
+    // in the parent. Once fixed, add back `columns` to the dependency array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [useCustom, peerType]);
+
+  const handleUseCustom = useCallback(
+    (state: boolean) => {
+      setUseCustom(state);
+      if (!state) {
+        setSelectedColumnName('');
+
+        // clear custom column types already set
+        setRows((prev) =>
+          prev.map((row) => {
+            if (row.source !== tableRow.source) return row;
+            return {
+              ...row,
+              columns: row.columns.map((col) => ({
+                ...col,
+                destinationType: '',
+              })),
+            };
+          })
+        );
+      }
+    },
+    [tableRow.source, setRows]
+  );
+
+  const handleCreateColumn = useCallback(
+    (value: string) => {
+      if (selectedColumnName) {
+        setRows((prev) =>
+          prev.map((row) => {
+            if (row.source !== tableRow.source) return row;
+
+            const columnExistsInRow = row.columns.some(
+              (col) => col.sourceName === selectedColumnName
+            );
+            if (!columnExistsInRow) {
+              return {
+                ...row,
+                columns: [
+                  ...row.columns,
+                  {
+                    sourceName: selectedColumnName,
+                    destinationName: '',
+                    destinationType: value,
+                    ordering: 0,
+                    nullableEnabled: false,
+                  },
+                ],
+              };
+            } else {
+              return {
+                ...row,
+                columns: row.columns.map((col) =>
+                  col.sourceName === selectedColumnName
+                    ? { ...col, destinationType: value }
+                    : col
+                ),
+              };
+            }
+          })
+        );
+        setSelectedColumnName('');
+      }
+    },
+    [tableRow.source, setRows, selectedColumnName]
+  );
+
+  const handleUpdateColumn = useCallback(
+    (entry: { columnName: string; destinationType: string }, value: string) => {
+      setRows((prev) =>
+        prev.map((row) => {
+          if (row.source !== tableRow.source) return row;
+
+          if (value === '') {
+            return {
+              ...row,
+              columns: row.columns.filter(
+                (col) => col.sourceName !== entry.columnName
+              ),
+            };
+          } else {
+            return {
+              ...row,
+              columns: row.columns.map((col) =>
+                col.sourceName === entry.columnName
+                  ? { ...col, destinationType: value }
+                  : col
+              ),
+            };
+          }
+        })
+      );
+    },
+    [tableRow.source, setRows]
+  );
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignContent: 'center',
+        rowGap: '0.5rem',
+      }}
+    >
+      <RowWithCheckbox
+        label={
+          <Label as='label' style={{ fontSize: 13 }}>
+            Use custom destination column type
+          </Label>
+        }
+        action={
+          <Checkbox
+            style={{ marginLeft: 0 }}
+            checked={useCustom}
+            onCheckedChange={handleUseCustom}
+          />
+        }
+      />
+      {useCustom && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.5rem',
+          }}
+        >
+          {customColumnTypeList.length > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                gap: '0.5rem',
+                flexDirection: 'column',
+              }}
+            >
+              {customColumnTypeList.map((mapping) => (
+                <div
+                  key={mapping.columnName}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                  }}
+                >
+                  <div style={{ width: '30%' }}>
+                    <ReactSelect
+                      value={{
+                        value: mapping.columnName,
+                        label: mapping.columnName,
+                      }}
+                      theme={SelectTheme}
+                      styles={engineOptionStyles}
+                    />
+                  </div>
+                  <span>→</span>
+                  <div style={{ width: '30%' }}>
+                    <ReactSelect
+                      value={{
+                        value: mapping.destinationType,
+                        label: mapping.destinationType,
+                      }}
+                      onChange={(val) =>
+                        val?.value && handleUpdateColumn(mapping, val.value)
+                      }
+                      theme={SelectTheme}
+                      styles={engineOptionStyles}
+                      options={destinationTypeOptions(mapping.columnName)}
+                    />
+                  </div>
+                  <Button
+                    variant='normalBorderless'
+                    onClick={() => handleUpdateColumn(mapping, '')}
+                  >
+                    <Icon name='close' />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {availableColumns.length > 0 && (
+            <div
+              style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}
+            >
+              <div style={{ width: '30%' }}>
+                <ReactSelect
+                  placeholder='Column'
+                  value={
+                    selectedColumnName
+                      ? { value: selectedColumnName, label: selectedColumnName }
+                      : null
+                  }
+                  onChange={(val) =>
+                    val?.value && setSelectedColumnName(val.value)
+                  }
+                  options={availableColumns.map((col) => ({
+                    value: col.name,
+                    label: col.name,
+                  }))}
+                  theme={SelectTheme}
+                  styles={engineOptionStyles}
+                />
+              </div>
+              <span>→</span>
+              <div style={{ width: '30%' }}>
+                <ReactSelect
+                  placeholder='Destination type'
+                  value={null}
+                  onChange={(val) =>
+                    val?.value && handleCreateColumn(val.value)
+                  }
+                  options={
+                    selectedColumnName
+                      ? destinationTypeOptions(selectedColumnName)
+                      : []
+                  }
+                  theme={SelectTheme}
+                  styles={engineOptionStyles}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -38,8 +38,8 @@ import {
 
 import { Divider } from '@tremor/react';
 import ReactSelect from 'react-select';
+import CustomColumnType from './customColumnType';
 import SelectSortingKeys from './sortingkey';
-
 interface SchemaBoxProps {
   sourcePeer: string;
   schema: string;
@@ -456,7 +456,7 @@ export default function SchemaBox({
                               DBType[DBType.CLICKHOUSE].toString() && (
                               <div
                                 style={{
-                                  width: '50%',
+                                  width: '100%',
                                   display: 'flex',
                                   flexDirection: 'column',
                                   rowGap: '0.5rem',
@@ -468,13 +468,33 @@ export default function SchemaBox({
                                     marginTop: '0.5rem',
                                   }}
                                 />
-                                <SelectSortingKeys
+                                <div style={{ width: '50%' }}>
+                                  <SelectSortingKeys
+                                    columns={
+                                      columns?.map((column) => column.name) ??
+                                      []
+                                    }
+                                    loading={columnsLoading}
+                                    tableRow={row}
+                                    setRows={setRows}
+                                  />
+                                </div>
+                                <Divider
+                                  style={{
+                                    ...columnBoxDividerStyle,
+                                    marginTop: '0.5rem',
+                                  }}
+                                />
+                                <CustomColumnType
                                   columns={
-                                    columns?.map((column) => column.name) ?? []
+                                    columns?.filter(
+                                      (column) => !row.exclude.has(column.name)
+                                    ) ?? []
                                   }
-                                  loading={columnsLoading}
                                   tableRow={row}
+                                  rows={rows}
                                   setRows={setRows}
+                                  peerType={peerType}
                                 />
                               </div>
                             )}

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -479,18 +479,8 @@ export default function SchemaBox({
                                     setRows={setRows}
                                   />
                                 </div>
-                                <Divider
-                                  style={{
-                                    ...columnBoxDividerStyle,
-                                    marginTop: '0.5rem',
-                                  }}
-                                />
                                 <CustomColumnType
-                                  columns={
-                                    columns?.filter(
-                                      (column) => !row.exclude.has(column.name)
-                                    ) ?? []
-                                  }
+                                  columns={columns}
                                   tableRow={row}
                                   rows={rows}
                                   setRows={setRows}

--- a/ui/app/mirrors/create/cdc/tablemapping.tsx
+++ b/ui/app/mirrors/create/cdc/tablemapping.tsx
@@ -103,7 +103,7 @@ export default function TablePicker({
           />
         </div>
       </div>
-      <div style={{ maxHeight: '70vh', overflow: 'scroll' }}>
+      <div>
         {searchedSchemas ? (
           searchedSchemas.map((schema) => (
             <SchemaBox

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -12,6 +12,7 @@ import {
 import { DBType, dBTypeToJSON } from '@/grpc_generated/peers';
 import {
   AllTablesResponse,
+  ColumnsTypeConversionResponse,
   CreateCDCFlowRequest,
   CreateQRepFlowRequest,
   PeerPublicationsResponse,
@@ -488,6 +489,16 @@ export async function fetchAllTables(peerName: string) {
     }
   ).then((res) => res.json());
   return tablesRes.tables;
+}
+
+export async function fetchAllTypeConversions(peerType: DBType) {
+  const typeConversionsRes: ColumnsTypeConversionResponse = await fetch(
+    `/api/v1/peers/columns/all_type_conversions?destination_peer_type=${encodeURIComponent(peerType)}`,
+    {
+      cache: 'no-store',
+    }
+  ).then((res) => res.json());
+  return typeConversionsRes.conversions;
 }
 
 export async function handleValidateCDC(


### PR DESCRIPTION
Create frontend for [custom column type conversion.](https://github.com/PeerDB-io/peerdb/pull/2989).

It creates a dropdown of possible conversions determined by the backend. Right now only numeric -> string is supported.
If there are no available conversion, the option for `use custom column destination type` will be hidden.

![Screenshot 2025-05-29 at 06 36 32@2x](https://github.com/user-attachments/assets/db910430-1ca9-424a-8954-f0bb651bc24a)

Test: locally created a table that contains column with numeric type, create ClickPipe via UI, and see CH table get created with String type.
