### PR TITLE
Respect `PEERDB_NULLABLE` for custom type mappings

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -122,7 +122,11 @@ func generateCreateTableSQLForNormalizedTable(
 					if col.DestinationType != "" {
 						clickHouseType = col.DestinationType
 					}
+					if col.AutoDetectNullable {
+						columnNullableEnabled = tableSchema.NullableEnabled && column.Nullable
+					} else {
 					columnNullableEnabled = col.NullableEnabled
+					}
 					break
 				}
 			}
@@ -135,6 +139,10 @@ func generateCreateTableSQLForNormalizedTable(
 			)
 			if err != nil {
 				return "", fmt.Errorf("error while converting column type to ClickHouse type: %w", err)
+			}
+		} else {
+			if columnNullableEnabled {
+				clickHouseType = fmt.Sprintf("Nullable(%s)", clickHouseType)
 			}
 		}
 

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -21,6 +21,7 @@ message ColumnSetting {
   string destination_type = 3;
   int32 ordering = 4;
   bool nullable_enabled = 5;
+  bool auto_detect_nullable = 6;
 }
 
 message TableMapping {

--- a/ui/app/mirrors/create/cdc/customColumnType.tsx
+++ b/ui/app/mirrors/create/cdc/customColumnType.tsx
@@ -159,6 +159,7 @@ export default function CustomColumnType({
                     destinationType: value,
                     ordering: 0,
                     nullableEnabled: false,
+                    autoDetectNullable: true,
                   },
                 ],
               };

--- a/ui/app/mirrors/create/cdc/sortingkey.tsx
+++ b/ui/app/mirrors/create/cdc/sortingkey.tsx
@@ -75,6 +75,7 @@ export default function SelectSortingKeys({
               destinationType: '',
               ordering: orderingIndex + 1,
               nullableEnabled: false,
+              autoDetectNullable: true,
             });
           }
         });


### PR DESCRIPTION
Currently setting `PEERDB_NULLABLE` does not propagate nullability of source column to clickhouse when specifying custom column types. As result mapping `NUMERIC NULL` from postgres to `String` in CH creates column of type `String` instead of `Nullable(String)`. This PR aims to fix it.
