### PR TITLE
mongo: use enum for readPreference instead of string

### DIFF
--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -511,7 +511,7 @@ func parseAsClientOptions(config *protos.MongoConfig) (*options.ClientOptions, e
 		clientOptions.SetReadPreference(readpref.SecondaryPreferred())
 	case protos.ReadPreference_NEAREST:
 		clientOptions.SetReadPreference(readpref.Nearest())
-	case protos.ReadPreference_NULL:
+	case protos.ReadPreference_PREFERENCE_UNKNOWN:
 		// use `secondaryPreferred` as default
 		clientOptions.SetReadPreference(readpref.SecondaryPreferred())
 	default:

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -500,19 +500,22 @@ func parseAsClientOptions(config *protos.MongoConfig) (*options.ClientOptions, e
 		// always use majority read concern for correctness
 		SetReadConcern(readconcern.Majority())
 
-	// TODO: once it's wired through the UI, indicate with a clear error if this field is empty
-	if config.ReadPreference == "" {
+	switch config.ReadPreference {
+	case protos.ReadPreference_PRIMARY:
+		clientOptions.SetReadPreference(readpref.Primary())
+	case protos.ReadPreference_PRIMARY_PREFERRED:
+		clientOptions.SetReadPreference(readpref.PrimaryPreferred())
+	case protos.ReadPreference_SECONDARY:
+		clientOptions.SetReadPreference(readpref.Secondary())
+	case protos.ReadPreference_SECONDARY_PREFERRED:
 		clientOptions.SetReadPreference(readpref.SecondaryPreferred())
-	} else {
-		mode, err := readpref.ModeFromString(config.ReadPreference)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing read preference mode: %w", err)
-		}
-		readPreference, err := readpref.New(mode)
-		if err != nil {
-			return nil, fmt.Errorf("error creating read preference from mode: %w", err)
-		}
-		clientOptions.SetReadPreference(readPreference)
+	case protos.ReadPreference_NEAREST:
+		clientOptions.SetReadPreference(readpref.Nearest())
+	case protos.ReadPreference_NULL:
+		// use `secondaryPreferred` as default
+		clientOptions.SetReadPreference(readpref.SecondaryPreferred())
+	default:
+		return nil, fmt.Errorf("invalid ReadPreference: %s", config.ReadPreference)
 	}
 
 	if !config.DisableTls {

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -664,8 +664,9 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .unwrap_or_default(),
                 read_preference: opts
                     .get("read_preference")
-                    .map(|s| s.to_string())
-                    .unwrap_or_default(),
+                    .context("no read preference specified")?
+                    .parse::<i32>()
+                    .context("unable to parse read preference as valid int")?,
             };
             Config::MongoConfig(mongo_config)
         }

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -63,7 +63,7 @@ message PubSubConfig {
 }
 
 enum ReadPreference {
-  NULL = 0;
+  PREFERENCE_UNKNOWN = 0;
   PRIMARY = 1;
   PRIMARY_PREFERRED = 2;
   SECONDARY = 3;

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -62,6 +62,15 @@ message PubSubConfig {
   GcpServiceAccount service_account = 1;
 }
 
+enum ReadPreference {
+  NULL = 0;
+  PRIMARY = 1;
+  PRIMARY_PREFERRED = 2;
+  SECONDARY = 3;
+  SECONDARY_PREFERRED = 4;
+  NEAREST = 5;
+}
+
 message MongoConfig {
   // can be a mongodb:// URI mapping to discrete hosts or a mongodb+srv:// URI
   // mapping to a DNS SRV record.
@@ -71,7 +80,7 @@ message MongoConfig {
   bool disable_tls = 4;
   string tls_host = 5;
   optional string root_ca = 6 [(peerdb_redacted) = true];
-  string read_preference = 7;
+  ReadPreference read_preference = 7;
 }
 
 message AwsAuthStaticCredentialsConfig {

--- a/ui/app/peers/create/[peerType]/helpers/mo.ts
+++ b/ui/app/peers/create/[peerType]/helpers/mo.ts
@@ -66,5 +66,5 @@ export const blankMongoSetting: MongoConfig = {
   password: '',
   disableTls: false,
   tlsHost: '',
-  readPreference: '',
+  readPreference: 0,
 };

--- a/ui/app/settings/page.tsx
+++ b/ui/app/settings/page.tsx
@@ -234,7 +234,7 @@ export default function SettingsPage() {
         style={{
           display: 'flex',
           flexDirection: 'column',
-          rowGap: '0.5rem'
+          rowGap: '0.5rem',
         }}
       >
         {filteredSettings.map((setting) => (


### PR DESCRIPTION
Use enum instead of string for readPreference to match driver; more compact for wiring over the network as well.