### PR TITLE
mongo: enable ShardedCluster + better code sharing for validation

### DIFF
--- a/flow/connectors/mongo/validate.go
+++ b/flow/connectors/mongo/validate.go
@@ -2,25 +2,20 @@ package connmongo
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	shared_mongo "github.com/PeerDB-io/peerdb/flow/shared/mongo"
 )
 
 func (c *MongoConnector) ValidateCheck(ctx context.Context) error {
-	version, err := c.GetVersion(ctx)
-	if err != nil {
+	if err := shared_mongo.ValidateServerCompatibility(ctx, c.client); err != nil {
 		return err
 	}
-	cmp, err := shared_mongo.CompareServerVersions(version, shared_mongo.MinSupportedVersion)
-	if err != nil {
+
+	if err := shared_mongo.ValidateUserRoles(ctx, c.client); err != nil {
 		return err
 	}
-	if cmp == -1 {
-		return fmt.Errorf("require minimum mongo version %s", shared_mongo.MinSupportedVersion)
-	}
+
 	return nil
 }
 
@@ -29,20 +24,8 @@ func (c *MongoConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.F
 		return nil
 	}
 
-	if _, err := shared_mongo.GetReplSetGetStatus(ctx, c.client); err != nil {
+	if err := shared_mongo.ValidateOplogRetention(ctx, c.client); err != nil {
 		return err
-	}
-
-	serverStatus, err := shared_mongo.GetServerStatus(ctx, c.client)
-	if err != nil {
-		return err
-	}
-	if serverStatus.StorageEngine.Name != "wiredTiger" {
-		return errors.New("storage engine must be 'wiredTiger'")
-	}
-	if serverStatus.OplogTruncation.OplogMinRetentionHours == 0 ||
-		serverStatus.OplogTruncation.OplogMinRetentionHours < shared_mongo.MinOplogRetentionHours {
-		return errors.New("oplog retention must be set to >= 24 hours")
 	}
 
 	return nil

--- a/flow/shared/mongo/commands.go
+++ b/flow/shared/mongo/commands.go
@@ -12,7 +12,7 @@ type BuildInfo struct {
 	Version string `bson:"version"`
 }
 
-func GetBuildInfo(ctx context.Context, client *mongo.Client) (*BuildInfo, error) {
+func GetBuildInfo(ctx context.Context, client *mongo.Client) (BuildInfo, error) {
 	return runCommand[BuildInfo](ctx, client, "buildInfo")
 }
 
@@ -21,7 +21,7 @@ type ReplSetGetStatus struct {
 	MyState int    `bson:"myState"`
 }
 
-func GetReplSetGetStatus(ctx context.Context, client *mongo.Client) (*ReplSetGetStatus, error) {
+func GetReplSetGetStatus(ctx context.Context, client *mongo.Client) (ReplSetGetStatus, error) {
 	return runCommand[ReplSetGetStatus](ctx, client, "replSetGetStatus")
 }
 
@@ -38,7 +38,7 @@ type ServerStatus struct {
 	OplogTruncation OplogTruncation `bson:"oplogTruncation"`
 }
 
-func GetServerStatus(ctx context.Context, client *mongo.Client) (*ServerStatus, error) {
+func GetServerStatus(ctx context.Context, client *mongo.Client) (ServerStatus, error) {
 	return runCommand[ServerStatus](ctx, client, "serverStatus")
 }
 
@@ -55,7 +55,7 @@ type Role struct {
 	DB   string `bson:"db"`
 }
 
-func GetConnectionStatus(ctx context.Context, client *mongo.Client) (*ConnectionStatus, error) {
+func GetConnectionStatus(ctx context.Context, client *mongo.Client) (ConnectionStatus, error) {
 	return runCommand[ConnectionStatus](ctx, client, "connectionStatus")
 }
 
@@ -64,21 +64,21 @@ type HelloResponse struct {
 	Hosts []string `bson:"hosts,omitempty"`
 }
 
-func GetHelloResponse(ctx context.Context, client *mongo.Client) (*HelloResponse, error) {
+func GetHelloResponse(ctx context.Context, client *mongo.Client) (HelloResponse, error) {
 	return runCommand[HelloResponse](ctx, client, "hello")
 }
 
-func runCommand[T any](ctx context.Context, client *mongo.Client, command string) (*T, error) {
+func runCommand[T any](ctx context.Context, client *mongo.Client, command string) (T, error) {
+	var result T
 	singleResult := client.Database("admin").RunCommand(ctx, bson.D{
 		bson.E{Key: command, Value: 1},
 	})
 	if singleResult.Err() != nil {
-		return nil, fmt.Errorf("'%s' failed: %v", command, singleResult.Err())
+		return result, fmt.Errorf("'%s' failed: %v", command, singleResult.Err())
 	}
 
-	var result T
 	if err := singleResult.Decode(&result); err != nil {
-		return nil, fmt.Errorf("'%s' failed: %v", command, err)
+		return result, fmt.Errorf("'%s' failed: %v", command, err)
 	}
-	return &result, nil
+	return result, nil
 }

--- a/flow/shared/mongo/commands.go
+++ b/flow/shared/mongo/commands.go
@@ -1,0 +1,84 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+type BuildInfo struct {
+	Version string `bson:"version"`
+}
+
+func GetBuildInfo(ctx context.Context, client *mongo.Client) (*BuildInfo, error) {
+	return runCommand[BuildInfo](ctx, client, "buildInfo")
+}
+
+type ReplSetGetStatus struct {
+	Set     string `bson:"set"`
+	MyState int    `bson:"myState"`
+}
+
+func GetReplSetGetStatus(ctx context.Context, client *mongo.Client) (*ReplSetGetStatus, error) {
+	return runCommand[ReplSetGetStatus](ctx, client, "replSetGetStatus")
+}
+
+type OplogTruncation struct {
+	OplogMinRetentionHours float64 `bson:"oplogMinRetentionHours"`
+}
+
+type StorageEngine struct {
+	Name string `bson:"name"`
+}
+
+type ServerStatus struct {
+	StorageEngine   StorageEngine   `bson:"storageEngine"`
+	OplogTruncation OplogTruncation `bson:"oplogTruncation"`
+}
+
+func GetServerStatus(ctx context.Context, client *mongo.Client) (*ServerStatus, error) {
+	return runCommand[ServerStatus](ctx, client, "serverStatus")
+}
+
+type ConnectionStatus struct {
+	AuthInfo AuthInfo `bson:"authInfo"`
+}
+
+type AuthInfo struct {
+	AuthenticatedUserRoles []Role `bson:"authenticatedUserRoles"`
+}
+
+type Role struct {
+	Role string `bson:"role"`
+	DB   string `bson:"db"`
+}
+
+func GetConnectionStatus(ctx context.Context, client *mongo.Client) (*ConnectionStatus, error) {
+	return runCommand[ConnectionStatus](ctx, client, "connectionStatus")
+}
+
+type HelloResponse struct {
+	Msg   string   `bson:"msg,omitempty"`
+	Hosts []string `bson:"hosts,omitempty"`
+}
+
+func GetHelloResponse(ctx context.Context, client *mongo.Client) (*HelloResponse, error) {
+	return runCommand[HelloResponse](ctx, client, "hello")
+}
+
+func runCommand[T any](ctx context.Context, client *mongo.Client, command string) (*T, error) {
+	singleResult := client.Database("admin").RunCommand(ctx, bson.D{
+		bson.E{Key: command, Value: 1},
+	})
+	if singleResult.Err() != nil {
+		return nil, fmt.Errorf("'%s' failed: %v", command, singleResult.Err())
+	}
+
+	var result T
+	if err := singleResult.Decode(&result); err != nil {
+		return nil, fmt.Errorf("'%s' failed: %v", command, err)
+	}
+	return &result, nil
+}


### PR DESCRIPTION
Change Streams API is documented to work out-of-the-box for sharded cluster. This PR updates the shared validation code to:
- check to make sure that the instance is either replica set or sharded cluster (previously, it ran `replSetGetStatus` to check this, we can instead use 'hello' command which is more general)
- add explicit validation for required roles (`readAnyDatabase`, `clusterMonitor`)
- better separation of concern by creating a `commands.go` file for all the db commands, while `validation.go` implements the validation logic -- will follow up with ClickPipes side as well. 

Testing:
- [x]  tested replica set on Atlas
- [x] test replica set on EC2
- [x] test sharded cluster on Atlas
- [x] test sharded clsuter on EC2