### PR TITLE
MySQL: Move binary format fetch outside

### DIFF
--- a/flow/connectors/utils/avro_writer.go
+++ b/flow/connectors/utils/avro_writer.go
@@ -247,11 +247,16 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(
 	})
 	defer shutdown()
 
+	format, err := internal.PeerDBBinaryFormat(ctx, env)
+	if err != nil {
+		return 0, err
+	}
+
 	for qrecord := range p.stream.Records {
 		if err := ctx.Err(); err != nil {
 			return numRows.Load(), err
 		} else {
-			avroMap, err := avroConverter.Convert(ctx, env, qrecord, typeConversions, numericTruncator)
+			avroMap, err := avroConverter.Convert(ctx, env, qrecord, typeConversions, numericTruncator, format)
 			if err != nil {
 				logger.Error("Failed to convert QRecord to Avro compatible map", slog.Any("error", err))
 				return numRows.Load(), fmt.Errorf("failed to convert QRecord to Avro compatible map: %w", err)

--- a/flow/model/conversion_avro.go
+++ b/flow/model/conversion_avro.go
@@ -54,6 +54,7 @@ func (qac *QRecordAvroConverter) Convert(
 	qrecord []types.QValue,
 	typeConversions map[string]types.TypeConversion,
 	numericTruncator SnapshotTableNumericTruncator,
+	format internal.BinaryFormat,
 ) (map[string]any, error) {
 	m := make(map[string]any, len(qrecord))
 	for idx, val := range qrecord {
@@ -64,6 +65,7 @@ func (qac *QRecordAvroConverter) Convert(
 			ctx, env, val,
 			&qac.Schema.Fields[idx], qac.TargetDWH, qac.logger, qac.UnboundedNumericAsString,
 			numericTruncator.Get(idx),
+			format,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert QValue to Avro-compatible value: %w", err)

--- a/flow/model/conversion_avro.go
+++ b/flow/model/conversion_avro.go
@@ -62,7 +62,7 @@ func (qac *QRecordAvroConverter) Convert(
 			val = typeConversion.ValueConversion(val)
 		}
 		avroVal, err := qvalue.QValueToAvro(
-			ctx, env, val,
+			ctx, val,
 			&qac.Schema.Fields[idx], qac.TargetDWH, qac.logger, qac.UnboundedNumericAsString,
 			numericTruncator.Get(idx),
 			format,

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -198,6 +198,7 @@ func QValueToAvro(
 		Stat:                     stat,
 		TargetDWH:                targetDWH,
 		UnboundedNumericAsString: unboundedNumericAsString,
+		binaryFormat:             binaryFormat,
 	}
 
 	switch v := value.(type) {

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -179,12 +179,14 @@ type QValueAvroConverter struct {
 	Stat                     *NumericStat
 	TargetDWH                protos.DBType
 	UnboundedNumericAsString bool
+	binaryFormat             internal.BinaryFormat
 }
 
 func QValueToAvro(
 	ctx context.Context, env map[string]string,
 	value types.QValue, field *types.QField, targetDWH protos.DBType, logger log.Logger,
 	unboundedNumericAsString bool, stat *NumericStat,
+	binaryFormat internal.BinaryFormat,
 ) (any, error) {
 	if value.Value() == nil {
 		return nil, nil
@@ -257,11 +259,7 @@ func QValueToAvro(
 	case types.QValueNumeric:
 		return c.processNumeric(v.Val), nil
 	case types.QValueBytes:
-		format, err := internal.PeerDBBinaryFormat(ctx, env)
-		if err != nil {
-			return nil, err
-		}
-		return c.processBytes(v.Val, format), nil
+		return c.processBytes(v.Val), nil
 	case types.QValueJSON:
 		return c.processJSON(v.Val), nil
 	case types.QValueHStore:
@@ -468,16 +466,16 @@ func (c *QValueAvroConverter) processArrayNumeric(arrayNum []decimal.Decimal) an
 	return transformedNumArr
 }
 
-func (c *QValueAvroConverter) processBytes(byteData []byte, format internal.BinaryFormat) any {
-	if c.TargetDWH == protos.DBType_CLICKHOUSE && format != internal.BinaryFormatRaw {
+func (c *QValueAvroConverter) processBytes(byteData []byte) any {
+	if c.TargetDWH == protos.DBType_CLICKHOUSE && c.binaryFormat != internal.BinaryFormatRaw {
 		var encoded string
-		switch format {
+		switch c.binaryFormat {
 		case internal.BinaryFormatBase64:
 			encoded = base64.StdEncoding.EncodeToString(byteData)
 		case internal.BinaryFormatHex:
 			encoded = strings.ToUpper(hex.EncodeToString(byteData))
 		default:
-			panic(fmt.Sprintf("unhandled binary format: %d", format))
+			panic(fmt.Sprintf("unhandled binary format: %d", c.binaryFormat))
 		}
 		if c.Nullable {
 			return &encoded

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -183,7 +183,7 @@ type QValueAvroConverter struct {
 }
 
 func QValueToAvro(
-	ctx context.Context, env map[string]string,
+	ctx context.Context,
 	value types.QValue, field *types.QField, targetDWH protos.DBType, logger log.Logger,
 	unboundedNumericAsString bool, stat *NumericStat,
 	binaryFormat internal.BinaryFormat,


### PR DESCRIPTION
During a parallel initial load from MySQL to ClickHouse, it was observed that the PeerDBBinaryFormat call in QValueToAvro which gets the value of the binary format dynamic setting from catalog was taking ~60% of CPU utilisation of the flow-worker pod.
Makes sense - making a call to Postgres for every single record can be expensive
This PR moves this fetch outside the loop on the pulled records.

Also some lint in `cdc_flow.go`