### PR TITLE
fallback to full table partitions for Timescale compressed hypertables

### DIFF
--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -170,13 +170,13 @@ func (a *SnapshotActivity) LoadTableSchema(
 func (a *SnapshotActivity) GetParallelLoadKeyForTables(
 	ctx context.Context,
 	input *protos.FlowConnectionConfigs,
-) (*protos.GetParallelLoadKeyForTablesOutput, error) {
+) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {
 	connector, err := connectors.GetByNameAs[connectors.QRepPullConnectorCore](ctx, nil, a.CatalogPool, input.SourceName)
 	if err != nil {
 		return nil, a.Alerter.LogFlowError(ctx, input.FlowJobName, fmt.Errorf("failed to get connector: %w", err))
 	}
 
-	output, err := connector.GetParallelLoadKeyForTables(ctx, &protos.GetParallelLoadKeyForTablesInput{
+	output, err := connector.GetParallelLoadKeyForTables(ctx, &protos.GetDefaultPartitionKeyForTablesInput{
 		TableMappings: input.TableMappings,
 	})
 	if err != nil {

--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -167,7 +167,7 @@ func (a *SnapshotActivity) LoadTableSchema(
 	return internal.LoadTableSchemaFromCatalog(ctx, a.CatalogPool, flowName, tableName)
 }
 
-func (a *SnapshotActivity) GetParallelLoadKeyForTables(
+func (a *SnapshotActivity) GetDefaultPartitionKeyForTables(
 	ctx context.Context,
 	input *protos.FlowConnectionConfigs,
 ) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {
@@ -176,7 +176,7 @@ func (a *SnapshotActivity) GetParallelLoadKeyForTables(
 		return nil, a.Alerter.LogFlowError(ctx, input.FlowJobName, fmt.Errorf("failed to get connector: %w", err))
 	}
 
-	output, err := connector.GetParallelLoadKeyForTables(ctx, &protos.GetDefaultPartitionKeyForTablesInput{
+	output, err := connector.GetDefaultPartitionKeyForTables(ctx, &protos.GetDefaultPartitionKeyForTablesInput{
 		TableMappings: input.TableMappings,
 	})
 	if err != nil {

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -226,7 +226,8 @@ type QRepPullConnectorCore interface {
 	// GetQRepPartitions returns the partitions for a given table that haven't been synced yet.
 	GetQRepPartitions(ctx context.Context, config *protos.QRepConfig, last *protos.QRepPartition) ([]*protos.QRepPartition, error)
 
-	GetParallelLoadKeyForTables(ctx context.Context, input *protos.GetParallelLoadKeyForTablesInput) (*protos.GetParallelLoadKeyForTablesOutput, error)
+	GetParallelLoadKeyForTables(ctx context.Context,
+		input *protos.GetDefaultPartitionKeyForTablesInput) (*protos.GetDefaultPartitionKeyForTablesOutput, error)
 }
 
 type QRepPullConnector interface {

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -226,7 +226,7 @@ type QRepPullConnectorCore interface {
 	// GetQRepPartitions returns the partitions for a given table that haven't been synced yet.
 	GetQRepPartitions(ctx context.Context, config *protos.QRepConfig, last *protos.QRepPartition) ([]*protos.QRepPartition, error)
 
-	GetParallelLoadKeyForTables(ctx context.Context,
+	GetDefaultPartitionKeyForTables(ctx context.Context,
 		input *protos.GetDefaultPartitionKeyForTablesInput) (*protos.GetDefaultPartitionKeyForTablesOutput, error)
 }
 

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -225,6 +225,8 @@ type QRepPullConnectorCore interface {
 
 	// GetQRepPartitions returns the partitions for a given table that haven't been synced yet.
 	GetQRepPartitions(ctx context.Context, config *protos.QRepConfig, last *protos.QRepPartition) ([]*protos.QRepPartition, error)
+
+	GetParallelLoadKeyForTables(ctx context.Context, input *protos.GetParallelLoadKeyForTablesInput) (*protos.GetParallelLoadKeyForTablesOutput, error)
 }
 
 type QRepPullConnector interface {

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -137,10 +137,10 @@ func (c *MongoConnector) GetQRepPartitions(
 
 func (c *MongoConnector) GetParallelLoadKeyForTables(
 	ctx context.Context,
-	input *protos.GetParallelLoadKeyForTablesInput,
-) (*protos.GetParallelLoadKeyForTablesOutput, error) {
-	return &protos.GetParallelLoadKeyForTablesOutput{
-		TableParallelLoadKeyMapping: make(map[string]string),
+	input *protos.GetDefaultPartitionKeyForTablesInput,
+) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {
+	return &protos.GetDefaultPartitionKeyForTablesOutput{
+		TableDefaultPartitionKeyMapping: make(map[string]string),
 	}, nil
 }
 

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -140,7 +140,7 @@ func (c *MongoConnector) GetDefaultPartitionKeyForTables(
 	input *protos.GetDefaultPartitionKeyForTablesInput,
 ) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {
 	return &protos.GetDefaultPartitionKeyForTablesOutput{
-		TableDefaultPartitionKeyMapping: make(map[string]string),
+		TableDefaultPartitionKeyMapping: nil,
 	}, nil
 }
 

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -135,6 +135,15 @@ func (c *MongoConnector) GetQRepPartitions(
 	return partitions, nil
 }
 
+func (c *MongoConnector) GetParallelLoadKeyForTables(
+	ctx context.Context,
+	input *protos.GetParallelLoadKeyForTablesInput,
+) (*protos.GetParallelLoadKeyForTablesOutput, error) {
+	return &protos.GetParallelLoadKeyForTablesOutput{
+		TableParallelLoadKeyMapping: make(map[string]string),
+	}, nil
+}
+
 func (c *MongoConnector) PullQRepRecords(
 	ctx context.Context,
 	otelManager *otel_metrics.OtelManager,

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -135,7 +135,7 @@ func (c *MongoConnector) GetQRepPartitions(
 	return partitions, nil
 }
 
-func (c *MongoConnector) GetParallelLoadKeyForTables(
+func (c *MongoConnector) GetDefaultPartitionKeyForTables(
 	ctx context.Context,
 	input *protos.GetDefaultPartitionKeyForTablesInput,
 ) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {

--- a/flow/connectors/mysql/qrep.go
+++ b/flow/connectors/mysql/qrep.go
@@ -132,10 +132,10 @@ func (c *MySqlConnector) GetQRepPartitions(
 
 func (c *MySqlConnector) GetParallelLoadKeyForTables(
 	ctx context.Context,
-	input *protos.GetParallelLoadKeyForTablesInput,
-) (*protos.GetParallelLoadKeyForTablesOutput, error) {
-	return &protos.GetParallelLoadKeyForTablesOutput{
-		TableParallelLoadKeyMapping: make(map[string]string),
+	input *protos.GetDefaultPartitionKeyForTablesInput,
+) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {
+	return &protos.GetDefaultPartitionKeyForTablesOutput{
+		TableDefaultPartitionKeyMapping: make(map[string]string),
 	}, nil
 }
 

--- a/flow/connectors/mysql/qrep.go
+++ b/flow/connectors/mysql/qrep.go
@@ -130,7 +130,7 @@ func (c *MySqlConnector) GetQRepPartitions(
 	return partitionHelper.GetPartitions(), nil
 }
 
-func (c *MySqlConnector) GetParallelLoadKeyForTables(
+func (c *MySqlConnector) GetDefaultPartitionKeyForTables(
 	ctx context.Context,
 	input *protos.GetDefaultPartitionKeyForTablesInput,
 ) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {

--- a/flow/connectors/mysql/qrep.go
+++ b/flow/connectors/mysql/qrep.go
@@ -135,7 +135,7 @@ func (c *MySqlConnector) GetDefaultPartitionKeyForTables(
 	input *protos.GetDefaultPartitionKeyForTablesInput,
 ) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {
 	return &protos.GetDefaultPartitionKeyForTablesOutput{
-		TableDefaultPartitionKeyMapping: make(map[string]string),
+		TableDefaultPartitionKeyMapping: nil,
 	}, nil
 }
 

--- a/flow/connectors/mysql/qrep.go
+++ b/flow/connectors/mysql/qrep.go
@@ -22,29 +22,6 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
-func (c *MySqlConnector) GetDataTypeOfWatermarkColumn(
-	ctx context.Context,
-	watermarkTableName string,
-	watermarkColumn string,
-) (types.QValueKind, byte, error) {
-	if watermarkColumn == "" {
-		return "", 0, errors.New("watermark column is not specified in the config")
-	}
-
-	query := fmt.Sprintf("SELECT `%s` FROM %s LIMIT 0", watermarkColumn, watermarkTableName)
-	rs, err := c.Execute(ctx, query)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to execute query for watermark column type: %w", err)
-	}
-
-	if len(rs.Fields) == 0 {
-		return "", 0, fmt.Errorf("no fields returned from select query: %s", query)
-	}
-
-	qk, err := qkindFromMysql(rs.Fields[0])
-	return qk, rs.Fields[0].Type, err
-}
-
 func (c *MySqlConnector) GetQRepPartitions(
 	ctx context.Context,
 	config *protos.QRepConfig,
@@ -151,6 +128,15 @@ func (c *MySqlConnector) GetQRepPartitions(
 	}
 
 	return partitionHelper.GetPartitions(), nil
+}
+
+func (c *MySqlConnector) GetParallelLoadKeyForTables(
+	ctx context.Context,
+	input *protos.GetParallelLoadKeyForTablesInput,
+) (*protos.GetParallelLoadKeyForTablesOutput, error) {
+	return &protos.GetParallelLoadKeyForTablesOutput{
+		TableParallelLoadKeyMapping: make(map[string]string),
+	}, nil
 }
 
 func (c *MySqlConnector) PullQRepRecords(

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1200,18 +1200,12 @@ func (c *PostgresConnector) EnsurePullability(
 }
 
 func (c *PostgresConnector) ExportTxSnapshot(ctx context.Context, env map[string]string) (*protos.ExportTxSnapshotOutput, any, error) {
-	pgversion, err := c.MajorVersion(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("[export-snapshot] error getting PG version: %w", err)
-	}
-
 	skipSnapshotExport, err := internal.PeerDBSkipSnapshotExport(ctx, env)
 	if err != nil {
 		c.logger.Error("failed to check PEERDB_SKIP_SNAPSHOT_EXPORT, proceeding with export snapshot", slog.Any("error", err))
 	} else if skipSnapshotExport {
 		return &protos.ExportTxSnapshotOutput{
-			SnapshotName:     "",
-			SupportsTidScans: pgversion >= shared.POSTGRES_13,
+			SnapshotName: "",
 		}, nil, err
 	}
 
@@ -1242,8 +1236,7 @@ func (c *PostgresConnector) ExportTxSnapshot(ctx context.Context, env map[string
 	needRollback = false
 
 	return &protos.ExportTxSnapshotOutput{
-		SnapshotName:     snapshotName,
-		SupportsTidScans: pgversion >= shared.POSTGRES_13,
+		SnapshotName: snapshotName,
 	}, tx, err
 }
 

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -69,7 +69,7 @@ func (c *PostgresConnector) GetQRepPartitions(
 	return c.getNumRowsPartitions(ctx, getPartitionsTx, config, last)
 }
 
-func (c *PostgresConnector) GetParallelLoadKeyForTables(
+func (c *PostgresConnector) GetDefaultPartitionKeyForTables(
 	ctx context.Context,
 	input *protos.GetDefaultPartitionKeyForTablesInput,
 ) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -261,7 +261,7 @@ func (s *SnapshotFlowExecution) cloneTables(
 
 	var res *protos.GetDefaultPartitionKeyForTablesOutput
 	if err := workflow.ExecuteActivity(getParallelLoadKeyForTablesCtx,
-		snapshot.GetParallelLoadKeyForTables, s.config).Get(ctx, &res); err != nil {
+		snapshot.GetDefaultPartitionKeyForTables, s.config).Get(ctx, &res); err != nil {
 		return fmt.Errorf("failed to close slot keep alive for peer flow: %w", err)
 	}
 

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -259,8 +259,9 @@ func (s *SnapshotFlowExecution) cloneTables(
 		},
 	})
 
-	var res *protos.GetParallelLoadKeyForTablesOutput
-	if err := workflow.ExecuteActivity(getParallelLoadKeyForTablesCtx, snapshot.GetParallelLoadKeyForTables, s.config).Get(ctx, &res); err != nil {
+	var res *protos.GetDefaultPartitionKeyForTablesOutput
+	if err := workflow.ExecuteActivity(getParallelLoadKeyForTablesCtx,
+		snapshot.GetParallelLoadKeyForTables, s.config).Get(ctx, &res); err != nil {
 		return fmt.Errorf("failed to close slot keep alive for peer flow: %w", err)
 	}
 
@@ -274,7 +275,7 @@ func (s *SnapshotFlowExecution) cloneTables(
 			slog.String("snapshotName", snapshotName),
 		)
 		if v.PartitionKey == "" {
-			v.PartitionKey = res.TableParallelLoadKeyMapping[source]
+			v.PartitionKey = res.TableDefaultPartitionKeyMapping[source]
 		}
 		if err := s.cloneTable(ctx, boundSelector, snapshotName, v); err != nil {
 			s.logger.Error("failed to start clone child workflow", slog.Any("error", err))

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -262,7 +262,7 @@ func (s *SnapshotFlowExecution) cloneTables(
 	var res *protos.GetDefaultPartitionKeyForTablesOutput
 	if err := workflow.ExecuteActivity(getParallelLoadKeyForTablesCtx,
 		snapshot.GetDefaultPartitionKeyForTables, s.config).Get(ctx, &res); err != nil {
-		return fmt.Errorf("failed to close slot keep alive for peer flow: %w", err)
+		return fmt.Errorf("failed to get default partition keys for tables: %w", err)
 	}
 
 	boundSelector := shared.NewBoundSelector(ctx, "CloneTablesSelector", maxParallelClones)

--- a/flow/workflows/snapshot_flow.go
+++ b/flow/workflows/snapshot_flow.go
@@ -244,7 +244,6 @@ func (s *SnapshotFlowExecution) cloneTables(
 	snapshotType snapshotType,
 	slotName string,
 	snapshotName string,
-	supportsTIDScans bool,
 	maxParallelClones int,
 ) error {
 	if snapshotType == SNAPSHOT_TYPE_SLOT {
@@ -253,13 +252,19 @@ func (s *SnapshotFlowExecution) cloneTables(
 		s.logger.Info("cloning tables in tx snapshot mode", slog.String("snapshot", snapshotName))
 	}
 
-	boundSelector := shared.NewBoundSelector(ctx, "CloneTablesSelector", maxParallelClones)
+	getParallelLoadKeyForTablesCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval: 1 * time.Minute,
+		},
+	})
 
-	defaultPartitionCol := "ctid"
-	if !supportsTIDScans {
-		s.logger.Info("Postgres version too old for TID scans, might use full table partitions!")
-		defaultPartitionCol = ""
+	var res *protos.GetParallelLoadKeyForTablesOutput
+	if err := workflow.ExecuteActivity(getParallelLoadKeyForTablesCtx, snapshot.GetParallelLoadKeyForTables, s.config).Get(ctx, &res); err != nil {
+		return fmt.Errorf("failed to close slot keep alive for peer flow: %w", err)
 	}
+
+	boundSelector := shared.NewBoundSelector(ctx, "CloneTablesSelector", maxParallelClones)
 
 	for _, v := range s.config.TableMappings {
 		source := v.SourceTableIdentifier
@@ -269,7 +274,7 @@ func (s *SnapshotFlowExecution) cloneTables(
 			slog.String("snapshotName", snapshotName),
 		)
 		if v.PartitionKey == "" {
-			v.PartitionKey = defaultPartitionCol
+			v.PartitionKey = res.TableParallelLoadKeyMapping[source]
 		}
 		if err := s.cloneTable(ctx, boundSelector, snapshotName, v); err != nil {
 			s.logger.Error("failed to start clone child workflow", slog.Any("error", err))
@@ -304,11 +309,9 @@ func (s *SnapshotFlowExecution) cloneTablesWithSlot(
 	}()
 	var slotName string
 	var snapshotName string
-	var supportsTidScans bool
 	if slotInfo != nil {
 		slotName = slotInfo.SlotName
 		snapshotName = slotInfo.SnapshotName
-		supportsTidScans = slotInfo.SupportsTidScans
 	}
 
 	s.logger.Info("cloning tables in parallel", slog.Int("parallelism", numTablesInParallel))
@@ -316,7 +319,6 @@ func (s *SnapshotFlowExecution) cloneTablesWithSlot(
 		SNAPSHOT_TYPE_SLOT,
 		slotName,
 		snapshotName,
-		supportsTidScans,
 		numTablesInParallel,
 	); err != nil {
 		s.logger.Error("failed to clone tables", slog.Any("error", err))
@@ -411,7 +413,6 @@ func SnapshotFlowWorkflow(
 			SNAPSHOT_TYPE_TX,
 			"",
 			txnSnapshotState.SnapshotName,
-			txnSnapshotState.SupportsTIDScans,
 			numTablesInParallel,
 		); err != nil {
 			return fmt.Errorf("failed to clone tables: %w", err)

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -561,10 +561,10 @@ message AdditionalContextMetadata{
   FlowOperation operation = 1;
 }
 
-message GetParallelLoadKeyForTablesInput {
+message GetDefaultPartitionKeyForTablesInput {
   repeated TableMapping table_mappings = 1;
 }
 
-message GetParallelLoadKeyForTablesOutput {
-  map<string, string> table_parallel_load_key_mapping = 1;
+message GetDefaultPartitionKeyForTablesOutput {
+  map<string, string> table_default_partition_key_mapping = 1;
 }

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -156,9 +156,9 @@ message SetupReplicationInput {
 }
 
 message SetupReplicationOutput {
+  reserved 3;
   string slot_name = 1;
   string snapshot_name = 2;
-  bool supports_tid_scans = 3;
 }
 
 message CreateRawTableInput {
@@ -460,8 +460,8 @@ message IsQRepPartitionSyncedInput {
 }
 
 message ExportTxSnapshotOutput {
+  reserved 2;
   string snapshot_name = 1;
-  bool supports_tid_scans = 2;
 }
 
 enum DynconfValueType {
@@ -559,4 +559,12 @@ message FlowContextMetadata{
 
 message AdditionalContextMetadata{
   FlowOperation operation = 1;
+}
+
+message GetParallelLoadKeyForTablesInput {
+  repeated TableMapping table_mappings = 1;
+}
+
+message GetParallelLoadKeyForTablesOutput {
+  map<string, string> table_parallel_load_key_mapping = 1;
 }


### PR DESCRIPTION
The PR adds a new activity, `GetDefaultPartitionKeyForTables,` during Snapshot, which is supposed to return the default "partition" key for each table if not overridden by the user. For Postgres, we check for PG14+ (when TID range scan was added), and if that is there, we also check if the Timescale extension is installed and for compressed hypertables. If any are found, disable the partition key for those.

For Mongo/MySQL it currently returns an empty key for every table. But can be changed.