### PR TITLE
Allow updating of the `snapshot` variables for mirror

### DIFF
--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -153,6 +153,10 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 		config.IdleTimeoutSeconds = state.SyncFlowOptions.IdleTimeoutSeconds
 		config.MaxBatchSize = state.SyncFlowOptions.BatchSize
 		config.TableMappings = state.SyncFlowOptions.TableMappings
+
+		config.SnapshotMaxParallelWorkers = state.FlowConfigUpdate.SnapshotMaxParallelWorkers
+		config.SnapshotNumTablesInParallel = state.FlowConfigUpdate.SnapshotNumTablesInParallel
+		config.SnapshotNumRowsPerPartition = state.FlowConfigUpdate.SnapshotNumRowsPerPartition
 	}
 
 	srcType, err := connectors.LoadPeerType(ctx, h.pool, config.SourceName)

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -98,6 +98,11 @@ func updateFlowConfigWithLatestSettings(
 	cloneCfg.MaxBatchSize = state.SyncFlowOptions.BatchSize
 	cloneCfg.IdleTimeoutSeconds = state.SyncFlowOptions.IdleTimeoutSeconds
 	cloneCfg.TableMappings = state.SyncFlowOptions.TableMappings
+
+	// Update `snapshot` settings
+	cloneCfg.SnapshotMaxParallelWorkers = cfg.SnapshotMaxParallelWorkers
+	cloneCfg.SnapshotNumTablesInParallel = cfg.SnapshotNumTablesInParallel
+	cloneCfg.SnapshotNumRowsPerPartition = cfg.SnapshotNumRowsPerPartition
 	return cloneCfg
 }
 

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -422,6 +422,10 @@ message CDCFlowConfigUpdate {
   repeated TableMapping removed_tables = 5;
   // updates keys in the env map, existing keys left unchanged
   map<string, string> updated_env = 6;
+  // updating snapshot settings
+  uint32 snapshot_num_rows_per_partition = 7;
+  uint32 snapshot_max_parallel_workers = 8;
+  uint32 snapshot_num_tables_in_parallel = 9;
 }
 
 message QRepFlowConfigUpdate {


### PR DESCRIPTION
As part of our use-case we have tables of varying sizes and we would like
to be able to tweak the snapshot sizes/concurrency to ensure a smooth
initial snapshot.

This would also allow us to bump the concurrency for the initial sync if
we need to do this in lower traffic hours vs peak traffic.
