### PR TITLE
mongo: update config with fields for username/password/tls

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -401,8 +401,12 @@ jobs:
           ELASTICSEARCH_TEST_ADDRESS: http://localhost:9200
           CI_PG_VERSION: ${{ matrix.db-version.pg }}
           CI_MYSQL_VERSION: ${{ matrix.db-version.mysql }}
-          CI_MONGO_ADMIN_URI: mongodb://admin:admin@localhost:27017/?replicaSet=rs0&authSource=admin
-          CI_MONGO_URI: mongodb://csuser:cspass@localhost:27017/?replicaSet=rs0&authSource=admin
+          CI_MONGO_ADMIN_URI: mongodb://localhost:27017/?replicaSet=rs0&authSource=admin
+          CI_MONGO_ADMIN_USERNAME: "admin"
+          CI_MONGO_ADMIN_PASSWORD: "admin"
+          CI_MONGO_URI: mongodb://localhost:27017/?replicaSet=rs0&authSource=admin
+          CI_MONGO_USERNAME: "csuser"
+          CI_MONGO_PASSWORD: "cspass"
           ENABLE_OTEL_METRICS: ${{ (matrix.db-version.pg == '16' || matrix.db-version.mysql == 'mysql-pos') && 'true' || 'false' }}
           OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: http://localhost:4317
           OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: grpc

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -2,6 +2,7 @@ package connmongo
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -11,7 +12,9 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/connstring"
 	"go.temporal.io/sdk/log"
 
 	metadataStore "github.com/PeerDB-io/peerdb/flow/connectors/external_metadata"
@@ -43,11 +46,12 @@ func NewMongoConnector(ctx context.Context, config *protos.MongoConfig) (*MongoC
 		return nil, err
 	}
 
-	client, err := mongo.Connect(options.Client().
-		SetAppName("PeerDB Mongo Connector").
-		SetReadPreference(readpref.SecondaryPreferred()).
-		SetCompressors([]string{"zstd", "snappy"}).
-		ApplyURI(config.Uri))
+	clientOptions, err := parseAsClientOptions(config)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := mongo.Connect(clientOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -381,4 +385,46 @@ func defaultPipeline() mongo.Pipeline {
 			{Key: "ns", Value: 1},
 		}}},
 	}
+}
+
+func parseAsClientOptions(config *protos.MongoConfig) (*options.ClientOptions, error) {
+	connStr, err := connstring.Parse(config.Uri)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing uri: %w", err)
+	}
+
+	if connStr.Username != "" || connStr.Password != "" {
+		return nil, fmt.Errorf("connection string should not contain username and password")
+	}
+
+	clientOptions := options.Client().
+		ApplyURI(config.Uri).
+		SetAppName("PeerDB Mongo Connector").
+		SetAuth(options.Credential{
+			Username: config.Username,
+			Password: config.Password,
+		}).
+		// always use compression
+		SetCompressors([]string{"zstd", "snappy"}).
+		// always use majority read concern for correctness
+		SetReadConcern(readconcern.Majority())
+
+	// allow user to override with other read preference
+	if connStr.ReadPreference == "" {
+		clientOptions.SetReadPreference(readpref.SecondaryPreferred())
+	}
+
+	if !config.DisableTls && len(connStr.Hosts) > 0 {
+		tlsConfig, err := shared.CreateTlsConfig(tls.VersionTLS12, config.RootCa, connStr.Hosts[0], config.TlsHost, false)
+		if err != nil {
+			return nil, err
+		}
+		clientOptions.SetTLSConfig(tlsConfig)
+	}
+
+	err = clientOptions.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("error validating client options: %w", err)
+	}
+	return clientOptions, nil
 }

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -394,7 +394,7 @@ func parseAsClientOptions(config *protos.MongoConfig) (*options.ClientOptions, e
 	}
 
 	if connStr.Username != "" || connStr.Password != "" {
-		return nil, fmt.Errorf("connection string should not contain username and password")
+		return nil, errors.New("connection string should not contain username and password")
 	}
 
 	clientOptions := options.Client().
@@ -414,8 +414,8 @@ func parseAsClientOptions(config *protos.MongoConfig) (*options.ClientOptions, e
 		clientOptions.SetReadPreference(readpref.SecondaryPreferred())
 	}
 
