### PR TITLE
mongo: always  convert  `_id` to string  + no parallel initial load

### DIFF
--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -24,8 +24,10 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
-const DefaultDocumentKeyColumnName = "_id"
-const DefaultFullDocumentColumnName = "_full_document"
+const (
+	DefaultDocumentKeyColumnName  = "_id"
+	DefaultFullDocumentColumnName = "_full_document"
+)
 
 type MongoConnector struct {
 	*metadataStore.PostgresMetadata
@@ -297,7 +299,7 @@ func (c *MongoConnector) PullRecords(
 		if documentKey, found := changeDoc["documentKey"]; found {
 			if len(documentKey.(bson.D)) == 0 || documentKey.(bson.D)[0].Key != DefaultDocumentKeyColumnName {
 				// should never happen
-				return fmt.Errorf("invalid document key, expect _id")
+				return errors.New("invalid document key, expect _id")
 			}
 			id := documentKey.(bson.D)[0].Value
 			qValue, err := qValueStringFromKey(id)
@@ -319,7 +321,7 @@ func (c *MongoConnector) PullRecords(
 		} else {
 			// should never happen with fullDocument='UpdateLookup',
 			// fail loudly for now so we can investigate if it does
-			return fmt.Errorf("fullDocument field not found")
+			return errors.New("fullDocument field not found")
 		}
 
 		if operationType, ok := changeDoc["operationType"]; ok {

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -24,6 +24,9 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
+const DefaultDocumentKeyColumnName = "_id"
+const DefaultFullDocumentColumnName = "_full_document"
+
 type MongoConnector struct {
 	*metadataStore.PostgresMetadata
 	config *protos.MongoConfig
@@ -122,13 +125,13 @@ func (c *MongoConnector) GetTableSchema(
 ) (map[string]*protos.TableSchema, error) {
 	result := make(map[string]*protos.TableSchema, len(tableMappings))
 	idFieldDescription := &protos.FieldDescription{
-		Name:         "_id",
+		Name:         DefaultDocumentKeyColumnName,
 		Type:         string(types.QValueKindString),
 		TypeModifier: -1,
 		Nullable:     false,
 	}
 	dataFieldDescription := &protos.FieldDescription{
-		Name:         "_full_document",
+		Name:         DefaultFullDocumentColumnName,
 		Type:         string(types.QValueKindJSON),
 		TypeModifier: -1,
 		Nullable:     false,
@@ -137,7 +140,7 @@ func (c *MongoConnector) GetTableSchema(
 	for _, tm := range tableMappings {
 		result[tm.SourceTableIdentifier] = &protos.TableSchema{
 			TableIdentifier:       tm.SourceTableIdentifier,
-			PrimaryKeyColumns:     []string{"_id"},
+			PrimaryKeyColumns:     []string{DefaultDocumentKeyColumnName},
 			IsReplicaIdentityFull: true,
 			System:                protos.TypeSystem_Q,
 			NullableEnabled:       false,
@@ -289,18 +292,33 @@ func (c *MongoConnector) PullRecords(
 		sourceTableName := changeDoc["ns"].(bson.D)[0].Value.(string) + "." + changeDoc["ns"].(bson.D)[1].Value.(string)
 		destinationTableName := req.TableNameMapping[sourceTableName].Name
 
-		documentKey := changeDoc["documentKey"].(bson.D)
 		items := model.NewRecordItems(2)
-		items.AddColumn("_id",
-			types.QValueString{Val: documentKey[0].Value.(bson.ObjectID).Hex()})
-		if fullDocument, ok := changeDoc["fullDocument"]; ok {
-			fullDocJSON, err := bson.MarshalExtJSON(fullDocument, true, true)
-			if err != nil {
-				return fmt.Errorf("failed to marshal fullDocument to JSON: %w", err)
+
+		if documentKey, found := changeDoc["documentKey"]; found {
+			if len(documentKey.(bson.D)) == 0 || documentKey.(bson.D)[0].Key != DefaultDocumentKeyColumnName {
+				return fmt.Errorf("invalid document key, expect _id")
 			}
-			items.AddColumn("_full_document", types.QValueJSON{Val: string(fullDocJSON)})
+			id := documentKey.(bson.D)[0].Value
+			qValue, err := qValueStringFromKey(id)
+			if err != nil {
+				return fmt.Errorf("failed to convert _id to string: %w", err)
+			}
+			items.AddColumn(DefaultDocumentKeyColumnName, qValue)
 		} else {
-			items.AddColumn("_full_document", types.QValueJSON{Val: "{}"})
+			// should never happen
+			return fmt.Errorf("documentKey field not found")
+		}
+
+		if fullDocument, found := changeDoc["fullDocument"]; found {
+			qValue, err := qValueJSONFromDocument(fullDocument.(bson.D))
+			if err != nil {
+				return fmt.Errorf("failed to convert fullDocument to JSON: %w", err)
+			}
+			items.AddColumn(DefaultFullDocumentColumnName, qValue)
+		} else {
+			// should never happen with fullDocument='UpdateLookup',
+			// fail loudly for now so we can investigate if it does
+			return fmt.Errorf("fullDocument field not found")
 		}
 
 		if operationType, ok := changeDoc["operationType"]; ok {

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -296,6 +296,7 @@ func (c *MongoConnector) PullRecords(
 
 		if documentKey, found := changeDoc["documentKey"]; found {
 			if len(documentKey.(bson.D)) == 0 || documentKey.(bson.D)[0].Key != DefaultDocumentKeyColumnName {
+				// should never happen
 				return fmt.Errorf("invalid document key, expect _id")
 			}
 			id := documentKey.(bson.D)[0].Value
@@ -306,7 +307,7 @@ func (c *MongoConnector) PullRecords(
 			items.AddColumn(DefaultDocumentKeyColumnName, qValue)
 		} else {
 			// should never happen
-			return fmt.Errorf("documentKey field not found")
+			return errors.New("documentKey field not found")
 		}
 
 		if fullDocument, found := changeDoc["fullDocument"]; found {

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -113,16 +113,17 @@ func (c *MongoConnector) PullQRepRecords(
 
 func getDefaultSchema() types.QRecordSchema {
 	schema := make([]types.QField, 0, 2)
-	schema = append(schema, types.QField{
-		Name:     DefaultDocumentKeyColumnName,
-		Type:     types.QValueKindString,
-		Nullable: false,
-	})
-	schema = append(schema, types.QField{
-		Name:     DefaultFullDocumentColumnName,
-		Type:     types.QValueKindJSON,
-		Nullable: false,
-	})
+	schema = append(
+		schema, types.QField{
+			Name:     DefaultDocumentKeyColumnName,
+			Type:     types.QValueKindString,
+			Nullable: false,
+		},
+		types.QField{
+			Name:     DefaultFullDocumentColumnName,
+			Type:     types.QValueKindJSON,
+			Nullable: false,
+		})
 	return types.QRecordSchema{Fields: schema}
 }
 
@@ -136,7 +137,7 @@ func toRangeFilter(partitionRange *protos.PartitionRange) (bson.D, error) {
 			}},
 		}, nil
 	default:
-		return nil, fmt.Errorf("unsupported partition range type")
+		return nil, errors.New("unsupported partition range type")
 	}
 }
 

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -35,50 +35,6 @@ func (c *MongoConnector) GetQRepPartitions(
 	}
 
 	partitionHelper := utils.NewPartitionHelper(c.logger)
-	// TODO: test against large collection to evaluate performance of bucketing logic; exclude partition logic for now.
-	//if last != nil && last.Range != nil {
-	//	return nil, errors.ErrUnsupported
-	//}
-	//parseWatermarkTable, err := utils.ParseSchemaTable(config.WatermarkTable)
-	//if err != nil {
-	//	return nil, fmt.Errorf("unable to parse watermark table: %w", err)
-	//}
-	//collection := c.client.Database(parseWatermarkTable.Schema).Collection(parseWatermarkTable.Table)
-	//collectionCount, err := collection.CountDocuments(ctx, bson.D{})
-	//if err != nil {
-	//	return nil, fmt.Errorf("failed to get collection count: %w", err)
-	//}
-	//numBuckets := math.Ceil(float64(collectionCount) / float64(config.NumRowsPerPartition))
-	//pipeline := mongo.Pipeline{
-	//	bson.D{
-	//		bson.E{Key: "$bucketAuto", Value: bson.D{
-	//			bson.E{Key: "groupBy", Value: "$_id"},
-	//			bson.E{Key: "buckets", Value: numBuckets},
-	//		}},
-	//	},
-	//}
-	//cursor, err := collection.Aggregate(ctx, pipeline)
-	//if err != nil {
-	//	return nil, fmt.Errorf("failed to get partitions: %w", err)
-	//}
-	//defer cursor.Close(ctx)
-	//
-	//var results []struct {
-	//	ID struct {
-	//		Min bson.ObjectID `bson:"min"`
-	//		Max bson.ObjectID `bson:"max"`
-	//	} `bson:"_id"`
-	//	Count int `bson:"count"`
-	//}
-	//if err = cursor.All(ctx, &results); err != nil {
-	//	return nil, fmt.Errorf("failed to decode partitions: %w", err)
-	//}
-	//
-	//for _, result := range results {
-	//	if err := partitionHelper.AddPartition(result.ID.Min, result.ID.Max); err != nil {
-	//		return nil, fmt.Errorf("failed to add partition: %w", err)
-	//	}
-	//}
 	return partitionHelper.GetPartitions(), nil
 }
 
@@ -210,7 +166,6 @@ func qValuesFromDocument(doc bson.D) ([]types.QValue, int64, error) {
 	}
 	qValues = append(qValues, qvalueDoc)
 
-	// TODO: more accurate size calculation
 	size += int64(len(qvalueDoc.Val))
 
 	return qValues, size, nil

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -113,8 +113,8 @@ func (c *MongoConnector) PullQRepRecords(
 
 func getDefaultSchema() types.QRecordSchema {
 	schema := make([]types.QField, 0, 2)
-	schema = append(
-		schema, types.QField{
+	schema = append(schema,
+		types.QField{
 			Name:     DefaultDocumentKeyColumnName,
 			Type:     types.QValueKindString,
 			Nullable: false,

--- a/flow/connectors/mongo/qvalue_convert.go
+++ b/flow/connectors/mongo/qvalue_convert.go
@@ -1,0 +1,57 @@
+package connmongo
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func qValueStringFromKey(key any) (types.QValueString, error) {
+	var val string
+	switch v := key.(type) {
+	case int:
+		val = strconv.Itoa(v)
+	case int32:
+		val = strconv.Itoa(int(v))
+	case int64:
+		val = strconv.FormatInt(v, 10)
+	case string:
+		val = v
+	case float32:
+		val = strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case float64:
+		val = strconv.FormatFloat(v, 'f', -1, 64)
+	case bson.Decimal128:
+		val = v.String()
+	case bson.ObjectID:
+		val = v.Hex()
+	case bson.Timestamp:
+		// https://www.mongodb.com/docs/v7.0/reference/bson-types/#timestamps
+		ts := (uint64(v.T) << 32) | uint64(v.I)
+		val = strconv.FormatUint(ts, 10)
+	case bson.DateTime:
+		val = strconv.FormatInt(int64(v), 10)
+	case bson.Binary:
+		val = base64.StdEncoding.EncodeToString(v.Data)
+	case bson.D:
+		jsonb, err := bson.MarshalExtJSON(key, true, true)
+		if err != nil {
+			return types.QValueString{}, fmt.Errorf("error marshalling key '%v': %w", key, err)
+		}
+		val = string(jsonb)
+	default:
+		return types.QValueString{}, fmt.Errorf("unexpected key '%v' with format: %T", key, key)
+	}
+	return types.QValueString{Val: val}, nil
+}
+
+func qValueJSONFromDocument(document bson.D) (types.QValueJSON, error) {
+	jsonb, err := bson.MarshalExtJSON(document, true, true)
+	if err != nil {
+		return types.QValueJSON{}, fmt.Errorf("error marshalling document: %w", err)
+	}
+	return types.QValueJSON{Val: string(jsonb), IsArray: false}, nil
+}

--- a/flow/connectors/mongo/qvalue_convert.go
+++ b/flow/connectors/mongo/qvalue_convert.go
@@ -1,55 +1,21 @@
 package connmongo
 
 import (
-	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"strconv"
-
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
-	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func qValueStringFromKey(key any) (types.QValueString, error) {
-	var val string
-	switch v := key.(type) {
-	case int:
-		val = strconv.Itoa(v)
-	case int32:
-		val = strconv.Itoa(int(v))
-	case int64:
-		val = strconv.FormatInt(v, 10)
-	case string:
-		val = v
-	case float32:
-		val = strconv.FormatFloat(float64(v), 'f', -1, 32)
-	case float64:
-		val = strconv.FormatFloat(v, 'f', -1, 64)
-	case bson.Decimal128:
-		val = v.String()
-	case bson.ObjectID:
-		val = v.Hex()
-	case bson.Timestamp:
-		// https://www.mongodb.com/docs/v7.0/reference/bson-types/#timestamps
-		ts := (uint64(v.T) << 32) | uint64(v.I)
-		val = strconv.FormatUint(ts, 10)
-	case bson.DateTime:
-		val = strconv.FormatInt(int64(v), 10)
-	case bson.Binary:
-		val = base64.StdEncoding.EncodeToString(v.Data)
-	case bson.D:
-		jsonb, err := bson.MarshalExtJSON(key, true, true)
-		if err != nil {
-			return types.QValueString{}, fmt.Errorf("error marshalling key '%v': %w", key, err)
-		}
-		val = string(jsonb)
-	default:
-		return types.QValueString{}, fmt.Errorf("unexpected key '%v' with format: %T", key, key)
+	jsonb, err := json.Marshal(key)
+	if err != nil {
+		return types.QValueString{}, fmt.Errorf("error marshalling key: %w", err)
 	}
-	return types.QValueString{Val: val}, nil
+	return types.QValueString{Val: string(jsonb)}, nil
 }
 
-func qValueJSONFromDocument(document bson.D) (types.QValueJSON, error) {
-	jsonb, err := bson.MarshalExtJSON(document, true, true)
+func qValueJSONFromDocument(document interface{}) (types.QValueJSON, error) {
+	jsonb, err := json.Marshal(document)
 	if err != nil {
 		return types.QValueJSON{}, fmt.Errorf("error marshalling document: %w", err)
 	}

--- a/flow/connectors/mongo/qvalue_convert.go
+++ b/flow/connectors/mongo/qvalue_convert.go
@@ -3,6 +3,7 @@ package connmongo
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 

--- a/flow/connectors/mongo/schema.go
+++ b/flow/connectors/mongo/schema.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 )
 
 func (c *MongoConnector) GetAllTables(ctx context.Context) (*protos.AllTablesResponse, error) {
@@ -21,7 +22,7 @@ func (c *MongoConnector) GetAllTables(ctx context.Context) (*protos.AllTablesRes
 			return nil, fmt.Errorf("failed to get collections: %w", err)
 		}
 		for _, collName := range collNames {
-			tableNames = append(tableNames, fmt.Sprintf("%.%", dbName, collName))
+			tableNames = append(tableNames, fmt.Sprintf("%s.%s", dbName, collName))
 		}
 	}
 	return &protos.AllTablesResponse{


### PR DESCRIPTION
Previously we assume that `_id` must be ObjectId type in mongoDB. 

However, it's possible for `_id` to contain other data types. To start,  keep `_id` simple by always converting to a string type in destination table. 

This PR also removed partitioning logic for now -- will evaluate `$bucketAuto` on large collections to determine if  it scales well. 

Lastly, this PR moved conversion logic to `qvalue_convert.go` so it can be used by both snapshot and cdc.

Testing:
- [x] manual local e2e testing (will add e2e test in subsequent PR)