### PR TITLE
Make drop flow synchronous 

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -396,10 +396,10 @@ func (h *FlowRequestHandler) FlowStateChange(
 			}
 		case protos.FlowStatus_STATUS_TERMINATING, protos.FlowStatus_STATUS_TERMINATED:
 			if currState != protos.FlowStatus_STATUS_TERMINATED && currState != protos.FlowStatus_STATUS_TERMINATING {
-				if currState == protos.FlowStatus_STATUS_COMPLETED {
-					changeErr = h.shutdownFlow(ctx, req.FlowJobName, req.DropMirrorStats, req.SkipDestinationDrop)
-				} else {
-					changeErr = model.FlowSignalStateChange.SignalClientWorkflow(ctx, h.temporalClient, workflowID, "", req)
+				changeErr = h.shutdownFlow(ctx, req.FlowJobName, req.DropMirrorStats, req.SkipDestinationDrop)
+				if changeErr != nil {
+					slog.Error("unable to shutdown flow", logs, slog.Any("error", changeErr))
+					return nil, fmt.Errorf("unable to shutdown flow: %w", changeErr)
 				}
 			}
 		default:

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -376,16 +376,7 @@ func CDCFlowWorkflow(
 			state.ActiveSignal = model.FlowSignalHandler(state.ActiveSignal, val, logger)
 		})
 		flowSignalStateChangeChan.AddToSelector(selector, func(val *protos.FlowStateChangeRequest, _ bool) {
-			if val.RequestedFlowState == protos.FlowStatus_STATUS_TERMINATING {
-				state.ActiveSignal = model.TerminateSignal
-				dropCfg := syncStateToConfigProtoInCatalog(ctx, cfg, state)
-				state.DropFlowInput = &protos.DropFlowInput{
-					FlowJobName:           dropCfg.FlowJobName,
-					FlowConnectionConfigs: dropCfg,
-					DropFlowStats:         val.DropMirrorStats,
-					SkipDestinationDrop:   val.SkipDestinationDrop,
-				}
-			} else if val.RequestedFlowState == protos.FlowStatus_STATUS_RESYNC {
+			if val.RequestedFlowState == protos.FlowStatus_STATUS_RESYNC {
 				state.ActiveSignal = model.ResyncSignal
 				cfg.Resync = true
 				cfg.DoInitialSnapshot = true
@@ -476,15 +467,6 @@ func CDCFlowWorkflow(
 		flowSignalStateChangeChan.AddToSelector(selector, func(val *protos.FlowStateChangeRequest, _ bool) {
 			if val.RequestedFlowState == protos.FlowStatus_STATUS_PAUSED {
 				logger.Warn("pause requested during setup, ignoring")
-			} else if val.RequestedFlowState == protos.FlowStatus_STATUS_TERMINATING {
-				state.ActiveSignal = model.TerminateSignal
-				dropCfg := syncStateToConfigProtoInCatalog(ctx, cfg, state)
-				state.DropFlowInput = &protos.DropFlowInput{
-					FlowJobName:           dropCfg.FlowJobName,
-					FlowConnectionConfigs: dropCfg,
-					DropFlowStats:         val.DropMirrorStats,
-					SkipDestinationDrop:   val.SkipDestinationDrop,
-				}
 			} else if val.RequestedFlowState == protos.FlowStatus_STATUS_RESYNC {
 				state.ActiveSignal = model.ResyncSignal
 				cfg.Resync = true
@@ -685,16 +667,7 @@ func CDCFlowWorkflow(
 	})
 	flowSignalStateChangeChan.AddToSelector(mainLoopSelector, func(val *protos.FlowStateChangeRequest, _ bool) {
 		finished = true
-		if val.RequestedFlowState == protos.FlowStatus_STATUS_TERMINATING {
-			state.ActiveSignal = model.TerminateSignal
-			dropCfg := syncStateToConfigProtoInCatalog(ctx, cfg, state)
-			state.DropFlowInput = &protos.DropFlowInput{
-				FlowJobName:           dropCfg.FlowJobName,
-				FlowConnectionConfigs: dropCfg,
-				DropFlowStats:         val.DropMirrorStats,
-				SkipDestinationDrop:   val.SkipDestinationDrop,
-			}
-		} else if val.RequestedFlowState == protos.FlowStatus_STATUS_RESYNC {
+		if val.RequestedFlowState == protos.FlowStatus_STATUS_RESYNC {
 			state.ActiveSignal = model.ResyncSignal
 			cfg.Resync = true
 			cfg.DoInitialSnapshot = true


### PR DESCRIPTION
There are some auxilliary actions that need to be taken during the dropping of a mirror. For instance, you would need to drop the user of the warehouse. 
That can only be done once the destination peer artifacts such as some raw tables are dropped - doing that requires the user.
Instead of forcing PeerDB clients to poll for catalog deletion of the mirror, this PR makes the drop flow request synchronous.