### PR TITLE
Convert PG Composite Types to Tuples in CH

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -147,6 +148,20 @@ func (c *PostgresConnector) fetchCustomTypeMapping(ctx context.Context) (map[uin
 			return nil, err
 		}
 		c.customTypeMapping = customTypeMapping
+
+		var compositeTypeNames []string
+		for _, typeData := range customTypeMapping {
+			if typeData.Type == 'c' && typeData.Delim == 0 { // Only composite types
+				compositeTypeNames = append(compositeTypeNames, typeData.Name)
+			}
+		}
+		types, err := c.conn.LoadTypes(ctx, compositeTypeNames)
+		if err != nil {
+			c.logger.Error("failed to load composite types",
+				slog.Any("error", err), slog.Any("composite_type_names", compositeTypeNames))
+			return nil, fmt.Errorf("failed to load composite types: %w", err)
+		}
+		c.typeMap.RegisterTypes(types)
 	}
 	return c.customTypeMapping, nil
 }
@@ -872,6 +887,29 @@ func (c *PostgresConnector) getCompositeTypeDetails(ctx context.Context, system 
 			if err != nil {
 				return nil, fmt.Errorf("error getting composite type details for subfield %d: %w", subfield.Type.OID, err)
 			}
+		} else if subColType == "array_composite" {
+			slog.Info("array composite type detected, fetching element type details",
+				slog.Any("subfieldTypeOID", subfield.Type.OID),
+				slog.String("subfieldName", subfield.Name),
+			)
+			var elemOID uint32
+			err := c.conn.QueryRow(ctx,
+				`select typelem from pg_type where oid = $1`, subfield.Type.OID).Scan(&elemOID)
+			if err != nil {
+				return nil, fmt.Errorf("error getting array element type OID for %d: %w", subfield.Type.OID, err)
+			}
+			elemTypeDetails, err := c.getCompositeTypeDetails(ctx, system, version, customTypeMapping, elemOID)
+
+			subCompositeFields = append(subCompositeFields, &protos.FieldDescription{
+				Name:         subfield.Name,
+				Type:         "composite",
+				TypeModifier: -1,
+				Nullable:     false,
+				Composite:    elemTypeDetails,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error getting composite type details for array element %d: %w", elemOID, err)
+			}
 		}
 		result = append(result, &protos.FieldDescription{
 			Name:         subfield.Name,
@@ -950,14 +988,21 @@ func (c *PostgresConnector) getTableSchemaForTable(
 	if err != nil {
 		return nil, fmt.Errorf("error getting table schema for table %s: %w", schemaTable, err)
 	}
-	fields := rows.FieldDescriptions()
+
+	var fieldsCopy []pgconn.FieldDescription
+	{
+		fields := rows.FieldDescriptions()
+		fieldsCopy = make([]pgconn.FieldDescription, len(fields))
+		copy(fieldsCopy, fields)
+	}
+
 	rows.Close()
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating over table schema: %w", err)
 	}
-	columnNames := make([]string, 0, len(fields))
-	columns := make([]*protos.FieldDescription, 0, len(fields))
-	for _, fieldDescription := range fields {
+	columnNames := make([]string, 0, len(fieldsCopy))
+	columns := make([]*protos.FieldDescription, 0, len(fieldsCopy))
+	for _, fieldDescription := range fieldsCopy {
 		var colType string
 		var err error
 		switch system {
@@ -979,8 +1024,33 @@ func (c *PostgresConnector) getTableSchemaForTable(
 			}
 			composite = subtypes
 		}
+		if colType == "array_composite" {
+			slog.Info("array composite type detected, fetching element type details",
+				slog.Any("subfieldTypeOID", fieldDescription.DataTypeOID),
+				slog.String("subfieldName", fieldDescription.Name),
+			)
+			var elemOID uint32
+			err := c.conn.QueryRow(ctx,
+				`select typelem from pg_type where oid = $1`, fieldDescription.DataTypeOID).Scan(&elemOID)
+			if err != nil {
+				return nil, fmt.Errorf("error getting array element type OID for %d: %w", fieldDescription.DataTypeOID, err)
+			}
+			elemTypeDetails, err := c.getCompositeTypeDetails(ctx, system, version, customTypeMapping, elemOID)
+
+			composite = append(composite, &protos.FieldDescription{
+				Name:         fieldDescription.Name,
+				Type:         "composite",
+				TypeModifier: -1,
+				Nullable:     false,
+				Composite:    elemTypeDetails,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error getting composite type details for array element %d: %w", elemOID, err)
+			}
+		}
 
 		columnNames = append(columnNames, fieldDescription.Name)
+		slog.Info("fieldDescription", slog.String("name", fieldDescription.Name))
 		_, nullable := nullableCols[fieldDescription.Name]
 		columns = append(columns, &protos.FieldDescription{
 			Name:         fieldDescription.Name,

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -845,6 +845,45 @@ func (c *PostgresConnector) GetSelectedColumns(
 	return columns, nil
 }
 
+func (c *PostgresConnector) getCompositeTypeDetails(ctx context.Context, system protos.TypeSystem, version uint32,
+	customTypeMapping map[uint32]shared.CustomDataType, OID uint32) ([]*protos.FieldDescription, error) {
+	result := make([]*protos.FieldDescription, 0)
+	subfields, err := shared.GetCompositeDataTypeDetails(ctx, c.conn, OID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting composite data type details for %d: %w", OID, err)
+	}
+	for _, subfield := range subfields {
+		var subColType string
+		var err error
+		switch system {
+		case protos.TypeSystem_PG:
+			subColType, err = c.postgresOIDToName(subfield.Type.OID, customTypeMapping)
+		case protos.TypeSystem_Q:
+			qColType := c.postgresOIDToQValueKind(subfield.Type.OID, customTypeMapping, version)
+			subColType = string(qColType)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error getting type name for subfield %d: %w", subfield.Type.OID, err)
+		}
+		subCompositeFields := make([]*protos.FieldDescription, 0)
+		if subColType == "composite" {
+			subCompositeFields, err = c.getCompositeTypeDetails(ctx, system, version, customTypeMapping, subfield.Type.OID)
+			if err != nil {
+				return nil, fmt.Errorf("error getting composite type details for subfield %d: %w", subfield.Type.OID, err)
+			}
+		}
+		result = append(result, &protos.FieldDescription{
+			Name:         subfield.Name,
+			Type:         subColType,
+			TypeModifier: subfield.TypeModifier,
+			Nullable:     !subfield.NotNull,
+			Composite:    subCompositeFields,
+		})
+	}
+	return result, nil
+}
+
 func (c *PostgresConnector) getTableSchemaForTable(
 	ctx context.Context,
 	env map[string]string,
@@ -911,9 +950,11 @@ func (c *PostgresConnector) getTableSchemaForTable(
 	if err != nil {
 		return nil, fmt.Errorf("error getting table schema for table %s: %w", schemaTable, err)
 	}
-	defer rows.Close()
-
 	fields := rows.FieldDescriptions()
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating over table schema: %w", err)
+	}
 	columnNames := make([]string, 0, len(fields))
 	columns := make([]*protos.FieldDescription, 0, len(fields))
 	for _, fieldDescription := range fields {
@@ -930,6 +971,15 @@ func (c *PostgresConnector) getTableSchemaForTable(
 			return nil, fmt.Errorf("error getting type name for %d: %w", fieldDescription.DataTypeOID, err)
 		}
 
+		composite := make([]*protos.FieldDescription, 0)
+		if colType == "composite" {
+			subtypes, err := c.getCompositeTypeDetails(ctx, system, version, customTypeMapping, fieldDescription.DataTypeOID)
+			if err != nil {
+				return nil, fmt.Errorf("error getting composite type details for %d: %w", fieldDescription.DataTypeOID, err)
+			}
+			composite = subtypes
+		}
+
 		columnNames = append(columnNames, fieldDescription.Name)
 		_, nullable := nullableCols[fieldDescription.Name]
 		columns = append(columns, &protos.FieldDescription{
@@ -937,11 +987,8 @@ func (c *PostgresConnector) getTableSchemaForTable(
 			Type:         colType,
 			TypeModifier: fieldDescription.TypeModifier,
 			Nullable:     nullable,
+			Composite:    composite,
 		})
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating over table schema: %w", err)
 	}
 	// if we have no pkey, we will use all columns as the pkey for the MERGE statement
 	if replicaIdentityType == ReplicaIdentityFull && len(pKeyCols) == 0 {

--- a/flow/connectors/postgres/qrep_query_executor.go
+++ b/flow/connectors/postgres/qrep_query_executor.go
@@ -71,28 +71,80 @@ func (qe *QRepQueryExecutor) executeQueryInTx(ctx context.Context, tx pgx.Tx, cu
 	return rows, nil
 }
 
+// buildQFieldFromOID recursively builds a QField from a PostgreSQL OID, handling nested composite types
+func (qe *QRepQueryExecutor) buildQFieldFromOID(name string, oid uint32, typeModifier int32) types.QField {
+	ctype := qe.postgresOIDToQValueKind(oid, qe.customTypeMapping, qe.version)
+
+	if ctype == types.QValueKindNumeric || ctype == types.QValueKindArrayNumeric {
+		precision, scale := datatypes.ParseNumericTypmod(typeModifier)
+		return types.QField{
+			Name:      name,
+			Type:      ctype,
+			Nullable:  true,
+			Precision: precision,
+			Scale:     scale,
+		}
+	} else if ctype == types.QValueKindComposite {
+		if typ, ok := qe.typeMap.TypeForOID(oid); ok {
+			if cc, ok := typ.Codec.(*pgtype.CompositeCodec); ok {
+				subQFields := make([]*types.QField, 0)
+				for _, f := range cc.Fields {
+					// Recursively build subfields, handling nested composite types
+					subField := qe.buildQFieldFromOID(f.Name, f.Type.OID, -1)
+					subQFields = append(subQFields, &subField)
+				}
+				return types.QField{
+					Name:      name,
+					Type:      ctype,
+					Nullable:  false,
+					SubFields: subQFields,
+				}
+			}
+		}
+		qe.logger.Error("[pg_query_executor] type not found for oid or not a composite type",
+			slog.String("type_oid", fmt.Sprintf("%d", oid)),
+			slog.String("type_name", name))
+		return types.QField{
+			Name:     name,
+			Type:     ctype,
+			Nullable: false,
+		}
+	} else if ctype == types.QValueKindArrayComposite {
+		if typ, ok := qe.typeMap.TypeForOID(oid); ok {
+			if ac, ok := typ.Codec.(*pgtype.ArrayCodec); ok {
+				subQFields := make([]*types.QField, 0)
+				subField := qe.buildQFieldFromOID(ac.ElementType.Name, ac.ElementType.OID, -1)
+				subQFields = append(subQFields, &subField)
+				return types.QField{
+					Name:      name,
+					Type:      ctype,
+					Nullable:  true,
+					SubFields: subQFields,
+				}
+			}
+		}
+		qe.logger.Error("[pg_query_executor] type not found for oid or not an array composite type",
+			slog.String("type_oid", fmt.Sprintf("%d", oid)),
+			slog.String("type_name", name))
+		return types.QField{
+			Name:     name,
+			Type:     ctype,
+			Nullable: true,
+		}
+	} else {
+		return types.QField{
+			Name:     name,
+			Type:     ctype,
+			Nullable: true,
+		}
+	}
+}
+
 // FieldDescriptionsToSchema converts a slice of pgconn.FieldDescription to a QRecordSchema.
 func (qe *QRepQueryExecutor) fieldDescriptionsToSchema(fds []pgconn.FieldDescription) types.QRecordSchema {
 	qfields := make([]types.QField, len(fds))
 	for i, fd := range fds {
-		ctype := qe.postgresOIDToQValueKind(fd.DataTypeOID, qe.customTypeMapping, qe.version)
-		// there isn't a way to know if a column is nullable or not
-		if ctype == types.QValueKindNumeric || ctype == types.QValueKindArrayNumeric {
-			precision, scale := datatypes.ParseNumericTypmod(fd.TypeModifier)
-			qfields[i] = types.QField{
-				Name:      fd.Name,
-				Type:      ctype,
-				Nullable:  true,
-				Precision: precision,
-				Scale:     scale,
-			}
-		} else {
-			qfields[i] = types.QField{
-				Name:     fd.Name,
-				Type:     ctype,
-				Nullable: true,
-			}
-		}
+		qfields[i] = qe.buildQFieldFromOID(fd.Name, fd.DataTypeOID, fd.TypeModifier)
 	}
 	return types.NewQRecordSchema(qfields)
 }

--- a/flow/connectors/utils/cdc_store.go
+++ b/flow/connectors/utils/cdc_store.go
@@ -112,6 +112,7 @@ func init() {
 	gob.Register(types.QValueCIDR{})
 	gob.Register(types.QValueINET{})
 	gob.Register(types.QValueMacaddr{})
+	gob.Register(types.QValueComposite{})
 	gob.Register(types.QValueArrayFloat32{})
 	gob.Register(types.QValueArrayFloat64{})
 	gob.Register(types.QValueArrayInt16{})
@@ -126,6 +127,7 @@ func init() {
 	gob.Register(types.QValueArrayBoolean{})
 	gob.Register(types.QValueArrayUUID{})
 	gob.Register(types.QValueArrayNumeric{})
+	gob.Register(types.QValueArrayComposite{})
 }
 
 func (c *cdcStore[T]) initPebbleDB() error {

--- a/flow/model/conversion_avro.go
+++ b/flow/model/conversion_avro.go
@@ -102,7 +102,7 @@ func GetAvroSchemaDefinition(
 	avroFields := make([]*avro.Field, 0, len(qRecordSchema.Fields))
 
 	for _, qField := range qRecordSchema.Fields {
-		avroType, err := qvalue.GetAvroSchemaFromQValueKind(ctx, env, qField.Type, targetDWH, qField.Precision, qField.Scale)
+		avroType, err := qvalue.GetAvroSchemaFromQValueKind(ctx, env, qField, targetDWH)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -53,12 +53,10 @@ func ConvertToAvroCompatibleName(columnName string) string {
 func GetAvroSchemaFromQValueKind(
 	ctx context.Context,
 	env map[string]string,
-	kind types.QValueKind,
+	qField types.QField,
 	targetDWH protos.DBType,
-	precision int16,
-	scale int16,
 ) (avro.Schema, error) {
-	switch kind {
+	switch qField.Type {
 	case types.QValueKindString, types.QValueKindEnum, types.QValueKindQChar, types.QValueKindCIDR,
 		types.QValueKindINET, types.QValueKindMacaddr:
 		return avro.NewPrimitiveSchema(avro.String, nil), nil
@@ -94,7 +92,7 @@ func GetAvroSchemaFromQValueKind(
 		}
 		return avro.NewPrimitiveSchema(avro.Bytes, nil), nil
 	case types.QValueKindNumeric:
-		return getAvroNumericSchema(ctx, env, targetDWH, precision, scale)
+		return getAvroNumericSchema(ctx, env, targetDWH, qField.Precision, qField.Scale)
 	case types.QValueKindInt256:
 		return avro.NewFixedSchema("int256", "", 32, nil)
 	case types.QValueKindUInt256:
@@ -116,6 +114,44 @@ func GetAvroSchemaFromQValueKind(
 		return avro.NewPrimitiveSchema(avro.Long, avro.NewPrimitiveLogicalSchema(avro.TimestampMicros)), nil
 	case types.QValueKindHStore, types.QValueKindJSON, types.QValueKindJSONB:
 		return avro.NewPrimitiveSchema(avro.String, nil), nil
+	case types.QValueKindComposite:
+		if qField.SubFields == nil || len(qField.SubFields) == 0 {
+			return nil, fmt.Errorf("composite subfields are required for composite type but none provided")
+		}
+
+		avroFields := make([]*avro.Field, 0, len(qField.SubFields))
+		for _, field := range qField.SubFields {
+			fieldSchema, err := GetAvroSchemaFromQValueKind(
+				ctx, env, *field, targetDWH)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get avro schema for composite field %s: %w", field.Name, err)
+			}
+
+			if field.Nullable {
+				fieldSchema, err = avro.NewUnionSchema([]avro.Schema{avro.NewNullSchema(), fieldSchema})
+				if err != nil {
+					return nil, fmt.Errorf("failed to create nullable union for composite field %s: %w", field.Name, err)
+				}
+			}
+
+			avroField, err := avro.NewField(ConvertToAvroCompatibleName(field.Name), fieldSchema)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create avro field for composite field %s: %w", field.Name, err)
+			}
+			avroFields = append(avroFields, avroField)
+		}
+
+		return avro.NewRecordSchema(qField.Name, "", avroFields)
+	case types.QValueKindArrayComposite:
+		if qField.SubFields == nil || len(qField.SubFields) != 1 {
+			return nil, fmt.Errorf("array composite subfields must contain exactly one field definition")
+		}
+		fieldSchema, err := GetAvroSchemaFromQValueKind(
+			ctx, env, *qField.SubFields[0], targetDWH)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get avro schema for array composite field %s: %w", qField.Name, err)
+		}
+		return avro.NewArraySchema(fieldSchema), nil
 	case types.QValueKindArrayFloat32:
 		return avro.NewArraySchema(avro.NewPrimitiveSchema(avro.Float, nil)), nil
 	case types.QValueKindArrayFloat64:
@@ -141,7 +177,7 @@ func GetAvroSchemaFromQValueKind(
 	case types.QValueKindArrayString, types.QValueKindArrayEnum:
 		return avro.NewArraySchema(avro.NewPrimitiveSchema(avro.String, nil)), nil
 	case types.QValueKindArrayNumeric:
-		numericSchema, err := getAvroNumericSchema(ctx, env, targetDWH, precision, scale)
+		numericSchema, err := getAvroNumericSchema(ctx, env, targetDWH, qField.Precision, qField.Scale)
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +186,7 @@ func GetAvroSchemaFromQValueKind(
 		// lets attempt to do invalid as a string
 		return avro.NewPrimitiveSchema(avro.String, nil), nil
 	default:
-		return nil, fmt.Errorf("unsupported types.QValueKind type: %s", kind)
+		return nil, fmt.Errorf("unsupported types.QValueKind type: %s", qField.Type)
 	}
 }
 
@@ -186,7 +222,7 @@ func QValueToAvro(
 	value types.QValue, field *types.QField, targetDWH protos.DBType, logger log.Logger,
 	unboundedNumericAsString bool, stat *NumericStat,
 ) (any, error) {
-	if value.Value() == nil {
+	if value.Value() == nil && value.Kind() != types.QValueKindComposite {
 		return nil, nil
 	}
 
@@ -197,6 +233,8 @@ func QValueToAvro(
 		TargetDWH:                targetDWH,
 		UnboundedNumericAsString: unboundedNumericAsString,
 	}
+
+	// if value.Kind() == types.QValueKindComposite {
 
 	switch v := value.(type) {
 	case types.QValueInvalid:
@@ -296,6 +334,10 @@ func QValueToAvro(
 		return c.processArrayUUID(v.Val), nil
 	case types.QValueArrayNumeric:
 		return c.processArrayNumeric(v.Val), nil
+	case types.QValueComposite:
+		return c.processComposite(ctx, env, v.Val, v.Fields)
+	case types.QValueArrayComposite:
+		return c.processArrayComposite(ctx, env, v.Val)
 	default:
 		return nil, fmt.Errorf("[toavro] unsupported %T", value)
 	}
@@ -620,6 +662,121 @@ func (c *QValueAvroConverter) processArrayFloat64(arrayData []float64) any {
 
 func (c *QValueAvroConverter) processArrayString(arrayData []string) any {
 	return arrayData
+}
+
+// processComposite converts a composite type (PostgreSQL user-defined type) to Avro format
+// It recursively processes each field in the composite type, handling nested composites
+func (c *QValueAvroConverter) processComposite(
+	ctx context.Context,
+	env map[string]string,
+	compositeVal map[string]types.QValue,
+	fieldTypes map[string]types.QValueKind,
+) (any, error) {
+	slog.Info("Processing composite type", slog.Any("column", c.QField.Name), slog.Any("compositeVal", compositeVal), slog.Any("fieldTypes", fieldTypes))
+
+	if compositeVal == nil {
+		// return record with nil value for each field
+		result := make(map[string]any)
+		for _, subfield := range c.QField.SubFields {
+			if subfield.Type == types.QValueKindComposite {
+				subfieldTypes := make(map[string]types.QValueKind)
+				for _, subSubField := range subfield.SubFields {
+					subfieldTypes[subSubField.Name] = subSubField.Type
+				}
+				sc := QValueAvroConverter{
+					QField:                   subfield,
+					logger:                   c.logger,
+					Stat:                     c.Stat,
+					TargetDWH:                c.TargetDWH,
+					UnboundedNumericAsString: c.UnboundedNumericAsString,
+				}
+				convertedSubfield, err := sc.processComposite(ctx, env, nil, subfieldTypes)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert composite field %s: %w", subfield.Name, err)
+				}
+				result[subfield.Name] = convertedSubfield
+			} else if subfield.Type.IsArray() {
+				result[subfield.Name] = make([]any, 0)
+			} else {
+				result[subfield.Name] = nil
+			}
+		}
+		if c.Nullable {
+			if len(result) == 0 {
+				return nil, nil // return nil for empty composite
+			}
+			return &result, nil // return record with nil values for each field
+		}
+		return result, nil
+	}
+
+	result := make(map[string]any)
+
+	// Process each field in the composite type
+	for fieldName, fieldValue := range compositeVal {
+		// Get the field type for proper conversion
+		fieldType, exists := fieldTypes[fieldName]
+		if !exists {
+			// If field type is not known, try to infer from the value
+			fieldType = fieldValue.Kind()
+		}
+
+		// Create a temporary QField for this composite field
+		tempField := &types.QField{
+			Name:     fieldName,
+			Type:     fieldType,
+			Nullable: true, // Assume nullable for safety
+			// TODO: Handle precision and scale for numeric types if needed
+		}
+
+		convertedValue, err := QValueToAvro(
+			ctx, env, fieldValue, tempField, c.TargetDWH, c.logger,
+			c.UnboundedNumericAsString, c.Stat,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert composite field %s: %w", fieldName, err)
+		}
+
+		avroFieldName := ConvertToAvroCompatibleName(fieldName)
+		result[avroFieldName] = convertedValue
+	}
+
+	if c.Nullable {
+		if len(result) == 0 {
+			return nil, nil
+		}
+		return &result, nil
+	}
+
+	slog.Info("Converted composite type to Avro format", slog.Any("result", result))
+
+	return result, nil
+}
+
+func (c *QValueAvroConverter) processArrayComposite(
+	ctx context.Context,
+	env map[string]string,
+	arrayCompositeVal []types.QValueComposite,
+) (any, error) {
+	if arrayCompositeVal == nil {
+		return make([]any, 0), nil
+	}
+
+	convertedArray := make([]any, 0, len(arrayCompositeVal))
+	for _, compositeVal := range arrayCompositeVal {
+		convertedValue, err := c.processComposite(ctx, env, compositeVal.Val, compositeVal.Fields)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert array composite value: %w", err)
+		}
+		convertedArray = append(convertedArray, convertedValue)
+	}
+	if c.Nullable {
+		if len(convertedArray) == 0 {
+			return nil, nil
+		}
+		return &convertedArray, nil
+	}
+	return convertedArray, nil
 }
 
 func TruncateNumeric(

--- a/flow/model/qvalue/kind.go
+++ b/flow/model/qvalue/kind.go
@@ -91,12 +91,16 @@ func ToDWHColumnType(
 			colType = "JSON"
 		} else if kind == types.QValueKindComposite {
 			colType = "Tuple("
-			if column.Composite == nil {
-				return "", fmt.Errorf("composite type is nil for column %s", column.Name)
+			if column.Composite == nil || len(column.Composite) == 0 {
+				return "", fmt.Errorf("composite type is nil or empty for column %s", column.Name)
 			}
 			for _, subfield := range column.Composite {
 				if subfield == nil {
 					return "", fmt.Errorf("composite field is nil for column %s", column.Name)
+				}
+				// Clickhouse does not support Nullable(Tuple(...)) so we use Tuple(Nullable(...), Nullable(...), ...)
+				if nullableEnabled && column.Nullable {
+					subfield.Nullable = true
 				}
 				subfieldType, err := ToDWHColumnType(ctx, types.QValueKind(subfield.Type), env, dwhType, dwhVersion, subfield, nullableEnabled)
 				if err != nil {
@@ -105,12 +109,21 @@ func ToDWHColumnType(
 				colType += fmt.Sprintf("%s %s, ", subfield.Name, subfieldType)
 			}
 			colType = strings.TrimSuffix(colType, ", ") + ")"
+		} else if kind == types.QValueKindArrayComposite {
+			if column.Composite == nil || len(column.Composite) != 1 {
+				return "", fmt.Errorf("composite array type %s must have exactly 1 subfield", column.Name)
+			}
+			elementType, err := ToDWHColumnType(ctx, types.QValueKind(column.Composite[0].Type), env, dwhType, dwhVersion, column.Composite[0], nullableEnabled)
+			if err != nil {
+				return "", fmt.Errorf("failed to get DWH column type for composite field %s: %w", column.Composite[0].Name, err)
+			}
+			colType = fmt.Sprintf("Array(%s)", elementType)
 		} else if val, ok := types.QValueKindToClickHouseTypeMap[kind]; ok {
 			colType = val
 		} else {
 			colType = "String"
 		}
-		if nullableEnabled && column.Nullable && !kind.IsArray() {
+		if nullableEnabled && column.Nullable && !kind.IsArray() && kind != types.QValueKindComposite {
 			if colType == "LowCardinality(String)" {
 				colType = "LowCardinality(Nullable(String))"
 			} else {

--- a/flow/model/qvalue/kind.go
+++ b/flow/model/qvalue/kind.go
@@ -3,6 +3,7 @@ package qvalue
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	chproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 
@@ -88,6 +89,22 @@ func ToDWHColumnType(
 			colType = fmt.Sprintf("Array(%s)", colType)
 		} else if kind == types.QValueKindJSON && ShouldUseNativeJSONType(ctx, env, dwhVersion) {
 			colType = "JSON"
+		} else if kind == types.QValueKindComposite {
+			colType = "Tuple("
+			if column.Composite == nil {
+				return "", fmt.Errorf("composite type is nil for column %s", column.Name)
+			}
+			for _, subfield := range column.Composite {
+				if subfield == nil {
+					return "", fmt.Errorf("composite field is nil for column %s", column.Name)
+				}
+				subfieldType, err := ToDWHColumnType(ctx, types.QValueKind(subfield.Type), env, dwhType, dwhVersion, subfield, nullableEnabled)
+				if err != nil {
+					return "", fmt.Errorf("failed to get DWH column type for composite field %s: %w", subfield.Name, err)
+				}
+				colType += fmt.Sprintf("%s %s, ", subfield.Name, subfieldType)
+			}
+			colType = strings.TrimSuffix(colType, ", ") + ")"
 		} else if val, ok := types.QValueKindToClickHouseTypeMap[kind]; ok {
 			colType = val
 		} else {

--- a/flow/shared/postgres.go
+++ b/flow/shared/postgres.go
@@ -47,6 +47,7 @@ func GetCustomDataTypes(ctx context.Context, conn *pgx.Conn) (map[uint32]CustomD
 	if err != nil {
 		return nil, fmt.Errorf("failed to get customTypeMapping: %w", err)
 	}
+	defer rows.Close()
 
 	customTypeMap := map[uint32]CustomDataType{}
 	var typeID pgtype.Uint32
@@ -58,6 +59,74 @@ func GetCustomDataTypes(ctx context.Context, conn *pgx.Conn) (map[uint32]CustomD
 		return nil, fmt.Errorf("failed to scan into custom type mapping: %w", err)
 	}
 	return customTypeMap, nil
+}
+
+type CompositeField struct {
+	Name         string
+	Type         pgtype.Type
+	TypeModifier int32
+	NotNull      bool
+}
+
+func GetCompositeDataTypeDetails(ctx context.Context, conn *pgx.Conn, dataTypeOID uint32) ([]CompositeField, error) {
+	rows, err := conn.Query(ctx, fmt.Sprintf(`
+		SELECT
+			att.attnum                              AS ordinal_position,
+			att.attname                             AS field,
+			att.atttypid                            AS field_type_oid,   -- ← here
+			pt.typname                              AS field_type_name,  -- readable
+			att.atttypmod       					AS type_modifier,  
+			att.attnotnull                          AS not_null,
+			pg_catalog.col_description(att.attrelid,
+									att.attnum)  AS comment
+		FROM   pg_type       ct                    -- the composite type
+		JOIN   pg_class      cls ON cls.oid = ct.typrelid
+		JOIN   pg_attribute  att ON att.attrelid = cls.oid
+		JOIN   pg_type       pt  ON pt.oid  = att.atttypid   -- lookup base type
+		WHERE  ct.oid = '%d'
+		AND  att.attnum  > 0          -- skip system columns
+		AND  NOT att.attisdropped
+		ORDER  BY att.attnum;
+		`, dataTypeOID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get composite type details for oid %d: %w", dataTypeOID, err)
+	}
+	defer rows.Close()
+	var ordinal pgtype.Uint32
+	var field pgtype.Text
+	var fieldTypeOID pgtype.Uint32
+	var fieldTypeName pgtype.Text
+	var typeModifier int32
+	var notNull pgtype.Bool
+	var comment pgtype.Text
+	result := make([]CompositeField, 0)
+	for rows.Next() {
+		if err := rows.Scan(&ordinal, &field, &fieldTypeOID, &fieldTypeName, &typeModifier, &notNull, &comment); err != nil {
+			return nil, fmt.Errorf("failed to scan composite type details for oid %d: %w", dataTypeOID, err)
+		}
+		if fieldTypeOID.Uint32 == 0 {
+			return nil, fmt.Errorf("field type OID is zero for field %s in composite type oid %d", field.String, dataTypeOID)
+		}
+		if field.String == "" {
+			return nil, fmt.Errorf("field name is empty for field with OID %d in composite type oid %d", fieldTypeOID.Uint32, dataTypeOID)
+		}
+		result = append(result, CompositeField{
+			Name: field.String,
+			Type: pgtype.Type{
+				Name: fieldTypeName.String,
+				OID:  fieldTypeOID.Uint32,
+			},
+			TypeModifier: typeModifier,
+			NotNull:      notNull.Bool,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error while iterating over composite type details for oid %d: %w", dataTypeOID, err)
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no fields found for composite type %d", dataTypeOID)
+	}
+	return result, nil
 }
 
 func RegisterExtensions(ctx context.Context, conn *pgx.Conn, version uint32) error {

--- a/flow/shared/postgres.go
+++ b/flow/shared/postgres.go
@@ -73,16 +73,16 @@ func GetCompositeDataTypeDetails(ctx context.Context, conn *pgx.Conn, dataTypeOI
 		SELECT
 			att.attnum                              AS ordinal_position,
 			att.attname                             AS field,
-			att.atttypid                            AS field_type_oid,   -- ← here
-			pt.typname                              AS field_type_name,  -- readable
+			att.atttypid                            AS field_type_oid,
+			pt.typname                              AS field_type_name,
 			att.atttypmod       					AS type_modifier,  
 			att.attnotnull                          AS not_null,
 			pg_catalog.col_description(att.attrelid,
 									att.attnum)  AS comment
-		FROM   pg_type       ct                    -- the composite type
+		FROM   pg_type       ct
 		JOIN   pg_class      cls ON cls.oid = ct.typrelid
 		JOIN   pg_attribute  att ON att.attrelid = cls.oid
-		JOIN   pg_type       pt  ON pt.oid  = att.atttypid   -- lookup base type
+		JOIN   pg_type       pt  ON pt.oid  = att.atttypid
 		WHERE  ct.oid = '%d'
 		AND  att.attnum  > 0          -- skip system columns
 		AND  NOT att.attisdropped

--- a/flow/shared/postgres/type_conversion.go
+++ b/flow/shared/postgres/type_conversion.go
@@ -122,6 +122,13 @@ func CustomTypeToQKind(typeData shared.CustomDataType, version uint32) types.QVa
 			return types.QValueKindEnum
 		}
 	}
+	if typeData.Type == 'c' {
+		if typeData.Delim != 0 {
+			return types.QValueKindArrayComposite
+		} else {
+			return types.QValueKindComposite
+		}
+	}
 
 	if typeData.Delim != 0 {
 		return types.QValueKindArrayString

--- a/flow/shared/types/kind.go
+++ b/flow/shared/types/kind.go
@@ -45,6 +45,8 @@ const (
 	QValueKindINET    QValueKind = "inet"
 	QValueKindMacaddr QValueKind = "macaddr"
 
+	QValueKindComposite QValueKind = "composite"
+
 	// array types
 	QValueKindArrayFloat32     QValueKind = "array_float32"
 	QValueKindArrayFloat64     QValueKind = "array_float64"
@@ -62,6 +64,7 @@ const (
 	QValueKindArrayJSONB       QValueKind = "array_jsonb"
 	QValueKindArrayUUID        QValueKind = "array_uuid"
 	QValueKindArrayNumeric     QValueKind = "array_numeric"
+	QValueKindArrayComposite   QValueKind = "array_composite"
 )
 
 func (kind QValueKind) IsArray() bool {

--- a/flow/shared/types/qschema.go
+++ b/flow/shared/types/qschema.go
@@ -11,6 +11,7 @@ type QField struct {
 	Precision int16
 	Scale     int16
 	Nullable  bool
+	SubFields []*QField // For composite types, this holds the sub-fields
 }
 
 type QRecordSchema struct {

--- a/flow/shared/types/qvalue.go
+++ b/flow/shared/types/qvalue.go
@@ -833,3 +833,46 @@ func (v QValueArrayNumeric) LValue(ls *lua.LState) lua.LValue {
 		return shared.LuaDecimal.New(ls, x)
 	})
 }
+
+type QValueComposite struct {
+	Val    map[string]QValue     // Field name -> field value mapping
+	Fields map[string]QValueKind // Field name -> field type mapping for schema info
+}
+
+func (QValueComposite) Kind() QValueKind {
+	return QValueKindComposite
+}
+
+func (v QValueComposite) Value() any {
+	return v.Val
+}
+
+func (v QValueComposite) LValue(ls *lua.LState) lua.LValue {
+	table := ls.NewTable()
+	for fieldName, fieldValue := range v.Val {
+		table.RawSetString(fieldName, fieldValue.LValue(ls))
+	}
+	return table
+}
+
+type QValueArrayComposite struct {
+	Val []QValueComposite
+}
+
+func (QValueArrayComposite) Kind() QValueKind {
+	return QValueKindArrayComposite
+}
+func (v QValueArrayComposite) Value() any {
+	return v.Val
+}
+func (v QValueArrayComposite) LValue(ls *lua.LState) lua.LValue {
+	table := ls.NewTable()
+	for i, composite := range v.Val {
+		compositeTable := ls.NewTable()
+		for fieldName, fieldValue := range composite.Val {
+			compositeTable.RawSetString(fieldName, fieldValue.LValue(ls))
+		}
+		table.RawSetInt(i+1, compositeTable) // Lua tables are 1-indexed
+	}
+	return table
+}

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -180,6 +180,7 @@ message FieldDescription {
   string type = 2;
   int32 type_modifier = 3;
   bool nullable = 4;
+  repeated FieldDescription composite = 5;
 }
 
 message SetupTableSchemaBatchInput {


### PR DESCRIPTION
Currently custom composite types from postgres are saved as strings in CH which makes it inconvenient to access/filter/sort/etc them. This PR adds functionality converting composite types to Tuple. 

1. Nested composite types and arrays of composites are supported
2. Clickhouse doesn't have `Nullable(Tuple(...))` so instead every field of tuple is created `Nullable` (if `PEERDB_NULLABLE` is enabled)
3. Apparently this feature should be wrapped in setting to make existing mirrors won't break.
4. I tested only the direct scenario, PG -> CH mirror. PG -> PG and others were not tested