### PR TITLE
API endpoint for total rows synced by mirror

### DIFF
--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -613,7 +613,7 @@ func (h *FlowRequestHandler) TotalRowsSyncedByCDCMirror(
 	if !req.ExcludeInitialLoad {
 		err := h.pool.QueryRow(ctx, `SELECT SUM(rows_in_partition) FILTER (WHERE end_time IS NOT NULL) AS NumRowsSynced
 		FROM peerdb_stats.qrep_partitions
-		WHERE flow_name = $1`, req.FlowJobName).Scan(&totalRowsInitialLoad)
+		WHERE parent_mirror_name = $1`, req.FlowJobName).Scan(&totalRowsInitialLoad)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get total rows synced via CDC for mirror %s: %w", req.FlowJobName, err)
 		}

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -611,9 +611,10 @@ func (h *FlowRequestHandler) TotalRowsSyncedByMirror(
 	}
 
 	if !req.ExcludeInitialLoad {
-		err := h.pool.QueryRow(ctx, `SELECT SUM(rows_in_partition) FILTER (WHERE end_time IS NOT NULL) AS NumRowsSynced
-		FROM peerdb_stats.qrep_partitions
-		WHERE parent_mirror_name = $1`, req.FlowJobName).Scan(&totalRowsInitialLoad)
+		err := h.pool.QueryRow(ctx, `
+		SELECT SUM(rows_in_partition) AS NumRowsSynced
+        FROM peerdb_stats.qrep_partitions
+        WHERE parent_mirror_name = $1 AND end_time IS NOT NULL`, req.FlowJobName).Scan(&totalRowsInitialLoad)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get total rows synced via CDC for mirror %s: %w", req.FlowJobName, err)
 		}

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -595,6 +595,37 @@ func (h *FlowRequestHandler) CDCBatches(ctx context.Context, req *protos.GetCDCB
 	}, nil
 }
 
+func (h *FlowRequestHandler) TotalRowsSyncedByCDCMirror(
+	ctx context.Context,
+	req *protos.TotalRowsSyncedByMirrorRequest,
+) (*protos.TotalRowsSyncedByMirrorResponse, error) {
+	var totalRowsCDC int64
+	var totalRowsInitialLoad int64
+	if !req.ExcludeCdc {
+		cdcErr := h.pool.QueryRow(ctx, `SELECT SUM(total_count),
+		FROM peerdb_stats.cdc_table_aggregate_counts
+		WHERE flow_name = $1`, req.FlowJobName).Scan(&totalRowsCDC)
+		if cdcErr != nil {
+			return nil, fmt.Errorf("unable to get total rows synced via CDC for mirror %s: %w", req.FlowJobName, cdcErr)
+		}
+	}
+
+	if !req.ExcludeInitialLoad {
+		err := h.pool.QueryRow(ctx, `SELECT SUM(rows_in_partition) FILTER (WHERE end_time IS NOT NULL) AS NumRowsSynced
+		FROM peerdb_stats.qrep_partitions
+		WHERE flow_name = $1`, req.FlowJobName).Scan(&totalRowsInitialLoad)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get total rows synced via CDC for mirror %s: %w", req.FlowJobName, err)
+		}
+	}
+
+	return &protos.TotalRowsSyncedByMirrorResponse{
+		TotalCountCDC:         totalRowsCDC,
+		TotalCountInitialLoad: totalRowsInitialLoad,
+		TotalCount:            totalRowsCDC + totalRowsInitialLoad,
+	}, nil
+}
+
 func (h *FlowRequestHandler) CDCTableTotalCounts(
 	ctx context.Context,
 	req *protos.CDCTableTotalCountsRequest,

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -602,7 +602,7 @@ func (h *FlowRequestHandler) TotalRowsSyncedByMirror(
 	var totalRowsCDC int64
 	var totalRowsInitialLoad int64
 	if !req.ExcludeCdc {
-		cdcErr := h.pool.QueryRow(ctx, `SELECT SUM(total_count),
+		cdcErr := h.pool.QueryRow(ctx, `SELECT SUM(total_count)
 		FROM peerdb_stats.cdc_table_aggregate_counts
 		WHERE flow_name = $1`, req.FlowJobName).Scan(&totalRowsCDC)
 		if cdcErr != nil {

--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -595,7 +595,7 @@ func (h *FlowRequestHandler) CDCBatches(ctx context.Context, req *protos.GetCDCB
 	}, nil
 }
 
-func (h *FlowRequestHandler) TotalRowsSyncedByCDCMirror(
+func (h *FlowRequestHandler) TotalRowsSyncedByMirror(
 	ctx context.Context,
 	req *protos.TotalRowsSyncedByMirrorRequest,
 ) (*protos.TotalRowsSyncedByMirrorResponse, error) {

--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -781,7 +781,7 @@ func (s Suite) TestTotalRowsSyncedByMirror() {
 	e2e.RequireEqualTables(s.ch, "table2", "id,val")
 
 	// check total rows synced
-	mirrorTotalRowsSynced, err := s.TotalRowsSyncedByCDCMirror(s.t.Context(), &protos.TotalRowsSyncedByMirrorRequest{
+	mirrorTotalRowsSynced, err := s.TotalRowsSyncedByMirror(s.t.Context(), &protos.TotalRowsSyncedByMirrorRequest{
 		FlowJobName: flowConnConfig.FlowJobName,
 	})
 	require.NoError(s.t, err)

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -155,6 +155,18 @@ message CDCTableTotalCountsResponse {
   repeated CDCTableRowCounts tables_data = 2;
 }
 
+message TotalRowsSyncedByMirrorRequest {
+  string flow_job_name = 1;
+  bool exclude_cdc = 2; // if true, only initial load rows are counted
+  bool exclude_initial_load = 3; // if true, only cdc rows are counted
+}
+
+message TotalRowsSyncedByMirrorResponse {
+  int64 totalCountCDC = 1;
+  int64 totalCountInitialLoad = 2;
+  int64 totalCount = 3;
+}
+
 message PeerSchemasResponse { repeated string schemas = 1; }
 
 message PeerPublicationsResponse { repeated string publication_names = 1; }
@@ -706,6 +718,13 @@ service FlowService {
   rpc GetFlowTags(GetFlowTagsRequest) returns (GetFlowTagsResponse) {
     option (google.api.http) = {
       get : "/v1/flows/tags/{flow_name}"
+    };
+  }
+
+  rpc TotalRowsSyncedByCDCMirror(TotalRowsSyncedByMirrorRequest)
+      returns (TotalRowsSyncedByMirrorResponse) {
+    option (google.api.http) = {
+      get : "/v1/mirrors/total_rows_synced/{flow_job_name}"
     };
   }
 }

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -721,7 +721,7 @@ service FlowService {
     };
   }
 
-  rpc TotalRowsSyncedByCDCMirror(TotalRowsSyncedByMirrorRequest)
+  rpc TotalRowsSyncedByMirror(TotalRowsSyncedByMirrorRequest)
       returns (TotalRowsSyncedByMirrorResponse) {
     option (google.api.http) = {
       get : "/v1/mirrors/total_rows_synced/{flow_job_name}"


### PR DESCRIPTION
Currently to get the total rows synced by a mirror across CDC and initial load, clients of our API would have to call `CDCTableTotalCounts` and `InitialLoadSummary` and in the case of the latter they would have to sum the `NumRowsSynced` field of all entries. Not to mention both these API calls would be overfetching if we just want a single count.

This PR introduces a new endpoint dedicated to getting the sum total rows synced by CDC and initial load.
An API test has been included.