### PR TITLE
mongo: allow write to JSON in CH when FF is enabled

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -147,7 +147,7 @@ func (c *ClickHouseConnector) ReplayTableSchemaDeltas(
 		for _, addedColumn := range schemaDelta.AddedColumns {
 			qvKind := types.QValueKind(addedColumn.Type)
 			clickHouseColType, err := qvalue.ToDWHColumnType(
-				ctx, qvKind, env, protos.DBType_CLICKHOUSE, addedColumn, schemaDelta.NullableEnabled,
+				ctx, qvKind, env, protos.DBType_CLICKHOUSE, c.chVersion, addedColumn, schemaDelta.NullableEnabled,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to convert column type %s to ClickHouse type: %w", addedColumn.Type, err)

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -33,7 +33,7 @@ type ClickHouseConnector struct {
 	logger        log.Logger
 	config        *protos.ClickhouseConfig
 	credsProvider *utils.ClickHouseS3Credentials
-	chVersion     string
+	chVersion     *chproto.Version
 }
 
 func NewClickHouseConnector(
@@ -109,7 +109,7 @@ func NewClickHouseConnector(
 			Provider:   credentialsProvider,
 			BucketPath: awsBucketPath,
 		},
-		chVersion: clickHouseVersion.Version.String(),
+		chVersion: &clickHouseVersion.Version,
 	}
 
 	if credentials.AWS.SessionToken != "" {
@@ -363,15 +363,15 @@ func (c *ClickHouseConnector) processTableComparison(dstTableName string, srcSch
 }
 
 func (c *ClickHouseConnector) GetVersion(ctx context.Context) (string, error) {
-	if c.chVersion != "" {
-		return c.chVersion, nil
+	if c.chVersion != nil {
+		return c.chVersion.String(), nil
 	}
 
 	clickhouseVersion, err := c.database.ServerVersion()
 	if err != nil {
 		return "", fmt.Errorf("failed to get ClickHouse version: %w", err)
 	}
-	c.logger.Info("[clickhouse] version", slog.Any("version", clickhouseVersion.DisplayName))
+	c.logger.Info("[clickhouse] version", slog.String("version", clickhouseVersion.DisplayName))
 	return clickhouseVersion.Version.String(), nil
 }
 

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -33,6 +33,7 @@ type ClickHouseConnector struct {
 	logger        log.Logger
 	config        *protos.ClickhouseConfig
 	credsProvider *utils.ClickHouseS3Credentials
+	chVersion     string
 }
 
 func NewClickHouseConnector(
@@ -95,6 +96,10 @@ func NewClickHouseConnector(
 		return nil, err
 	}
 
+	clickHouseVersion, err := database.ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ClickHouse version: %w", err)
+	}
 	connector := &ClickHouseConnector{
 		database:         database,
 		PostgresMetadata: pgMetadata,
@@ -104,15 +109,12 @@ func NewClickHouseConnector(
 			Provider:   credentialsProvider,
 			BucketPath: awsBucketPath,
 		},
+		chVersion: clickHouseVersion.Version.String(),
 	}
 
 	if credentials.AWS.SessionToken != "" {
 		// 24.3.1 is minimum version of ClickHouse that actually supports session token
 		// https://github.com/ClickHouse/ClickHouse/issues/61230
-		clickHouseVersion, err := database.ServerVersion()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get ClickHouse version: %w", err)
-		}
 		if !chproto.CheckMinVersion(
 			chproto.Version{Major: 24, Minor: 3, Patch: 1},
 			clickHouseVersion.Version,
@@ -361,6 +363,10 @@ func (c *ClickHouseConnector) processTableComparison(dstTableName string, srcSch
 }
 
 func (c *ClickHouseConnector) GetVersion(ctx context.Context) (string, error) {
+	if c.chVersion != "" {
+		return c.chVersion, nil
+	}
+
 	clickhouseVersion, err := c.database.ServerVersion()
 	if err != nil {
 		return "", fmt.Errorf("failed to get ClickHouse version: %w", err)
@@ -424,6 +430,8 @@ func GetTableSchemaForTable(tm *protos.TableMapping, columns []driver.ColumnType
 			qkind = types.QValueKindArrayUUID
 		case "Array(DateTime64(6))":
 			qkind = types.QValueKindArrayTimestamp
+		case "JSON":
+			qkind = types.QValueKindJSON
 		default:
 			if strings.Contains(column.DatabaseTypeName(), "Decimal") {
 				if strings.HasPrefix(column.DatabaseTypeName(), "Array(") {

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	chproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
@@ -86,7 +87,7 @@ func generateCreateTableSQLForNormalizedTable(
 	config *protos.SetupNormalizedTableBatchInput,
 	tableIdentifier string,
 	tableSchema *protos.TableSchema,
-	chVersion string,
+	chVersion *chproto.Version,
 ) (string, error) {
 	var tableMapping *protos.TableMapping
 	for _, tm := range config.TableMappings {

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -62,6 +62,7 @@ func (c *ClickHouseConnector) SetupNormalizedTable(
 		config,
 		destinationTableIdentifier,
 		sourceTableSchema,
+		c.chVersion,
 	)
 	if err != nil {
 		return false, fmt.Errorf("error while generating create table sql for destination ClickHouse table: %w", err)
@@ -85,6 +86,7 @@ func generateCreateTableSQLForNormalizedTable(
 	config *protos.SetupNormalizedTableBatchInput,
 	tableIdentifier string,
 	tableSchema *protos.TableSchema,
+	chVersion string,
 ) (string, error) {
 	var tableMapping *protos.TableMapping
 	for _, tm := range config.TableMappings {
@@ -131,7 +133,7 @@ func generateCreateTableSQLForNormalizedTable(
 		if clickHouseType == "" {
 			var err error
 			clickHouseType, err = qvalue.ToDWHColumnType(
-				ctx, colType, config.Env, protos.DBType_CLICKHOUSE, column, tableSchema.NullableEnabled || columnNullableEnabled,
+				ctx, colType, config.Env, protos.DBType_CLICKHOUSE, chVersion, column, tableSchema.NullableEnabled || columnNullableEnabled,
 			)
 			if err != nil {
 				return "", fmt.Errorf("error while converting column type to ClickHouse type: %w", err)
@@ -407,6 +409,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				sourceSchemaAsDestinationColumn,
 				req.Env,
 				rawTbl,
+				c.chVersion,
 			)
 			insertIntoSelectQuery, err := queryGenerator.BuildQuery(ctx)
 			if err != nil {

--- a/flow/connectors/clickhouse/normalize_query.go
+++ b/flow/connectors/clickhouse/normalize_query.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	chproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
@@ -15,7 +17,7 @@ import (
 type NormalizeQueryGenerator struct {
 	env                             map[string]string
 	tableNameSchemaMapping          map[string]*protos.TableSchema
-	chVersion                       string
+	chVersion                       *chproto.Version
 	Query                           string
 	TableName                       string
 	rawTableName                    string
@@ -41,7 +43,7 @@ func NewNormalizeQueryGenerator(
 	sourceSchemaAsDestinationColumn bool,
 	env map[string]string,
 	rawTableName string,
-	chVersion string,
+	chVersion *chproto.Version,
 ) *NormalizeQueryGenerator {
 	return &NormalizeQueryGenerator{
 		TableName:                       tableName,

--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
-const chVersion = "25.3.0"
-
 func Test_GetOrderByColumns_WithColMap_AndOrdering(t *testing.T) {
 	tableMappingForTest := &protos.TableMapping{
 		SourceTableIdentifier:      "test_table",
@@ -191,7 +189,7 @@ func TestBuildQuery_Basic(t *testing.T) {
 		sourceSchemaAsDestinationColumn,
 		env,
 		rawTableName,
-		chVersion,
+		nil,
 	)
 
 	query, err := g.BuildQuery(ctx)
@@ -246,7 +244,7 @@ func TestBuildQuery_WithPrimaryUpdate(t *testing.T) {
 		sourceSchemaAsDestinationColumn,
 		env,
 		rawTableName,
-		chVersion,
+		nil,
 	)
 
 	query, err := g.BuildQuery(ctx)
@@ -298,7 +296,7 @@ func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {
 		sourceSchemaAsDestinationColumn,
 		env,
 		rawTableName,
-		chVersion,
+		nil,
 	)
 
 	query, err := g.BuildQuery(ctx)
@@ -347,7 +345,7 @@ func TestBuildQuery_WithNumParts(t *testing.T) {
 		sourceSchemaAsDestinationColumn,
 		env,
 		rawTableName,
-		chVersion,
+		nil,
 	)
 
 	query, err := g.BuildQuery(ctx)

--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
+const chVersion = "25.3.0"
+
 func Test_GetOrderByColumns_WithColMap_AndOrdering(t *testing.T) {
 	tableMappingForTest := &protos.TableMapping{
 		SourceTableIdentifier:      "test_table",
@@ -189,6 +191,7 @@ func TestBuildQuery_Basic(t *testing.T) {
 		sourceSchemaAsDestinationColumn,
 		env,
 		rawTableName,
+		chVersion,
 	)
 
 	query, err := g.BuildQuery(ctx)
@@ -243,6 +246,7 @@ func TestBuildQuery_WithPrimaryUpdate(t *testing.T) {
 		sourceSchemaAsDestinationColumn,
 		env,
 		rawTableName,
+		chVersion,
 	)
 
 	query, err := g.BuildQuery(ctx)
@@ -294,6 +298,7 @@ func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {
 		sourceSchemaAsDestinationColumn,
 		env,
 		rawTableName,
+		chVersion,
 	)
 
 	query, err := g.BuildQuery(ctx)
@@ -342,6 +347,7 @@ func TestBuildQuery_WithNumParts(t *testing.T) {
 		sourceSchemaAsDestinationColumn,
 		env,
 		rawTableName,
+		chVersion,
 	)
 
 	query, err := g.BuildQuery(ctx)

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -282,7 +282,7 @@ func (s *ClickHouseAvroSyncMethod) pushS3DataToClickHouse(
 		avroColName = peerdb_clickhouse.QuoteIdentifier(avroColName)
 
 		if field.Type == types.QValueKindJSON &&
-			qvalue.ShouldUseNativeJSONType(ctx, config.Env, protos.DBType_CLICKHOUSE, s.ClickHouseConnector.chVersion) {
+			qvalue.ShouldUseNativeJSONType(ctx, config.Env, s.ClickHouseConnector.chVersion) {
 			avroColName = fmt.Sprintf("JSONExtractString(%s)", avroColName)
 		}
 

--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -14,6 +14,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	peerdb_clickhouse "github.com/PeerDB-io/peerdb/flow/shared/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
@@ -263,7 +264,8 @@ func (s *ClickHouseAvroSyncMethod) pushS3DataToClickHouse(
 
 	selectedColumnNames := make([]string, 0, len(schema.Fields))
 	insertedColumnNames := make([]string, 0, len(schema.Fields))
-	for _, colName := range schema.GetColumnNames() {
+	for _, field := range schema.Fields {
+		colName := field.Name
 		for _, excludedColumn := range config.Exclude {
 			if colName == excludedColumn {
 				continue
@@ -276,7 +278,15 @@ func (s *ClickHouseAvroSyncMethod) pushS3DataToClickHouse(
 				slog.String("avroFieldName", avroColName))
 			return fmt.Errorf("destination column %s not found in avro schema", colName)
 		}
-		selectedColumnNames = append(selectedColumnNames, peerdb_clickhouse.QuoteIdentifier(avroColName))
+
+		avroColName = peerdb_clickhouse.QuoteIdentifier(avroColName)
+
+		if field.Type == types.QValueKindJSON &&
+			qvalue.ShouldUseNativeJSONType(ctx, config.Env, protos.DBType_CLICKHOUSE, s.ClickHouseConnector.chVersion) {
+			avroColName = fmt.Sprintf("JSONExtractString(%s)", avroColName)
+		}
+
+		selectedColumnNames = append(selectedColumnNames, avroColName)
 		insertedColumnNames = append(insertedColumnNames, peerdb_clickhouse.QuoteIdentifier(colName))
 	}
 	if sourceSchemaAsDestinationColumn {

--- a/flow/connectors/snowflake/merge_stmt_generator.go
+++ b/flow/connectors/snowflake/merge_stmt_generator.go
@@ -36,7 +36,7 @@ func (m *mergeStmtGenerator) generateMergeStmt(ctx context.Context, env map[stri
 	for _, column := range columns {
 		genericColumnType := column.Type
 		qvKind := types.QValueKind(genericColumnType)
-		sfType, err := qvalue.ToDWHColumnType(ctx, qvKind, env, protos.DBType_SNOWFLAKE, "", column, normalizedTableSchema.NullableEnabled)
+		sfType, err := qvalue.ToDWHColumnType(ctx, qvKind, env, protos.DBType_SNOWFLAKE, nil, column, normalizedTableSchema.NullableEnabled)
 		if err != nil {
 			return "", fmt.Errorf("failed to convert column type %s to snowflake type: %w", genericColumnType, err)
 		}

--- a/flow/connectors/snowflake/merge_stmt_generator.go
+++ b/flow/connectors/snowflake/merge_stmt_generator.go
@@ -36,7 +36,7 @@ func (m *mergeStmtGenerator) generateMergeStmt(ctx context.Context, env map[stri
 	for _, column := range columns {
 		genericColumnType := column.Type
 		qvKind := types.QValueKind(genericColumnType)
-		sfType, err := qvalue.ToDWHColumnType(ctx, qvKind, env, protos.DBType_SNOWFLAKE, column, normalizedTableSchema.NullableEnabled)
+		sfType, err := qvalue.ToDWHColumnType(ctx, qvKind, env, protos.DBType_SNOWFLAKE, "", column, normalizedTableSchema.NullableEnabled)
 		if err != nil {
 			return "", fmt.Errorf("failed to convert column type %s to snowflake type: %w", genericColumnType, err)
 		}

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -362,7 +362,7 @@ func (c *SnowflakeConnector) ReplayTableSchemaDeltas(
 		for _, addedColumn := range schemaDelta.AddedColumns {
 			qvKind := types.QValueKind(addedColumn.Type)
 			sfColtype, err := qvalue.ToDWHColumnType(
-				ctx, qvKind, env, protos.DBType_SNOWFLAKE, "", addedColumn, schemaDelta.NullableEnabled,
+				ctx, qvKind, env, protos.DBType_SNOWFLAKE, nil, addedColumn, schemaDelta.NullableEnabled,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to convert column type %s to snowflake type: %w",
@@ -661,7 +661,7 @@ func generateCreateTableSQLForNormalizedTable(
 		normalizedColName := SnowflakeIdentifierNormalize(column.Name)
 		qvKind := types.QValueKind(genericColumnType)
 		sfColType, err := qvalue.ToDWHColumnType(
-			ctx, qvKind, config.Env, protos.DBType_SNOWFLAKE, "", column, tableSchema.NullableEnabled,
+			ctx, qvKind, config.Env, protos.DBType_SNOWFLAKE, nil, column, tableSchema.NullableEnabled,
 		)
 		if err != nil {
 			slog.Warn(fmt.Sprintf("failed to convert column type %s to snowflake type", genericColumnType),

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -362,7 +362,7 @@ func (c *SnowflakeConnector) ReplayTableSchemaDeltas(
 		for _, addedColumn := range schemaDelta.AddedColumns {
 			qvKind := types.QValueKind(addedColumn.Type)
 			sfColtype, err := qvalue.ToDWHColumnType(
-				ctx, qvKind, env, protos.DBType_SNOWFLAKE, addedColumn, schemaDelta.NullableEnabled,
+				ctx, qvKind, env, protos.DBType_SNOWFLAKE, "", addedColumn, schemaDelta.NullableEnabled,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to convert column type %s to snowflake type: %w",
@@ -661,7 +661,7 @@ func generateCreateTableSQLForNormalizedTable(
 		normalizedColName := SnowflakeIdentifierNormalize(column.Name)
 		qvKind := types.QValueKind(genericColumnType)
 		sfColType, err := qvalue.ToDWHColumnType(
-			ctx, qvKind, config.Env, protos.DBType_SNOWFLAKE, column, tableSchema.NullableEnabled,
+			ctx, qvKind, config.Env, protos.DBType_SNOWFLAKE, "", column, tableSchema.NullableEnabled,
 		)
 		if err != nil {
 			slog.Warn(fmt.Sprintf("failed to convert column type %s to snowflake type", genericColumnType),

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -250,6 +250,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 	{
+		Name:             "PEERDB_CLICKHOUSE_ENABLE_JSON",
+		Description:      "Map JSON datatype from source to JSON in ClickHouse instead of String",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
+		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
+	},
+	{
 		Name:             "PEERDB_INTERVAL_SINCE_LAST_NORMALIZE_THRESHOLD_MINUTES",
 		Description:      "Duration in minutes since last normalize to start alerting, 0 disables all alerting entirely",
 		DefaultValue:     "240",
@@ -556,6 +564,10 @@ func PeerDBClickHouseParallelNormalize(ctx context.Context, env map[string]strin
 
 func PeerDBEnableClickHouseNumericAsString(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_UNBOUNDED_NUMERIC_AS_STRING")
+}
+
+func PeerDBEnableClickHouseJSON(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_ENABLE_JSON")
 }
 
 func PeerDBSnowflakeMergeParallelism(ctx context.Context, env map[string]string) (int64, error) {


### PR DESCRIPTION
Currently QValueJson gets converted to String in ClickHouse. For Mongo we want to be able to write `_full_document` as JSON type. This PR will default to JSON in CH if these are all true:
1) Schema is QValueJson
2) CH version supports JSON (25.3 is when JSON is first introduced)
3) JSON is enabled by FF (default to false)

Test: 
- e2e test
- tested locally, with FF on (as JSON) and off (as String)

Next step: look into enabling this setting by default -- but for Mongo only.