### PR TITLE
ClickHouse: Maintain info on batch-wise pushed rows

### DIFF
--- a/flow/connectors/external_metadata/store.go
+++ b/flow/connectors/external_metadata/store.go
@@ -256,6 +256,17 @@ func (p *PostgresMetadata) UpdateNormalizeBatchID(ctx context.Context, jobName s
 	return nil
 }
 
+func (p *PostgresMetadata) UpdatePushedRows(ctx context.Context, jobName string, tableRowsPerBatchMap map[int64]uint64) error {
+	for batchID, numRows := range tableRowsPerBatchMap {
+		if err := monitoring.UpdateRowsPushedForCDCBatch(ctx, p.pool, jobName, batchID, numRows); err != nil {
+			p.logger.Error("failed to update rows pushed for cdc batch", slog.Int64("batchID", batchID), slog.Any("error", err))
+			return fmt.Errorf("failed to update rows pushed for cdc batch: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func (p *PostgresMetadata) FinishQRepPartition(
 	ctx context.Context,
 	partition *protos.QRepPartition,

--- a/flow/connectors/utils/monitoring/monitoring.go
+++ b/flow/connectors/utils/monitoring/monitoring.go
@@ -76,6 +76,22 @@ func AddCDCBatchForFlow(ctx context.Context, pool shared.CatalogPool, flowJobNam
 	return nil
 }
 
+func UpdateRowsPushedForCDCBatch(
+	ctx context.Context,
+	pool shared.CatalogPool,
+	flowJobName string,
+	batchID int64,
+	numRows uint64,
+) error {
+	if _, err := pool.Exec(ctx,
+		"UPDATE peerdb_stats.cdc_batches SET rows_pushed=$1 WHERE flow_name=$2 AND batch_id=$3",
+		numRows, flowJobName, batchID,
+	); err != nil {
+		return fmt.Errorf("error while updating rows_pushed in cdc_batch: %w", err)
+	}
+	return nil
+}
+
 // update num records and end-lsn for a cdc batch
 func UpdateNumRowsAndEndLSNForCDCBatch(
 	ctx context.Context,

--- a/nexus/catalog/migrations/V47__pushed_rows_batch.sql
+++ b/nexus/catalog/migrations/V47__pushed_rows_batch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE peerdb_stats.cdc_batches
+    ADD COLUMN IF NOT EXISTS pushed_rows BIGINT DEFAULT 0;


### PR DESCRIPTION
This PR introduces a column in the `cdc_batches` stats table in catalog called `pushed_rows`.
In ClickHouse destination peer's `NormalizeRecords` , we are updating this column after every table is normalized by getting the count of the table's records count from raw table for the range of batches and inserting the same into the above stats table.