### PR TITLE
mongo: set allow_nullable_key = 1 only when custom sort keys are used

### DIFF
--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -34,7 +34,7 @@ func Test_GetOrderByColumns_WithColMap_AndOrdering(t *testing.T) {
 	}
 
 	expected := []string{"`my id`", "`name`"}
-	actual := getOrderedOrderByColumns(tableMappingForTest, sourcePkeys, colNameMap)
+	actual, allowNullableKey := getOrderedOrderByColumns(tableMappingForTest, sourcePkeys, colNameMap)
 
 	if len(expected) != len(actual) {
 		t.Fatalf("Expected %v, got %v", expected, actual)
@@ -45,6 +45,8 @@ func Test_GetOrderByColumns_WithColMap_AndOrdering(t *testing.T) {
 			t.Fatalf("Expected %v, got %v", expected, actual)
 		}
 	}
+
+	require.True(t, allowNullableKey)
 }
 
 func Test_GetOrderByColumns_NoOrdering_NoColMap(t *testing.T) {
@@ -65,7 +67,7 @@ func Test_GetOrderByColumns_NoOrdering_NoColMap(t *testing.T) {
 
 	sourcePkeys := []string{"my id"}
 	expected := []string{"`my id`"}
-	actual := getOrderedOrderByColumns(tableMappingForTest, sourcePkeys, nil)
+	actual, allowNullableKey := getOrderedOrderByColumns(tableMappingForTest, sourcePkeys, nil)
 
 	if len(expected) != len(actual) {
 		t.Fatalf("Expected %v, got %v", expected, actual)
@@ -76,6 +78,8 @@ func Test_GetOrderByColumns_NoOrdering_NoColMap(t *testing.T) {
 			t.Fatalf("Expected %v, got %v", expected, actual)
 		}
 	}
+
+	require.False(t, allowNullableKey)
 }
 
 func Test_GetOrderByColumns_WithColMap_NoOrdering(t *testing.T) {
@@ -100,7 +104,7 @@ func Test_GetOrderByColumns_WithColMap_NoOrdering(t *testing.T) {
 		"name":  "name",
 	}
 	expected := []string{"`my id destination`", "`name`"}
-	actual := getOrderedOrderByColumns(tableMappingForTest, sourcePkeys, colNameMap)
+	actual, allowNullableKey := getOrderedOrderByColumns(tableMappingForTest, sourcePkeys, colNameMap)
 
 	if len(expected) != len(actual) {
 		t.Fatalf("Expected %v, got %v", expected, actual)
@@ -111,6 +115,8 @@ func Test_GetOrderByColumns_WithColMap_NoOrdering(t *testing.T) {
 			t.Fatalf("Expected %v, got %v", expected, actual)
 		}
 	}
+
+	require.False(t, allowNullableKey)
 }
 
 func Test_GetOrderByColumns_NoColMap_WithOrdering(t *testing.T) {
@@ -133,7 +139,7 @@ func Test_GetOrderByColumns_NoColMap_WithOrdering(t *testing.T) {
 
 	sourcePkeys := []string{"my id", "name"}
 	expected := []string{"`my id`", "`name`"}
-	actual := getOrderedOrderByColumns(tableMappingForTest, sourcePkeys, nil)
+	actual, allowNullableKey := getOrderedOrderByColumns(tableMappingForTest, sourcePkeys, nil)
 
 	if len(expected) != len(actual) {
 		t.Fatalf("Expected %v, got %v", expected, actual)
@@ -144,6 +150,8 @@ func Test_GetOrderByColumns_NoColMap_WithOrdering(t *testing.T) {
 			t.Fatalf("Expected %v, got %v", expected, actual)
 		}
 	}
+
+	require.True(t, allowNullableKey)
 }
 
 func TestBuildQuery_Basic(t *testing.T) {

--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -33,7 +33,7 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 	dstTableNames := slices.Collect(maps.Keys(processedMapping))
 
 	// In the case of resync, we don't need to check the content or structure of the original tables;
-	// they'll anyways get swapped out with the _resync tables which we CREATE OR REPLACE
+	// they'll always get swapped out with the _resync tables which we CREATE OR REPLACE
 	// also in case of this setting; multiple source tables can be mapped to the same destination table
 	// so ignore the check in this case as well
 	sourceSchemaAsDestinationColumn, err := internal.PeerDBSourceSchemaAsDestinationColumn(ctx, cfg.Env)


### PR DESCRIPTION
Kept the `allow_nullable_key = 1` logic relatively simple:
- when using custom ordering ->  allow nullable key
- when using default primary keys from source dbs -> do not allow nullable key

In theory, we could tighten `allow_nullable_key = 1`  to only when custom ordering keys contains columns that are nullable and have nullable enabled, but given the current nullable and enableNullable configuration is relatively nuanced (i.e. schema level vs. column level), doing so would make it harder to reason about when allow_nullable_key are configured and also more maintenance overhead. So I kept the logic here relatively simple -- for now it's fine to allow_nullable_key = 1 even if the destination PKs are non-nullable. And this won't apply to Mongo since we don't allow custom sort keys there.