### PR TITLE
mongo: use same partial reporting mechanism as mysql

### DIFF
--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -34,9 +35,10 @@ const (
 
 type MongoConnector struct {
 	*metadataStore.PostgresMetadata
-	config *protos.MongoConfig
-	client *mongo.Client
-	logger log.Logger
+	config    *protos.MongoConfig
+	client    *mongo.Client
+	logger    log.Logger
+	bytesRead atomic.Int64
 }
 
 func NewMongoConnector(ctx context.Context, config *protos.MongoConfig) (*MongoConnector, error) {

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/PeerDB-io/peerdb/flow/shared"
 	"log/slog"
 	"math"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
+	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 

--- a/flow/connectors/mysql/qrep.go
+++ b/flow/connectors/mysql/qrep.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/PeerDB-io/peerdb/flow/shared"
 	"log/slog"
 	"strconv"
 	"text/template"
@@ -18,6 +17,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
+	"github.com/PeerDB-io/peerdb/flow/shared"
 	shared_mysql "github.com/PeerDB-io/peerdb/flow/shared/mysql"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )

--- a/flow/connectors/utils/monitoring/monitoring.go
+++ b/flow/connectors/utils/monitoring/monitoring.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -17,6 +18,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	shared_mysql "github.com/PeerDB-io/peerdb/flow/shared/mysql"
 )
@@ -445,4 +447,18 @@ func AuditSchemaDelta(ctx context.Context, pool *pgxpool.Pool,
 		return fmt.Errorf("failed to insert row into table: %w", err)
 	}
 	return nil
+}
+
+func ReportOngoingBytesFetched(ctx context.Context, bytesRead *atomic.Int64, otelManager *otel_metrics.OtelManager) {
+	ticker := time.NewTicker(time.Minute)
+	for {
+		select {
+		case <-ticker.C:
+			if read := bytesRead.Swap(0); read != 0 {
+				otelManager.Metrics.FetchedBytesCounter.Add(ctx, read)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/PeerDB-io/peerdb/pull/3180

~(not sure if `monitoring` is the right package or if there's a better place for this util function)~