### PR TITLE
qrep: continuous ingestion metrics

### DIFF
--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -245,14 +245,15 @@ type QRepPullConnector interface {
 	QRepPullConnectorCore
 
 	// PullQRepRecords returns the records for a given partition.
-	PullQRepRecords(context.Context, *protos.QRepConfig, *protos.QRepPartition, *model.QRecordStream) (int64, int64, error)
+	PullQRepRecords(context.Context, *otel_metrics.OtelManager, *protos.QRepConfig, *protos.QRepPartition, *model.QRecordStream) (int64, error)
 }
 
 type QRepPullPgConnector interface {
 	QRepPullConnectorCore
 
 	// PullPgQRepRecords returns the records for a given partition.
-	PullPgQRepRecords(context.Context, *protos.QRepConfig, *protos.QRepPartition, connpostgres.PgCopyWriter) (int64, int64, error)
+	PullPgQRepRecords(context.Context, *otel_metrics.OtelManager,
+		*protos.QRepConfig, *protos.QRepPartition, connpostgres.PgCopyWriter) (int64, error)
 }
 
 type QRepSyncConnectorCore interface {

--- a/flow/connectors/postgres/qrep_bench_test.go
+++ b/flow/connectors/postgres/qrep_bench_test.go
@@ -13,6 +13,7 @@ func BenchmarkQRepQueryExecutor(b *testing.B) {
 	query := "SELECT * FROM bench.large_table"
 
 	ctx := b.Context()
+
 	connector, err := NewPostgresConnector(ctx, nil, internal.GetCatalogPostgresConfigFromEnv(ctx))
 	require.NoError(b, err, "error while creating connector")
 	defer connector.Close()
@@ -24,7 +25,7 @@ func BenchmarkQRepQueryExecutor(b *testing.B) {
 	// Run the benchmark
 	for b.Loop() {
 		// Execute the query and process the rows
-		_, err := qe.ExecuteAndProcessQuery(ctx, query)
+		_, err := qe.ExecuteAndProcessQuery(ctx, nil, query)
 		require.NoError(b, err, "error while executing query")
 	}
 }

--- a/flow/connectors/postgres/qrep_query_executor_test.go
+++ b/flow/connectors/postgres/qrep_query_executor_test.go
@@ -60,7 +60,8 @@ func TestExecuteAndProcessQuery(t *testing.T) {
 	qe, err := connector.NewQRepQueryExecutor(ctx, shared.InternalVersion_Latest, "test flow", "test part")
 	require.NoError(t, err, "error while creating QRepQueryExecutor")
 
-	batch, err := qe.ExecuteAndProcessQuery(t.Context(), fmt.Sprintf("SELECT * FROM %s.test", utils.QuoteIdentifier(schemaName)))
+	batch, err := qe.ExecuteAndProcessQuery(t.Context(), nil,
+		fmt.Sprintf("SELECT * FROM %s.test", utils.QuoteIdentifier(schemaName)))
 	require.NoError(t, err, "error while executing query")
 	require.Len(t, batch.Records, 1, "expected 1 record")
 	require.Equal(t, "testdata", batch.Records[0][1].Value(), "expected 'testdata'")
@@ -147,7 +148,7 @@ func TestSupportedDataTypes(t *testing.T) {
 	qe, err := connector.NewQRepQueryExecutor(ctx, shared.InternalVersion_Latest, "test flow", "test part")
 	require.NoError(t, err, "error while creating QRepQueryExecutor")
 	// Select the row back out of the table
-	batch, err := qe.ExecuteAndProcessQuery(t.Context(),
+	batch, err := qe.ExecuteAndProcessQuery(t.Context(), nil,
 		fmt.Sprintf("SELECT * FROM %s.test", utils.QuoteIdentifier(schemaName)))
 	require.NoError(t, err, "error while processing rows")
 	require.Len(t, batch.Records, 1, "expected 1 record")
@@ -599,7 +600,7 @@ func TestStringDataTypes(t *testing.T) {
 			qe, err := connector.NewQRepQueryExecutor(ctx, shared.InternalVersion_Latest, "test flow", "test part")
 			require.NoError(t, err)
 			// Select the row back out of the table
-			batch, err := qe.ExecuteAndProcessQuery(t.Context(),
+			batch, err := qe.ExecuteAndProcessQuery(t.Context(), nil,
 				fmt.Sprintf("SELECT * FROM %s.test_strings", utils.QuoteIdentifier(schemaName)))
 			require.NoError(t, err)
 			require.Len(t, batch.Records, 1)

--- a/flow/connectors/postgres/sink_pg.go
+++ b/flow/connectors/postgres/sink_pg.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/postgres/sanitize"
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
+	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
@@ -48,24 +49,25 @@ func (p PgCopyWriter) SetSchema(schema []string) {
 
 func (p PgCopyWriter) ExecuteQueryWithTx(
 	ctx context.Context,
+	_ *otel_metrics.OtelManager,
 	qe *QRepQueryExecutor,
 	tx pgx.Tx,
 	query string,
 	args ...any,
-) (int64, int64, error) {
+) (int64, error) {
 	defer shared.RollbackTx(tx, qe.logger)
 
 	if qe.snapshot != "" {
 		if _, err := tx.Exec(ctx, "SET TRANSACTION SNAPSHOT "+utils.QuoteLiteral(qe.snapshot)); err != nil {
 			qe.logger.Error("[pg_query_executor] failed to set snapshot",
 				slog.Any("error", err), slog.String("query", query))
-			return 0, 0, fmt.Errorf("[pg_query_executor] failed to set snapshot: %w", err)
+			return 0, fmt.Errorf("[pg_query_executor] failed to set snapshot: %w", err)
 		}
 	}
 
 	norows, err := tx.Query(ctx, query+" limit 0", args...)
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
 
 	fieldDescriptions := norows.FieldDescriptions()
@@ -78,7 +80,7 @@ func (p PgCopyWriter) ExecuteQueryWithTx(
 
 	query, err = sanitize.SanitizeSQL(query, args...)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to apply parameters to copy subquery: %w", err)
+		return 0, fmt.Errorf("failed to apply parameters to copy subquery: %w", err)
 	}
 
 	copyQuery := fmt.Sprintf("COPY (%s) TO STDOUT", query)
@@ -87,19 +89,19 @@ func (p PgCopyWriter) ExecuteQueryWithTx(
 	if err != nil {
 		qe.logger.Info("[pg_query_executor] failed to copy",
 			slog.String("copyQuery", copyQuery), slog.Any("error", err))
-		return 0, 0, fmt.Errorf("[pg_query_executor] failed to copy: %w", err)
+		return 0, fmt.Errorf("[pg_query_executor] failed to copy: %w", err)
 	}
 
 	qe.logger.Info("Committing transaction")
 	if err := tx.Commit(ctx); err != nil {
 		qe.logger.Error("[pg_query_executor] failed to commit transaction", slog.Any("error", err))
-		return 0, 0, fmt.Errorf("[pg_query_executor] failed to commit transaction: %w", err)
+		return 0, fmt.Errorf("[pg_query_executor] failed to commit transaction: %w", err)
 	}
 
 	totalRecordsFetched := ct.RowsAffected()
 	qe.logger.Info(fmt.Sprintf("[pg_query_executor] committed transaction for query '%s', rows = %d",
 		query, totalRecordsFetched))
-	return totalRecordsFetched, 0, nil
+	return totalRecordsFetched, nil
 }
 
 func (p PgCopyWriter) Close(err error) {

--- a/flow/e2e/pg.go
+++ b/flow/e2e/pg.go
@@ -200,8 +200,7 @@ func (s *PostgresSource) GetRows(ctx context.Context, suffix string, table strin
 		return nil, err
 	}
 
-	return pgQueryExecutor.ExecuteAndProcessQuery(
-		ctx,
+	return pgQueryExecutor.ExecuteAndProcessQuery(ctx, nil,
 		fmt.Sprintf(`SELECT %s FROM e2e_test_%s.%s ORDER BY id`, cols, suffix, utils.QuoteIdentifier(table)),
 	)
 }
@@ -213,8 +212,7 @@ func (s *PostgresSource) GetRowsOnly(ctx context.Context, suffix string, table s
 		return nil, err
 	}
 
-	return pgQueryExecutor.ExecuteAndProcessQuery(
-		ctx,
+	return pgQueryExecutor.ExecuteAndProcessQuery(ctx, nil,
 		fmt.Sprintf(`SELECT %s FROM ONLY e2e_test_%s.%s ORDER BY id`, cols, suffix, utils.QuoteIdentifier(table)),
 	)
 }
@@ -250,7 +248,7 @@ func (s *PostgresSource) Query(ctx context.Context, query string) (*model.QRecor
 		return nil, err
 	}
 
-	return pgQueryExecutor.ExecuteAndProcessQuery(ctx, query)
+	return pgQueryExecutor.ExecuteAndProcessQuery(ctx, nil, query)
 }
 
 func (s *PostgresSource) GetLogCount(ctx context.Context, flowJobName, errorType, pattern string) (int, error) {

--- a/flow/e2e/postgres/postgres.go
+++ b/flow/e2e/postgres/postgres.go
@@ -69,8 +69,7 @@ func (s PeerFlowE2ETestSuitePG) GetRows(table string, cols string) (*model.QReco
 		return nil, err
 	}
 
-	return pgQueryExecutor.ExecuteAndProcessQuery(
-		s.t.Context(),
+	return pgQueryExecutor.ExecuteAndProcessQuery(s.t.Context(), nil,
 		fmt.Sprintf(`SELECT %s FROM e2e_test_%s.%s ORDER BY id`, cols, s.suffix, utils.QuoteIdentifier(table)),
 	)
 }


### PR DESCRIPTION
previous addition of qrep metrics would only report bytes sent after partition sent

this doesn't work well with MySQL's large unpartitioned initial loads. Report bytes sent throughout process

Rows not included continuously to keep records sent tied to successful partitions 