### PR TITLE
Better flow statuses for renaming and table removal phases 

### DIFF
--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -351,6 +351,7 @@ func processTableRemovals(
 	cfg *protos.FlowConnectionConfigs,
 	state *CDCFlowWorkflowState,
 ) error {
+	state.updateStatus(ctx, logger, protos.FlowStatus_STATUS_MODIFYING)
 	removeTablesSelector := workflow.NewNamedSelector(ctx, "RemoveTables")
 	removeTablesSelector.AddReceive(ctx.Done(), func(_ workflow.ReceiveChannel, _ bool) {})
 	flowSignalStateChangeChan := model.FlowSignalStateChange.GetSignalChannel(ctx)
@@ -728,6 +729,7 @@ func CDCFlowWorkflow(
 		}
 
 		if cfg.Resync {
+			state.updateStatus(ctx, logger, protos.FlowStatus_STATUS_RESYNC)
 			renameOpts := &protos.RenameTablesInput{
 				FlowJobName:       cfg.FlowJobName,
 				PeerName:          cfg.DestinationName,

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -412,6 +412,7 @@ enum FlowStatus {
   STATUS_COMPLETED = 8;
   STATUS_RESYNC = 9;
   STATUS_FAILED = 10;
+  STATUS_MODIFYING = 11;
 }
 
 message CDCFlowConfigUpdate {


### PR DESCRIPTION
## Why
There are currently two states in the lifecycle of a mirror where the status is `Running` but the mirror is not running/in CDC.

### Table removal

Currently, when a mirror is in the process of removing tables, the status shows up as `Running`, when in reality the mirror is not in a position to accept flow state change signals; if you were to request a table removal during an ongoing table removal, your request would "succeed" as far as the API call goes but the signal is not acted upon by the worker.

A consequence and another pain point is that there is no way to programmatically know if a mirror is finished with its table removal as the state is always Running.

### Renaming phase of resync

The last step of a resync is an activity where we exchange the _resync tables with the originals. Much like table removal, this is a state where the mirror cannot be paused/edited.

### What
- This PR introduces a `Modifying` flow state for table removal.
- Sets the status to `RESYNC` during renaming.

- [ ] Automated and functional testing pending