### PR TITLE
move mysql qvalue logic to shared

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -28,6 +28,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/datatypes"
+	chmysql "github.com/PeerDB-io/peerdb/flow/shared/mysql"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
@@ -105,7 +106,7 @@ func (c *MySqlConnector) getTableSchemaForTable(
 		if err != nil {
 			return nil, err
 		}
-		qkind, err := qkindFromMysqlColumnType(dataType)
+		qkind, err := chmysql.QkindFromMysqlColumnType(dataType)
 		if err != nil {
 			return nil, err
 		}
@@ -672,7 +673,7 @@ func (c *MySqlConnector) processAlterTableQuery(ctx context.Context, catalogPool
 						slog.String("tableName", sourceTableName))
 					continue
 				}
-				qkind, err := qkindFromMysqlColumnType(col.Tp.InfoSchemaStr())
+				qkind, err := chmysql.QkindFromMysqlColumnType(col.Tp.InfoSchemaStr())
 				if err != nil {
 					return err
 				}

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -101,67 +101,6 @@ func qkindFromMysql(field *mysql.Field) (types.QValueKind, error) {
 	}
 }
 
-func qkindFromMysqlColumnType(ct string) (types.QValueKind, error) {
-	ct, isUnsigned := strings.CutSuffix(ct, " unsigned")
-	ct, param, _ := strings.Cut(ct, "(")
-	switch strings.ToLower(ct) {
-	case "json":
-		return types.QValueKindJSON, nil
-	case "char", "varchar", "text", "set", "tinytext", "mediumtext", "longtext":
-		return types.QValueKindString, nil
-	case "enum":
-		return types.QValueKindEnum, nil
-	case "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob":
-		return types.QValueKindBytes, nil
-	case "date":
-		return types.QValueKindDate, nil
-	case "time":
-		return types.QValueKindTime, nil
-	case "datetime", "timestamp":
-		return types.QValueKindTimestamp, nil
-	case "decimal", "numeric":
-		return types.QValueKindNumeric, nil
-	case "float":
-		return types.QValueKindFloat32, nil
-	case "double":
-		return types.QValueKindFloat64, nil
-	case "tinyint":
-		if strings.HasPrefix(param, "1)") {
-			return types.QValueKindBoolean, nil
-		} else if isUnsigned {
-			return types.QValueKindUInt8, nil
-		} else {
-			return types.QValueKindInt8, nil
-		}
-	case "smallint", "year":
-		if isUnsigned {
-			return types.QValueKindUInt16, nil
-		} else {
-			return types.QValueKindInt16, nil
-		}
-	case "mediumint", "int":
-		if isUnsigned {
-			return types.QValueKindUInt32, nil
-		} else {
-			return types.QValueKindInt32, nil
-		}
-	case "bit":
-		return types.QValueKindUInt64, nil
-	case "bigint":
-		if isUnsigned {
-			return types.QValueKindUInt64, nil
-		} else {
-			return types.QValueKindInt64, nil
-		}
-	case "vector":
-		return types.QValueKindArrayFloat32, nil
-	case "geometry", "point", "polygon", "linestring", "multipoint", "multipolygon", "geomcollection":
-		return types.QValueKindGeometry, nil
-	default:
-		return types.QValueKind(""), fmt.Errorf("unknown mysql type %s", ct)
-	}
-}
-
 func QRecordSchemaFromMysqlFields(tableSchema *protos.TableSchema, fields []*mysql.Field) (types.QRecordSchema, error) {
 	tableColumns := make(map[string]*protos.FieldDescription, len(tableSchema.Columns))
 	for _, col := range tableSchema.Columns {

--- a/flow/connectors/mysql/schema.go
+++ b/flow/connectors/mysql/schema.go
@@ -95,7 +95,7 @@ func (c *MySqlConnector) GetColumns(ctx context.Context, schema string, table st
 		if err != nil {
 			return nil, err
 		}
-		qkind, err := qkindFromMysqlColumnType(columnType)
+		qkind, err := mysql.QkindFromMysqlColumnType(columnType)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -580,10 +580,6 @@ func (s ClickHouseSuite) Test_Large_Numeric() {
 }
 
 func (s ClickHouseSuite) Test_Destination_Type_Conversion() {
-	if _, ok := s.source.(*e2e.PostgresSource); !ok {
-		s.t.Skip("only applies to postgres")
-	}
-
 	srcTableName := "test_destination_type_conversion"
 	srcFullName := s.attachSchemaSuffix(srcTableName)
 	dstTableName := "test_destination_type_conversion"

--- a/flow/shared/clickhouse/type_conversion.go
+++ b/flow/shared/clickhouse/type_conversion.go
@@ -13,18 +13,14 @@ stage the schema/data in the converted type format, and therefore
 successfully uploaded to the desired destination type in ClickHouse.
 
 To add a type conversion:
-	(1) In flow/model/types/type_converter.go:
+
+	(1) In flow/model/shared/type_converter.go:
 	- implement a SchemaConversionFn interface to convert the QField type
 	- implement a ValueConversionFn interface to convert the QValue data
 
 	(2) Add the new conversion to the `supportedDestinationTypes` map here
 		(if destination type doesn't exist, create a new map entry for it).
-
-The ListSupportedTypeConversions function returns the full list of supported
-type conversions. Note that the source types are QValueKind, this allows
-the implementation to be source-connector agnostic.
 */
-
 var SupportedDestinationTypes = map[string][]types.TypeConversion{
 	"String": {types.NewTypeConversion(
 		types.NumericToStringSchemaConversion,
@@ -32,6 +28,8 @@ var SupportedDestinationTypes = map[string][]types.TypeConversion{
 	)},
 }
 
+// returns the full list of supported type conversions. The keys are
+// QValueKind to allows the implementation to be source-connector agnostic.
 func ListSupportedTypeConversions() map[types.QValueKind][]string {
 	typeConversions := make(map[types.QValueKind][]string)
 

--- a/flow/shared/mysql/type_conversion.go
+++ b/flow/shared/mysql/type_conversion.go
@@ -1,0 +1,69 @@
+package mysql
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
+)
+
+func QkindFromMysqlColumnType(ct string) (types.QValueKind, error) {
+	ct, isUnsigned := strings.CutSuffix(ct, " unsigned")
+	ct, param, _ := strings.Cut(ct, "(")
+	switch strings.ToLower(ct) {
+	case "json":
+		return types.QValueKindJSON, nil
+	case "char", "varchar", "text", "set", "tinytext", "mediumtext", "longtext":
+		return types.QValueKindString, nil
+	case "enum":
+		return types.QValueKindEnum, nil
+	case "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob":
+		return types.QValueKindBytes, nil
+	case "date":
+		return types.QValueKindDate, nil
+	case "time":
+		return types.QValueKindTime, nil
+	case "datetime", "timestamp":
+		return types.QValueKindTimestamp, nil
+	case "decimal", "numeric":
+		return types.QValueKindNumeric, nil
+	case "float":
+		return types.QValueKindFloat32, nil
+	case "double":
+		return types.QValueKindFloat64, nil
+	case "tinyint":
+		if strings.HasPrefix(param, "1)") {
+			return types.QValueKindBoolean, nil
+		} else if isUnsigned {
+			return types.QValueKindUInt8, nil
+		} else {
+			return types.QValueKindInt8, nil
+		}
+	case "smallint", "year":
+		if isUnsigned {
+			return types.QValueKindUInt16, nil
+		} else {
+			return types.QValueKindInt16, nil
+		}
+	case "mediumint", "int":
+		if isUnsigned {
+			return types.QValueKindUInt32, nil
+		} else {
+			return types.QValueKindInt32, nil
+		}
+	case "bit":
+		return types.QValueKindUInt64, nil
+	case "bigint":
+		if isUnsigned {
+			return types.QValueKindUInt64, nil
+		} else {
+			return types.QValueKindInt64, nil
+		}
+	case "vector":
+		return types.QValueKindArrayFloat32, nil
+	case "geometry", "point", "polygon", "linestring", "multipoint", "multipolygon", "geomcollection":
+		return types.QValueKindGeometry, nil
+	default:
+		return types.QValueKind(""), fmt.Errorf("unknown mysql type %s", ct)
+	}
+}


### PR DESCRIPTION
Follow up to https://github.com/PeerDB-io/peerdb/pull/3012 -- move MySQL -> qvalue type mapping logic to shared package.

Test: CI + locally tested a simple flow with MySQL.