### PR TITLE
mongo: preserve float type from mongo to ch

### DIFF
--- a/flow/connectors/clickhouse/qrep_avro_sync.go
+++ b/flow/connectors/clickhouse/qrep_avro_sync.go
@@ -289,7 +289,7 @@ func (s *ClickHouseAvroSyncMethod) pushS3DataToClickHouse(
 
 		if (field.Type == types.QValueKindJSON || field.Type == types.QValueKindJSONB) &&
 			qvalue.ShouldUseNativeJSONType(ctx, config.Env, s.ClickHouseConnector.chVersion) {
-			avroColName = fmt.Sprintf("JSONExtractString(%s)", avroColName)
+			avroColName = fmt.Sprintf("CAST(%s, 'JSON')", avroColName)
 		}
 
 		selectedColumnNames = append(selectedColumnNames, avroColName)

--- a/flow/connectors/mongo/codec_test.go
+++ b/flow/connectors/mongo/codec_test.go
@@ -135,6 +135,26 @@ func TestMarshalDocument(t *testing.T) {
 			input:    bson.D{{Key: "a", Value: float64(-3.14159265359)}},
 			expected: `{"a":-3.14159265359}`,
 		},
+		{
+			desc:     "float64 max int64",
+			input:    bson.D{{Key: "a", Value: float64(math.MaxInt64)}},
+			expected: `{"a":9223372036854775808.0}`,
+		},
+		{
+			desc:     "float64 min int64",
+			input:    bson.D{{Key: "a", Value: float64(math.MinInt64)}},
+			expected: `{"a":-9223372036854775808.0}`,
+		},
+		{
+			desc:     "float64 greater than max int64",
+			input:    bson.D{{Key: "a", Value: math.Pow(2, 65)}},
+			expected: `{"a":36893488147419103232.0}`,
+		},
+		{
+			desc:     "float64 less than min int64",
+			input:    bson.D{{Key: "a", Value: -math.Pow(2, 65)}},
+			expected: `{"a":-36893488147419103232.0}`,
+		},
 
 		// Special float values - NaN and Infinity (these are handled by our custom codec)
 		{
@@ -151,16 +171,6 @@ func TestMarshalDocument(t *testing.T) {
 			desc:     "float64 -Inf",
 			input:    bson.D{{Key: "a", Value: math.Inf(-1)}},
 			expected: `{"a":"-Inf"}`,
-		},
-		{
-			desc:     "float64 from max int64",
-			input:    bson.D{{Key: "a", Value: float64(math.MaxInt64)}},
-			expected: `{"a":9223372036854775808.0}`,
-		},
-		{
-			desc:     "float64 from min int64",
-			input:    bson.D{{Key: "a", Value: float64(math.MinInt64)}},
-			expected: `{"a":-9223372036854775808.0}`,
 		},
 
 		// Null values

--- a/flow/connectors/mongo/codec_test.go
+++ b/flow/connectors/mongo/codec_test.go
@@ -136,6 +136,11 @@ func TestMarshalDocument(t *testing.T) {
 			expected: `{"a":-3.14159265359}`,
 		},
 		{
+			desc:     "float64 0 fractional value",
+			input:    bson.D{{Key: "a", Value: float64(3)}},
+			expected: `{"a":3.0}`,
+		},
+		{
 			desc:     "float64 max int64",
 			input:    bson.D{{Key: "a", Value: float64(math.MaxInt64)}},
 			expected: `{"a":9223372036854775808.0}`,
@@ -201,9 +206,9 @@ func TestMarshalDocument(t *testing.T) {
 				{Key: "inner3", Value: true},
 				{
 					Key: "inner4", Value: bson.D{
-						{Key: "a", Value: math.NaN()},
-						{Key: "b", Value: []string{"hello", "world"}},
-					},
+					{Key: "a", Value: math.NaN()},
+					{Key: "b", Value: []string{"hello", "world"}},
+				},
 				},
 			}}},
 			expected: `{"nested":{"inner1":"str","inner2":1,"inner3":true,"inner4":{"a":"NaN","b":["hello","world"]}}}`,

--- a/flow/connectors/mongo/codec_test.go
+++ b/flow/connectors/mongo/codec_test.go
@@ -206,9 +206,9 @@ func TestMarshalDocument(t *testing.T) {
 				{Key: "inner3", Value: true},
 				{
 					Key: "inner4", Value: bson.D{
-					{Key: "a", Value: math.NaN()},
-					{Key: "b", Value: []string{"hello", "world"}},
-				},
+						{Key: "a", Value: math.NaN()},
+						{Key: "b", Value: []string{"hello", "world"}},
+					},
 				},
 			}}},
 			expected: `{"nested":{"inner1":"str","inner2":1,"inner3":true,"inner4":{"a":"NaN","b":["hello","world"]}}}`,

