### PR TITLE
ch distributed: don't use Distributed when ShardingKey not specified

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -195,7 +195,7 @@ func (c *ClickHouseConnector) ReplayTableSchemaDeltas(
 			}
 
 			// Distributed table isn't created for null tables, no need to alter shard tables that don't exist
-			if c.config.Cluster != "" && (tm == nil || tm.Engine != protos.TableEngine_CH_ENGINE_NULL) {
+			if c.config.Cluster != "" && (tm != nil && tm.ShardingKey != "" && tm.Engine != protos.TableEngine_CH_ENGINE_NULL) {
 				if err := c.execWithLogging(ctx,
 					fmt.Sprintf("ALTER TABLE %s%s ADD COLUMN IF NOT EXISTS %s %s",
 						peerdb_clickhouse.QuoteIdentifier(schemaDelta.DstTableName+"_shard"), onCluster,

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -130,7 +130,7 @@ func (c *ClickHouseConnector) generateCreateTableSQLForNormalizedTable(
 	var stmtBuilder strings.Builder
 	var stmtBuilderDistributed strings.Builder
 	var builders []*strings.Builder
-	if c.config.Cluster != "" && tmEngine != protos.TableEngine_CH_ENGINE_NULL {
+	if c.config.Cluster != "" && tableMapping.ShardingKey != "" && tmEngine != protos.TableEngine_CH_ENGINE_NULL {
 		builders = []*strings.Builder{&stmtBuilder, &stmtBuilderDistributed}
 	} else {
 		builders = []*strings.Builder{&stmtBuilder}
@@ -146,7 +146,7 @@ func (c *ClickHouseConnector) generateCreateTableSQLForNormalizedTable(
 		if !config.IsResync {
 			builder.WriteString("IF NOT EXISTS ")
 		}
-		if c.config.Cluster != "" && tmEngine != protos.TableEngine_CH_ENGINE_NULL && idx == 0 {
+		if c.config.Cluster != "" && tableMapping.ShardingKey != "" && tmEngine != protos.TableEngine_CH_ENGINE_NULL && idx == 0 {
 			// distributed table gets destination name, avoid naming conflict
 			builder.WriteString(peerdb_clickhouse.QuoteIdentifier(tableIdentifier + "_shard"))
 		} else {
@@ -232,7 +232,7 @@ func (c *ClickHouseConnector) generateCreateTableSQLForNormalizedTable(
 			stmtBuilder.WriteString(" SETTINGS allow_nullable_key = 1")
 		}
 
-		if c.config.Cluster != "" {
+		if c.config.Cluster != "" && tableMapping.ShardingKey != "" {
 			fmt.Fprintf(&stmtBuilderDistributed, " ENGINE = Distributed(%s,%s,%s",
 				peerdb_clickhouse.QuoteIdentifier(c.config.Cluster),
 				peerdb_clickhouse.QuoteIdentifier(c.config.Database),


### PR DESCRIPTION
this supports having ReplicatedMergeTree created on replicas without using Distributed engine

TODO how to handle raw table