### PR TITLE
mongo: implement connector interface for fetching schemas

### DIFF
--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -93,8 +93,8 @@ func (h *FlowRequestHandler) ListPeers(
 ) (*protos.ListPeersResponse, error) {
 	query := "SELECT name, type FROM peers"
 	if internal.PeerDBOnlyClickHouseAllowed() {
-		// only postgres, mysql, and clickhouse
-		query += " WHERE type IN (3, 7, 8)"
+		// only postgres, mysql, mongo,and clickhouse
+		query += " WHERE type IN (2, 3, 7, 8)"
 	}
 	rows, err := h.pool.Query(ctx, query)
 	if err != nil {
@@ -113,10 +113,10 @@ func (h *FlowRequestHandler) ListPeers(
 	sourceItems := make([]*protos.PeerListItem, 0, len(peers))
 	destinationItems := make([]*protos.PeerListItem, 0, len(peers))
 	for _, peer := range peers {
-		if peer.Type == protos.DBType_POSTGRES || peer.Type == protos.DBType_MYSQL {
+		if peer.Type == protos.DBType_POSTGRES || peer.Type == protos.DBType_MYSQL || peer.Type == protos.DBType_MONGO {
 			sourceItems = append(sourceItems, peer)
 		}
-		if peer.Type != protos.DBType_MYSQL && (!internal.PeerDBOnlyClickHouseAllowed() || peer.Type == protos.DBType_CLICKHOUSE) {
+		if peer.Type != protos.DBType_MYSQL && peer.Type != protos.DBType_MONGO && (!internal.PeerDBOnlyClickHouseAllowed() || peer.Type == protos.DBType_CLICKHOUSE) {
 			destinationItems = append(destinationItems, peer)
 		}
 	}

--- a/flow/connectors/mongo/schema.go
+++ b/flow/connectors/mongo/schema.go
@@ -1,0 +1,97 @@
+package connmongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (c *MongoConnector) GetAllTables(ctx context.Context) (*protos.AllTablesResponse, error) {
+	tableNames := make([]string, 0)
+
+	dbNames, err := c.getAllDatabaseNames(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get databases: %w", err)
+	}
+	tableNames = append(tableNames, dbNames...)
+	return &protos.AllTablesResponse{
+		Tables: tableNames,
+	}, nil
+}
+
+func (c *MongoConnector) GetSchemas(ctx context.Context) (*protos.PeerSchemasResponse, error) {
+	dbNames, err := c.getAllDatabaseNames(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get databases: %w", err)
+	}
+	return &protos.PeerSchemasResponse{
+		Schemas: dbNames,
+	}, nil
+}
+
+func (c *MongoConnector) GetTablesInSchema(ctx context.Context, schema string, cdcEnabled bool) (*protos.SchemaTablesResponse, error) {
+	db := c.client.Database(schema)
+	collectionNames, err := db.ListCollectionNames(ctx, bson.D{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get collections: %w", err)
+	}
+
+	response := protos.SchemaTablesResponse{
+		Tables: make([]*protos.TableResponse, 0, len(collectionNames)),
+	}
+
+	for _, collectionName := range collectionNames {
+		tableResp := &protos.TableResponse{
+			TableName: collectionName,
+			CanMirror: true,
+			// TODO: implement TableSize fetching
+			TableSize: "",
+		}
+		response.Tables = append(response.Tables, tableResp)
+	}
+
+	return &response, nil
+}
+
+// TODO: replace placeholder values, how should we displace source columns in mongodb?
+func (c *MongoConnector) GetColumns(ctx context.Context, schema string, table string) (*protos.TableColumnsResponse, error) {
+	return &protos.TableColumnsResponse{
+		Columns: []*protos.ColumnsItem{
+			{
+				Name:  "_id",
+				Type:  "ObjectId",
+				IsKey: true,
+			},
+			{
+				Name:  "_full_document",
+				Type:  "string",
+				IsKey: false,
+			},
+		},
+	}, nil
+}
+
+// Get all database names, but excluding MongoDB's default databases
+func (c *MongoConnector) getAllDatabaseNames(ctx context.Context) ([]string, error) {
+	// TODO: investigate why query fails when this logic is added to the filter
+	excludedDatabaseSet := map[string]bool{
+		"config": true,
+		"admin":  true,
+		"local":  true,
+	}
+	filter := bson.D{}
+	dbs, err := c.client.ListDatabaseNames(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	var filteredDbNames []string
+	for _, db := range dbs {
+		if _, ok := excludedDatabaseSet[db]; !ok {
+			filteredDbNames = append(filteredDbNames, db)
+		}
+	}
+
+	return filteredDbNames, nil
+}

--- a/flow/connectors/mongo/schema.go
+++ b/flow/connectors/mongo/schema.go
@@ -15,7 +15,15 @@ func (c *MongoConnector) GetAllTables(ctx context.Context) (*protos.AllTablesRes
 	if err != nil {
 		return nil, fmt.Errorf("failed to get databases: %w", err)
 	}
-	tableNames = append(tableNames, dbNames...)
+	for _, dbName := range dbNames {
+		collNames, err := c.client.Database(dbName).ListCollectionNames(ctx, bson.D{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get collections: %w", err)
+		}
+		for _, collName := range collNames {
+			tableNames = append(tableNames, fmt.Sprintf("%.%", dbName, collName))
+		}
+	}
 	return &protos.AllTablesResponse{
 		Tables: tableNames,
 	}, nil
@@ -55,21 +63,10 @@ func (c *MongoConnector) GetTablesInSchema(ctx context.Context, schema string, c
 	return &response, nil
 }
 
-// TODO: replace placeholder values, how should we displace source columns in mongodb?
+// TODO: determine if/how we want to support this
 func (c *MongoConnector) GetColumns(ctx context.Context, schema string, table string) (*protos.TableColumnsResponse, error) {
 	return &protos.TableColumnsResponse{
-		Columns: []*protos.ColumnsItem{
-			{
-				Name:  "_id",
-				Type:  "ObjectId",
-				IsKey: true,
-			},
-			{
-				Name:  "_full_document",
-				Type:  "string",
-				IsKey: false,
-			},
-		},
+		Columns: []*protos.ColumnsItem{},
 	}, nil
 }
 


### PR DESCRIPTION
Implement connector interface for fetching databases, tables, and columns. For now, ~we use hard-coded _destination_ columns as placeholders.~ return empty columns.

Open discussion: since Mongo is schemaless, fetching column types becomes nontrivial:
- scanning the entire dataset and infer data types is too expensive
- a more practical approach would be to sample a small subset of rows and give a best-effort data types.
