### PR TITLE
Allow to pass existing CH tables to validate

### DIFF
--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -48,7 +48,7 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 
 	if !(cfg.Resync || sourceSchemaAsDestinationColumn) {
 		if err := chvalidate.CheckIfTablesEmptyAndEngine(ctx, c.logger, c.database,
-			dstTableNames, cfg.DoInitialSnapshot, internal.PeerDBOnlyClickHouseAllowed(), initialLoadAllowNonEmptyTables,
+			dstTableNames, nil, cfg.DoInitialSnapshot, internal.PeerDBOnlyClickHouseAllowed(), initialLoadAllowNonEmptyTables,
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
When the pipe is resumed with a table config update, we should validate existing destination tables too as they could change while the pipe was paused.

This change allows the shared package to support that.