### PR TITLE
Validate mirror: no need to get source schemas for resync

### DIFF
--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -12,6 +12,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/connectors"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
+	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 )
 
@@ -20,6 +21,7 @@ var CustomColumnTypeRegex = regexp.MustCompile(`^$|^[a-zA-Z][a-zA-Z0-9(),]*$`)
 func (h *FlowRequestHandler) ValidateCDCMirror(
 	ctx context.Context, req *protos.CreateCDCFlowRequest,
 ) (*protos.ValidateCDCMirrorResponse, error) {
+	ctx = context.WithValue(ctx, shared.FlowNameKey, req.ConnectionConfigs.FlowJobName)
 	underMaintenance, err := internal.PeerDBMaintenanceModeEnabled(ctx, nil)
 	if err != nil {
 		slog.Error("unable to check maintenance mode", slog.Any("error", err))

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -92,14 +92,7 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 		if getTableSchemaError != nil {
 			return nil, fmt.Errorf("failed to get source table schema: %w", getTableSchemaError)
 		}
-	} else {
-		// No need to get table schema for resync, as we will create or replace the tables
-		tableSchemaMap = make(map[string]*protos.TableSchema, len(req.ConnectionConfigs.TableMappings))
-		for _, tm := range req.ConnectionConfigs.TableMappings {
-			tableSchemaMap[tm.DestinationTableIdentifier] = &protos.TableSchema{}
-		}
 	}
-
 	if err := dstConn.ValidateMirrorDestination(ctx, req.ConnectionConfigs, tableSchemaMap); err != nil {
 		return nil, err
 	}

--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -24,10 +24,10 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 		}
 	}
 
-	peerDBColumns := []string{signColName, versionColName}
-	if cfg.SyncedAtColName != "" {
-		peerDBColumns = append(peerDBColumns, strings.ToLower(cfg.SyncedAtColName))
+	if cfg.Resync {
+		return nil // no need to validate schema for resync, as we will create or replace the tables
 	}
+
 	// this is for handling column exclusion, processed schema does that in a step
 	processedMapping := internal.BuildProcessedSchemaMapping(cfg.TableMappings, tableNameSchemaMapping, c.logger)
 	dstTableNames := slices.Collect(maps.Keys(processedMapping))
@@ -46,7 +46,7 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 		return err
 	}
 
-	if !(cfg.Resync || sourceSchemaAsDestinationColumn) {
+	if !sourceSchemaAsDestinationColumn {
 		if err := chvalidate.CheckIfTablesEmptyAndEngine(ctx, c.logger, c.database,
 			dstTableNames, cfg.DoInitialSnapshot, internal.PeerDBOnlyClickHouseAllowed(), initialLoadAllowNonEmptyTables,
 		); err != nil {
@@ -57,6 +57,11 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 	chTableColumnsMapping, err := chvalidate.GetTableColumnsMapping(ctx, c.logger, c.database, dstTableNames)
 	if err != nil {
 		return err
+	}
+
+	peerDBColumns := []string{signColName, versionColName}
+	if cfg.SyncedAtColName != "" {
+		peerDBColumns = append(peerDBColumns, strings.ToLower(cfg.SyncedAtColName))
 	}
 
 	for _, tableMapping := range cfg.TableMappings {
@@ -70,15 +75,14 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 			continue
 		}
 
-		if !cfg.Resync {
-			// for resync, we don't need to check the content or structure of the original tables;
-			// they'll anyways get swapped out with the _resync tables which we CREATE OR REPLACE
-			if err := c.processTableComparison(dstTableName, processedMapping[dstTableName],
-				chTableColumnsMapping[dstTableName], peerDBColumns, tableMapping,
-			); err != nil {
-				return err
-			}
+		// for resync, we don't need to check the content or structure of the original tables;
+		// they'll anyways get swapped out with the _resync tables which we CREATE OR REPLACE
+		if err := c.processTableComparison(dstTableName, processedMapping[dstTableName],
+			chTableColumnsMapping[dstTableName], peerDBColumns, tableMapping,
+		); err != nil {
+			return err
 		}
+
 	}
 	return nil
 }

--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -82,7 +82,6 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 		); err != nil {
 			return err
 		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
We get source schemas for validating destination tables' schemas, which in the case of resync we do not do. Hence no need to fetch schemas from source in the case of resync