### PR TITLE
[ui] update settings page layout to `flex-col`

### DIFF
--- a/ui/app/settings/page.tsx
+++ b/ui/app/settings/page.tsx
@@ -232,9 +232,9 @@ export default function SettingsPage() {
       />
       <div
         style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
-          gap: '16px',
+          display: 'flex',
+          flexDirection: 'column',
+          rowGap: '0.5rem'
         }}
       >
         {filteredSettings.map((setting) => (


### PR DESCRIPTION
It's been a little tricky to use the settings page. tiny fix to make it a little more readable

**Current**
<img width="1509" height="833" alt="Screenshot 2025-07-14 at 19 11 20" src="https://github.com/user-attachments/assets/2abf59a6-d1e1-44c9-9b37-870ad338f128" />


**Proposed**
<img width="1505" height="841" alt="Screenshot 2025-07-14 at 19 11 14" src="https://github.com/user-attachments/assets/5842ea35-af9a-41a2-9aef-01daa810c333" />