### PR TITLE
[mongo] parallel snapshot for ObjectID key

### DIFF
--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -134,8 +134,7 @@ func parseAsClientOptions(config *protos.MongoConfig, meteredDialer utils.Metere
 		SetCompressors([]string{"zstd", "snappy"}).
 		// always use majority read concern for correctness
 		SetReadConcern(readconcern.Majority()).
-		SetDialer(&meteredDialer).
-		SetDirect(true)
+		SetDialer(&meteredDialer)
 
 	switch config.ReadPreference {
 	case protos.ReadPreference_PRIMARY:

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -134,7 +134,8 @@ func parseAsClientOptions(config *protos.MongoConfig, meteredDialer utils.Metere
 		SetCompressors([]string{"zstd", "snappy"}).
 		// always use majority read concern for correctness
 		SetReadConcern(readconcern.Majority()).
-		SetDialer(&meteredDialer)
+		SetDialer(&meteredDialer).
+		SetDirect(true)
 
 	switch config.ReadPreference {
 	case protos.ReadPreference_PRIMARY:

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	shared_mongo "github.com/PeerDB-io/peerdb/flow/shared/mongo"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
-	"github.com/google/uuid"
 )
 
 func (c *MongoConnector) GetQRepPartitions(
@@ -160,7 +160,6 @@ func (c *MongoConnector) PullQRepRecords(
 	defer shutDown()
 
 	filter := bson.D{}
-	// FullTablePartition is always true until parallel initial load is implemented, see `GetQRepPartitions`
 	if !partition.FullTablePartition {
 		filter, err = toRangeFilter(config.WatermarkColumn, partition.Range)
 		if err != nil {

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -25,14 +25,103 @@ func (c *MongoConnector) GetQRepPartitions(
 	config *protos.QRepConfig,
 	last *protos.QRepPartition,
 ) ([]*protos.QRepPartition, error) {
-	// default to FullTablePartition=true until parallel initial load is implemented
-	return []*protos.QRepPartition{
+	fullTablePartition := []*protos.QRepPartition{
 		{
 			PartitionId:        shared_mongo.MongoFullTablePartitionId,
 			Range:              nil,
 			FullTablePartition: true,
 		},
-	}, nil
+	}
+
+	if config.WatermarkColumn == "" {
+		return fullTablePartition, nil
+	}
+
+	if config.NumRowsPerPartition <= 0 {
+		return nil, errors.New("num rows per partition must be greater than 0")
+	} else if last != nil && last.Range != nil {
+		return nil, fmt.Errorf("last partition is not supported for MongoDB connector, got: %v", last)
+	}
+
+	numRowsPerPartition := int64(config.NumRowsPerPartition)
+	parseWatermarkTable, err := utils.ParseSchemaTable(config.WatermarkTable)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse watermark table: %w", err)
+	}
+	collection := c.client.Database(parseWatermarkTable.Schema).Collection(parseWatermarkTable.Table)
+
+	c.logger.Info("[mongo] fetching count of documents for partitioning",
+		slog.String("watermark_table", config.WatermarkTable))
+	totalRows, err := collection.CountDocuments(ctx, bson.D{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to count documents in collection %s: %w", parseWatermarkTable.Table, err)
+	}
+	if totalRows == 0 {
+		return []*protos.QRepPartition{}, nil
+	}
+
+	// Calculate the number of partitions
+	adjustedPartitions := shared.AdjustNumPartitions(totalRows, numRowsPerPartition)
+	c.logger.Info("[mongo] partition details",
+		slog.Int64("totalRows", totalRows),
+		slog.Int64("desiredNumRowsPerPartition", numRowsPerPartition),
+		slog.Int64("adjustedNumPartitions", adjustedPartitions.AdjustedNumPartitions),
+		slog.Int64("adjustedNumRowsPerPartition", adjustedPartitions.AdjustedNumRowsPerPartition))
+
+	// no need to bother with bucketAuto if we have only one partition
+	if adjustedPartitions.AdjustedNumPartitions == 1 {
+		return fullTablePartition, nil
+	}
+
+	if config.WatermarkColumn != DefaultDocumentKeyColumnName {
+		return nil, fmt.Errorf("only %s is currently supported as watermark column for MongoDB connector", DefaultDocumentKeyColumnName)
+	}
+
+	// Use bucketAuto to create partitions based on _id field
+	bucketAutoPipeline := []bson.D{
+		{
+			{Key: "$bucketAuto", Value: bson.D{
+				{Key: "groupBy", Value: "$" + config.WatermarkColumn},
+				{Key: "buckets", Value: adjustedPartitions.AdjustedNumPartitions},
+			}},
+		},
+	}
+
+	cursor, err := collection.Aggregate(ctx, bucketAutoPipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate for bucket partitions: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	partitionHelper := utils.NewPartitionHelper(c.logger)
+	for cursor.Next(ctx) {
+		var bucket struct {
+			ID struct {
+				Min bson.ObjectID `bson:"min"`
+				Max bson.ObjectID `bson:"max"`
+			} `bson:"_id"`
+		}
+		if err := cursor.Decode(&bucket); err != nil {
+			return nil, fmt.Errorf("failed to decode bucket: %w", err)
+		}
+
+		if err := partitionHelper.AddPartition(bucket.ID.Min, bucket.ID.Max); err != nil {
+			return nil, fmt.Errorf("failed to add partition: %w", err)
+		}
+	}
+	if err := cursor.Err(); err != nil {
+		if errors.Is(err, context.Canceled) {
+			c.logger.Warn("context canceled while performing bucketAuto aggregation",
+				slog.String("watermark_table", config.WatermarkTable))
+		} else {
+			c.logger.Error("error while performing bucketAuto aggregation",
+				slog.String("watermark_table", config.WatermarkTable),
+				slog.String("error", err.Error()))
+		}
+		return nil, fmt.Errorf("cursor error during bucketAuto aggregation: %w", err)
+	}
+
+	return partitionHelper.GetPartitions(), nil
 }
 
 func (c *MongoConnector) PullQRepRecords(
@@ -63,11 +152,15 @@ func (c *MongoConnector) PullQRepRecords(
 	filter := bson.D{}
 	// FullTablePartition is always true until parallel initial load is implemented, see `GetQRepPartitions`
 	if !partition.FullTablePartition {
-		filter, err = toRangeFilter(partition.Range)
+		filter, err = toRangeFilter(config.WatermarkColumn, partition.Range)
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to convert partition range to filter: %w", err)
 		}
 	}
+	c.logger.Info("[mongo] filter for partition",
+		slog.Any("partition", partition.PartitionId),
+		slog.String("watermark_table", config.WatermarkTable),
+		slog.Any("filter", filter))
 
 	batchSize := config.NumRowsPerPartition
 	if config.NumRowsPerPartition == 0 || config.NumRowsPerPartition > math.MaxInt32 {
@@ -129,13 +222,22 @@ func GetDefaultSchema() types.QRecordSchema {
 	return types.QRecordSchema{Fields: schema}
 }
 
-func toRangeFilter(partitionRange *protos.PartitionRange) (bson.D, error) {
+func toRangeFilter(watermarkColumn string, partitionRange *protos.PartitionRange) (bson.D, error) {
 	switch r := partitionRange.Range.(type) {
 	case *protos.PartitionRange_ObjectIdRange:
+		startObjectID, err := bson.ObjectIDFromHex(r.ObjectIdRange.Start)
+		if err != nil {
+			return nil, fmt.Errorf("invalid start ObjectId %s: %w", r.ObjectIdRange.Start, err)
+		}
+		endObjectID, err := bson.ObjectIDFromHex(r.ObjectIdRange.End)
+		if err != nil {
+			return nil, fmt.Errorf("invalid end ObjectId %s: %w", r.ObjectIdRange.End, err)
+		}
+
 		return bson.D{
-			bson.E{Key: DefaultDocumentKeyColumnName, Value: bson.D{
-				bson.E{Key: "$gte", Value: r.ObjectIdRange.Start},
-				bson.E{Key: "$lte", Value: r.ObjectIdRange.End},
+			bson.E{Key: watermarkColumn, Value: bson.D{
+				bson.E{Key: "$gte", Value: startObjectID},
+				bson.E{Key: "$lte", Value: endObjectID},
 			}},
 		}, nil
 	default:

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -53,7 +53,8 @@ func (c *MongoConnector) GetQRepPartitions(
 
 	c.logger.Info("[mongo] fetching count of documents for partitioning",
 		slog.String("watermark_table", config.WatermarkTable))
-	totalRows, err := collection.CountDocuments(ctx, bson.D{})
+	// estimated, worst case we are off by a few documents but should be fine for partitioning
+	totalRows, err := collection.EstimatedDocumentCount(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count documents in collection %s: %w", parseWatermarkTable.Table, err)
 	}

--- a/flow/connectors/mysql/qrep.go
+++ b/flow/connectors/mysql/qrep.go
@@ -121,12 +121,6 @@ func (c *MySqlConnector) GetQRepPartitions(
 		}
 
 		// Calculate the number of partitions
-		numPartitions = totalRows / numRowsPerPartition
-		if totalRows%numRowsPerPartition != 0 {
-			numPartitions++
-		}
-
-		// Calculate the number of partitions
 		adjustedPartitions := shared.AdjustNumPartitions(totalRows, numRowsPerPartition)
 		c.logger.Info("[mysql] partition details",
 			slog.Int64("totalRows", totalRows),

--- a/flow/connectors/mysql/qrep.go
+++ b/flow/connectors/mysql/qrep.go
@@ -126,12 +126,19 @@ func (c *MySqlConnector) GetQRepPartitions(
 			numPartitions++
 		}
 
-		c.logger.Info("queried info for partitioning",
-			slog.Int64("totalRows", totalRows), slog.Int64("numPartitions", numPartitions), slog.Int64("rowsPerPartition", numRowsPerPartition))
+		// Calculate the number of partitions
+		adjustedPartitions := shared.AdjustNumPartitions(totalRows, numRowsPerPartition)
+		c.logger.Info("[mysql] partition details",
+			slog.Int64("totalRows", totalRows),
+			slog.Int64("desiredNumRowsPerPartition", numRowsPerPartition),
+			slog.Int64("adjustedNumPartitions", adjustedPartitions.AdjustedNumPartitions),
+			slog.Int64("adjustedNumRowsPerPartition", adjustedPartitions.AdjustedNumRowsPerPartition))
+
+		numPartitions = adjustedPartitions.AdjustedNumPartitions
 	}
 
-	watermarkMyType := rs.Fields[0].Type
-	watermarkQKind, err := qkindFromMysql(rs.Fields[0])
+	watermarkMyType := rs.Fields[1].Type
+	watermarkQKind, err := qkindFromMysql(rs.Fields[1])
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert mysql type to qvaluekind: %w", err)
 	}
@@ -143,7 +150,7 @@ func (c *MySqlConnector) GetQRepPartitions(
 	}
 	val2, err := QValueFromMysqlFieldValue(watermarkQKind, watermarkMyType, rs.Values[0][1])
 	if err != nil {
-		return nil, fmt.Errorf("fialed to convert partition maximum to qvalue: %w", err)
+		return nil, fmt.Errorf("failed to convert partition maximum to qvalue: %w", err)
 	}
 	if err := partitionHelper.AddPartitionsWithRange(val1.Value(), val2.Value(), numPartitions); err != nil {
 		return nil, fmt.Errorf("failed to add partitions: %w", err)

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -131,7 +131,7 @@ func (c *PostgresConnector) getNumRowsPartitions(
 
 		// Calculate the number of partitions
 		adjustedPartitions := shared.AdjustNumPartitions(totalRows.Int64, numRowsPerPartition)
-		c.logger.Info("partition adjustment details",
+		c.logger.Info("[postgres] partition adjustment details",
 			slog.Int64("totalRows", totalRows.Int64),
 			slog.Int64("desiredNumRowsPerPartition", numRowsPerPartition),
 			slog.Int64("adjustedNumPartitions", adjustedPartitions.AdjustedNumPartitions),

--- a/flow/connectors/utils/partition.go
+++ b/flow/connectors/utils/partition.go
@@ -99,7 +99,7 @@ func comparePartitionRanges(
 			return c
 		}
 		return cmp.Compare(prevTuple.OffsetNumber, currTuple.OffsetNumber)
-		// we can compare ObjectIDs, but not sure if doing this is correct so returning 0
+		// we can compare ObjectIDs, but not sure if doing this is correct
 	case *protos.PartitionRange_ObjectIdRange:
 		cr, ok := currentPartition.partitionRange.Range.(*protos.PartitionRange_ObjectIdRange)
 		if !ok {

--- a/flow/e2e/mongo/mongo_test.go
+++ b/flow/e2e/mongo/mongo_test.go
@@ -158,7 +158,7 @@ func (s MongoClickhouseSuite) Test_Simple_Flow_Partitioned() {
 	}
 
 	tc := e2e.NewTemporalClient(t)
-	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+	env := e2e.ExecutePeerflow(t, tc, flowConnConfig)
 
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load to match", srcTable, dstTable, "_id,_full_document")
 

--- a/flow/e2e/mongo/mongo_test.go
+++ b/flow/e2e/mongo/mongo_test.go
@@ -130,6 +130,53 @@ func (s MongoClickhouseSuite) Test_Simple_Flow() {
 	e2e.RequireEnvCanceled(t, env)
 }
 
+func (s MongoClickhouseSuite) Test_Simple_Flow_Partitioned() {
+	t := s.T()
+	srcDatabase := GetTestDatabase(s.Suffix())
+	srcTable := "test_simple_partitioned"
+	dstTable := "test_simple_dst_partitioned"
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName:   e2e.AddSuffix(s, srcTable),
+		TableMappings: e2e.TableMappings(s, srcTable, dstTable),
+		Destination:   s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.TableMappings[0].PartitionKey = "_id"
+	flowConnConfig.SnapshotNumRowsPerPartition = 10
+
+	adminClient := s.Source().(*MongoSource).AdminClient()
+	collection := adminClient.Database(srcDatabase).Collection(srcTable)
+	// insert 1000 rows into the source table for initial load
+	for i := range 1000 {
+		testKey := fmt.Sprintf("init_key_%d", i)
+		testValue := fmt.Sprintf("init_value_%d", i)
+		res, err := collection.InsertOne(t.Context(), bson.D{bson.E{Key: testKey, Value: testValue}}, options.InsertOne())
+		require.NoError(t, err)
+		require.True(t, res.Acknowledged)
+	}
+
+	tc := e2e.NewTemporalClient(t)
+	env := e2e.ExecutePeerflow(t.Context(), tc, peerflow.CDCFlowWorkflow, flowConnConfig, nil)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load to match", srcTable, dstTable, "_id,_full_document")
+
+	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
+	// insert 10 rows into the source table for cdc
+	for i := range 10 {
+		testKey := fmt.Sprintf("test_key_%d", i)
+		testValue := fmt.Sprintf("test_value_%d", i)
+		res, err := collection.InsertOne(t.Context(), bson.D{bson.E{Key: testKey, Value: testValue}}, options.InsertOne())
+		require.NoError(t, err)
+		require.True(t, res.Acknowledged)
+	}
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "cdc events to match", srcTable, dstTable, "_id,_full_document")
+	env.Cancel(t.Context())
+	e2e.RequireEnvCanceled(t, env)
+}
+
 func (s MongoClickhouseSuite) Test_Inconsistent_Schema() {
 	t := s.T()
 

--- a/stacks/mongo/init-mongo.sh
+++ b/stacks/mongo/init-mongo.sh
@@ -74,4 +74,4 @@ done
 
 # Start MongoDB with auth (no fork, logs to stdout)
 echo "Starting MongoDB with authentication..."
-exec mongod --replSet rs0 --bind_ip_all --keyFile /etc/mongodb-keyfile --auth --ipv6
+exec mongod --replSet rs0 --bind_ip_all --keyFile /etc/mongodb-keyfile --auth --ipv6 --oplogMinRetentionHours 24


### PR DESCRIPTION
Need to give `WatermarkColumn` as input, otherwise falls back to full table partition.
Only `ObjectID` partitioning is supported, so it is intended for use with `_id` but should be general.

Also added "adjusted partitions" logic to MySQL

TODO testing