### PR TITLE
ch: classify ErrIncorrectData as MV error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -457,6 +457,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			} else if isClickHouseMvError(chException) {
 				return ErrorNotifyMVOrView, chErrorInfo
 			}
+		case chproto.ErrIncorrectData:
+			return ErrorNotifyMVOrView, chErrorInfo
 		case chproto.ErrQueryWasCancelled, chproto.ErrPocoException, chproto.ErrCannotReadFromSocket:
 			return ErrorRetryRecoverable, chErrorInfo
 		default:


### PR DESCRIPTION
```
Emitting classified error 'failed to sync records: QRepSync Error: code: 117, message: Cannot insert data into JSON column: Cannot read JSON object from JSON element: []: while converting source column `JSONExtractString(...)` to destination column ...: while executing 'FUNCTION _CAST(JSONExtractString(...) :: 8, Nullable(JSON) :: 14) -> _CAST(JSONExtractString(...), Nullable(JSON)) Nullable(JSON) : 13
```