### PR TITLE
scheduled tasks as one long running activity

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -730,9 +730,9 @@ func (a *FlowableActivity) SendWALHeartbeat(ctx context.Context) error {
 
 func (a *FlowableActivity) ScheduledTasks(ctx context.Context) error {
 	ticker := time.NewTicker(time.Minute)
-	walHeartbeatCounter := 12
+	walHeartbeatCounter := 10
 	for range ticker.C {
-		activity.RecordHeartbeat(ctx, "recording slot size")
+		activity.RecordHeartbeat(ctx, "running")
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -741,7 +741,7 @@ func (a *FlowableActivity) ScheduledTasks(ctx context.Context) error {
 		}
 		walHeartbeatCounter -= 1
 		if walHeartbeatCounter <= 0 {
-			walHeartbeatCounter = 12
+			walHeartbeatCounter = 10
 			if err := a.SendWALHeartbeat(ctx); err != nil {
 				slog.Error("[scheduled-tasks] SendWALHeartbeat failed", slog.Any("error", err))
 			}

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -728,6 +728,28 @@ func (a *FlowableActivity) SendWALHeartbeat(ctx context.Context) error {
 	return nil
 }
 
+func (a *FlowableActivity) ScheduledTasks(ctx context.Context) error {
+	ticker := time.NewTicker(time.Minute)
+	walHeartbeatCounter := 12
+	for range ticker.C {
+		activity.RecordHeartbeat(ctx, "recording slot size")
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := a.RecordSlotSizes(ctx); err != nil {
+			slog.Error("[scheduled-tasks] RecordSlotSizes failed", slog.Any("error", err))
+		}
+		walHeartbeatCounter -= 1
+		if walHeartbeatCounter <= 0 {
+			walHeartbeatCounter = 12
+			if err := a.SendWALHeartbeat(ctx); err != nil {
+				slog.Error("[scheduled-tasks] SendWALHeartbeat failed", slog.Any("error", err))
+			}
+		}
+	}
+	return nil
+}
+
 type flowInformation struct {
 	config     *protos.FlowConnectionConfigs
 	workflowID string

--- a/flow/cmd/api.go
+++ b/flow/cmd/api.go
@@ -251,11 +251,7 @@ func APIMain(ctx context.Context, args *APIServerParams) error {
 		TaskQueue: taskQueue,
 	}
 
-	if _, err := flowHandler.temporalClient.ExecuteWorkflow(
-		ctx,
-		workflowOptions,
-		peerflow.GlobalScheduleManagerWorkflow,
-	); err != nil {
+	if _, err := flowHandler.temporalClient.ExecuteWorkflow(ctx, workflowOptions, peerflow.ScheduledTasksWorkflow); err != nil {
 		return fmt.Errorf("unable to start scheduler workflow: %w", err)
 	}
 

--- a/flow/cmd/api.go
+++ b/flow/cmd/api.go
@@ -32,12 +32,11 @@ import (
 )
 
 type APIServerParams struct {
-	TemporalHostPort                 string
-	TemporalNamespace                string
-	Port                             uint16
-	GatewayPort                      uint16
-	EnableOtelMetrics                bool
-	RunScheduledTasksWithoutTemporal bool
+	TemporalHostPort  string
+	TemporalNamespace string
+	Port              uint16
+	GatewayPort       uint16
+	EnableOtelMetrics bool
 }
 
 type RecryptItem struct {

--- a/flow/e2e/postgres/peer_flow_pg_test.go
+++ b/flow/e2e/postgres/peer_flow_pg_test.go
@@ -47,14 +47,6 @@ func (s PeerFlowE2ETestSuitePG) checkPeerdbColumns(dstSchemaQualified string, ro
 	return nil
 }
 
-func (s PeerFlowE2ETestSuitePG) TestHeartbeat() {
-	// general testing of heartbeat workflow, not pg specific
-	require.NotNil(s.t, e2e.GeneratePostgresPeer(s.t))
-	tc := e2e.NewTemporalClient(s.t)
-	env := e2e.ExecuteWorkflow(s.t.Context(), tc, shared.PeerFlowTaskQueue, peerflow.HeartbeatFlowWorkflow)
-	e2e.EnvWaitForFinished(s.t, env, 5*time.Minute)
-}
-
 func (s PeerFlowE2ETestSuitePG) Test_Geospatial_PG() {
 	srcTableName := s.attachSchemaSuffix("test_geospatial_pg")
 	dstTableName := s.attachSchemaSuffix("test_geospatial_pg_dst")

--- a/flow/main.go
+++ b/flow/main.go
@@ -148,12 +148,6 @@ func main() {
 		Usage: "Port grpc-gateway listens on",
 	}
 
-	apiRunScheduledTasksWithoutTemporalFlag := &cli.BoolFlag{
-		Name:    "run-scheduled-tasks-without-temporal",
-		Value:   false,
-		Sources: cli.EnvVars("RUN_SCHEDULED_TASKS_WITHOUT_TEMPORAL"),
-	}
-
 	app := &cli.Command{
 		Name: "PeerDB Flows CLI",
 		Before: func(ctx context.Context, clicmd *cli.Command) (context.Context, error) {
@@ -236,19 +230,17 @@ func main() {
 				Flags: []cli.Flag{
 					apiPortFlag,
 					apiGatewayPortFlag,
-					apiRunScheduledTasksWithoutTemporalFlag,
 					temporalHostPortFlag,
 					temporalNamespaceFlag,
 					otelMetricsFlag,
 				},
 				Action: func(ctx context.Context, clicmd *cli.Command) error {
 					return cmd.APIMain(ctx, &cmd.APIServerParams{
-						Port:                             clicmd.Uint16(apiPortFlag.Name),
-						GatewayPort:                      clicmd.Uint16(apiGatewayPortFlag.Name),
-						TemporalHostPort:                 clicmd.String(temporalHostPortFlag.Name),
-						TemporalNamespace:                clicmd.String(temporalNamespaceFlag.Name),
-						EnableOtelMetrics:                clicmd.Bool(otelMetricsFlag.Name),
-						RunScheduledTasksWithoutTemporal: clicmd.Bool(apiRunScheduledTasksWithoutTemporalFlag.Name),
+						Port:              clicmd.Uint16(apiPortFlag.Name),
+						GatewayPort:       clicmd.Uint16(apiGatewayPortFlag.Name),
+						TemporalHostPort:  clicmd.String(temporalHostPortFlag.Name),
+						TemporalNamespace: clicmd.String(temporalNamespaceFlag.Name),
+						EnableOtelMetrics: clicmd.Bool(otelMetricsFlag.Name),
 					})
 				},
 			},

--- a/flow/main.go
+++ b/flow/main.go
@@ -136,6 +136,24 @@ func main() {
 		Usage: "Skip maintenance if the k8s service is missing, generally used during pre-upgrade hook",
 	}
 
+	apiPortFlag := &cli.Uint16Flag{
+		Name:    "port",
+		Aliases: []string{"p"},
+		Value:   8110,
+	}
+
+	apiGatewayPortFlag := &cli.Uint16Flag{
+		Name:  "gateway-port",
+		Value: 8111,
+		Usage: "Port grpc-gateway listens on",
+	}
+
+	apiRunScheduledTasksWithoutTemporalFlag := &cli.BoolFlag{
+		Name:    "run-scheduled-tasks-without-temporal",
+		Value:   false,
+		Sources: cli.EnvVars("RUN_SCHEDULED_TASKS_WITHOUT_TEMPORAL"),
+	}
+
 	app := &cli.Command{
 		Name: "PeerDB Flows CLI",
 		Before: func(ctx context.Context, clicmd *cli.Command) (context.Context, error) {
@@ -216,27 +234,21 @@ func main() {
 			{
 				Name: "api",
 				Flags: []cli.Flag{
-					&cli.Uint16Flag{
-						Name:    "port",
-						Aliases: []string{"p"},
-						Value:   8110,
-					},
-					// gateway port is the port that the grpc-gateway listens on
-					&cli.Uint16Flag{
-						Name:  "gateway-port",
-						Value: 8111,
-					},
+					apiPortFlag,
+					apiGatewayPortFlag,
+					apiRunScheduledTasksWithoutTemporalFlag,
 					temporalHostPortFlag,
 					temporalNamespaceFlag,
 					otelMetricsFlag,
 				},
 				Action: func(ctx context.Context, clicmd *cli.Command) error {
 					return cmd.APIMain(ctx, &cmd.APIServerParams{
-						Port:              clicmd.Uint16("port"),
-						GatewayPort:       clicmd.Uint16("gateway-port"),
-						TemporalHostPort:  clicmd.String(temporalHostPortFlag.Name),
-						TemporalNamespace: clicmd.String(temporalNamespaceFlag.Name),
-						EnableOtelMetrics: clicmd.Bool(otelMetricsFlag.Name),
+						Port:                             clicmd.Uint16(apiPortFlag.Name),
+						GatewayPort:                      clicmd.Uint16(apiGatewayPortFlag.Name),
+						TemporalHostPort:                 clicmd.String(temporalHostPortFlag.Name),
+						TemporalNamespace:                clicmd.String(temporalNamespaceFlag.Name),
+						EnableOtelMetrics:                clicmd.Bool(otelMetricsFlag.Name),
+						RunScheduledTasksWithoutTemporal: clicmd.Bool(apiRunScheduledTasksWithoutTemporalFlag.Name),
 					})
 				},
 			},

--- a/flow/workflows/register.go
+++ b/flow/workflows/register.go
@@ -14,8 +14,6 @@ func RegisterFlowWorkerWorkflows(w worker.WorkflowRegistry) {
 	w.RegisterWorkflow(XminFlowWorkflow)
 
 	w.RegisterWorkflow(GlobalScheduleManagerWorkflow)
-	w.RegisterWorkflow(HeartbeatFlowWorkflow)
-	w.RegisterWorkflow(RecordSlotSizeWorkflow)
 
 	w.RegisterWorkflow(StartMaintenanceWorkflow)
 	w.RegisterWorkflow(EndMaintenanceWorkflow)

--- a/flow/workflows/register.go
+++ b/flow/workflows/register.go
@@ -14,6 +14,9 @@ func RegisterFlowWorkerWorkflows(w worker.WorkflowRegistry) {
 	w.RegisterWorkflow(XminFlowWorkflow)
 
 	w.RegisterWorkflow(GlobalScheduleManagerWorkflow)
+	w.RegisterWorkflow(HeartbeatFlowWorkflow)
+	w.RegisterWorkflow(RecordSlotSizeWorkflow)
+	w.RegisterWorkflow(ScheduledTasksWorkflow)
 
 	w.RegisterWorkflow(StartMaintenanceWorkflow)
 	w.RegisterWorkflow(EndMaintenanceWorkflow)

--- a/flow/workflows/scheduled_flows.go
+++ b/flow/workflows/scheduled_flows.go
@@ -13,7 +13,7 @@ func GlobalScheduleManagerWorkflow(ctx workflow.Context) error {
 		WaitForCancellation: true,
 	})
 	scheduledTasksFuture := workflow.ExecuteActivity(ctx, flowable.ScheduledTasks)
-	if err := scheduledTasksFuture(ctx, nil); err != nil {
+	if err := scheduledTasksFuture.Get(ctx, nil); err != nil {
 		return err
 	}
 	return ctx.Err()

--- a/flow/workflows/scheduled_flows.go
+++ b/flow/workflows/scheduled_flows.go
@@ -12,8 +12,8 @@ func GlobalScheduleManagerWorkflow(ctx workflow.Context) error {
 		HeartbeatTimeout:    time.Hour,
 		WaitForCancellation: true,
 	})
-	slotSizeFuture := workflow.ExecuteActivity(ctx, flowable.ScheduledTasks)
-	if err := slotSizeFuture.Get(ctx, nil); err != nil {
+	scheduledTasksFuture := workflow.ExecuteActivity(ctx, flowable.ScheduledTasks)
+	if err := scheduledTasksFuture(ctx, nil); err != nil {
 		return err
 	}
 	return ctx.Err()

--- a/flow/workflows/scheduled_flows.go
+++ b/flow/workflows/scheduled_flows.go
@@ -3,61 +3,18 @@ package peerflow
 import (
 	"time"
 
-	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/workflow"
 )
 
-// RecordSlotSizeWorkflow monitors replication slot size
-func RecordSlotSizeWorkflow(ctx workflow.Context) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: time.Hour,
-	})
-	slotSizeFuture := workflow.ExecuteActivity(ctx, flowable.RecordSlotSizes)
-	return slotSizeFuture.Get(ctx, nil)
-}
-
-// HeartbeatFlowWorkflow sends WAL heartbeats
-func HeartbeatFlowWorkflow(ctx workflow.Context) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: time.Hour,
-	})
-	heartbeatFuture := workflow.ExecuteActivity(ctx, flowable.SendWALHeartbeat)
-	return heartbeatFuture.Get(ctx, nil)
-}
-
-func withCronOptions(ctx workflow.Context, workflowID string, cron string) workflow.Context {
-	return workflow.WithChildOptions(ctx,
-		workflow.ChildWorkflowOptions{
-			WorkflowID:          workflowID,
-			ParentClosePolicy:   enums.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
-			WaitForCancellation: true,
-			CronSchedule:        cron,
-		},
-	)
-}
-
 func GlobalScheduleManagerWorkflow(ctx workflow.Context) error {
-	info := workflow.GetInfo(ctx)
-
-	heartbeatCtx := withCronOptions(ctx,
-		"wal-heartbeat-"+info.OriginalRunID,
-		"*/12 * * * *")
-	workflow.ExecuteChildWorkflow(
-		heartbeatCtx,
-		HeartbeatFlowWorkflow,
-	)
-
-	slotSizeCtx := withCronOptions(ctx,
-		"record-slot-size-"+info.OriginalRunID,
-		"* * * * *")
-	workflow.ExecuteChildWorkflow(slotSizeCtx, RecordSlotSizeWorkflow)
-
-	ctx.Done().Receive(ctx, nil)
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: time.Hour * 24 * 365,
+		HeartbeatTimeout:    time.Hour,
+		WaitForCancellation: true,
+	})
+	slotSizeFuture := workflow.ExecuteActivity(ctx, flowable.ScheduledTasks)
+	if err := slotSizeFuture.Get(ctx, nil); err != nil {
+		return err
+	}
 	return ctx.Err()
 }

--- a/flow/workflows/scheduled_flows.go
+++ b/flow/workflows/scheduled_flows.go
@@ -3,10 +3,66 @@ package peerflow
 import (
 	"time"
 
+	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/workflow"
 )
 
+// RecordSlotSizeWorkflow monitors replication slot size
+func RecordSlotSizeWorkflow(ctx workflow.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: time.Hour,
+	})
+	slotSizeFuture := workflow.ExecuteActivity(ctx, flowable.RecordSlotSizes)
+	return slotSizeFuture.Get(ctx, nil)
+}
+
+// HeartbeatFlowWorkflow sends WAL heartbeats
+func HeartbeatFlowWorkflow(ctx workflow.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: time.Hour,
+	})
+	heartbeatFuture := workflow.ExecuteActivity(ctx, flowable.SendWALHeartbeat)
+	return heartbeatFuture.Get(ctx, nil)
+}
+
+func withCronOptions(ctx workflow.Context, workflowID string, cron string) workflow.Context {
+	return workflow.WithChildOptions(ctx,
+		workflow.ChildWorkflowOptions{
+			WorkflowID:          workflowID,
+			ParentClosePolicy:   enums.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+			WaitForCancellation: true,
+			CronSchedule:        cron,
+		},
+	)
+}
+
 func GlobalScheduleManagerWorkflow(ctx workflow.Context) error {
+	info := workflow.GetInfo(ctx)
+
+	heartbeatCtx := withCronOptions(ctx,
+		"wal-heartbeat-"+info.OriginalRunID,
+		"*/12 * * * *")
+	workflow.ExecuteChildWorkflow(
+		heartbeatCtx,
+		HeartbeatFlowWorkflow,
+	)
+
+	slotSizeCtx := withCronOptions(ctx,
+		"record-slot-size-"+info.OriginalRunID,
+		"* * * * *")
+	workflow.ExecuteChildWorkflow(slotSizeCtx, RecordSlotSizeWorkflow)
+
+	ctx.Done().Receive(ctx, nil)
+	return ctx.Err()
+}
+
+func ScheduledTasksWorkflow(ctx workflow.Context) error {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: time.Hour * 24 * 365,
 		HeartbeatTimeout:    time.Hour,


### PR DESCRIPTION
Adds a flag to api so that it runs the scheduled tasks itself using a couple tickers rather than pushing this through temporal

Eventually this flag will be the default, & the old code path can be removed

Put it in api for now since we'd rather not introduce yet another process, & api process was already chosen for killing/starting scheduled tasks. This is because api pod isn't expected to need horizontal scaling

This greatly cleans up temporal ui being flooded in record-slot-size workflows, & reduce temporal costs

Closes #2380