### PR TITLE
always get status from catalog

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -803,7 +803,7 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 			}
 			ctx = context.WithValue(ctx, internal.FlowMetadataKey, flowMetadata)
 			logger = internal.LoggerFromCtx(ctx)
-			status, sErr := internal.GetWorkflowStatus(ctx, a.CatalogPool, a.TemporalClient, info.workflowID)
+			status, sErr := internal.GetWorkflowStatus(ctx, a.CatalogPool, info.workflowID)
 			if sErr != nil {
 				logger.Error("Failed to get workflow status", slog.Any("error", sErr), slog.String("status", status.String()))
 			}

--- a/flow/activities/maintenance_activity.go
+++ b/flow/activities/maintenance_activity.go
@@ -63,7 +63,7 @@ func (a *MaintenanceActivity) GetAllMirrors(ctx context.Context) (*protos.Mainte
 }
 
 func (a *MaintenanceActivity) getMirrorStatus(ctx context.Context, mirror *protos.MaintenanceMirror) (protos.FlowStatus, error) {
-	return internal.GetWorkflowStatus(ctx, a.CatalogPool, a.TemporalClient, mirror.WorkflowId)
+	return internal.GetWorkflowStatus(ctx, a.CatalogPool, mirror.WorkflowId)
 }
 
 func (a *MaintenanceActivity) WaitForRunningSnapshots(

--- a/flow/internal/workflow.go
+++ b/flow/internal/workflow.go
@@ -7,68 +7,29 @@ import (
 	"log/slog"
 
 	"github.com/jackc/pgx/v5"
-	"go.temporal.io/sdk/client"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
-func getWorkflowStatusFromTemporal(ctx context.Context, temporalClient client.Client, workflowID string) (protos.FlowStatus, error) {
-	res, err := temporalClient.QueryWorkflow(ctx, workflowID, "", shared.FlowStatusQuery)
-	if err != nil {
-		slog.Error("failed to query status in workflow with ID "+workflowID, slog.Any("error", err))
-		return protos.FlowStatus_STATUS_UNKNOWN, fmt.Errorf("failed to query status in workflow with ID %s: %w", workflowID, err)
-	}
-	var state protos.FlowStatus
-	if err := res.Get(&state); err != nil {
-		slog.Error("failed to get status in workflow with ID "+workflowID, slog.Any("error", err))
-		return protos.FlowStatus_STATUS_UNKNOWN, fmt.Errorf("failed to get status in workflow with ID %s: %w", workflowID, err)
-	}
-	return state, nil
-}
-
 func GetWorkflowStatus(ctx context.Context, pool shared.CatalogPool,
-	temporalClient client.Client, workflowID string,
+	workflowID string,
 ) (protos.FlowStatus, error) {
 	var flowStatus protos.FlowStatus
 	err := pool.QueryRow(ctx, "SELECT status FROM flows WHERE workflow_id = $1", workflowID).Scan(&flowStatus)
-	if err != nil || flowStatus == protos.FlowStatus_STATUS_UNKNOWN {
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				slog.Warn("workflowId not found in catalog, will raise an error",
-					slog.String("workflowId", workflowID))
-				return protos.FlowStatus_STATUS_UNKNOWN, fmt.Errorf("workflowId not found in catalog: %w", err)
-			}
-			slog.Error("failed to get status for flow from catalog, will fall back to temporal",
-				slog.Any("error", err),
-				slog.String("flowID", workflowID))
-		} else if flowStatus == protos.FlowStatus_STATUS_UNKNOWN {
-			slog.Info("flow status from catalog is unknown, will fall back to temporal",
-				slog.String("flowID", workflowID))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			slog.Warn("workflowId not found in catalog, will raise an error",
+				slog.String("workflowId", workflowID))
+			return protos.FlowStatus_STATUS_UNKNOWN, fmt.Errorf("workflowId not found in catalog: %w", err)
 		}
-		var status protos.FlowStatus
-		if temporalClient != nil {
-			// this should only trigger for existing final-state mirrors once
-			var tctlErr error
-			status, tctlErr = getWorkflowStatusFromTemporal(ctx, temporalClient, workflowID)
-			if tctlErr != nil {
-				return status, tctlErr
-			}
-		} else {
-			slog.Error("temporal client is nil, cannot get status from temporal even though catalog has unknown status")
-			return protos.FlowStatus_STATUS_UNKNOWN, errors.New("temporal client is nil, cannot get status from temporal")
-		}
-		// only update the catalog if the status is COMPLETED, this a long state, maintenance wfs do not alter these and we can assume
-		// that any changes post read-through cache happen only on new workers
-		// additionally, TERMINATED and TERMINATING are end states as well
-		if err == nil && (status == protos.FlowStatus_STATUS_COMPLETED ||
-			status == protos.FlowStatus_STATUS_TERMINATED ||
-			status == protos.FlowStatus_STATUS_TERMINATING) {
-			return UpdateFlowStatusInCatalog(ctx, pool, workflowID, status)
-		}
-		return status, nil
+		slog.Error("failed to get status for flow from catalog",
+			slog.Any("error", err),
+			slog.String("flowID", workflowID))
+		return flowStatus, fmt.Errorf("failed ot get status for flow from catalog: %w", err)
+	} else if flowStatus == protos.FlowStatus_STATUS_UNKNOWN {
+		slog.Warn("flow status from catalog is unknown", slog.String("flowID", workflowID))
 	}
-
 	return flowStatus, nil
 }
 

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -37,7 +37,6 @@ const (
 	// Queries
 	CDCFlowStateQuery  = "q-cdc-flow-state"
 	QRepFlowStateQuery = "q-qrep-flow-state"
-	FlowStatusQuery    = "q-flow-status"
 )
 
 var MirrorNameSearchAttribute = temporal.NewSearchAttributeKeyString("MirrorName")

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -435,11 +435,10 @@ func CDCFlowWorkflow(
 	}); err != nil {
 		return state, fmt.Errorf("failed to set `%s` query handler: %w", shared.CDCFlowStateQuery, err)
 	}
-	if err := workflow.SetQueryHandler(ctx, shared.FlowStatusQuery, func() (protos.FlowStatus, error) {
+	_ = workflow.SetQueryHandler(ctx, "q-flow-status", func() (protos.FlowStatus, error) {
+		// no longer used, handler kept to avoid nondeterminism
 		return state.CurrentFlowStatus, nil
-	}); err != nil {
-		return state, fmt.Errorf("failed to set `%s` query handler: %w", shared.FlowStatusQuery, err)
-	}
+	})
 
 	if state.CurrentFlowStatus == protos.FlowStatus_STATUS_COMPLETED {
 		return state, nil

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -431,11 +431,10 @@ func setWorkflowQueries(ctx workflow.Context, state *protos.QRepFlowState) error
 	}
 
 	// Support a Query for the current status of the qrep flow.
-	if err := workflow.SetQueryHandler(ctx, shared.FlowStatusQuery, func() (protos.FlowStatus, error) {
+	_ = workflow.SetQueryHandler(ctx, "q-flow-status", func() (protos.FlowStatus, error) {
+		// no longer used, handler kept to avoid nondeterminism
 		return state.CurrentFlowStatus, nil
-	}); err != nil {
-		return fmt.Errorf("failed to set `%s` query handler: %w", shared.FlowStatusQuery, err)
-	}
+	})
 
 	return nil
 }


### PR DESCRIPTION
avoids various issues we've been having where status is in one place but not the other

TODO update tests to use catalog, this was also contributing to not seeing this issue in CI since catalog status was never used even tho it's what's always relied on in practice