### PR TITLE
mongo: handle validation edge case

### DIFF
--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -117,7 +118,9 @@ func parseAsClientOptions(config *protos.MongoConfig, meteredDialer utils.Metere
 		return nil, fmt.Errorf("error parsing uri: %w", err)
 	}
 
-	if connStr.Username != "" || connStr.Password != "" {
+	if connStr.Username != "" || connStr.Password != "" ||
+		// handle the edge case where '@' or ':@' in uri but no username/password provided
+		strings.Contains(connStr.Original[len(connStr.Scheme+"://"):len(connStr.Scheme+"://")+2], "@") {
 		return nil, errors.New("connection string should not contain username and password")
 	}
 


### PR DESCRIPTION
When @ is in uri, but not actual username/password, we get confusing error message like:
```
username required if URI contains user info
```
Handle this case to report a consistent error message:
```
connection string should not contain username and password
```

Test:
- tested via UI locally