### PR TITLE
mongo: add read preference to mongo config

### DIFF
--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -411,7 +411,7 @@ func parseAsClientOptions(config *protos.MongoConfig) (*options.ClientOptions, e
 		// always use majority read concern for correctness
 		SetReadConcern(readconcern.Majority())
 
-	// TODO: remove the empty string option once it's wired through the UI
+	// TODO: once it's wired through the UI, indicate with a clear error if this field is empty
 	if config.ReadPreference == "" {
 		clientOptions.SetReadPreference(readpref.SecondaryPreferred())
 	} else {

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -662,6 +662,10 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .get("tls_host")
                     .map(|s| s.to_string())
                     .unwrap_or_default(),
+                read_preference: opts.
+                    .get("read_preference")
+                    .context("missing read preference in Mongo config")
+                    .to_string(),
             };
             Config::MongoConfig(mongo_config)
         }

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -664,8 +664,8 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .unwrap_or_default(),
                 read_preference: opts
                     .get("read_preference")
-                    .context("missing read preference in Mongo config")
-                    .to_string(),
+                    .map(|s| s.to_string())
+                    .unwrap_or_default(),
             };
             Config::MongoConfig(mongo_config)
         }

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -662,7 +662,7 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .get("tls_host")
                     .map(|s| s.to_string())
                     .unwrap_or_default(),
-                read_preference: opts.
+                read_preference: opts
                     .get("read_preference")
                     .context("missing read preference in Mongo config")
                     .to_string(),

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -71,6 +71,7 @@ message MongoConfig {
   bool disable_tls = 4;
   string tls_host = 5;
   optional string root_ca = 6 [(peerdb_redacted) = true];
+  string read_preference = 7;
 }
 
 message AwsAuthStaticCredentialsConfig {

--- a/ui/app/peers/create/[peerType]/helpers/mo.ts
+++ b/ui/app/peers/create/[peerType]/helpers/mo.ts
@@ -59,4 +59,5 @@ export const blankMongoSetting: MongoConfig = {
   disableTls: false,
   tlsHost: '',
   rootCa: '',
+  readPreference: '',
 };


### PR DESCRIPTION
Implement backend to support passing ReadPreference as an explicit mongo config setting via UI