### PR TITLE
mongo: always return full table partition

### DIFF
--- a/flow/shared/mongo/qrep.go
+++ b/flow/shared/mongo/qrep.go
@@ -1,0 +1,3 @@
+package mongo
+
+const MongoFullTablePartitionId = "mongo-full-table-partition-id"


### PR DESCRIPTION
@Amogh-Bharadwaj  noticed an issue where initial load does not populate stats to db.

- Fix a bug where `nil` partition is returned.
- Make sure mongo also populate `qrep_partitions` table

Test: ran test locally and see that qrep_partition populated for mongo:
```
postgres=# select rows_synced, parent_mirror_name from qrep_partitions where parent_mirror_name = 'stats3';
 rows_synced | parent_mirror_name
-------------+--------------------
           4 | stats3
```