### PR TITLE
Add `AUTO_COMPRESS` environment variable

### DIFF
--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -202,10 +202,9 @@ func (s *SnowflakeAvroSyncHandler) putFileToStage(ctx context.Context, avroFile 
 
 	autoCompressionStr := ""
 	if autoCompression := internal.GetEnvString("PEERDB_SNOWFLAKE_AUTO_COMPRESSION", ""); autoCompression != "" {
-		autoCompressionStr = "AUTO_COMPRESS=" + autoCompression
+		autoCompressionStr = " AUTO_COMPRESS=" + autoCompression
 	}
-
-	putCmd := fmt.Sprintf("PUT file://%s @%s %s", avroFile.FilePath, stage, autoCompressionStr)
+	putCmd := fmt.Sprintf("PUT file://%s @%s%s", avroFile.FilePath, stage, autoCompressionStr)
 
 	if _, err := s.ExecContext(ctx, putCmd); err != nil {
 		return fmt.Errorf("failed to put file to stage: %w", err)


### PR DESCRIPTION
This allows us to skip the auto-compression enabled by default for
Snowflake. We require this, as Snowflake seems to struggle with certain
files that get auto-compressed and then fail to decompress successfully
with the following error:

```
Invalid data encountered during decompression for file: 'not_file',
compression type used: 'ZSTD', cause: 'Data corruption detected'
```