-	if !config.DisableTls && len(connStr.Hosts) > 0 {
-		tlsConfig, err := shared.CreateTlsConfig(tls.VersionTLS12, config.RootCa, connStr.Hosts[0], config.TlsHost, false)
+	if !config.DisableTls {
+		tlsConfig, err := shared.CreateTlsConfig(tls.VersionTLS12, config.RootCa, "", config.TlsHost, false)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/e2e/mongo/mongo_test.go
+++ b/flow/e2e/mongo/mongo_test.go
@@ -12,6 +12,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 
 	connmongo "github.com/PeerDB-io/peerdb/flow/connectors/mongo"
 	"github.com/PeerDB-io/peerdb/flow/e2e"
@@ -49,7 +50,14 @@ func SetupMongo(t *testing.T, suffix string) (*MongoSource, error) {
 	mongoUri := os.Getenv("CI_MONGO_URI")
 	require.NotEmpty(t, mongoUri, "missing CI_MONGO_URI env var")
 
-	mongoConfig := &protos.MongoConfig{Uri: mongoUri}
+	connStr, err := connstring.Parse(mongoUri)
+	require.NoError(t, err)
+	mongoConfig := &protos.MongoConfig{
+		Uri:        mongoUri,
+		Username:   connStr.Username,
+		Password:   connStr.Password,
+		DisableTls: true,
+	}
 
 	mongoConn, err := connmongo.NewMongoConnector(t.Context(), mongoConfig)
 	require.NoError(t, err, "failed to setup mongo connector")

--- a/flow/go.mod
+++ b/flow/go.mod
@@ -159,6 +159,7 @@ require (
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nexus-rpc/sdk-go v0.4.0 // indirect
@@ -201,6 +202,7 @@ require (
 	go.etcd.io/etcd/api/v3 v3.6.1 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.1 // indirect
 	go.etcd.io/etcd/client/v3 v3.6.1 // indirect
+	go.mongodb.org/mongo-driver v1.17.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.37.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 // indirect

--- a/flow/go.sum
+++ b/flow/go.sum
@@ -475,6 +475,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
+github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -701,6 +703,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.1/go.mod h1:aTkCp+6ixcVTZmrJGa7/Mc5nMNs59PEgB
 go.etcd.io/etcd/client/v3 v3.6.1 h1:KelkcizJGsskUXlsxjVrSmINvMMga0VWwFF0tSPGEP0=
 go.etcd.io/etcd/client/v3 v3.6.1/go.mod h1:fCbPUdjWNLfx1A6ATo9syUmFVxqHH9bCnPLBZmnLmMY=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
+go.mongodb.org/mongo-driver v1.17.4 h1:jUorfmVzljjr0FLzYQsGP8cgN/qzzxlY9Vh0C9KFXVw=
+go.mongodb.org/mongo-driver v1.17.4/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.mongodb.org/mongo-driver/v2 v2.2.2 h1:9cYuS3fl1Xhqwpfazso10V7BHQD58kCgtzhfAmJYz9c=
 go.mongodb.org/mongo-driver/v2 v2.2.2/go.mod h1:qQkDMhCGWl3FN509DfdPd4GRBLU/41zqF/k8eTRceps=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -645,6 +645,23 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .get("uri")
                     .context("no uri specified")?
                     .to_string(),
+                username: opts
+                    .get("username")
+                    .context("no username specified")?
+                    .to_string(),
+                password: opts
+                    .get("password")
+                    .context("no password specified")?
+                    .to_string(),
+                disable_tls: opts
+                    .get("disable_tls")
+                    .map(|s| s.parse::<bool>().unwrap_or_default())
+                    .unwrap_or_default(),
+                root_ca: opts.get("root_ca").map(|s| s.to_string()),
+                tls_host: opts
+                    .get("tls_host")
+                    .map(|s| s.to_string())
+                    .unwrap_or_default(),
             };
             Config::MongoConfig(mongo_config)
         }

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -65,7 +65,12 @@ message PubSubConfig {
 message MongoConfig {
   // can be a mongodb:// URI mapping to discrete hosts or a mongodb+srv:// URI
   // mapping to a DNS SRV record.
-  string uri = 1 [(peerdb_redacted) = true];
+  string uri = 1;
+  string username = 2;
+  string password = 3 [(peerdb_redacted) = true];
+  bool disable_tls = 4;
+  string tls_host = 5;
+  optional string root_ca = 6 [(peerdb_redacted) = true];
 }
 
 message AwsAuthStaticCredentialsConfig {

--- a/ui/app/peers/create/[peerType]/helpers/mo.ts
+++ b/ui/app/peers/create/[peerType]/helpers/mo.ts
@@ -7,10 +7,56 @@ export const mongoSetting: PeerSetting[] = [
     field: 'uri',
     stateHandler: (value, setter) =>
       setter((curr) => ({ ...curr, uri: value as string })),
-    tips: 'MongoDB connection string',
+    tips: 'SRV connection string (mongodb+srv://<srv-host>) or direct connection string (mongodb://<host1>,<host2>,<host3>).',
+  },
+  {
+    label: 'Username',
+    field: 'username',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, username: value as string })),
+    tips: 'Username associated with the user you provided.',
+  },
+  {
+    label: 'Password',
+    field: 'password',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, password: value as string })),
+    type: 'password',
+    tips: 'Password associated with the user you provided.',
+  },
+  {
+    label: 'Disable TLS?',
+    field: 'disableTls',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, disableTls: value as boolean })),
+    type: 'switch',
+    optional: true,
+    tips: 'If you are using a non-TLS connection, check this box.',
+  },
+  {
+    label: 'TLS Host',
+    field: 'tlsHost',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, tlsHost: value as string })),
+    optional: true,
+    tips: 'Overrides expected hostname during tls cert verification.',
+  },
+  {
+    label: 'Root Certificate',
+    field: 'rootCa',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, rootCa: value as string })),
+    type: 'file',
+    optional: true,
+    tips: 'Root certificate for TLS connection.',
   },
 ];
 
 export const blankMongoSetting: MongoConfig = {
   uri: '',
+  username: '',
+  password: '',
+  disableTls: false,
+  tlsHost: '',
+  rootCa: '',
 };

