### PR TITLE
change QValueTime/QValueTimeTZ to internally use time.Duration not time.Time

### DIFF
--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -24,7 +24,7 @@ type mergeStmtGenerator struct {
 
 // generateFlattenedCTE generates a flattened CTE.
 func (m *mergeStmtGenerator) generateFlattenedCTE(dstTable string, normalizedTableSchema *protos.TableSchema) string {
-	// for each column in the normalized table, generate CAST + JSON_EXTRACT_SCALAR
+	// for each column in the normalized table, generate CAST + JSON_VALUE
 	// statement.
 	flattenedProjs := make([]string, 0, len(normalizedTableSchema.Columns)+3)
 
@@ -58,13 +58,13 @@ func (m *mergeStmtGenerator) generateFlattenedCTE(dstTable string, normalizedTab
 		// this needs to be handled again
 		// TODO add interval types again
 		// case model.ColumnTypeInterval:
-		// castStmt = fmt.Sprintf("MAKE_INTERVAL(0,CAST(JSON_EXTRACT_SCALAR(_peerdb_data, '$.%s.Months') AS INT64),"+
-		// 	"CAST(JSON_EXTRACT_SCALAR(_peerdb_data, '$.%s.Days') AS INT64),0,0,"+
-		// 	"CAST(CAST(JSON_EXTRACT_SCALAR(_peerdb_data, '$.%s.Microseconds') AS INT64)/1000000 AS  INT64)) AS %s",
+		// castStmt = fmt.Sprintf("MAKE_INTERVAL(0,CAST(JSON_VALUE(_peerdb_data, '$.%s.Months') AS INT64),"+
+		// 	"CAST(JSON_VALUE(_peerdb_data, '$.%s.Days') AS INT64),0,0,"+
+		// 	"CAST(CAST(JSON_VALUE(_peerdb_data, '$.%s.Microseconds') AS INT64)/1000000 AS  INT64)) AS %s",
 		// 	column.Name, column.Name, column.Name, column.Name)
 		// TODO add proper granularity for time types, then restore this
 		// case model.ColumnTypeTime:
-		// 	castStmt = fmt.Sprintf("time(timestamp_micros(CAST(JSON_EXTRACT(_peerdb_data, '$.%s.Microseconds')"+
+		// 	castStmt = fmt.Sprintf("time(timestamp_micros(CAST(JSON_VALUE(_peerdb_data, '$.%s.Microseconds')"+
 		// 		" AS int64))) AS %s",
 		// 		column.Name, column.Name)
 		default:

--- a/flow/connectors/bigquery/merge_stmt_generator.go
+++ b/flow/connectors/bigquery/merge_stmt_generator.go
@@ -52,21 +52,6 @@ func (m *mergeStmtGenerator) generateFlattenedCTE(dstTable string, normalizedTab
 		case types.QValueKindGeography, types.QValueKindGeometry, types.QValueKindPoint:
 			castStmt = fmt.Sprintf("CAST(ST_GEOGFROMTEXT(JSON_VALUE(_peerdb_data, '$.%s')) AS %s) AS `%s`",
 				column.Name, bqTypeString, shortCol)
-		// MAKE_INTERVAL(years INT64, months INT64, days INT64, hours INT64, minutes INT64, seconds INT64)
-		// Expecting interval to be in the format of {"Microseconds":2000000,"Days":0,"Months":0,"Valid":true}
-		// json.Marshal in SyncRecords for Postgres already does this - once new data-stores are added,
-		// this needs to be handled again
-		// TODO add interval types again
-		// case model.ColumnTypeInterval:
-		// castStmt = fmt.Sprintf("MAKE_INTERVAL(0,CAST(JSON_VALUE(_peerdb_data, '$.%s.Months') AS INT64),"+
-		// 	"CAST(JSON_VALUE(_peerdb_data, '$.%s.Days') AS INT64),0,0,"+
-		// 	"CAST(CAST(JSON_VALUE(_peerdb_data, '$.%s.Microseconds') AS INT64)/1000000 AS  INT64)) AS %s",
-		// 	column.Name, column.Name, column.Name, column.Name)
-		// TODO add proper granularity for time types, then restore this
-		// case model.ColumnTypeTime:
-		// 	castStmt = fmt.Sprintf("time(timestamp_micros(CAST(JSON_VALUE(_peerdb_data, '$.%s.Microseconds')"+
-		// 		" AS int64))) AS %s",
-		// 		column.Name, column.Name)
 		default:
 			castStmt = fmt.Sprintf("CAST(JSON_VALUE(_peerdb_data, '$.%s') AS %s) AS `%s`",
 				column.Name, bqTypeString, shortCol)

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hamba/avro/v2"
 	"github.com/hamba/avro/v2/ocf"
 
-	avroutils "github.com/PeerDB-io/peerdb/flow/connectors/utils/avro"
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
@@ -358,8 +358,8 @@ func (s *QRepAvroSyncMethod) writeToStage(
 	stream *model.QRecordStream,
 	flowName string,
 ) (int64, error) {
-	var avroFile *avroutils.AvroFile
-	ocfWriter := avroutils.NewPeerDBOCFWriter(stream, avroSchema, ocf.Snappy, protos.DBType_BIGQUERY)
+	var avroFile *utils.AvroFile
+	ocfWriter := utils.NewPeerDBOCFWriter(stream, avroSchema, ocf.Snappy, protos.DBType_BIGQUERY)
 	idLog := slog.Group("write-metadata",
 		slog.String(string(shared.FlowNameKey), flowName),
 		slog.String("batchOrPartitionID", syncID),
@@ -378,9 +378,9 @@ func (s *QRepAvroSyncMethod) writeToStage(
 			return 0, fmt.Errorf("failed to close Avro file on GCS after writing: %w", err)
 		}
 
-		avroFile = &avroutils.AvroFile{
+		avroFile = &utils.AvroFile{
 			NumRecords:      numRecords,
-			StorageLocation: avroutils.AvroGCSStorage,
+			StorageLocation: utils.AvroGCSStorage,
 			FilePath:        avroFilePath,
 		}
 	} else {

--- a/flow/connectors/bigquery/qvalue_convert.go
+++ b/flow/connectors/bigquery/qvalue_convert.go
@@ -46,13 +46,10 @@ func qValueKindToBigQueryType(columnDescription *protos.FieldDescription, nullab
 	// time related
 	case types.QValueKindTimestamp, types.QValueKindTimestampTZ:
 		bqField.Type = bigquery.TimestampFieldType
-	// TODO: https://github.com/PeerDB-io/peerdb/issues/189 - DATE support is incomplete
 	case types.QValueKindDate:
 		bqField.Type = bigquery.DateFieldType
-	// TODO: https://github.com/PeerDB-io/peerdb/issues/189 - TIME/TIMETZ support is incomplete
 	case types.QValueKindTime, types.QValueKindTimeTZ:
 		bqField.Type = bigquery.TimeFieldType
-	// TODO: https://github.com/PeerDB-io/peerdb/issues/189 - handle INTERVAL types again,
 	// bytes
 	case types.QValueKindBytes:
 		bqField.Type = bigquery.BytesFieldType
@@ -76,7 +73,7 @@ func qValueKindToBigQueryType(columnDescription *protos.FieldDescription, nullab
 		bqField.Repeated = true
 	case types.QValueKindGeography, types.QValueKindGeometry, types.QValueKindPoint:
 		bqField.Type = bigquery.GeographyFieldType
-	// UUID related - stored as strings for now
+	// UUID related - stored as strings
 	case types.QValueKindUUID:
 		bqField.Type = bigquery.StringFieldType
 	case types.QValueKindArrayUUID:

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hamba/avro/v2/ocf"
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
-	avro "github.com/PeerDB-io/peerdb/flow/connectors/utils/avro"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
@@ -36,7 +35,7 @@ func NewClickHouseAvroSyncMethod(
 	}
 }
 
-func (s *ClickHouseAvroSyncMethod) CopyStageToDestination(ctx context.Context, avroFile *avro.AvroFile) error {
+func (s *ClickHouseAvroSyncMethod) CopyStageToDestination(ctx context.Context, avroFile *utils.AvroFile) error {
 	stagingPath := s.credsProvider.BucketPath
 	s3o, err := utils.NewS3BucketAndPrefix(stagingPath)
 	if err != nil {
@@ -155,7 +154,7 @@ func (s *ClickHouseAvroSyncMethod) pushDataToS3(
 	partition *protos.QRepPartition,
 	stream *model.QRecordStream,
 	destTypeConversions map[string]types.TypeConversion,
-) (*avro.AvroFile, error) {
+) (*utils.AvroFile, error) {
 	avroSchema, err := s.getAvroSchema(ctx, config.Env, dstTableName, schema, columnNameAvroFieldMap)
 	if err != nil {
 		return nil, err
@@ -166,9 +165,9 @@ func (s *ClickHouseAvroSyncMethod) pushDataToS3(
 		return nil, err
 	}
 
-	var avroFile *avro.AvroFile
+	var avroFile *utils.AvroFile
 	if avroChunking != 0 {
-		avroFile = &avro.AvroFile{
+		avroFile = &utils.AvroFile{
 			FilePath:   "",
 			NumRecords: 0,
 		}
@@ -347,9 +346,9 @@ func (s *ClickHouseAvroSyncMethod) writeToAvroFile(
 	identifierForFile string,
 	flowJobName string,
 	typeConversions map[string]types.TypeConversion,
-) (*avro.AvroFile, error) {
+) (*utils.AvroFile, error) {
 	stagingPath := s.credsProvider.BucketPath
-	ocfWriter := avro.NewPeerDBOCFWriter(stream, avroSchema, ocf.ZStandard, protos.DBType_CLICKHOUSE)
+	ocfWriter := utils.NewPeerDBOCFWriter(stream, avroSchema, ocf.ZStandard, protos.DBType_CLICKHOUSE)
 	s3o, err := utils.NewS3BucketAndPrefix(stagingPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse staging path: %w", err)

--- a/flow/connectors/clickhouse/s3_iam_role_test.go
+++ b/flow/connectors/clickhouse/s3_iam_role_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	avro "github.com/PeerDB-io/peerdb/flow/connectors/utils/avro"
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 )
 
@@ -56,9 +56,9 @@ func TestIAMRoleCanIssueSelectFromS3(t *testing.T) {
 	avroSync := NewClickHouseAvroSyncMethod(&protos.QRepConfig{
 		DestinationTableIdentifier: table.TableIdentifier,
 	}, conn)
-	require.NoError(t, avroSync.CopyStageToDestination(ctx, &avro.AvroFile{
+	require.NoError(t, avroSync.CopyStageToDestination(ctx, &utils.AvroFile{
 		FilePath:        "test-iam-role-can-issue-select-from-s3/datafile.avro.zst",
-		StorageLocation: avro.AvroS3Storage,
+		StorageLocation: utils.AvroS3Storage,
 		NumRecords:      3,
 	}))
 

--- a/flow/connectors/clickhouse/s3_stage.go
+++ b/flow/connectors/clickhouse/s3_stage.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	utils "github.com/PeerDB-io/peerdb/flow/connectors/utils/avro"
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -54,28 +54,15 @@ func qkindFromMysql(field *mysql.Field) (types.QValueKind, error) {
 		return types.QValueKindFloat64, nil
 	case mysql.MYSQL_TYPE_NULL:
 		return types.QValueKindInvalid, nil
-	case mysql.MYSQL_TYPE_TIMESTAMP:
-		return types.QValueKindTimestamp, nil
-	case mysql.MYSQL_TYPE_DATE:
+	case mysql.MYSQL_TYPE_DATE, mysql.MYSQL_TYPE_NEWDATE:
 		return types.QValueKindDate, nil
-	case mysql.MYSQL_TYPE_TIME:
-		return types.QValueKindTimestamp, nil
-	case mysql.MYSQL_TYPE_DATETIME:
+	case mysql.MYSQL_TYPE_TIMESTAMP, mysql.MYSQL_TYPE_TIME, mysql.MYSQL_TYPE_DATETIME,
+		mysql.MYSQL_TYPE_TIMESTAMP2, mysql.MYSQL_TYPE_DATETIME2, mysql.MYSQL_TYPE_TIME2:
 		return types.QValueKindTimestamp, nil
 	case mysql.MYSQL_TYPE_YEAR:
 		return types.QValueKindInt16, nil
-	case mysql.MYSQL_TYPE_NEWDATE:
-		return types.QValueKindDate, nil
-	case mysql.MYSQL_TYPE_VARCHAR:
-		return types.QValueKindString, nil
 	case mysql.MYSQL_TYPE_BIT:
 		return types.QValueKindInt64, nil
-	case mysql.MYSQL_TYPE_TIMESTAMP2:
-		return types.QValueKindTimestamp, nil
-	case mysql.MYSQL_TYPE_DATETIME2:
-		return types.QValueKindTimestamp, nil
-	case mysql.MYSQL_TYPE_TIME2:
-		return types.QValueKindTimestamp, nil
 	case mysql.MYSQL_TYPE_JSON:
 		return types.QValueKindJSON, nil
 	case mysql.MYSQL_TYPE_DECIMAL, mysql.MYSQL_TYPE_NEWDECIMAL:
@@ -90,7 +77,7 @@ func qkindFromMysql(field *mysql.Field) (types.QValueKind, error) {
 		} else {
 			return types.QValueKindString, nil
 		}
-	case mysql.MYSQL_TYPE_VAR_STRING, mysql.MYSQL_TYPE_STRING:
+	case mysql.MYSQL_TYPE_VAR_STRING, mysql.MYSQL_TYPE_STRING, mysql.MYSQL_TYPE_VARCHAR:
 		return types.QValueKindString, nil
 	case mysql.MYSQL_TYPE_GEOMETRY:
 		return types.QValueKindGeometry, nil
@@ -219,10 +206,11 @@ func processTime(str string) (time.Duration, error) {
 	}
 
 	sec := hpart*3600 + mpart*60 + spart
+	val := time.Duration(sec)*time.Second + time.Duration(nsec)
 	if isNeg {
-		return -time.Duration(sec)*time.Second - time.Duration(nsec), nil
+		return -val, nil
 	}
-	return time.Duration(sec)*time.Second + time.Duration(nsec), nil
+	return val, nil
 }
 
 func QValueFromMysqlFieldValue(qkind types.QValueKind, mytype byte, fv mysql.FieldValue) (types.QValue, error) {

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -170,6 +170,10 @@ func processTime(str string) (time.Duration, error) {
 		}
 	}
 
+	if nsec > 999999999 {
+		return 0, fmt.Errorf("nanoseconds (%d) should not exceed one second", nsec)
+	}
+
 	var err error
 	var spart, mpart, hpart uint64
 	h, ms, hasMS := strings.Cut(tpart, ":")

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -166,7 +166,7 @@ func processGeometryData(data []byte) types.QValueGeometry {
 }
 
 // https://dev.mysql.com/doc/refman/8.4/en/time.html
-func processTime(str string) (time.Time, error) {
+func processTime(str string) (time.Duration, error) {
 	abs, isNeg := strings.CutPrefix(str, "-")
 	tpart, frac, _ := strings.Cut(abs, ".")
 
@@ -174,7 +174,7 @@ func processTime(str string) (time.Time, error) {
 	if frac != "" {
 		fint, err := strconv.ParseUint(frac, 10, 64)
 		if err != nil {
-			return time.Time{}, err
+			return 0, err
 		}
 		if len(frac) <= 9 {
 			nsec = fint * uint64(math.Pow10(9-len(frac)))
@@ -215,14 +215,14 @@ func processTime(str string) (time.Time, error) {
 	}
 
 	if err != nil {
-		return time.Time{}, err
+		return 0, err
 	}
 
 	sec := hpart*3600 + mpart*60 + spart
 	if isNeg {
-		return time.Unix(-int64(sec), -int64(nsec)).UTC(), nil
+		return -time.Duration(sec)*time.Second - time.Duration(nsec), nil
 	}
-	return time.Unix(int64(sec), int64(nsec)).UTC(), nil
+	return time.Duration(sec)*time.Second + time.Duration(nsec), nil
 }
 
 func QValueFromMysqlFieldValue(qkind types.QValueKind, fv mysql.FieldValue) (types.QValue, error) {

--- a/flow/connectors/mysql/qvalue_convert_test.go
+++ b/flow/connectors/mysql/qvalue_convert_test.go
@@ -8,40 +8,42 @@ import (
 )
 
 func TestProcessTime(t *testing.T) {
+	epoch := time.Unix(0, 0).UTC()
+	//nolint:govet
 	for _, ts := range []struct {
-		out time.Time
+		out time.Duration
 		in  string
 	}{
-		{time.Date(1970, 1, 1, 23, 30, 0, 500000000, time.UTC), "23:30.5"},
-		{time.Date(1970, 2, 3, 8, 0, 1, 0, time.UTC), "800:0:1"},
-		{time.Date(1969, 11, 28, 15, 59, 59, 0, time.UTC), "-800:0:1"},
-		{time.Date(1969, 11, 28, 15, 59, 58, 900000000, time.UTC), "-800:0:1.1"},
-		{time.Date(1970, 1, 1, 0, 0, 1, 0, time.UTC), "1."},
-		{time.Date(1970, 1, 1, 0, 12, 34, 0, time.UTC), "1234"},
-		{time.Date(1970, 1, 1, 3, 12, 34, 0, time.UTC), "31234"},
-		{time.Date(1970, 1, 1, 0, 0, 1, 120000000, time.UTC), "1.12"},
-		{time.Date(1970, 1, 1, 0, 0, 1, 12000000, time.UTC), "1.012"},
-		{time.Date(1970, 1, 1, 0, 0, 1, 12300000, time.UTC), "1.0123"},
-		{time.Date(1970, 1, 1, 0, 0, 1, 1230000, time.UTC), "1.00123"},
-		{time.Date(1970, 1, 1, 0, 0, 1, 1000, time.UTC), "1.000001"},
-		{time.Date(1970, 1, 1, 0, 0, 1, 200, time.UTC), "1.0000002"},
-		{time.Date(1970, 1, 1, 0, 0, 1, 30, time.UTC), "1.00000003"},
-		{time.Date(1970, 1, 1, 0, 0, 1, 4, time.UTC), "1.000000004"},
-		{time.Time{}, "123.aa"},
-		{time.Time{}, "hh:00:00"},
-		{time.Time{}, "00:mm:00"},
-		{time.Time{}, "00:00:ss"},
-		{time.Time{}, "hh:00"},
-		{time.Time{}, "00:mm"},
-		{time.Time{}, "ss"},
-		{time.Time{}, "mm00"},
-		{time.Time{}, "00ss"},
-		{time.Time{}, "hh0000"},
-		{time.Time{}, "00mm00"},
-		{time.Time{}, "0000ss"},
+		{time.Date(1970, 1, 1, 23, 30, 0, 500000000, time.UTC).Sub(epoch), "23:30.5"},
+		{time.Date(1970, 2, 3, 8, 0, 1, 0, time.UTC).Sub(epoch), "800:0:1"},
+		{time.Date(1969, 11, 28, 15, 59, 59, 0, time.UTC).Sub(epoch), "-800:0:1"},
+		{time.Date(1969, 11, 28, 15, 59, 58, 900000000, time.UTC).Sub(epoch), "-800:0:1.1"},
+		{time.Date(1970, 1, 1, 0, 0, 1, 0, time.UTC).Sub(epoch), "1."},
+		{time.Date(1970, 1, 1, 0, 12, 34, 0, time.UTC).Sub(epoch), "1234"},
+		{time.Date(1970, 1, 1, 3, 12, 34, 0, time.UTC).Sub(epoch), "31234"},
+		{time.Date(1970, 1, 1, 0, 0, 1, 120000000, time.UTC).Sub(epoch), "1.12"},
+		{time.Date(1970, 1, 1, 0, 0, 1, 12000000, time.UTC).Sub(epoch), "1.012"},
+		{time.Date(1970, 1, 1, 0, 0, 1, 12300000, time.UTC).Sub(epoch), "1.0123"},
+		{time.Date(1970, 1, 1, 0, 0, 1, 1230000, time.UTC).Sub(epoch), "1.00123"},
+		{time.Date(1970, 1, 1, 0, 0, 1, 1000, time.UTC).Sub(epoch), "1.000001"},
+		{time.Date(1970, 1, 1, 0, 0, 1, 200, time.UTC).Sub(epoch), "1.0000002"},
+		{time.Date(1970, 1, 1, 0, 0, 1, 30, time.UTC).Sub(epoch), "1.00000003"},
+		{time.Date(1970, 1, 1, 0, 0, 1, 4, time.UTC).Sub(epoch), "1.000000004"},
+		{0, "123.aa"},
+		{0, "hh:00:00"},
+		{0, "00:mm:00"},
+		{0, "00:00:ss"},
+		{0, "hh:00"},
+		{0, "00:mm"},
+		{0, "ss"},
+		{0, "mm00"},
+		{0, "00ss"},
+		{0, "hh0000"},
+		{0, "00mm00"},
+		{0, "0000ss"},
 	} {
 		tm, err := processTime(ts.in)
-		if tm.IsZero() {
+		if tm == 0 {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -263,7 +263,7 @@ func (p *PostgresCDCSource) decodeColumnData(
 				dtOid == oid.T_timestamp || dtOid == oid.T_timestamptz {
 				// indicates year is more than 4 digits or something similar,
 				// which you can insert into postgres, but not representable by time.Time
-				p.logger.Warn("Invalidated time, nulled", slog.String("typeName", dt.Name), slog.String("value", string(data)))
+				p.logger.Warn("Invalidate time for destination, nulled", slog.String("typeName", dt.Name), slog.String("value", string(data)))
 				switch dtOid {
 				case oid.T_time:
 					return types.QValueNull(types.QValueKindTime), nil

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -262,10 +262,8 @@ func (p *PostgresCDCSource) decodeColumnData(
 			if dtOid == oid.T_time || dtOid == oid.T_timetz ||
 				dtOid == oid.T_timestamp || dtOid == oid.T_timestamptz {
 				// indicates year is more than 4 digits or something similar,
-				// which you can insert into postgres,
-				// but not representable by time.Time
-				p.logger.Warn(fmt.Sprintf("Invalidated and hence nulled %s data: %s",
-					dt.Name, string(data)))
+				// which you can insert into postgres, but not representable by time.Time
+				p.logger.Warn("Invalidated time, nulled", slog.String("typeName", dt.Name), slog.String("value", string(data)))
 				switch dtOid {
 				case oid.T_time:
 					return types.QValueNull(types.QValueKindTime), nil

--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -265,7 +265,7 @@ func (c *PostgresConnector) parseFieldFromPostgresOID(
 			return nil, fmt.Errorf("invalid interval: %v", value)
 		}
 
-		return types.QValueString{Val: string(intervalJSON)}, nil
+		return types.QValueInterval{Val: string(intervalJSON)}, nil
 	case types.QValueKindTSTZRange:
 		tstzrangeObject := value.(pgtype.Range[any])
 		lowerBoundType := tstzrangeObject.LowerType
@@ -280,17 +280,22 @@ func (c *PostgresConnector) parseFieldFromPostgresOID(
 			return nil, fmt.Errorf("[tstzrange]error for upper time bound: %w", err)
 		}
 
-		lowerBracket := "["
+		lowerBracket := byte('[')
 		if lowerBoundType == pgtype.Exclusive {
-			lowerBracket = "("
+			lowerBracket = '('
 		}
-		upperBracket := "]"
+		upperBracket := byte(']')
 		if upperBoundType == pgtype.Exclusive {
-			upperBracket = ")"
+			upperBracket = ')'
 		}
-		tstzrangeStr := fmt.Sprintf("%s%v,%v%s",
-			lowerBracket, lowerTime, upperTime, upperBracket)
-		return types.QValueTSTZRange{Val: tstzrangeStr}, nil
+		var sb strings.Builder
+		sb.Grow(len(lowerTime) + len(upperTime) + 3)
+		sb.WriteByte(lowerBracket)
+		sb.WriteString(lowerTime)
+		sb.WriteByte(',')
+		sb.WriteString(upperTime)
+		sb.WriteByte(upperBracket)
+		return types.QValueTSTZRange{Val: sb.String()}, nil
 	case types.QValueKindDate:
 		switch val := value.(type) {
 		case time.Time:
@@ -301,8 +306,7 @@ func (c *PostgresConnector) parseFieldFromPostgresOID(
 	case types.QValueKindTime:
 		timeVal := value.(pgtype.Time)
 		if timeVal.Valid {
-			// 86399999999 to prevent 24:00:00
-			return types.QValueTime{Val: time.UnixMicro(min(timeVal.Microseconds, 86399999999))}, nil
+			return types.QValueTime{Val: time.Duration(timeVal.Microseconds) * time.Microsecond}, nil
 		}
 	case types.QValueKindTimeTZ:
 		timeVal := value.(string)
@@ -325,7 +329,7 @@ func (c *PostgresConnector) parseFieldFromPostgresOID(
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse time: %w", err)
 		}
-		return types.QValueTimeTZ{Val: t.AddDate(1970, 0, 0)}, nil
+		return types.QValueTimeTZ{Val: t.Sub(time.Time{})}, nil
 	case types.QValueKindBoolean:
 		boolVal := value.(bool)
 		return types.QValueBoolean{Val: boolVal}, nil

--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -329,7 +329,7 @@ func (c *PostgresConnector) parseFieldFromPostgresOID(
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse time: %w", err)
 		}
-		return types.QValueTimeTZ{Val: t.Sub(shared.Year0000)}, nil
+		return types.QValueTimeTZ{Val: t.UTC().Sub(shared.Year0000)}, nil
 	case types.QValueKindBoolean:
 		boolVal := value.(bool)
 		return types.QValueBoolean{Val: boolVal}, nil

--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -329,7 +329,7 @@ func (c *PostgresConnector) parseFieldFromPostgresOID(
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse time: %w", err)
 		}
-		return types.QValueTimeTZ{Val: t.Sub(time.Time{})}, nil
+		return types.QValueTimeTZ{Val: t.Sub(shared.Year0000)}, nil
 	case types.QValueKindBoolean:
 		boolVal := value.(bool)
 		return types.QValueBoolean{Val: boolVal}, nil

--- a/flow/connectors/s3/qrep.go
+++ b/flow/connectors/s3/qrep.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hamba/avro/v2/ocf"
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
-	avro "github.com/PeerDB-io/peerdb/flow/connectors/utils/avro"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
@@ -82,7 +81,7 @@ func (c *S3Connector) writeToAvroFile(
 		return 0, fmt.Errorf("unsupported codec %s", c.codec)
 	}
 
-	writer := avro.NewPeerDBOCFWriter(stream, avroSchema, codec, protos.DBType_S3)
+	writer := utils.NewPeerDBOCFWriter(stream, avroSchema, codec, protos.DBType_S3)
 	avroFile, err := writer.WriteRecordsToS3(ctx, env, s3o.Bucket, s3AvroFileKey, c.credentialsProvider, nil, nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write records to S3: %w", err)

--- a/flow/connectors/snowflake/avro_file_writer_test.go
+++ b/flow/connectors/snowflake/avro_file_writer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 
-	avro "github.com/PeerDB-io/peerdb/flow/connectors/utils/avro"
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
@@ -41,9 +41,9 @@ func createQValue(t *testing.T, kind types.QValueKind, placeholder int) types.QV
 	case types.QValueKindTimestampTZ:
 		return types.QValueTimestampTZ{Val: time.Now()}
 	case types.QValueKindTime:
-		return types.QValueTime{Val: time.Now()}
+		return types.QValueTime{Val: 21600000000}
 	case types.QValueKindTimeTZ:
-		return types.QValueTimeTZ{Val: time.Now()}
+		return types.QValueTimeTZ{Val: 21600000000}
 	case types.QValueKindDate:
 		return types.QValueDate{Val: time.Now()}
 	case types.QValueKindNumeric:
@@ -152,7 +152,7 @@ func TestWriteRecordsToAvroFileHappyPath(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(records, avroSchema, ocf.Null, protos.DBType_SNOWFLAKE)
+	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.Null, protos.DBType_SNOWFLAKE)
 	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
@@ -179,7 +179,7 @@ func TestWriteRecordsToZstdAvroFileHappyPath(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(records, avroSchema, ocf.ZStandard, protos.DBType_SNOWFLAKE)
+	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.ZStandard, protos.DBType_SNOWFLAKE)
 	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
@@ -206,7 +206,7 @@ func TestWriteRecordsToDeflateAvroFileHappyPath(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(records, avroSchema, ocf.Deflate, protos.DBType_SNOWFLAKE)
+	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.Deflate, protos.DBType_SNOWFLAKE)
 	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
@@ -232,7 +232,7 @@ func TestWriteRecordsToAvroFileNonNull(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(records, avroSchema, ocf.Null, protos.DBType_SNOWFLAKE)
+	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.Null, protos.DBType_SNOWFLAKE)
 	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
@@ -259,7 +259,7 @@ func TestWriteRecordsToAvroFileAllNulls(t *testing.T) {
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
-	writer := avro.NewPeerDBOCFWriter(records, avroSchema, ocf.Null, protos.DBType_SNOWFLAKE)
+	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.Null, protos.DBType_SNOWFLAKE)
 	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 

--- a/flow/connectors/snowflake/client.go
+++ b/flow/connectors/snowflake/client.go
@@ -233,7 +233,10 @@ func toQValue(kind types.QValueKind, val any) (types.QValue, error) {
 				tt := t.Time
 				// anchor on unix epoch, some drivers anchor on 0001-01-01
 				return types.QValueTime{
-					Val: time.Date(1970, time.January, 1, tt.Hour(), tt.Minute(), tt.Second(), tt.Nanosecond(), time.UTC),
+					Val: time.Duration(tt.Hour())*time.Hour +
+						time.Duration(tt.Minute())*time.Minute +
+						time.Duration(tt.Second())*time.Second +
+						time.Duration(tt.Nanosecond())*time.Nanosecond,
 				}, nil
 			} else {
 				return types.QValueNull(kind), nil

--- a/flow/connectors/snowflake/client.go
+++ b/flow/connectors/snowflake/client.go
@@ -231,12 +231,12 @@ func toQValue(kind types.QValueKind, val any) (types.QValue, error) {
 		if t, ok := val.(*sql.NullTime); ok {
 			if t.Valid {
 				tt := t.Time
-				// anchor on unix epoch, some drivers anchor on 0001-01-01
+				h, m, s := tt.Clock()
 				return types.QValueTime{
-					Val: time.Duration(tt.Hour())*time.Hour +
-						time.Duration(tt.Minute())*time.Minute +
-						time.Duration(tt.Second())*time.Second +
-						time.Duration(tt.Nanosecond())*time.Nanosecond,
+					Val: time.Duration(h)*time.Hour +
+						time.Duration(m)*time.Minute +
+						time.Duration(s)*time.Second +
+						time.Duration(tt.Nanosecond()),
 				}, nil
 			} else {
 				return types.QValueNull(kind), nil

--- a/flow/connectors/snowflake/merge_stmt_generator.go
+++ b/flow/connectors/snowflake/merge_stmt_generator.go
@@ -58,11 +58,6 @@ func (m *mergeStmtGenerator) generateMergeStmt(ctx context.Context, env map[stri
 			flattenedCastsSQLArray = append(flattenedCastsSQLArray,
 				fmt.Sprintf("PARSE_JSON(CAST(%s:\"%s\" AS STRING)) AS %s",
 					toVariantColumnName, column.Name, targetColumnName))
-		// TODO: https://github.com/PeerDB-io/peerdb/issues/189 - handle time types and interval types
-		// case model.ColumnTypeTime:
-		// 	flattenedCastsSQLArray = append(flattenedCastsSQLArray, fmt.Sprintf("TIME_FROM_PARTS(0,0,0,%s:%s:"+
-		// 		"Microseconds*1000) "+
-		// 		"AS %s", toVariantColumnName, columnName, columnName))
 		case types.QValueKindNumeric:
 			precision, scale := numeric.GetNumericTypeForWarehouse(column.TypeModifier, numeric.SnowflakeNumericCompatibility{})
 			numericType := fmt.Sprintf("NUMERIC(%d,%d)", precision, scale)

--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -13,7 +13,6 @@ import (
 	_ "github.com/snowflakedb/gosnowflake"
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
-	avro "github.com/PeerDB-io/peerdb/flow/connectors/utils/avro"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -151,9 +150,9 @@ func (s *SnowflakeAvroSyncHandler) writeToAvroFile(
 	avroSchema *model.QRecordAvroSchemaDefinition,
 	partitionID string,
 	flowJobName string,
-) (*avro.AvroFile, error) {
+) (*utils.AvroFile, error) {
 	if s.config.StagingPath == "" {
-		ocfWriter := avro.NewPeerDBOCFWriter(stream, avroSchema, ocf.ZStandard, protos.DBType_SNOWFLAKE)
+		ocfWriter := utils.NewPeerDBOCFWriter(stream, avroSchema, ocf.ZStandard, protos.DBType_SNOWFLAKE)
 		tmpDir := fmt.Sprintf("%s/peerdb-avro-%s", os.TempDir(), flowJobName)
 		err := os.MkdirAll(tmpDir, os.ModePerm)
 		if err != nil {
@@ -169,7 +168,7 @@ func (s *SnowflakeAvroSyncHandler) writeToAvroFile(
 
 		return avroFile, nil
 	} else if strings.HasPrefix(s.config.StagingPath, "s3://") {
-		ocfWriter := avro.NewPeerDBOCFWriter(stream, avroSchema, ocf.ZStandard, protos.DBType_SNOWFLAKE)
+		ocfWriter := utils.NewPeerDBOCFWriter(stream, avroSchema, ocf.ZStandard, protos.DBType_SNOWFLAKE)
 		s3o, err := utils.NewS3BucketAndPrefix(s.config.StagingPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse staging path: %w", err)
@@ -194,8 +193,8 @@ func (s *SnowflakeAvroSyncHandler) writeToAvroFile(
 	return nil, fmt.Errorf("unsupported staging path: %s", s.config.StagingPath)
 }
 
-func (s *SnowflakeAvroSyncHandler) putFileToStage(ctx context.Context, avroFile *avro.AvroFile, stage string) error {
-	if avroFile.StorageLocation != avro.AvroLocalStorage {
+func (s *SnowflakeAvroSyncHandler) putFileToStage(ctx context.Context, avroFile *utils.AvroFile, stage string) error {
+	if avroFile.StorageLocation != utils.AvroLocalStorage {
 		s.logger.Info("no file to put to stage")
 		return nil
 	}

--- a/flow/connectors/utils/avro_writer.go
+++ b/flow/connectors/utils/avro_writer.go
@@ -18,7 +18,6 @@ import (
 	"github.com/djherbis/nio/v3"
 	"github.com/hamba/avro/v2/ocf"
 
-	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
@@ -96,12 +95,12 @@ func (p *peerDBOCFWriter) WriteRecordsToS3(
 	env map[string]string,
 	bucketName string,
 	key string,
-	s3Creds utils.AWSCredentialsProvider,
+	s3Creds AWSCredentialsProvider,
 	avroSize *atomic.Int64,
 	typeConversions map[string]types.TypeConversion,
 ) (*AvroFile, error) {
 	logger := internal.LoggerFromCtx(ctx)
-	s3svc, err := utils.CreateS3Client(ctx, s3Creds)
+	s3svc, err := CreateS3Client(ctx, s3Creds)
 	if err != nil {
 		logger.Error("failed to create S3 client", slog.Any("error", err))
 		return nil, fmt.Errorf("failed to create S3 client: %w", err)

--- a/flow/connectors/utils/cdc_store_test.go
+++ b/flow/connectors/utils/cdc_store_test.go
@@ -13,24 +13,10 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
-func getTimeForTesting(t *testing.T) time.Time {
-	t.Helper()
-	tv, err := time.Parse(time.RFC3339, "2021-08-01T08:02:00Z")
-	require.NoError(t, err)
-
-	millisToAdd := 716
-	tv = tv.Add(time.Millisecond * time.Duration(millisToAdd))
-
-	microSecondsToAdd := 506
-	tv = tv.Add(time.Microsecond * time.Duration(microSecondsToAdd))
-
-	return tv
-}
-
-func getDecimalForTesting(t *testing.T) decimal.Decimal {
-	t.Helper()
-	return decimal.New(9876543210, 123)
-}
+var (
+	timeForTesting    = time.Duration(18342121716506000)
+	decimalForTesting = decimal.New(9876543210, 123)
+)
 
 func genKeyAndRec(t *testing.T) (model.TableWithPkey, model.Record[model.RecordItems]) {
 	t.Helper()
@@ -39,8 +25,8 @@ func genKeyAndRec(t *testing.T) (model.TableWithPkey, model.Record[model.RecordI
 	_, err := rand.Read(pkeyColVal)
 	require.NoError(t, err)
 
-	tv := getTimeForTesting(t)
-	rv := getDecimalForTesting(t)
+	tv := timeForTesting
+	rv := decimalForTesting
 
 	key := model.TableWithPkey{
 		TableName:  "test_src_tbl",

--- a/flow/e2e/bigquery/bigquery_helper.go
+++ b/flow/e2e/bigquery/bigquery_helper.go
@@ -187,8 +187,10 @@ func toQValue(bqValue bigquery.Value) (types.QValue, error) {
 	case civil.Date:
 		return types.QValueDate{Val: v.In(time.UTC)}, nil
 	case civil.Time:
-		tm := time.Unix(int64(v.Hour)*3600+int64(v.Minute)*60+int64(v.Second), int64(v.Nanosecond))
-		return types.QValueTime{Val: tm}, nil
+		return types.QValueTime{Val: time.Duration(v.Hour)*time.Hour +
+			time.Duration(v.Minute)*time.Minute +
+			time.Duration(v.Second)*time.Second +
+			time.Duration(v.Nanosecond)*time.Nanosecond}, nil
 	case time.Time:
 		return types.QValueTimestamp{Val: v}, nil
 	case *big.Rat:

--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -185,7 +185,7 @@ func (s *MySqlSource) GetRows(ctx context.Context, suffix string, table string, 
 	for _, row := range rs.Values {
 		record := make([]types.QValue, 0, len(row))
 		for idx, val := range row {
-			qv, err := connmysql.QValueFromMysqlFieldValue(schema.Fields[idx].Type, val)
+			qv, err := connmysql.QValueFromMysqlFieldValue(schema.Fields[idx].Type, rs.Fields[idx].Type, val)
 			if err != nil {
 				return nil, err
 			}

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -158,7 +158,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 	// c36 lost tz info so does not compare equal
 	var c36 string
 	require.NoError(s.t, s.Conn().QueryRow(s.t.Context(), "select c36 from "+dstTableName).Scan(&c36))
-	require.Equal(s.t, "09:25:00+00", c36)
+	require.Equal(s.t, "06:25:00+00", c36)
 
 	env.Cancel(s.t.Context())
 	e2e.RequireEnvCanceled(s.t, env)

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -149,7 +149,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 	allCols := strings.Join([]string{
 		"c1", "c2", "c4",
 		"c40", "id", "c9", "c11", "c12", "c13", "c14", "c15",
-		"c21", "c29", "c33", "c34", "c35", "c36", "c37",
+		"c21", "c29", "c33", "c34", "c35", "c37",
 		"c7", "c8", "c32", "c42", "c43", "c44", "c45", "c46", "c47", "c48", "c49", "c50",
 	}, ",")
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "normalize types", func() bool {
@@ -159,6 +159,10 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 		}
 		return err == nil
 	})
+	// c36 converted to UTC, losing tz info, so does not compare equal
+	var c36 string
+	require.NoError(s.t, s.Conn().QueryRow(s.t.Context(), "select c36 from "+dstTableName).Scan(&c36))
+	require.Equal(s.t, "06:25:00+00", c36)
 
 	env.Cancel(s.t.Context())
 	e2e.RequireEnvCanceled(s.t, env)

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -153,7 +153,11 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 		"c7", "c8", "c32", "c42", "c43", "c44", "c45", "c46", "c47", "c48", "c49", "c50",
 	}, ",")
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "normalize types", func() bool {
-		return s.comparePGTables(srcTableName, dstTableName, allCols) == nil
+		err := s.comparePGTables(srcTableName, dstTableName, allCols)
+		if err != nil {
+			s.t.Log("QQQ", err)
+		}
+		return err == nil
 	})
 
 	env.Cancel(s.t.Context())

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -149,16 +149,12 @@ func (s PeerFlowE2ETestSuitePG) Test_Types_PG() {
 	allCols := strings.Join([]string{
 		"c1", "c2", "c4",
 		"c40", "id", "c9", "c11", "c12", "c13", "c14", "c15",
-		"c21", "c29", "c33", "c34", "c35", "c37",
+		"c21", "c29", "c33", "c34", "c35", "c36", "c37",
 		"c7", "c8", "c32", "c42", "c43", "c44", "c45", "c46", "c47", "c48", "c49", "c50",
 	}, ",")
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "normalize types", func() bool {
 		return s.comparePGTables(srcTableName, dstTableName, allCols) == nil
 	})
-	// c36 lost tz info so does not compare equal
-	var c36 string
-	require.NoError(s.t, s.Conn().QueryRow(s.t.Context(), "select c36 from "+dstTableName).Scan(&c36))
-	require.Equal(s.t, "06:25:00+00", c36)
 
 	env.Cancel(s.t.Context())
 	e2e.RequireEnvCanceled(s.t, env)

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -522,8 +522,7 @@ func (s PeerFlowE2ETestSuitePG) TestTransform() {
 	tc := e2e.NewTemporalClient(s.t)
 	env := e2e.RunQRepFlowWorkflow(s.t.Context(), tc, qrepConfig)
 	e2e.EnvWaitFor(s.t, env, 3*time.Minute, "waiting for first sync to complete", func() bool {
-		err := s.compareCounts(dstSchemaQualified, int64(numRows))
-		return err == nil
+		return s.compareCounts(dstSchemaQualified, int64(numRows)) == nil
 	})
 	require.NoError(s.t, env.Error(s.t.Context()))
 

--- a/flow/e2e/postgres/qrep_flow_pg_test.go
+++ b/flow/e2e/postgres/qrep_flow_pg_test.go
@@ -238,8 +238,7 @@ func (s PeerFlowE2ETestSuitePG) Test_PG_TypeSystemQRep() {
 	e2e.EnvWaitForFinished(s.t, env, 3*time.Minute)
 	require.NoError(s.t, env.Error(s.t.Context()))
 
-	err = s.comparePGTables(srcSchemaQualified, dstSchemaQualified, "*")
-	require.NoError(s.t, err)
+	require.NoError(s.t, s.comparePGTables(srcSchemaQualified, dstSchemaQualified, "*"))
 }
 
 func (s PeerFlowE2ETestSuitePG) Test_PeerDB_Columns_QRep_PG() {

--- a/flow/model/qrecord_copy_from_source.go
+++ b/flow/model/qrecord_copy_from_source.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -98,7 +99,7 @@ func (src *QRecordCopyFromSource) Values() ([]any, error) {
 		case types.QValueMacaddr:
 			values[i] = v.Val
 		case types.QValueTime:
-			values[i] = pgtype.Time{Microseconds: v.Val.UnixMicro(), Valid: true}
+			values[i] = pgtype.Time{Microseconds: int64(v.Val / time.Microsecond), Valid: true}
 		case types.QValueTSTZRange:
 			values[i] = v.Val
 		case types.QValueTimestamp:

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -313,15 +313,10 @@ func (c *QValueAvroConverter) processGoTime(t time.Duration) any {
 	// Snowflake has issues with avro timestamp types, returning as string form
 	// See: https://stackoverflow.com/questions/66104762/snowflake-date-column-have-incorrect-date-from-avro-file
 	if c.TargetDWH == protos.DBType_SNOWFLAKE {
-		t = max(min(t, 86399999999), 0)
+		t = max(min(t, 86399999999*time.Microsecond), 0)
 		return time.Time{}.Add(t).Format("15:04:05.999999")
-	} else if c.TargetDWH == protos.DBType_BIGQUERY {
-		return max(min(t, 86399999999), 0)
-	} else if c.TargetDWH == protos.DBType_POSTGRES {
-		return max(min(t, 86400000000), 0)
-	} else {
-		return t
 	}
+	return t
 }
 
 func (c *QValueAvroConverter) processGoTimestampTZ(t time.Time) any {

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -314,7 +314,7 @@ func (c *QValueAvroConverter) processGoTime(t time.Duration) any {
 	// See: https://stackoverflow.com/questions/66104762/snowflake-date-column-have-incorrect-date-from-avro-file
 	if c.TargetDWH == protos.DBType_SNOWFLAKE {
 		t = max(min(t, 86399999999), 0)
-		return time.Unix(0, 0).UTC().Add(t).Format("15:04:05.999999")
+		return time.Time{}.Add(t).Format("15:04:05.999999")
 	} else if c.TargetDWH == protos.DBType_BIGQUERY {
 		return max(min(t, 86399999999), 0)
 	} else if c.TargetDWH == protos.DBType_POSTGRES {

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -219,7 +219,7 @@ func QValueToAvro(
 	case types.QValueTime:
 		return c.processNullableUnion(c.processGoTime(v.Val))
 	case types.QValueTimeTZ:
-		return c.processNullableUnion(c.processGoTimeTZ(v.Val))
+		return c.processNullableUnion(c.processGoTime(v.Val))
 	case types.QValueTimestamp:
 		return c.processNullableUnion(c.processGoTimestamp(v.Val))
 	case types.QValueTimestampTZ:
@@ -309,22 +309,19 @@ func QValueToAvro(
 	}
 }
 
-func (c *QValueAvroConverter) processGoTimeTZ(t time.Time) any {
+func (c *QValueAvroConverter) processGoTime(t time.Duration) any {
 	// Snowflake has issues with avro timestamp types, returning as string form
 	// See: https://stackoverflow.com/questions/66104762/snowflake-date-column-have-incorrect-date-from-avro-file
 	if c.TargetDWH == protos.DBType_SNOWFLAKE {
-		return t.Format("15:04:05.999999-0700")
+		t = max(min(t, 86399999999), 0)
+		return time.Unix(0, 0).UTC().Add(t).Format("15:04:05.999999")
+	} else if c.TargetDWH == protos.DBType_BIGQUERY {
+		return max(min(t, 86399999999), 0)
+	} else if c.TargetDWH == protos.DBType_POSTGRES {
+		return max(min(t, 86400000000), 0)
+	} else {
+		return t
 	}
-	return time.Duration(t.UnixMicro()) * time.Microsecond
-}
-
-func (c *QValueAvroConverter) processGoTime(t time.Time) any {
-	// Snowflake has issues with avro timestamp types, returning as string form
-	// See: https://stackoverflow.com/questions/66104762/snowflake-date-column-have-incorrect-date-from-avro-file
-	if c.TargetDWH == protos.DBType_SNOWFLAKE {
-		return t.Format("15:04:05.999999")
-	}
-	return time.Duration(t.UnixMicro()) * time.Microsecond
 }
 
 func (c *QValueAvroConverter) processGoTimestampTZ(t time.Time) any {

--- a/flow/model/qvalue/equals.go
+++ b/flow/model/qvalue/equals.go
@@ -178,14 +178,12 @@ func compareGoTime(value1, value2 any) bool {
 	if !ok1 {
 		var tm time.Time
 		tm, ok1 = value1.(time.Time)
-		h, m, s := tm.Clock()
-		t1 = time.Duration(h)*time.Hour + time.Duration(m)*time.Minute + time.Duration(s)*time.Second
+		t1 = tm.Sub(time.Unix(0, 0).UTC())
 	}
 	if !ok2 {
 		var tm time.Time
 		tm, ok2 = value2.(time.Time)
-		h, m, s := tm.Clock()
-		t2 = time.Duration(h)*time.Hour + time.Duration(m)*time.Minute + time.Duration(s)*time.Second
+		t2 = tm.Sub(time.Unix(0, 0).UTC())
 	}
 
 	return ok1 && ok2 && t1 == t2

--- a/flow/model/qvalue/equals.go
+++ b/flow/model/qvalue/equals.go
@@ -172,16 +172,23 @@ func compareGoTimestamp(value1, value2 any) bool {
 }
 
 func compareGoTime(value1, value2 any) bool {
-	t1, ok1 := value1.(time.Time)
-	t2, ok2 := value2.(time.Time)
+	t1, ok1 := value1.(time.Duration)
+	t2, ok2 := value2.(time.Duration)
 
-	if !ok1 || !ok2 {
-		return false
+	if !ok1 {
+		var tm time.Time
+		tm, ok1 = value1.(time.Time)
+		h, m, s := tm.Clock()
+		t1 = time.Duration(h)*time.Hour + time.Duration(m)*time.Minute + time.Duration(s)*time.Second
+	}
+	if !ok2 {
+		var tm time.Time
+		tm, ok2 = value2.(time.Time)
+		h, m, s := tm.Clock()
+		t2 = time.Duration(h)*time.Hour + time.Duration(m)*time.Minute + time.Duration(s)*time.Second
 	}
 
-	h1, m1, s1 := t1.Clock()
-	h2, m2, s2 := t2.Clock()
-	return h1 == h2 && m1 == m2 && s1 == s2
+	return ok1 && ok2 && t1 == t2
 }
 
 func compareGoDate(value1, value2 any) bool {

--- a/flow/model/record_items.go
+++ b/flow/model/record_items.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/PeerDB-io/peerdb/flow/shared/datatypes"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
@@ -138,9 +139,9 @@ func (r RecordItems) toMap(opts ToJSONOptions) (map[string]any, error) {
 		case types.QValueDate:
 			jsonStruct[col] = v.Val.Format("2006-01-02")
 		case types.QValueTime:
-			jsonStruct[col] = v.Val.Format("15:04:05.999999")
+			jsonStruct[col] = time.Time{}.Add(v.Val).Format("15:04:05.999999")
 		case types.QValueTimeTZ:
-			jsonStruct[col] = v.Val.Format("15:04:05.999999")
+			jsonStruct[col] = time.Time{}.Add(v.Val).Format("15:04:05.999999")
 		case types.QValueArrayDate:
 			dateArr := v.Val
 			formattedDateArr := make([]string, 0, len(dateArr))

--- a/flow/pua/peerdb.go
+++ b/flow/pua/peerdb.go
@@ -175,6 +175,20 @@ func LVAsTime(ls *lua.LState, lv lua.LValue) time.Time {
 	return time.Time{}
 }
 
+func LVAsDuration(ls *lua.LState, lv lua.LValue) time.Duration {
+	switch v := lv.(type) {
+	case lua.LNumber:
+		ipart, fpart := math.Modf(float64(v))
+		return time.Duration(ipart)*time.Second + time.Duration(fpart*1e9)
+	case *lua.LUserData:
+		if tm, ok := v.Value.(time.Time); ok {
+			return tm.Sub(time.Unix(0, 0))
+		}
+	}
+	ls.RaiseError("Cannot convert %T to time.Time", lv)
+	return 0
+}
+
 func LuaRowNewIndex(ls *lua.LState) int {
 	_, row := LuaRow.Check(ls, 1)
 	key := ls.CheckString(2)
@@ -258,9 +272,9 @@ func LuaRowNewIndex(ls *lua.LState) int {
 	case types.QValueKindDate:
 		newqv = types.QValueDate{Val: LVAsTime(ls, val)}
 	case types.QValueKindTime:
-		newqv = types.QValueTime{Val: LVAsTime(ls, val)}
+		newqv = types.QValueTime{Val: LVAsDuration(ls, val)}
 	case types.QValueKindTimeTZ:
-		newqv = types.QValueTimeTZ{Val: LVAsTime(ls, val)}
+		newqv = types.QValueTimeTZ{Val: LVAsDuration(ls, val)}
 	case types.QValueKindNumeric:
 		newqv = types.QValueNumeric{Val: LVAsDecimal(ls, val)}
 	case types.QValueKindBytes:

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -1,8 +1,12 @@
 package shared
 
 import (
+	"time"
+
 	"go.temporal.io/sdk/temporal"
 )
+
+var Year0000 = time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC)
 
 type (
 	ContextKey  string

--- a/flow/shared/mysql/type_conversion.go
+++ b/flow/shared/mysql/type_conversion.go
@@ -21,9 +21,7 @@ func QkindFromMysqlColumnType(ct string) (types.QValueKind, error) {
 		return types.QValueKindBytes, nil
 	case "date":
 		return types.QValueKindDate, nil
-	case "time":
-		return types.QValueKindTime, nil
-	case "datetime", "timestamp":
+	case "datetime", "timestamp", "time":
 		return types.QValueKindTimestamp, nil
 	case "decimal", "numeric":
 		return types.QValueKindNumeric, nil

--- a/flow/shared/types/qvalue.go
+++ b/flow/shared/types/qvalue.go
@@ -321,7 +321,7 @@ func (v QValueDate) LValue(ls *lua.LState) lua.LValue {
 }
 
 type QValueTime struct {
-	Val time.Time
+	Val time.Duration
 }
 
 func (QValueTime) Kind() QValueKind {
@@ -333,11 +333,11 @@ func (v QValueTime) Value() any {
 }
 
 func (v QValueTime) LValue(ls *lua.LState) lua.LValue {
-	return shared.LuaTime.New(ls, v.Val)
+	return shared.LuaTime.New(ls, time.Unix(0, 0).UTC().Add(v.Val))
 }
 
 type QValueTimeTZ struct {
-	Val time.Time
+	Val time.Duration
 }
 
 func (QValueTimeTZ) Kind() QValueKind {
@@ -349,7 +349,7 @@ func (v QValueTimeTZ) Value() any {
 }
 
 func (v QValueTimeTZ) LValue(ls *lua.LState) lua.LValue {
-	return shared.LuaTime.New(ls, v.Val)
+	return shared.LuaTime.New(ls, time.Unix(0, 0).UTC().Add(v.Val))
 }
 
 type QValueInterval struct {


### PR DESCRIPTION
MySQL should instead map `time` to `QValueTimestamp` since `QValueTime` maps to types on destinations where time is expected to be the time part of a datetime (ie, from 00:00 up to 24:00). Keep existing QValueTime handling to not break existing mirrors. Note these existing mirrors have a problem where in cdc they will have time be modulos 24 hours

Another issue was that postgres time values over cdc on clickhouse were coming in with current year instead of unix epoch. This is because we relied on `parseDateTime64BestEffort` which interprets times without dates as happening in current year (or previous year in some cases). Adjust normalization to have year be 1970 in order to be consistent between qrep & cdc

This also helps allow in the future mapping QValueTime to DateTime instead of DateTime64

Adjust tests to not be so permissive, which let these discrepancies exist, but which going forward we should prevent