--- a/flow/connectors/mongo/codec_test.go
+++ b/flow/connectors/mongo/codec_test.go
@@ -126,19 +126,9 @@ func TestMarshalDocument(t *testing.T) {
 
 		// Floating point types - normal values
 		{
-			desc:     "float32",
-			input:    bson.D{{Key: "a", Value: float32(3.14)}},
-			expected: `{"a":3.14}`,
-		},
-		{
 			desc:     "float64",
 			input:    bson.D{{Key: "a", Value: float64(3.14159265359)}},
 			expected: `{"a":3.14159265359}`,
-		},
-		{
-			desc:     "negative float32",
-			input:    bson.D{{Key: "a", Value: float32(-3.14)}},
-			expected: `{"a":-3.14}`,
 		},
 		{
 			desc:     "negative float64",
@@ -163,19 +153,14 @@ func TestMarshalDocument(t *testing.T) {
 			expected: `{"a":"-Inf"}`,
 		},
 		{
-			desc:     "float32 NaN",
-			input:    bson.D{{Key: "a", Value: float32(math.NaN())}},
-			expected: `{"a":"NaN"}`,
+			desc:     "float64 from max int64",
+			input:    bson.D{{Key: "a", Value: float64(math.MaxInt64)}},
+			expected: `{"a":9223372036854775808.0}`,
 		},
 		{
-			desc:     "float32 +Inf",
-			input:    bson.D{{Key: "a", Value: float32(math.Inf(1))}},
-			expected: `{"a":"+Inf"}`,
-		},
-		{
-			desc:     "float32 -Inf",
-			input:    bson.D{{Key: "a", Value: float32(math.Inf(-1))}},
-			expected: `{"a":"-Inf"}`,
+			desc:     "float64 from min int64",
+			input:    bson.D{{Key: "a", Value: float64(math.MinInt64)}},
+			expected: `{"a":-9223372036854775808.0}`,
 		},
 
 		// Null values

--- a/flow/e2e/mongo/mongo_test.go
+++ b/flow/e2e/mongo/mongo_test.go
@@ -765,7 +765,7 @@ func (s MongoClickhouseSuite) Test_Json_Types() {
 		require.Contains(t, row, `"float64_min_int64":-9223372036854776000`)
 		require.Contains(t, row, `"float64_greater_than_max_int64":36893488147419103000`)
 		require.Contains(t, row, `"float64_less_than_min_int64":-36893488147419103000`)
-		require.Contains(t, row, `"float64_scientific_notation":1e100`)
+		require.Contains(t, row, `"float64_scientific_notation":1e+100`)
 		require.Contains(t, row, `"nan":"NaN"`)
 		require.Contains(t, row, `"pos_inf":"+Inf"`)
 		require.Contains(t, row, `"neg_inf":"-Inf"`)

--- a/flow/e2e/mongo/mongo_test.go
+++ b/flow/e2e/mongo/mongo_test.go
@@ -648,19 +648,15 @@ func (s MongoClickhouseSuite) Test_Json_Types() {
 		{Key: "neg_int64", Value: int64(-9223372036854775807)},
 
 		// Floating point types
-		{Key: "float32", Value: float32(3.14)},
 		{Key: "float64", Value: float64(3.14159265359)},
-		{Key: "neg_float32", Value: float32(-3.14)},
 		{Key: "neg_float64", Value: float64(-3.14159265359)},
+		{Key: "max_float64", Value: float64(math.MaxInt64)},
+		{Key: "min_float64", Value: float64(math.MinInt64)},
 
 		// Special float values
 		{Key: "nan", Value: math.NaN()},
 		{Key: "pos_inf", Value: math.Inf(1)},
 		{Key: "neg_inf", Value: math.Inf(-1)},
-		{Key: "float32_nan", Value: float32(math.NaN())},
-		{Key: "float32_pos_inf", Value: float32(math.Inf(1))},
-		{Key: "float32_neg_inf", Value: float32(math.Inf(-1))},
-
 		// Arrays with special floats
 		{Key: "array_mixed", Value: bson.A{1, "str", true}},
 		{Key: "array_special_floats", Value: bson.A{math.NaN(), math.Inf(1), math.Inf(-1)}},
@@ -760,16 +756,13 @@ func (s MongoClickhouseSuite) Test_Json_Types() {
 		require.Contains(t, row, `"neg_int16":-32768`)
 		require.Contains(t, row, `"neg_int32":-2147483648`)
 		require.Contains(t, row, `"neg_int64":-9223372036854775807`)
-		require.Contains(t, row, `"float32":3.14`)
 		require.Contains(t, row, `"float64":3.14159265359`)
-		require.Contains(t, row, `"neg_float32":-3.14`)
 		require.Contains(t, row, `"neg_float64":-3.14159265359`)
+		require.Contains(t, row, `"max_float64":9223372036854776000`)
+		require.Contains(t, row, `"min_float64":-9223372036854776000`)
 		require.Contains(t, row, `"nan":"NaN"`)
 		require.Contains(t, row, `"pos_inf":"+Inf"`)
 		require.Contains(t, row, `"neg_inf":"-Inf"`)
-		require.Contains(t, row, `"float32_nan":"NaN"`)
-		require.Contains(t, row, `"float32_pos_inf":"+Inf"`)
-		require.Contains(t, row, `"float32_neg_inf":"-Inf"`)
 		// mixed array promoted common type
 		require.Contains(t, row, `"array_mixed":["1","str","true"]`)
 		require.Contains(t, row, `"array_special_floats":["NaN","+Inf","-Inf"]`)

--- a/flow/e2e/mongo/mongo_test.go
+++ b/flow/e2e/mongo/mongo_test.go
@@ -650,8 +650,11 @@ func (s MongoClickhouseSuite) Test_Json_Types() {
 		// Floating point types
 		{Key: "float64", Value: float64(3.14159265359)},
 		{Key: "neg_float64", Value: float64(-3.14159265359)},
-		{Key: "max_float64", Value: float64(math.MaxInt64)},
-		{Key: "min_float64", Value: float64(math.MinInt64)},
+		{Key: "float64_max_int64", Value: float64(math.MaxInt64)},
+		{Key: "float64_min_int64", Value: float64(math.MinInt64)},
+		{Key: "float64_greater_than_max_int64", Value: math.Pow(2, 65)},
+		{Key: "float64_less_than_min_int64", Value: -math.Pow(2, 65)},
+		{Key: "float64_scientific_notation", Value: 1e100},
 
 		// Special float values
 		{Key: "nan", Value: math.NaN()},
@@ -758,8 +761,11 @@ func (s MongoClickhouseSuite) Test_Json_Types() {
 		require.Contains(t, row, `"neg_int64":-9223372036854775807`)
 		require.Contains(t, row, `"float64":3.14159265359`)
 		require.Contains(t, row, `"neg_float64":-3.14159265359`)
-		require.Contains(t, row, `"max_float64":9223372036854776000`)
-		require.Contains(t, row, `"min_float64":-9223372036854776000`)
+		require.Contains(t, row, `"float64_max_int64":9223372036854776000`)
+		require.Contains(t, row, `"float64_min_int64":-9223372036854776000`)
+		require.Contains(t, row, `"float64_greater_than_max_int64":36893488147419103000`)
+		require.Contains(t, row, `"float64_less_than_min_int64":-36893488147419103000`)
+		require.Contains(t, row, `"float64_scientific_notation":1e100`)
 		require.Contains(t, row, `"nan":"NaN"`)
 		require.Contains(t, row, `"pos_inf":"+Inf"`)
 		require.Contains(t, row, `"neg_inf":"-Inf"`)


### PR DESCRIPTION
- Remove codec + test for float32 handling (Mongo does not have a float32 equivalent so everything coming from changestream is float64)

- With this change, CDC path honors Double from Mongo to ClickHouse. However, QRep path does not. Given the same codec is used for marshaling, the difference in behavior here has to with how we handle data in qrep vs cdc.  

```

07bd249d78c1 :) SELECT JSONExtractString('{"number": 1.0, "number2": 1.1}');

   ┌─JSONExtractSt⋯er2": 1.1}')─┐
1. │ {"number":1,"number2":1.1} │
   └────────────────────────────┘
```
JSONExtractString converts `_full_document` column to JSON during initial load, erasing the explicit decimal and result in an Int64. Haven't thought of a good workaround for this without introducing a staging table similar to CDC.  Ideas welcome.

Update: 
Replace `JSONExtractString` with `CAST(<col>, 'JSON')` during qrep, which avoids this above quirk and correctly interprets floats with `.0` to Float64 in ClickHouse.

This also solves https://github.com/PeerDB-io/peerdb/issues/3274.