--- a/ui/app/peers/create/[peerType]/page.tsx
+++ b/ui/app/peers/create/[peerType]/page.tsx
@@ -18,6 +18,7 @@ import EventhubsForm from '@/components/PeerForms/Eventhubs/EventhubGroupConfig'
 import {
   ElasticsearchConfig,
   EventHubGroupConfig,
+  MongoConfig,
   MySqlConfig,
   PostgresConfig,
 } from '@/grpc_generated/peers';
@@ -35,6 +36,7 @@ import { ToastContainer } from 'react-toastify';
 import { handleCreate, handleValidate } from './handlers';
 import { clickhouseSetting } from './helpers/ch';
 import { getBlankSetting } from './helpers/common';
+import { mongoSetting } from './helpers/mo';
 import { mysqlSetting } from './helpers/my';
 import { postgresSetting } from './helpers/pg';
 import { snowflakeSetting } from './helpers/sf';
@@ -121,7 +123,13 @@ export default function CreateConfig({
           />
         );
       case 'MONGO':
-        return <MongoForm setter={setConfig} />;
+        return (
+          <MongoForm
+            settings={mongoSetting}
+            setter={setConfig}
+            config={config as MongoConfig}
+          />
+        );
       default:
         return <></>;
     }

--- a/ui/components/PeerForms/MongoForm.tsx
+++ b/ui/components/PeerForms/MongoForm.tsx
@@ -1,83 +1,163 @@
 import { PeerSetter } from '@/app/dto/PeersDTO';
-import { mongoSetting } from '@/app/peers/create/[peerType]/helpers/mo';
+import { PeerSetting } from '@/app/peers/create/[peerType]/helpers/common';
 import SelectTheme from '@/app/styles/select';
 import InfoPopover from '@/components/InfoPopover';
+import { handleFieldChange } from '@/components/PeerForms/common';
+import { MongoConfig } from '@/grpc_generated/peers';
 import { Label } from '@/lib/Label';
-import { RowWithSelect, RowWithTextField } from '@/lib/Layout';
+import { RowWithSelect, RowWithSwitch, RowWithTextField } from '@/lib/Layout';
+import { Switch } from '@/lib/Switch';
 import { TextField } from '@/lib/TextField';
 import { Tooltip } from '@/lib/Tooltip';
 import ReactSelect from 'react-select';
 
 interface MongoFormProps {
+  settings: PeerSetting[];
   setter: PeerSetter;
+  config: MongoConfig;
 }
 
