### PR TITLE
replace normalize requests channel

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -372,7 +372,7 @@ func (a *FlowableActivity) SyncFlow(
 			logger.Error("failed to sync records", slog.Any("error", syncErr))
 			syncState.Store(shared.Ptr("cleanup"))
 			close(syncDone)
-			normRequests.Broadcast() // signal syncDone closed
+			normRequests.Close()
 			return errors.Join(syncErr, group.Wait())
 		} else if syncResponse != nil {
 			totalRecordsSynced.Add(syncResponse.NumRecordsSynced)
@@ -390,7 +390,7 @@ func (a *FlowableActivity) SyncFlow(
 
 	syncState.Store(shared.Ptr("cleanup"))
 	close(syncDone)
-	normRequests.Broadcast() // signal syncDone closed
+	normRequests.Close()
 
 	waitErr := group.Wait()
 	if err := ctx.Err(); err != nil {

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -379,6 +379,7 @@ func (a *FlowableActivity) SyncFlow(
 			syncState.Store(shared.Ptr("cleanup"))
 			close(syncDone)
 			normRequests.Close()
+			normResponses.Close()
 			return errors.Join(syncErr, group.Wait())
 		} else if syncResponse != nil {
 			totalRecordsSynced.Add(syncResponse.NumRecordsSynced)

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -338,7 +338,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	if recordBatchSync.NeedsNormalize() {
 		syncState.Store(shared.Ptr("normalizing"))
 		normRequests.Update(res.CurrentSyncBatchID)
-		for normResponses.Load() <= res.CurrentSyncBatchID-normBufferSize {
+		for normResponses.Load() <= res.CurrentSyncBatchID-max(normBufferSize, 0) {
 			select {
 			case <-normResponses.Wait():
 			case <-ctx.Done():

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -682,7 +682,11 @@ func (a *FlowableActivity) normalizeLoop(
 
 	for {
 		normalizeWaiting.Store(true)
-		reqBatchID := normalizeRequests.Wait()
+		reqBatchID, ok := normalizeRequests.Wait()
+		if !ok {
+			logger.Info("[normalize-loop] lastChan closed")
+			return
+		}
 		select {
 		case <-syncDone:
 			logger.Info("[normalize-loop] syncDone closed")

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -409,14 +409,23 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		}, nil
 	}
 
-	if err := c.copyAvroStagesToDestination(ctx, req.FlowJobName, normBatchID, req.SyncBatchID, req.Env, req.Version); err != nil {
+	endBatchID := req.SyncBatchID
+	groupBatches, err := internal.PeerDBGroupNormalize(ctx, req.Env)
+	if err != nil {
+		c.logger.Error("failed to lookup PEERDB_GROUP_NORMALIZE, only normalizing 1 batch")
+	}
+	if !groupBatches {
+		endBatchID = min(endBatchID, normBatchID+1)
+	}
+
+	if err := c.copyAvroStagesToDestination(ctx, req.FlowJobName, normBatchID, endBatchID, req.Env, req.Version); err != nil {
 		return model.NormalizeResponse{}, fmt.Errorf("failed to copy avro stages to destination: %w", err)
 	}
 
 	destinationTableNames, err := c.getDistinctTableNamesInBatch(
 		ctx,
 		req.FlowJobName,
-		req.SyncBatchID,
+		endBatchID,
 		normBatchID,
 		req.TableNameSchemaMapping,
 	)
@@ -442,7 +451,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	parallelNormalize = min(max(parallelNormalize, 1), len(destinationTableNames))
 	c.logger.Info("[clickhouse-cdc] inserting batch...",
 		slog.Int64("StartBatchID", normBatchID),
-		slog.Int64("EndBatchID", req.SyncBatchID),
+		slog.Int64("EndBatchID", endBatchID),
 		slog.Int("connections", parallelNormalize))
 
 	numParts, err := internal.PeerDBClickHouseNormalizationParts(ctx, req.Env)
@@ -456,7 +465,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	periodicLogger := shared.Interval(ctx, 5*time.Minute, func() {
 		c.logger.Info("[clickhouse-cdc] inserting batch...",
 			slog.Int64("StartBatchID", normBatchID),
-			slog.Int64("EndBatchID", req.SyncBatchID),
+			slog.Int64("EndBatchID", endBatchID),
 			slog.Int("connections", parallelNormalize))
 	})
 	defer periodicLogger()
@@ -483,7 +492,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 
 			for insertIntoSelectQuery := range queries {
 				c.logger.Info("executing INSERT command to ClickHouse table",
-					slog.Int64("syncBatchId", req.SyncBatchID),
+					slog.Int64("syncBatchId", endBatchID),
 					slog.Int64("normalizeBatchId", normBatchID),
 					slog.String("destinationTable", insertIntoSelectQuery.TableName),
 					slog.String("query", insertIntoSelectQuery.Query))
@@ -491,7 +500,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				if err := c.execWithConnection(errCtx, chConn, insertIntoSelectQuery.Query); err != nil {
 					c.logger.Error("[clickhouse] error while inserting into target clickhouse table",
 						slog.String("table", insertIntoSelectQuery.TableName),
-						slog.Int64("syncBatchID", req.SyncBatchID),
+						slog.Int64("syncBatchID", endBatchID),
 						slog.Int64("normalizeBatchID", normBatchID),
 						slog.Any("error", err))
 					return fmt.Errorf("error while inserting into target clickhouse table %s: %w", insertIntoSelectQuery.TableName, err)
@@ -500,9 +509,9 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				if insertIntoSelectQuery.Part == numParts-1 {
 					c.logger.Info("[clickhouse] set last normalized batch id for table",
 						slog.String("table", insertIntoSelectQuery.TableName),
-						slog.Int64("syncBatchID", req.SyncBatchID),
+						slog.Int64("syncBatchID", endBatchID),
 						slog.Int64("lastNormalizedBatchID", normBatchID))
-					err := c.SetLastNormalizedBatchIDForTable(ctx, req.FlowJobName, insertIntoSelectQuery.TableName, req.SyncBatchID)
+					err := c.SetLastNormalizedBatchIDForTable(ctx, req.FlowJobName, insertIntoSelectQuery.TableName, endBatchID)
 					if err != nil {
 						return fmt.Errorf("error while setting last synced batch id for table %s: %w", insertIntoSelectQuery.TableName, err)
 					}
@@ -521,11 +530,11 @@ func (c *ClickHouseConnector) NormalizeRecords(
 
 		c.logger.Info("[clickhouse] last normalized batch id for table",
 			"table", tbl, "lastNormalizedBatchID", normalizeBatchIDForTable,
-			"syncBatchID", req.SyncBatchID)
+			"syncBatchID", endBatchID)
 		batchIdToLoadForTable := max(normBatchID, normalizeBatchIDForTable)
-		if batchIdToLoadForTable >= req.SyncBatchID {
+		if batchIdToLoadForTable >= endBatchID {
 			c.logger.Info("[clickhouse] table already synced to destination for this batch, skipping",
-				"table", tbl, "batchIdToLoadForTable", batchIdToLoadForTable, "syncBatchID", req.SyncBatchID)
+				"table", tbl, "batchIdToLoadForTable", batchIdToLoadForTable, "syncBatchID", endBatchID)
 			continue
 		}
 
@@ -535,7 +544,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				numPart,
 				req.TableNameSchemaMapping,
 				req.TableMappings,
-				req.SyncBatchID,
+				endBatchID,
 				batchIdToLoadForTable,
 				numParts,
 				enablePrimaryUpdate,
@@ -550,7 +559,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				close(queries)
 				c.logger.Error("[clickhouse] error while building insert into select query",
 					slog.String("table", tbl),
-					slog.Int64("syncBatchID", req.SyncBatchID),
+					slog.Int64("syncBatchID", endBatchID),
 					slog.Int64("normalizeBatchID", normBatchID),
 					slog.Any("error", err))
 				return model.NormalizeResponse{}, fmt.Errorf("error while building insert into select query for table %s: %w", tbl, err)
@@ -576,14 +585,14 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		return model.NormalizeResponse{}, err
 	}
 
-	if err := c.UpdateNormalizeBatchID(ctx, req.FlowJobName, req.SyncBatchID); err != nil {
-		c.logger.Error("[clickhouse] error while updating normalize batch id", slog.Int64("BatchID", req.SyncBatchID), slog.Any("error", err))
+	if err := c.UpdateNormalizeBatchID(ctx, req.FlowJobName, endBatchID); err != nil {
+		c.logger.Error("[clickhouse] error while updating normalize batch id", slog.Int64("BatchID", endBatchID), slog.Any("error", err))
 		return model.NormalizeResponse{}, err
 	}
 
 	return model.NormalizeResponse{
 		StartBatchID: normBatchID + 1,
-		EndBatchID:   req.SyncBatchID,
+		EndBatchID:   endBatchID,
 	}, nil
 }
 

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -41,6 +41,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
+		Name:             "PEERDB_GROUP_NORMALIZE",
+		Description:      "Controls whether normalize applies to one batch at a time, or all pending batches",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
+		TargetForSetting: protos.DynconfTarget_ALL,
+	},
+	{
 		Name:             "PEERDB_QUEUE_FLUSH_TIMEOUT_SECONDS",
 		Description:      "Frequency of flushing to queue, applicable for PeerDB Streams mirrors only",
 		DefaultValue:     "10",
@@ -518,6 +526,10 @@ func PeerDBCDCChannelBufferSize(ctx context.Context, env map[string]string) (int
 
 func PeerDBNormalizeChannelBufferSize(ctx context.Context, env map[string]string) (int, error) {
 	return dynamicConfSigned[int](ctx, env, "PEERDB_NORMALIZE_CHANNEL_BUFFER_SIZE")
+}
+
+func PeerDBGroupNormalize(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_GROUP_NORMALIZE")
 }
 
 func PeerDBQueueFlushTimeoutSeconds(ctx context.Context, env map[string]string) (time.Duration, error) {

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -524,8 +524,8 @@ func PeerDBCDCChannelBufferSize(ctx context.Context, env map[string]string) (int
 	return dynamicConfSigned[int](ctx, env, "PEERDB_CDC_CHANNEL_BUFFER_SIZE")
 }
 
-func PeerDBNormalizeChannelBufferSize(ctx context.Context, env map[string]string) (int, error) {
-	return dynamicConfSigned[int](ctx, env, "PEERDB_NORMALIZE_CHANNEL_BUFFER_SIZE")
+func PeerDBNormalizeBufferSize(ctx context.Context, env map[string]string) (int64, error) {
+	return dynamicConfSigned[int64](ctx, env, "PEERDB_NORMALIZE_CHANNEL_BUFFER_SIZE")
 }
 
 func PeerDBGroupNormalize(ctx context.Context, env map[string]string) (bool, error) {

--- a/flow/shared/concurrency/lastchan.go
+++ b/flow/shared/concurrency/lastchan.go
@@ -1,0 +1,40 @@
+package concurrency
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type LastChan struct {
+	cond sync.Cond
+	val  atomic.Int64
+}
+
+func NewLastChan() *LastChan {
+	return &LastChan{cond: sync.Cond{L: &sync.Mutex{}}}
+}
+
+func (lc *LastChan) Update(val int64) {
+	lc.val.Store(val)
+	lc.cond.Broadcast()
+}
+
+func (lc *LastChan) Broadcast() {
+	lc.cond.Broadcast()
+}
+
+func (lc *LastChan) MaybeWait(old int64) int64 {
+	if val := lc.val.Load(); val != old {
+		return val
+	}
+	return lc.Wait()
+}
+
+func (lc *LastChan) Wait() int64 {
+	lc.cond.Wait()
+	return lc.val.Load()
+}
+
+func (lc *LastChan) Load() int64 {
+	return lc.val.Load()
+}


### PR DESCRIPTION
tracks changes to atomic.Int64 so normalization always receives latest value,
each update closing a series of channels for synchronization