### PR TITLE
ch: never use params

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -248,14 +248,14 @@ func (c *ClickHouseConnector) RemoveTableEntriesFromRawTable(
 		// Better to use lightweight deletes here as the main goal is to
 		// not have the rows in the table be visible by the NormalizeRecords'
 		// INSERT INTO SELECT queries
-		err := c.execWithLogging(ctx, fmt.Sprintf("DELETE FROM `%s` WHERE _peerdb_destination_table_name = %s"+
+		if err := c.execWithLogging(ctx, fmt.Sprintf("DELETE FROM `%s` WHERE _peerdb_destination_table_name = %s"+
 			" AND _peerdb_batch_id > %d AND _peerdb_batch_id <= %d",
-			c.GetRawTableName(req.FlowJobName), peerdb_clickhouse.QuoteLiteral(tableName), req.NormalizeBatchId, req.SyncBatchId))
-		if err != nil {
+			c.GetRawTableName(req.FlowJobName), peerdb_clickhouse.QuoteLiteral(tableName), req.NormalizeBatchId, req.SyncBatchId),
+		); err != nil {
 			return fmt.Errorf("unable to remove table %s from raw table: %w", tableName, err)
 		}
 
-		c.logger.Info(fmt.Sprintf("successfully removed entries for table '%s' from raw table", tableName))
+		c.logger.Info("successfully removed entries for table from raw table", slog.String("table", tableName))
 	}
 
 	return nil

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -285,20 +285,20 @@ func Connect(ctx context.Context, env map[string]string, config *protos.Clickhou
 	return conn, nil
 }
 
-func (c *ClickHouseConnector) exec(ctx context.Context, query string, args ...any) error {
-	return chvalidate.Exec(ctx, c.logger, c.database, query, args...)
+func (c *ClickHouseConnector) exec(ctx context.Context, query string) error {
+	return chvalidate.Exec(ctx, c.logger, c.database, query)
 }
 
-func (c *ClickHouseConnector) execWithConnection(ctx context.Context, conn clickhouse.Conn, query string, args ...any) error {
-	return chvalidate.Exec(ctx, c.logger, conn, query, args...)
+func (c *ClickHouseConnector) execWithConnection(ctx context.Context, conn clickhouse.Conn, query string) error {
+	return chvalidate.Exec(ctx, c.logger, conn, query)
 }
 
-func (c *ClickHouseConnector) query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
-	return chvalidate.Query(ctx, c.logger, c.database, query, args...)
+func (c *ClickHouseConnector) query(ctx context.Context, query string) (driver.Rows, error) {
+	return chvalidate.Query(ctx, c.logger, c.database, query)
 }
 
-func (c *ClickHouseConnector) queryRow(ctx context.Context, query string, args ...any) driver.Row {
-	return chvalidate.QueryRow(ctx, c.logger, c.database, query, args...)
+func (c *ClickHouseConnector) queryRow(ctx context.Context, query string) driver.Row {
+	return chvalidate.QueryRow(ctx, c.logger, c.database, query)
 }
 
 func (c *ClickHouseConnector) Close() error {

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -461,7 +461,7 @@ func (c *ClickHouseConnector) getDistinctTableNamesInBatch(
 
 	q := fmt.Sprintf(
 		"SELECT DISTINCT _peerdb_destination_table_name FROM %s WHERE _peerdb_batch_id>%d AND _peerdb_batch_id<=%d",
-		rawTbl, normalizeBatchID, syncBatchID)
+		peerdb_clickhouse.QuoteIdentifier(rawTbl), normalizeBatchID, syncBatchID)
 
 	rows, err := c.query(ctx, q)
 	if err != nil {

--- a/flow/connectors/clickhouse/normalize_query.go
+++ b/flow/connectors/clickhouse/normalize_query.go
@@ -97,7 +97,7 @@ func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error
 						dstColName = col.DestinationName
 					}
 					if col.DestinationType != "" {
-						// TODO can we restrict this to avoid injection?
+						// TODO basic validation to avoid injection
 						clickHouseType = col.DestinationType
 					}
 					columnNullableEnabled = col.NullableEnabled

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared"
+	"github.com/PeerDB-io/peerdb/flow/shared/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 	peerflow "github.com/PeerDB-io/peerdb/flow/workflows"
 )
@@ -437,12 +438,14 @@ func (s ClickHouseSuite) WeirdTable(tableName string) {
 		CREATE TABLE IF NOT EXISTS %s (
 			id SERIAL PRIMARY KEY,
 			key TEXT NOT NULL,
-			"excludedColumn" TEXT
+			"includedColumn?" TEXT,
+			"excludedColumn?" TEXT
 		);
 	`, srcFullName))
 	require.NoError(s.t, err)
 
-	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf("INSERT INTO %s (key, \"excludedColumn\") VALUES ('init','excluded')", srcFullName))
+	_, err = s.Conn().Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (key, \"includedColumn?\", \"excludedColumn?\") VALUES ('init','include','exclude')", srcFullName))
 	require.NoError(s.t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
@@ -465,7 +468,8 @@ func (s ClickHouseSuite) WeirdTable(tableName string) {
 
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,\"key\"")
 
-	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf("INSERT INTO %s (key, \"excludedColumn\") VALUES ('cdc','excluded')", srcFullName))
+	_, err = s.Conn().Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (key, \"includedColumn?\", \"excludedColumn?\") VALUES ('cdc','still','ex')", srcFullName))
 	require.NoError(s.t, err)
 
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,\"key\"")
@@ -482,7 +486,7 @@ func (s ClickHouseSuite) WeirdTable(tableName string) {
 	// now test weird names with rename based resync
 	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
-	require.NoError(s.t, ch.Exec(s.t.Context(), fmt.Sprintf("DROP TABLE `%s`", dstTableName)))
+	require.NoError(s.t, ch.Exec(s.t.Context(), "DROP TABLE "+clickhouse.QuoteIdentifier(dstTableName)))
 	require.NoError(s.t, ch.Close())
 	flowConnConfig.Resync = true
 	env = e2e.ExecutePeerflow(s.t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
@@ -500,7 +504,7 @@ func (s ClickHouseSuite) WeirdTable(tableName string) {
 	// now test weird names with exchange based resync
 	ch, err = connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
-	require.NoError(s.t, ch.Exec(s.t.Context(), fmt.Sprintf("TRUNCATE TABLE `%s`", dstTableName)))
+	require.NoError(s.t, ch.Exec(s.t.Context(), "TRUNCATE TABLE "+clickhouse.QuoteIdentifier(dstTableName)))
 	require.NoError(s.t, ch.Close())
 	env = e2e.ExecutePeerflow(s.t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
@@ -515,6 +519,10 @@ func (s ClickHouseSuite) Test_WeirdTable_Keyword() {
 
 func (s ClickHouseSuite) Test_WeirdTable_MixedCase() {
 	s.WeirdTable("myMixedCaseTable")
+}
+
+func (s ClickHouseSuite) Test_WeirdTable_Question() {
+	s.WeirdTable("whatIsTable?")
 }
 
 func (s ClickHouseSuite) Test_WeirdTable_Dash() {

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -522,6 +522,7 @@ func (s ClickHouseSuite) Test_WeirdTable_MixedCase() {
 }
 
 func (s ClickHouseSuite) Test_WeirdTable_Question() {
+	s.t.SkipNow() // TODO fix avro errors by sanitizing names
 	s.WeirdTable("whatIsTable?")
 }
 

--- a/flow/shared/clickhouse/escape.go
+++ b/flow/shared/clickhouse/escape.go
@@ -3,7 +3,7 @@ package clickhouse
 import "strings"
 
 func mustEscape(char byte) bool {
-	return char == '\'' || char == '`' || char == '\\' || char == '?' || char == '\t' || char == '\n'
+	return char == '\'' || char == '`' || char == '\\' || char == '\t' || char == '\n'
 }
 
 // escaped size only needs to iterate on bytes, ASCII will never appear within multibyte utf8 characters

--- a/flow/shared/clickhouse/escape.go
+++ b/flow/shared/clickhouse/escape.go
@@ -3,7 +3,7 @@ package clickhouse
 import "strings"
 
 func mustEscape(char byte) bool {
-	return char == '\'' || char == '`' || char == '\\' || char == '\t' || char == '\n'
+	return char == '\'' || char == '`' || char == '\\' || char == '?' || char == '\t' || char == '\n'
 }
 
 // escaped size only needs to iterate on bytes, ASCII will never appear within multibyte utf8 characters


### PR DESCRIPTION
hit error due to ?s in column names

looking at clickhouse-go's bind.go, ? can be escaped as `\?`
but this doesn't apply when no params passed, in which case we need to not prepend `\`
also `$1` can't be escaped so queries which mix user supplied identifiers & params are never safe
conclusion: never use params, we already handle escaping strings ourselves in most cases

on handling escaping ourselves: cleanup code to call Quote functions more diligently