### PR TITLE
mongo: fix bug in `getPartitionForStartAndEnd`

### DIFF
--- a/flow/connectors/utils/partition.go
+++ b/flow/connectors/utils/partition.go
@@ -322,9 +322,7 @@ func (p *PartitionHelper) getPartitionForStartAndEnd(start any, end any) (*proto
 	case pgtype.TID:
 		return createTIDPartition(v, end.(pgtype.TID)), nil
 	case bson.ObjectID:
-		p.partitions = append(p.partitions, createObjectIdPartition(v, end.(bson.ObjectID)))
-		p.prevStart = v
-		p.prevEnd = end
+		return createObjectIdPartition(v, end.(bson.ObjectID)), nil
 	default:
 		return nil, fmt.Errorf("unsupported type: %T", v)
 	}


### PR DESCRIPTION
Mongo's case handling is not correct. This didn't surface as an issue since we currently don't support partitioned load.