### PR TITLE
Mongo: limit max length of marshaled floats

### DIFF
--- a/flow/connectors/mongo/codec.go
+++ b/flow/connectors/mongo/codec.go
@@ -154,8 +154,13 @@ func CreateExtendedJSONMarshaler() jsoniter.API {
 	return config
 }
 
+// Assume (and test) that values outside of these limits will come out in scientific notation
+// and will be parsed as floats either way
+var limit = math.Pow10(21)
+var negLimit = -limit
+
 func writeFloat64WithExplicitDecimal(v float64, stream *jsoniter.Stream) {
-	if v == math.Trunc(v) {
+	if v > negLimit && v < limit && v == math.Trunc(v) {
 		// use explicit decimal to hint ClickHouse to parse as float
 		stream.WriteRaw(strconv.FormatFloat(v, 'f', 1, 64))
 	} else {


### PR DESCRIPTION
Numbers like 1e300 (anything > 1e21) technically pass the check of being an integer but scientific notation would be a better hint then spelling out all their digits with a `.0`, also avoiding the size of s3 payload and the raw table getting ballooned.

We're not expecting a lot of such values but just something for a peace of mind.