### PR TITLE
mysql: don't update gset on QueryEvent

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -389,7 +389,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 			"syncBatchID", req.SyncBatchID)
 		batchIdToLoadForTable := max(normBatchID, normalizeBatchIDForTable)
 		if batchIdToLoadForTable >= req.SyncBatchID {
-			c.logger.Info("[clickhouse] "+tbl+" already synced to destination for this batch, skipping",
+			c.logger.Info("[clickhouse] table already synced to destination for this batch, skipping",
 				"table", tbl, "batchIdToLoadForTable", batchIdToLoadForTable, "syncBatchID", req.SyncBatchID)
 			continue
 		}

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -452,14 +452,9 @@ func (c *MySqlConnector) PullRecords(
 				c.logger.Info("rotate", slog.String("name", pos.Name), slog.Uint64("pos", uint64(pos.Pos)))
 			}
 		case *replication.QueryEvent:
-			if !inTx {
-				if gset != nil {
-					gset = ev.GSet
-					req.RecordStream.UpdateLatestCheckpointText(gset.String())
-				} else if event.Header.LogPos > pos.Pos {
-					pos.Pos = event.Header.LogPos
-					req.RecordStream.UpdateLatestCheckpointText(fmt.Sprintf("!f:%s,%x", pos.Name, pos.Pos))
-				}
+			if !inTx && gset == nil && event.Header.LogPos > pos.Pos {
+				pos.Pos = event.Header.LogPos
+				req.RecordStream.UpdateLatestCheckpointText(fmt.Sprintf("!f:%s,%x", pos.Name, pos.Pos))
 			}
 			if mysqlParser == nil {
 				mysqlParser = parser.New()


### PR DESCRIPTION
there's a sequence of events where we miss transaction we care about
if query event comes in transaction before we see row data we care about