### PR TITLE
mysql: more accurate bean counting

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -425,8 +425,6 @@ func (c *MySqlConnector) PullRecords(
 			return err
 		}
 
-		otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(event.RawData)))
-
 		switch ev := event.Event.(type) {
 		case *replication.GTIDEvent:
 			if ev.ImmediateCommitTimestamp > 0 {
@@ -482,6 +480,7 @@ func (c *MySqlConnector) PullRecords(
 			exclusion := req.TableNameMapping[sourceTableName].Exclude
 			schema := req.TableNameSchemaMapping[destinationTableName]
 			if schema != nil {
+				otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(event.RawData)))
 				inTx = true
 				enumMap := ev.Table.EnumStrValueMap()
 				setMap := ev.Table.SetStrValueMap()

--- a/flow/connectors/mysql/metered_dialer.go
+++ b/flow/connectors/mysql/metered_dialer.go
@@ -1,5 +1,8 @@
 package connmysql
 
+/* go-mysql does not expose raw bytes for streaming selects,
+ * thus this allows accurately measuring fetched bytes */
+
 import (
 	"context"
 	"net"

--- a/flow/connectors/mysql/metered_dialer.go
+++ b/flow/connectors/mysql/metered_dialer.go
@@ -1,0 +1,30 @@
+package connmysql
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+
+	"github.com/go-mysql-org/go-mysql/client"
+)
+
+type MeteredConn struct {
+	net.Conn
+	BytesRead atomic.Int64
+}
+
+func (mc *MeteredConn) Read(b []byte) (int, error) {
+	read, err := mc.Conn.Read(b)
+	mc.BytesRead.Add(int64(read))
+	return read, err
+}
+
+func NewMeteredDialer(innerDialer client.Dialer) client.Dialer {
+	return func(ctx context.Context, network string, address string) (net.Conn, error) {
+		conn, err := innerDialer(ctx, network, address)
+		if err != nil {
+			return conn, err
+		}
+		return &MeteredConn{Conn: conn}, nil
+	}
+}


### PR DESCRIPTION
cdc: only count row events which aren't ignored
qrep: meter connection rather than making terrible estimate based on decoded row values

based on talking upstream (https://github.com/go-mysql-org/go-mysql/issues/1044) this was the recommended approach