### PR TITLE
mongo: add more CI test for mongo connector

### DIFF
--- a/flow/e2e/mongo/mongo_test.go
+++ b/flow/e2e/mongo/mongo_test.go
@@ -10,13 +10,13 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
-	"github.com/PeerDB-io/peerdb/flow/connectors/mongo"
+	connmongo "github.com/PeerDB-io/peerdb/flow/connectors/mongo"
 	"github.com/PeerDB-io/peerdb/flow/e2e"
-	"github.com/PeerDB-io/peerdb/flow/e2e/clickhouse"
+	e2e_clickhouse "github.com/PeerDB-io/peerdb/flow/e2e/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/e2eshared"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/shared"
-	"github.com/PeerDB-io/peerdb/flow/workflows"
+	peerflow "github.com/PeerDB-io/peerdb/flow/workflows"
 )
 
 type MongoClickhouseSuite struct {
@@ -99,6 +99,113 @@ func (s MongoClickhouseSuite) Test_Simple_Flow() {
 	}
 
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "cdc events to match", srcTable, dstTable, "_id,_full_document")
+	env.Cancel(t.Context())
+	e2e.RequireEnvCanceled(t, env)
+}
+
+func (s MongoClickhouseSuite) Test_Inconsistent_Schema() {
+	t := s.T()
+
+	srcDatabase := GetTestDatabase(s.Suffix())
+	srcTable := "test_schema_change"
+	dstTable := "test_schema_change_dst"
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:   e2e.AddSuffix(s, srcTable),
+		TableMappings: e2e.TableMappings(s, srcTable, dstTable),
+		Destination:   s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+
+	client := s.Source().Connector().(*connmongo.MongoConnector).Client()
+	collection := client.Database(srcDatabase).Collection(srcTable)
+
+	// adding/removing fields should work
+	docs := []bson.D{
+		{bson.E{Key: "field1", Value: 1}},
+		{bson.E{Key: "field1", Value: 2}, bson.E{Key: "field2", Value: "v1"}},
+		{bson.E{Key: "field2", Value: "v2"}},
+	}
+	for _, doc := range docs {
+		res, err := collection.InsertOne(t.Context(), doc, options.InsertOne())
+		require.NoError(t, err)
+		require.True(t, res.Acknowledged)
+	}
+
+	tc := e2e.NewTemporalClient(t)
+	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load to match", srcTable, dstTable, "_id,_full_document")
+
+	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
+
+	// inconsistent data type for a given field should work
+	docs = []bson.D{
+		{bson.E{Key: "field3", Value: 3}},
+		{bson.E{Key: "field3", Value: "3"}},
+	}
+	for _, doc := range docs {
+		res, err := collection.InsertOne(t.Context(), doc, options.InsertOne())
+		require.NoError(t, err)
+		require.True(t, res.Acknowledged)
+	}
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "cdc events to match", srcTable, dstTable, "_id,_full_document")
+
+	env.Cancel(t.Context())
+	e2e.RequireEnvCanceled(t, env)
+}
+
+func (s MongoClickhouseSuite) Test_Update_Replace_Delete_Events() {
+	t := s.T()
+
+	srcDatabase := GetTestDatabase(s.Suffix())
+	srcTable := "test_update_replace_delete"
+	dstTable := "test_update_replace_delete_dst"
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:   e2e.AddSuffix(s, srcTable),
+		TableMappings: e2e.TableMappings(s, srcTable, dstTable),
+		Destination:   s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+
+	client := s.Source().Connector().(*connmongo.MongoConnector).Client()
+	collection := client.Database(srcDatabase).Collection(srcTable)
+
+	insertRes, err := collection.InsertOne(t.Context(), bson.D{bson.E{Key: "key", Value: 1}}, options.InsertOne())
+	require.NoError(t, err)
+	require.True(t, insertRes.Acknowledged)
+
+	tc := e2e.NewTemporalClient(t)
+	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable, dstTable, "_id,_full_document")
+
+	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
+
+	updateRes, err := collection.UpdateOne(
+		t.Context(),
+		bson.D{bson.E{Key: "key", Value: 1}},
+		bson.D{bson.E{Key: "$set", Value: bson.D{bson.E{Key: "key", Value: 2}}}},
+		options.UpdateOne())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), updateRes.ModifiedCount)
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "update event", srcTable, dstTable, "_id,_full_document")
+
+	replaceRes, err := collection.ReplaceOne(
+		t.Context(),
+		bson.D{bson.E{Key: "key", Value: 2}},
+		bson.D{bson.E{Key: "key", Value: 3}},
+		options.Replace())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), replaceRes.ModifiedCount)
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "replace event", srcTable, dstTable, "_id,_full_document")
+
+	deleteRes, err := collection.DeleteOne(t.Context(), bson.D{bson.E{Key: "key", Value: 3}}, options.DeleteOne())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), deleteRes.DeletedCount)
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "delete event", srcTable, dstTable, "_id,_full_document")
+
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
 }


### PR DESCRIPTION
Add e2e tests for:
- update/replace/delete events
- "schema evolution"

Testing: tests should pass CI, will then point to `mongo-ci` branch.