### PR TITLE
mongo: handle resume token from table not in changestream

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -131,6 +131,7 @@ func (c *MongoConnector) PullRecords(
 
 	var resumeToken bson.Raw
 	var err error
+
 	if req.LastOffset.Text != "" {
 		// If we have a last offset, we resume from that point
 		c.logger.Info("[mongo] resuming change stream", slog.String("resumeToken", req.LastOffset.Text))
@@ -156,6 +157,9 @@ func (c *MongoConnector) PullRecords(
 			changeStreamOpts.SetStartAtOperationTime(&timestamp)
 			changeStreamOpts.SetResumeAfter(nil)
 			changeStream, err = c.client.Watch(ctx, pipeline, changeStreamOpts)
+			if err != nil {
+				return fmt.Errorf("failed to recreate change stream: %w", err)
+			}
 		} else {
 			return fmt.Errorf("failed to create change stream: %w", err)
 		}

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -219,16 +219,33 @@ func (c *MongoConnector) PullRecords(
 		return nil
 	}
 
-	recreateChangeStream := func() error {
+	recreateChangeStream := func(useOperationTime bool) error {
+		// extract the most recent resumeToken
+		resumeToken := changeStream.ResumeToken()
+		if resumeToken == nil {
+			return errors.New("resume token is nil")
+		}
+
+		// close existing change stream
 		if err := changeStream.Close(ctx); err != nil {
 			return fmt.Errorf("failed to close change stream: %w", err)
 		}
 
+		// reset context timeout
 		cancelTimeout()
 		timeoutCtx, cancelTimeout = context.WithTimeout(ctx, time.Hour)
 
-		if resumeToken := changeStream.ResumeToken(); resumeToken != nil {
+		// set resume point based on whether operation time should be used or not
+		if useOperationTime {
+			timestamp, err := decodeTimestampFromResumeToken(resumeToken)
+			if err != nil {
+				return fmt.Errorf("failed to decode resume token: %w", err)
+			}
+			changeStreamOpts.SetStartAtOperationTime(&timestamp)
+			changeStreamOpts.SetResumeAfter(nil)
+		} else {
 			changeStreamOpts.SetResumeAfter(resumeToken)
+			changeStreamOpts.SetStartAtOperationTime(nil)
 		}
 
 		changeStream, err = c.client.Watch(ctx, pipeline, changeStreamOpts)
@@ -240,28 +257,34 @@ func (c *MongoConnector) PullRecords(
 	}
 
 	for recordCount < req.MaxBatchSize {
-		ok := changeStream.Next(timeoutCtx)
-		if !ok {
-			if err := changeStream.Err(); err != nil && errors.Is(err, context.DeadlineExceeded) {
+		if ok := changeStream.Next(timeoutCtx); !ok {
+			err := changeStream.Err()
+			if err == nil {
+				return errors.New("unexpected: changestream.Next() returned false but no change stream error was recorded")
+			}
+
+			if errors.Is(err, context.DeadlineExceeded) {
 				if recordCount > 0 {
 					break
 				}
-
 				// update with PostBatchResumeToken on empty batch
 				// ref: https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md
 				checkpoint()
 				// DeadlineExceeded errors are deemed not recoverable/resumable, so we have to create a new change stream instance
-				csErr := recreateChangeStream()
-				if csErr != nil {
+				if err := recreateChangeStream(false); err != nil {
 					return fmt.Errorf("failed to recreate change stream: %w", err)
 				}
 				continue
 			}
-			if err := changeStream.Err(); err != nil {
-				return fmt.Errorf("change stream error: %w", err)
-			} else {
-				return errors.New("unexpected: Next returned false but no change stream error was recorded")
+
+			if isResumeTokenNotFoundError(err) {
+				if err := recreateChangeStream(true); err != nil {
+					return fmt.Errorf("failed to recreate change stream: %w", err)
+				}
+				continue
 			}
+
+			return fmt.Errorf("change stream error: %w", err)
 		}
 
 		var changeEvent ChangeEvent
@@ -378,6 +401,14 @@ func createPipeline(tableNameMapping map[string]model.NameAndExclude) (mongo.Pip
 	)
 
 	return pipeline, nil
+}
+
+// This can happen if the resumeToken we are attempting to `ResumeAfter` refers to a table that has been
+// filtered out of the change stream pipeline (for example, if a user pauses and edits a mirror). If
+// this happens, we decode the resumeToken and extract its operation time, and start a new changeStream
+// with `StartAtOperationTime` instead of `ResumeAfter`.
+func isResumeTokenNotFoundError(err error) bool {
+	return strings.Contains(err.Error(), "cannot resume stream; the resume token was not found.")
 }
 
 // stubs for CDCPullConnectorCore

--- a/flow/connectors/mongo/resume_token.go
+++ b/flow/connectors/mongo/resume_token.go
@@ -1,0 +1,65 @@
+package connmongo
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// https://github.com/mongodb/mongo/blob/ebe22809e0641182af43c9e3d00b1e1d6fcb52cc/src/mongo/db/storage/key_string/key_string.cpp#L91
+const kTimestamp = 130
+
+// ResumeToken always contains a "_data" field
+// ref: https://github.com/mongodb/mongo/blob/ebe22809e0641182af43c9e3d00b1e1d6fcb52cc/src/mongo/db/pipeline/resume_token.h#L134-L151
+func decodeTimestampFromResumeToken(resumeToken bson.Raw) (bson.Timestamp, error) {
+	var tokenDoc struct {
+		Data string `bson:"_data"`
+	}
+
+	err := bson.Unmarshal(resumeToken, &tokenDoc)
+	if err != nil {
+		return bson.Timestamp{}, err
+	}
+
+	if tokenDoc.Data == "" {
+		return bson.Timestamp{}, errors.New("missing _data field")
+	}
+
+	return decodeTimestampFromKeyString(tokenDoc.Data)
+}
+
+// ResumeToken's _data field is an encoded hex string. It always starts with a 'timestamp', representing clusterTime
+// ref: https://github.com/mongodb/mongo/blob/ebe22809e0641182af43c9e3d00b1e1d6fcb52cc/src/mongo/db/pipeline/resume_token.cpp#L136-L192
+func decodeTimestampFromKeyString(hexData string) (bson.Timestamp, error) {
+	// decode the hex string to bytes
+	keyStringBytes, err := hex.DecodeString(hexData)
+	if err != nil {
+		return bson.Timestamp{}, fmt.Errorf("invalid hex string in _data field: %w", err)
+	}
+
+	// the resume token should be at least 9 bytes:
+	// - first byte encodes kTimestamp
+	// - next 8 bytes encode the 64-bit timestamp value in big-endian order
+	if len(keyStringBytes) < 9 {
+		return bson.Timestamp{}, errors.New("KeyString data too short for timestamp")
+	}
+	typeByte := keyStringBytes[0]
+	if int32(typeByte) != kTimestamp {
+		return bson.Timestamp{}, fmt.Errorf("invalid type expecting %d, got %d", kTimestamp, typeByte)
+	}
+	timestampBytes := keyStringBytes[1:9]
+	timestampValue := binary.BigEndian.Uint64(timestampBytes)
+
+	// high 32 bits = seconds, low 32 bits = increment
+	// https://www.mongodb.com/docs/manual/reference/bson-types/#timestamps
+	epochSeconds := uint32(timestampValue >> 32)
+	increment := uint32(timestampValue & 0xFFFFFFFF)
+
+	return bson.Timestamp{
+		T: epochSeconds,
+		I: increment,
+	}, nil
+}

--- a/flow/connectors/mongo/resume_token_test.go
+++ b/flow/connectors/mongo/resume_token_test.go
@@ -1,0 +1,18 @@
+package connmongo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeTimestampFromKeyString(t *testing.T) {
+	// expected 'T' and 'I' can be derived in mongosh:
+	//     snippet install resumetoken
+	//     decodeResumeToken('<RESUME TOKEN>')
+	//nolint:lll
+	ts, err := decodeTimestampFromKeyString("82687F3418000000012B042C0100296E5A100402029C35AFFD457AA3093B44F7D71C6D463C6F7065726174696F6E54797065003C696E736572740046646F63756D656E744B65790046645F69640064687F3418245CA5A3B5F47124000004")
+	require.NoError(t, err)
+	require.Equal(t, uint32(1753166872), ts.T)
+	require.Equal(t, uint32(1), ts.I)
+}


### PR DESCRIPTION
See https://github.com/PeerDB-io/peerdb/issues/3246 for problem description.

Evaluated a few options:
1. persist previous table mapping so we can gracefully remove table from pipeline when we detect a table is deleted by doing so after changestream has been successfully resumed
- pro: relatively simple to implement
- con: need to store table mapping to catalog which may require db schema change

2. persist per-table resume tokens to `lastCheckpointText`, so we can always resume to a different table's token that exists in the pipeline
- pro: we can re-use `lastCheckpointText` without changing db schema
- con:  overhead of ser/deser resume tokens to/from string on checkpoint; more complex logic to find the "next best resume token" if last resumeToken doesn't work

3. decode resume token to extract clusterTime so we can set `ResumeAtOperationTime` instead
- pro: cleanest solution, as no additional data is needed other than the resume token itself that we already store at `lastCheckpointText`
- con: no existing mongo/bson library to decode resumeToken, need custom implementation

I ended up going with approach 3 because:
- The fact clusterTime is the first item to decode from resumeToken makes the implementation quite simple
- I expect the resumeToken format to be relatively stable so minimum maintenance should be needed
- Minimum performance overhead with this approach, since we only need to handle `decodeTimestampFromResumeToken` if we encounter this specific `the resume token was not found.` error which is quite rare

Test: locally + add e2e test