-export default function MongoForm({ setter }: MongoFormProps) {
+export default function MongoForm({
+  settings,
+  setter,
+  config,
+}: MongoFormProps) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', rowGap: '0.5rem' }}>
-      {mongoSetting.map((setting, index) => {
-        return setting.type === 'select' ? (
-          <RowWithSelect
-            key={index}
-            label={<Label>{setting.label}</Label>}
-            action={
-              <ReactSelect
-                placeholder={setting.placeholder}
-                onChange={(val) =>
-                  val && setting.stateHandler(val.value, setter)
+    <>
+      {settings.map((setting, id) => {
+        if (setting.type === 'switch') {
+          return (
+            <RowWithSwitch
+              key={id}
+              label={
+                <Label>
+                  {setting.label}{' '}
+                  {!setting.optional && (
+                    <Tooltip
+                      style={{ width: '100%' }}
+                      content='This is a required field.'
+                    >
+                      <Label colorName='lowContrast' colorSet='destructive'>
+                        *
+                      </Label>
+                    </Tooltip>
+                  )}
+                </Label>
+              }
+              action={
+                <div>
+                  <Switch
+                    onCheckedChange={(val: boolean) =>
+                      setting.stateHandler(val, setter)
+                    }
+                  />
+                  {setting.tips && (
+                    <InfoPopover
+                      tips={setting.tips}
+                      link={setting.helpfulLink}
+                    />
+                  )}
+                </div>
+              }
+            />
+          );
+        }
+
+        if (setting.type === 'select') {
+          return (
+            <div key={id}>
+              <RowWithSelect
+                label={
+                  <Label>
+                    {setting.label}
+                    {!setting.optional && (
+                      <Tooltip
+                        style={{ width: '100%' }}
+                        content='This is a required field.'
+                      >
+                        <Label colorName='lowContrast' colorSet='destructive'>
+                          *
+                        </Label>
+                      </Tooltip>
+                    )}
+                  </Label>
                 }
-                options={setting.options}
-                theme={SelectTheme}
+                action={
+                  <div>
+                    <div>
+                      <ReactSelect
+                        placeholder={setting.placeholder}
+                        defaultValue={setting.options?.find(
+                          ({ value }) => value === setting.default
+                        )}
+                        onChange={(val) =>
+                          val && setting.stateHandler(val.value, setter)
+                        }
+                        options={setting.options}
+                        theme={SelectTheme}
+                      />
+                    </div>
+                    {setting.tips && (
+                      <InfoPopover
+                        tips={setting.tips}
+                        link={setting.helpfulLink}
+                      />
+                    )}
+                  </div>
+                }
               />
-            }
-          />
-        ) : (
-          <RowWithTextField
-            key={index}
-            label={
-              <Label>
-                {setting.label}{' '}
-                {!setting.optional && (
-                  <Tooltip
-                    style={{ width: '100%' }}
-                    content='This is a required field.'
-                  >
-                    <Label colorName='lowContrast' colorSet='destructive'>
-                      *
-                    </Label>
-                  </Tooltip>
-                )}
-              </Label>
-            }
-            action={
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                }}
-              >
-                <TextField
-                  variant='simple'
+            </div>
+          );
+        }
+
+        return (
+          <div key={id}>
+            <RowWithTextField
+              label={
+                <Label>
+                  {setting.label}{' '}
+                  {!setting.optional && (
+                    <Tooltip content='This is a required field.'>
+                      <Label colorName='lowContrast' colorSet='destructive'>
+                        *
+                      </Label>
+                    </Tooltip>
+                  )}
+                </Label>
+              }
+              action={
+                <div
                   style={{
-                    border: 'auto',
-                    width: '100%',
+                    display: 'flex',
+                    flexDirection: 'row',
+                    alignItems: 'center',
                   }}
-                  type={setting.type || 'text'}
-                  defaultValue={setting.default}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setting.stateHandler(e.target.value, setter)
-                  }
-                  placeholder={setting.placeholder}
-                />
-                {setting.tips && (
-                  <InfoPopover tips={setting.tips} link={setting.helpfulLink} />
-                )}
-              </div>
-            }
-          />
+                >
+                  <TextField
+                    variant='simple'
+                    style={
+                      setting.type === 'file'
+                        ? { border: 'none', height: 'auto' }
+                        : { border: 'auto' }
+                    }
+                    type={setting.type}
+                    defaultValue={setting.default}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      handleFieldChange(e, setting, setter)
+                    }
+                  />
+                  {setting.tips && (
+                    <InfoPopover
+                      tips={setting.tips}
+                      link={setting.helpfulLink}
+                    />
+                  )}
+                </div>
+              }
+            />
+          </div>
         );
       })}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
- Separate out username and password to separate fields.
- Add default client options - currently give user override options via connection string, we can also choose to ignore user options always use default 
- Add TLS support
- Apply corresponding changes to frontend.

TODO: verify TLS works as expected