### PR TITLE
fix: improve S3 credential handling and chunk processing in ClickHouse sync

### DIFF
--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -232,6 +232,11 @@ func (s *ClickHouseAvroSyncMethod) pushDataToS3(
 		totalRecords = avroFile.NumRecords
 	}
 
+	s.logger.Info("finished writing avro chunks to S3",
+		slog.String("partitionId", partition.PartitionId),
+		slog.Int("totalChunks", len(avroFiles)),
+		slog.Int64("totalRecords", totalRecords))
+
 	return avroFiles, totalRecords, nil
 }
 

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -219,9 +219,7 @@ func (s *ClickHouseAvroSyncMethod) pushDataToS3(
 		if err := ctx.Err(); err != nil {
 			return nil, 0, err
 		}
-	}
-
-	if len(avroFiles) == 0 {
+	} else {
 		avroFile, err := s.writeToAvroFile(
 			ctx, config.Env, stream, nil, avroSchema, partition.PartitionId, config.FlowJobName, destTypeConversions,
 		)


### PR DESCRIPTION
- Retrieve fresh AWS credentials for each part and chunk to prevent expiration during long-running operations
- Refactor chunk handling to process individual files instead of wildcards
  - Changed pushDataToS3 to return array of AvroFile pointers
  - Updated pushS3DataToClickHouse to process each chunk separately
- Add detailed logging for chunk and part processing for better debugging

This ensures reliable data loading for large datasets with multiple chunks and parts by preventing credential timeout errors and enabling proper per-file credential refresh.