### PR TITLE
fix small perf regression

### DIFF
--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -53,14 +53,15 @@ func (c *PostgresConnector) postgresOIDToQValueKind(
 	customTypeMapping map[uint32]shared.CustomDataType,
 ) types.QValueKind {
 	colType, err := postgres.PostgresOIDToQValueKind(recvOID, customTypeMapping, c.typeMap)
-	_, warned := c.hushWarnOID[recvOID]
-	if err != nil && !warned {
-		c.logger.Warn(
-			"unsupported field type",
-			slog.Int64("oid", int64(recvOID)),
-			slog.String("typeName", err.Error()),
-			slog.String("mapping", string(colType)))
-		c.hushWarnOID[recvOID] = struct{}{}
+	if err != nil {
+		if _, warned := c.hushWarnOID[recvOID]; !warned {
+			c.logger.Warn(
+				"unsupported field type",
+				slog.Int64("oid", int64(recvOID)),
+				slog.String("typeName", err.Error()),
+				slog.String("mapping", string(colType)))
+			c.hushWarnOID[recvOID] = struct{}{}
+		}
 	}
 	return colType
 }


### PR DESCRIPTION
Undo a small perf regression I accidentally introduced in https://github.com/PeerDB-io/peerdb/pull/3012.

I assume >99% of the time `PostgresOIDToQValueKind` does not return an error. O(1) is cheap but not free, and given this function is in the hot path for CDC, I'll be pedantic about it.
