### PR TITLE
refactor(aws-creds-cache): set default cache expiry to 1 hour

### DIFF
--- a/flow/connectors/utils/aws.go
+++ b/flow/connectors/utils/aws.go
@@ -295,6 +295,10 @@ func GetAWSCredentialsProvider(ctx context.Context, connectorName string, peerCr
 	}
 
 	awsConfig, err := config.LoadDefaultConfig(ctx, func(options *config.LoadOptions) error {
+		options.CredentialsCacheOptions = func(options *aws.CredentialsCacheOptions) {
+			options.ExpiryWindow = time.Hour
+			options.ExpiryWindowJitterFrac = 0
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
> All credential providers passed to or returned by LoadDefaultConfig are wrapped in a [CredentialsCache](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/aws#CredentialsCache) automatically. This enables caching and credential rotation that is concurrency safe. If you explicitly configure a provider on aws.Config directly, you must also explicitly wrap the provider with this type using [NewCredentialsCache](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/aws#NewCredentialsCache).

Not sure if we can fully remove the cache, but we can make the cache expiry to 1 hour before creds expire so the creds are valid for atleast 1 hour