### PR TITLE
Lower s3 chunking default from 33GB to 10GB

### DIFF
--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -164,7 +164,7 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 	{
 		Name:         "PEERDB_S3_BYTES_PER_AVRO_FILE",
 		Description:  "S3 upload chunk size in bytes, needed for large unpartitioned initial loads.",
-		DefaultValue: "33333333333", // chosen to be round 30GB, but align with about half of 64MiB because S3 part size
+		DefaultValue: "10000000000", // 10GB, not GiB so to not align with 64MiB to avoid always having tiny part at end
 		ValueType:    protos.DynconfValueType_INT,
 		ApplyMode:    protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 	},


### PR DESCRIPTION
seeing errors on smaller instances over memory consumption & taking too long to process 30GB