### PR TITLE
Log all progress

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -675,7 +675,7 @@ func (a *FlowableActivity) startNormalize(
 		}
 
 		logger.Info("normalized batches",
-			slog.Int64("StartBatchID", res.StartBatchID), slog.Int64("EndBatchID", res.EndBatchID), slog.Int64("SyncBatchID", batchID))
+			slog.Int64("startBatchID", res.StartBatchID), slog.Int64("endBatchID", res.EndBatchID), slog.Int64("syncBatchID", batchID))
 		normalizeResponses.Update(res.EndBatchID)
 		if res.EndBatchID >= batchID {
 			return nil

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -249,7 +249,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		}
 		syncBatchID += 1
 		syncingBatchID.Store(syncBatchID)
-		logger.Info("begin pulling records for batch", slog.Int64("SyncBatchID", syncBatchID))
+		logger.Info("begin pulling records for batch", slog.Int64("syncBatchID", syncBatchID))
 
 		if err := monitoring.AddCDCBatchForFlow(errCtx, a.CatalogPool, flowName, monitoring.CDCBatchInfo{
 			BatchID:     syncBatchID,
@@ -279,7 +279,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 			a.Alerter.LogFlowWarning(ctx, flowName, warning)
 		}
 
-		logger.Info("finished pulling records for batch", slog.Int64("SyncBatchID", syncBatchID))
+		logger.Info("finished pulling records for batch", slog.Int64("syncBatchID", syncBatchID))
 		return nil
 	})
 
@@ -645,7 +645,7 @@ func (a *FlowableActivity) startNormalize(
 		return fmt.Errorf("failed to get table name schema mapping: %w", err)
 	}
 
-	logger.Info("normalizing batch", slog.Int64("SyncBatchID", batchID))
+	logger.Info("normalizing batch", slog.Int64("syncBatchID", batchID))
 	res, err := dstConn.NormalizeRecords(ctx, &model.NormalizeRecordsRequest{
 		FlowJobName:            config.FlowJobName,
 		Env:                    config.Env,

--- a/flow/connectors/clickhouse/avro_sync.go
+++ b/flow/connectors/clickhouse/avro_sync.go
@@ -193,6 +193,9 @@ func (s *ClickHouseAvroSyncMethod) pushDataToS3(
 		return nil, 0, err
 	}
 
+	s.logger.Info("writing avro chunks to S3 start",
+		slog.String("partitionId", partition.PartitionId))
+
 	var avroFiles []utils.AvroFile
 	var totalRecords int64
 
@@ -358,7 +361,17 @@ func (s *ClickHouseAvroSyncMethod) pushS3DataToClickHouse(
 					slog.Any("error", err))
 				return exceptions.NewQRepSyncError(err, config.DestinationTableIdentifier, s.ClickHouseConnector.config.Database)
 			}
+			s.logger.Info("inserted part",
+				slog.Uint64("part", i),
+				slog.Uint64("numParts", numParts),
+				slog.Int("chunkIdx", chunkIdx),
+				slog.Int("totalChunks", len(avroFiles)))
 		}
+
+		s.logger.Info("processed chunk",
+			slog.Int("chunkIdx", chunkIdx),
+			slog.Int("totalChunks", len(avroFiles)),
+			slog.String("avroFilePath", avroFile.FilePath))
 	}
 
 	return nil

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -450,8 +450,8 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	}
 	parallelNormalize = min(max(parallelNormalize, 1), len(destinationTableNames))
 	c.logger.Info("[clickhouse-cdc] inserting batch...",
-		slog.Int64("StartBatchID", normBatchID),
-		slog.Int64("EndBatchID", endBatchID),
+		slog.Int64("startBatchID", normBatchID),
+		slog.Int64("endBatchID", endBatchID),
 		slog.Int("connections", parallelNormalize))
 
 	numParts, err := internal.PeerDBClickHouseNormalizationParts(ctx, req.Env)
@@ -464,8 +464,8 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	// there is no other indication of progress, so we log every 5 minutes.
 	periodicLogger := shared.Interval(ctx, 5*time.Minute, func() {
 		c.logger.Info("[clickhouse-cdc] inserting batch...",
-			slog.Int64("StartBatchID", normBatchID),
-			slog.Int64("EndBatchID", endBatchID),
+			slog.Int64("startBatchID", normBatchID),
+			slog.Int64("endBatchID", endBatchID),
 			slog.Int("connections", parallelNormalize))
 	})
 	defer periodicLogger()
@@ -492,8 +492,8 @@ func (c *ClickHouseConnector) NormalizeRecords(
 
 			for insertIntoSelectQuery := range queries {
 				c.logger.Info("executing INSERT command to ClickHouse table",
-					slog.Int64("syncBatchId", endBatchID),
-					slog.Int64("normalizeBatchId", normBatchID),
+					slog.Int64("syncBatchID", endBatchID),
+					slog.Int64("normalizeBatchID", normBatchID),
 					slog.String("destinationTable", insertIntoSelectQuery.TableName),
 					slog.String("query", insertIntoSelectQuery.Query),
 					slog.Int("parallelWorker", i))

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -441,8 +441,8 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	}
 	parallelNormalize = min(max(parallelNormalize, 1), len(destinationTableNames))
 	c.logger.Info("[clickhouse-cdc] inserting batch...",
-		slog.Int64("StartBatchID", normBatchID),
-		slog.Int64("EndBatchID", req.SyncBatchID),
+		slog.Int64("normalizeBatchID", normBatchID),
+		slog.Int64("syncBatchID", req.SyncBatchID),
 		slog.Int("connections", parallelNormalize))
 
 	numParts, err := internal.PeerDBClickHouseNormalizationParts(ctx, req.Env)
@@ -455,8 +455,8 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	// there is no other indication of progress, so we log every 5 minutes.
 	periodicLogger := shared.Interval(ctx, 5*time.Minute, func() {
 		c.logger.Info("[clickhouse-cdc] inserting batch...",
-			slog.Int64("StartBatchID", normBatchID),
-			slog.Int64("EndBatchID", req.SyncBatchID),
+			slog.Int64("normalizeBatchID", normBatchID),
+			slog.Int64("syncBatchID", req.SyncBatchID),
 			slog.Int("connections", parallelNormalize))
 	})
 	defer periodicLogger()
@@ -483,16 +483,18 @@ func (c *ClickHouseConnector) NormalizeRecords(
 
 			for insertIntoSelectQuery := range queries {
 				c.logger.Info("executing INSERT command to ClickHouse table",
-					slog.Int64("syncBatchId", req.SyncBatchID),
-					slog.Int64("normalizeBatchId", normBatchID),
+					slog.Int64("syncBatchID", req.SyncBatchID),
+					slog.Int64("normalizeBatchID", normBatchID),
 					slog.String("destinationTable", insertIntoSelectQuery.TableName),
-					slog.String("query", insertIntoSelectQuery.Query))
+					slog.String("query", insertIntoSelectQuery.Query),
+					slog.Int("parallelWorker", i))
 
 				if err := c.execWithConnection(errCtx, chConn, insertIntoSelectQuery.Query); err != nil {
 					c.logger.Error("[clickhouse] error while inserting into target clickhouse table",
 						slog.String("table", insertIntoSelectQuery.TableName),
 						slog.Int64("syncBatchID", req.SyncBatchID),
 						slog.Int64("normalizeBatchID", normBatchID),
+						slog.Int("parallelWorker", i),
 						slog.Any("error", err))
 					return fmt.Errorf("error while inserting into target clickhouse table %s: %w", insertIntoSelectQuery.TableName, err)
 				}
@@ -501,13 +503,19 @@ func (c *ClickHouseConnector) NormalizeRecords(
 					c.logger.Info("[clickhouse] set last normalized batch id for table",
 						slog.String("table", insertIntoSelectQuery.TableName),
 						slog.Int64("syncBatchID", req.SyncBatchID),
-						slog.Int64("lastNormalizedBatchID", normBatchID))
+						slog.Int64("lastNormalizedBatchID", normBatchID),
+						slog.Int("parallelWorker", i))
 					err := c.SetLastNormalizedBatchIDForTable(ctx, req.FlowJobName, insertIntoSelectQuery.TableName, req.SyncBatchID)
 					if err != nil {
 						return fmt.Errorf("error while setting last synced batch id for table %s: %w", insertIntoSelectQuery.TableName, err)
 					}
 				}
 			}
+
+			c.logger.Info("executed INSERT commands to ClickHouse",
+				slog.Int64("syncBatchID", req.SyncBatchID),
+				slog.Int64("normalizeBatchID", normBatchID),
+				slog.Int("parallelWorker", i))
 			return nil
 		})
 	}

--- a/flow/connectors/external_metadata/store.go
+++ b/flow/connectors/external_metadata/store.go
@@ -222,7 +222,7 @@ func (p *PostgresMetadata) SetLastOffset(ctx context.Context, jobName string, of
 }
 
 func (p *PostgresMetadata) FinishBatch(ctx context.Context, jobName string, syncBatchID int64, offset model.CdcCheckpoint) error {
-	p.logger.Info("finishing batch", "SyncBatchID", syncBatchID, "offset", offset)
+	p.logger.Info("finishing batch", "syncBatchID", syncBatchID, "offset", offset)
 	if _, err := p.pool.Exec(ctx, `
 		INSERT INTO `+lastSyncStateTableName+` (job_name, last_offset, last_text, sync_batch_id)
 		VALUES ($1, $2, $3, $4)

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -148,7 +148,6 @@ func (c *MongoConnector) PullRecords(
 	}
 
 	c.totalBytesRead.Store(0)
-	c.deltaBytesRead.Store(0)
 	changeStream, err := c.client.Watch(ctx, pipeline, changeStreamOpts)
 	if err != nil {
 		if isResumeTokenNotFoundError(err) && resumeToken != nil {

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -171,14 +171,17 @@ func (c *MongoConnector) PullRecords(
 		if recordCount == 0 {
 			req.RecordStream.SignalAsEmpty()
 		}
-		c.logger.Info("[mongo] PullRecords finished streaming", slog.Uint64("records", uint64(recordCount)))
+		c.logger.Info("[mongo] PullRecords finished streaming",
+			slog.Uint64("records", uint64(recordCount)),
+			slog.Int64("bytes", c.meter.TotalBytesRead()),
+			slog.Int("channelLen", req.RecordStream.ChannelLen()))
 	}()
 	// before the first record arrives, we wait for up to an hour before resetting context timeout
 	// after the first record arrives, we switch to configured idleTimeout
 	timeoutCtx, cancelTimeout := context.WithTimeout(ctx, time.Hour)
 
 	reportBytesShutdown := shared.Interval(ctx, time.Second*10, func() {
-		read := c.bytesRead.Swap(0)
+		read := c.meter.DeltaBytesRead()
 		otelManager.Metrics.AllFetchedBytesCounter.Add(ctx, read)
 		otelManager.Metrics.FetchedBytesCounter.Add(ctx, read)
 	})
@@ -186,7 +189,7 @@ func (c *MongoConnector) PullRecords(
 	defer func() {
 		cancelTimeout()
 		reportBytesShutdown()
-		read := c.bytesRead.Swap(0)
+		read := c.meter.DeltaBytesRead()
 		otelManager.Metrics.AllFetchedBytesCounter.Add(ctx, read)
 		otelManager.Metrics.FetchedBytesCounter.Add(ctx, read)
 	}()
@@ -246,6 +249,12 @@ func (c *MongoConnector) PullRecords(
 		if recordCount == 1 {
 			req.RecordStream.SignalAsNotEmpty()
 			timeoutCtx, cancelTimeout = context.WithTimeout(ctx, req.IdleTimeout)
+		}
+		if recordCount%50000 == 0 {
+			c.logger.Info("[mongo] PullRecords streaming",
+				slog.Uint64("records", uint64(recordCount)),
+				slog.Int64("bytes", c.meter.TotalBytesRead()),
+				slog.Int("channelLen", req.RecordStream.ChannelLen()))
 		}
 		return nil
 	}

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -31,10 +32,10 @@ const (
 type MongoConnector struct {
 	logger log.Logger
 	*metadataStore.PostgresMetadata
-	config *protos.MongoConfig
-	client *mongo.Client
-	ssh    utils.SSHTunnel
-	meter  utils.Meter
+	config    *protos.MongoConfig
+	client    *mongo.Client
+	ssh       utils.SSHTunnel
+	bytesRead atomic.Int64
 }
 
 func NewMongoConnector(ctx context.Context, config *protos.MongoConfig) (*MongoConnector, error) {
@@ -58,9 +59,9 @@ func NewMongoConnector(ctx context.Context, config *protos.MongoConfig) (*MongoC
 
 	var meteredDialer utils.MeteredDialer
 	if sshTunnel.Client != nil {
-		meteredDialer = utils.NewMeteredDialer(&mongoConnector.meter, sshTunnel.Client.DialContext, true)
+		meteredDialer = utils.NewMeteredDialer(&mongoConnector.bytesRead, sshTunnel.Client.DialContext, true)
 	} else {
-		meteredDialer = utils.NewMeteredDialer(&mongoConnector.meter, (&net.Dialer{Timeout: time.Minute}).DialContext, false)
+		meteredDialer = utils.NewMeteredDialer(&mongoConnector.bytesRead, (&net.Dialer{Timeout: time.Minute}).DialContext, false)
 	}
 
 	clientOptions, err := parseAsClientOptions(config, meteredDialer)

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -161,9 +161,9 @@ func (c *MongoConnector) PullQRepRecords(
 
 	stream.SetSchema(GetDefaultSchema())
 
-	c.bytesRead.Store(0)
+	c.meter.Reset()
 	shutDown := shared.Interval(ctx, time.Minute, func() {
-		if read := c.bytesRead.Swap(0); read != 0 {
+		if read := c.meter.DeltaBytesRead(); read != 0 {
 			otelManager.Metrics.FetchedBytesCounter.Add(ctx, read)
 		}
 	})
@@ -186,6 +186,8 @@ func (c *MongoConnector) PullQRepRecords(
 		batchSize = math.MaxInt32
 	}
 
+	c.logger.Info("[mongo] pulling records start")
+
 	// MongoDb will use the lesser of batchSize and 16MiB
 	// https://www.mongodb.com/docs/manual/reference/method/cursor.batchsize/
 	cursor, err := collection.Find(ctx, filter, options.Find().SetBatchSize(int32(batchSize)))
@@ -206,6 +208,12 @@ func (c *MongoConnector) PullQRepRecords(
 		}
 		stream.Records <- record
 		totalRecords += 1
+		if totalRecords%50000 == 0 {
+			c.logger.Info("[mongo] pulling records",
+				slog.Int64("records", totalRecords),
+				slog.Int64("bytes", c.meter.TotalBytesRead()),
+				slog.Int("channelLen", len(stream.Records)))
+		}
 	}
 	close(stream.Records)
 	if err := cursor.Err(); err != nil {
@@ -222,7 +230,12 @@ func (c *MongoConnector) PullQRepRecords(
 		return 0, 0, fmt.Errorf("cursor error: %w", err)
 	}
 
-	return totalRecords, c.bytesRead.Swap(0), nil
+	c.logger.Info("[mongo] pulled records",
+		slog.Int64("records", totalRecords),
+		slog.Int64("bytes", c.meter.TotalBytesRead()),
+		slog.Int("channelLen", len(stream.Records)))
+
+	return totalRecords, c.meter.DeltaBytesRead(), nil
 }
 
 func GetDefaultSchema() types.QRecordSchema {

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -323,7 +323,6 @@ func (c *MySqlConnector) PullRecords(
 		return err
 	}
 	defer syncer.Close()
-	c.meter.Reset()
 	c.logger.Info("[mysql] PullRecords started streaming")
 
 	var skewLossReported bool

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -32,7 +32,7 @@ type MySqlConnector struct {
 	logger        log.Logger
 	rdsAuth       *utils.RDSAuth
 	serverVersion string
-	bytesRead     atomic.Int64
+	meter         utils.Meter
 }
 
 func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlConnector, error) {
@@ -127,9 +127,9 @@ func (c *MySqlConnector) ConnectionActive(context.Context) error {
 func (c *MySqlConnector) Dialer() client.Dialer {
 	var meteredDialer utils.MeteredDialer
 	if c.ssh.Client != nil {
-		meteredDialer = utils.NewMeteredDialer(&c.bytesRead, c.ssh.Client.DialContext, false)
+		meteredDialer = utils.NewMeteredDialer(&c.meter, c.ssh.Client.DialContext, false)
 	} else {
-		meteredDialer = utils.NewMeteredDialer(&c.bytesRead, (&net.Dialer{Timeout: time.Minute}).DialContext, false)
+		meteredDialer = utils.NewMeteredDialer(&c.meter, (&net.Dialer{Timeout: time.Minute}).DialContext, false)
 	}
 	return meteredDialer.DialContext
 }

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -32,7 +32,7 @@ type MySqlConnector struct {
 	logger        log.Logger
 	rdsAuth       *utils.RDSAuth
 	serverVersion string
-	meter         utils.Meter
+	bytesRead     atomic.Int64
 }
 
 func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlConnector, error) {
@@ -127,9 +127,9 @@ func (c *MySqlConnector) ConnectionActive(context.Context) error {
 func (c *MySqlConnector) Dialer() client.Dialer {
 	var meteredDialer utils.MeteredDialer
 	if c.ssh.Client != nil {
-		meteredDialer = utils.NewMeteredDialer(&c.meter, c.ssh.Client.DialContext, false)
+		meteredDialer = utils.NewMeteredDialer(&c.bytesRead, c.ssh.Client.DialContext, false)
 	} else {
-		meteredDialer = utils.NewMeteredDialer(&c.meter, (&net.Dialer{Timeout: time.Minute}).DialContext, false)
+		meteredDialer = utils.NewMeteredDialer(&c.bytesRead, (&net.Dialer{Timeout: time.Minute}).DialContext, false)
 	}
 	return meteredDialer.DialContext
 }

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -436,12 +436,18 @@ func PullCdcRecords[Items model.Items](
 		}
 	}()
 
+	logger.Info("pulling records start")
+
 	shutdown := shared.Interval(ctx, time.Minute, func() {
 		logger.Info("pulling records", slog.Int("records", cdcRecordsStorage.Len()))
 	})
 	defer shutdown()
 
 	nextStandbyMessageDeadline := time.Now().Add(req.IdleTimeout)
+
+	pkmRequiresResponse := false
+	waitingForCommit := false
+	fetchedBytes := 0
 
 	addRecordWithKey := func(key model.TableWithPkey, rec model.Record[Items]) error {
 		if err := cdcRecordsStorage.Set(logger, key, rec); err != nil {
@@ -456,11 +462,15 @@ func PullCdcRecords[Items model.Items](
 			nextStandbyMessageDeadline = time.Now().Add(req.IdleTimeout)
 			logger.Info(fmt.Sprintf("pushing the standby deadline to %s", nextStandbyMessageDeadline))
 		}
+		if cdcRecordsStorage.Len()%50000 == 0 {
+			logger.Info("pulling records",
+				slog.Int("records", cdcRecordsStorage.Len()),
+				slog.Int("bytes", fetchedBytes),
+				slog.Int("channelLen", records.ChannelLen()),
+				slog.Bool("waitingForCommit", waitingForCommit))
+		}
 		return nil
 	}
-
-	pkmRequiresResponse := false
-	waitingForCommit := false
 
 	pkmEmptyBatchThrottleThresholdSeconds, err := internal.PeerDBPKMEmptyBatchThrottleThresholdSeconds(ctx, req.Env)
 	if err != nil {
@@ -484,19 +494,28 @@ func PullCdcRecords[Items model.Items](
 
 			if time.Since(standByLastLogged) > 10*time.Second {
 				logger.Info("Sent Standby status message",
-					slog.Int("records", cdcRecordsStorage.Len()))
+					slog.Int("records", cdcRecordsStorage.Len()),
+					slog.Int("bytes", fetchedBytes),
+					slog.Int("channelLen", records.ChannelLen()),
+					slog.Bool("waitingForCommit", waitingForCommit))
 				standByLastLogged = time.Now()
 			}
 		}
 
 		if p.commitLock == nil {
 			if cdcRecordsStorage.Len() >= int(req.MaxBatchSize) {
+				logger.Info("batch filled, returning currently accumulated records",
+					slog.Int("records", cdcRecordsStorage.Len()),
+					slog.Int("bytes", fetchedBytes),
+					slog.Int("channelLen", records.ChannelLen()))
 				return nil
 			}
 
 			if waitingForCommit {
 				logger.Info("commit received, returning currently accumulated records",
-					slog.Int("records", cdcRecordsStorage.Len()))
+					slog.Int("records", cdcRecordsStorage.Len()),
+					slog.Int("bytes", fetchedBytes),
+					slog.Int("channelLen", records.ChannelLen()))
 				return nil
 			}
 		}
@@ -508,11 +527,15 @@ func PullCdcRecords[Items model.Items](
 
 				if p.commitLock == nil {
 					logger.Info("no commit lock, returning currently accumulated records",
-						slog.Int("records", cdcRecordsStorage.Len()))
+						slog.Int("records", cdcRecordsStorage.Len()),
+						slog.Int("bytes", fetchedBytes),
+						slog.Int("channelLen", records.ChannelLen()))
 					return nil
 				} else {
 					logger.Info("commit lock, waiting for commit to return records",
-						slog.Int("records", cdcRecordsStorage.Len()))
+						slog.Int("records", cdcRecordsStorage.Len()),
+						slog.Int("bytes", fetchedBytes),
+						slog.Int("channelLen", records.ChannelLen()))
 					waitingForCommit = true
 				}
 			} else {
@@ -542,7 +565,9 @@ func PullCdcRecords[Items model.Items](
 		if err != nil && p.commitLock == nil {
 			if pgconn.Timeout(err) {
 				logger.Info("Stand-by deadline reached, returning currently accumulated records",
-					slog.Int("records", cdcRecordsStorage.Len()))
+					slog.Int("records", cdcRecordsStorage.Len()),
+					slog.Int("bytes", fetchedBytes),
+					slog.Int("channelLen", records.ChannelLen()))
 				return nil
 			} else {
 				return fmt.Errorf("ReceiveMessage failed: %w", err)
@@ -589,6 +614,7 @@ func PullCdcRecords[Items model.Items](
 
 				if rec != nil {
 					p.otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(msg.Data)))
+					fetchedBytes += len(msg.Data)
 					tableName := rec.GetDestinationTableName()
 					switch r := rec.(type) {
 					case *model.UpdateRecord[Items]:

--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -461,7 +461,10 @@ func corePullQRepRecords(
 		return numRecords, numBytes, err
 	}
 
-	c.logger.Info(fmt.Sprintf("pulled %d records", numRecords), partitionIdLog)
+	c.logger.Info(fmt.Sprintf("pulled %d records", numRecords),
+		partitionIdLog,
+		slog.Int64("records", numRecords),
+		slog.Int64("bytes", numBytes))
 	return numRecords, numBytes, nil
 }
 

--- a/flow/connectors/postgres/qrep_query_executor.go
+++ b/flow/connectors/postgres/qrep_query_executor.go
@@ -105,7 +105,7 @@ func (qe *QRepQueryExecutor) processRowsStream(
 ) (int64, int64, error) {
 	var numRows int64
 	var numBytes int64
-	const logPerRows = 10000
+	const logPerRows = 50000
 
 	for rows.Next() {
 		if err := ctx.Err(); err != nil {
@@ -125,12 +125,19 @@ func (qe *QRepQueryExecutor) processRowsStream(
 		}
 
 		if numRows%logPerRows == 0 {
-			qe.logger.Info("processing row stream", slog.String("cursor", cursorName),
-				slog.Int64("records", numRows), slog.Int64("bytes", numBytes))
+			qe.logger.Info("processing row stream",
+				slog.String("cursor", cursorName),
+				slog.Int64("records", numRows),
+				slog.Int64("bytes", numBytes),
+				slog.Int("channelLen", len(stream.Records)))
 		}
 	}
 
-	qe.logger.Info("processed row stream", slog.String("cursor", cursorName), slog.Int64("records", numRows), slog.Int64("bytes", numBytes))
+	qe.logger.Info("processed row stream",
+		slog.String("cursor", cursorName),
+		slog.Int64("records", numRows),
+		slog.Int64("bytes", numBytes),
+		slog.Int("channelLen", len(stream.Records)))
 	return numRows, numBytes, nil
 }
 

--- a/flow/model/cdc_stream.go
+++ b/flow/model/cdc_stream.go
@@ -115,6 +115,10 @@ func (r *CDCStream[T]) GetRecords() <-chan Record[T] {
 	return r.records
 }
 
+func (r *CDCStream[T]) ChannelLen() int {
+	return len(r.records)
+}
+
 func (r *CDCStream[T]) AddSchemaDelta(
 	tableNameMapping map[string]NameAndExclude,
 	delta *protos.TableSchemaDelta,


### PR DESCRIPTION
If something is slow, hanging or not hanging, we should be able to tell what it is from logs.

Add progress logs where they're missing, in pull, sync, normalize, qrep/cdc
Standardize cadence to 50000 records (10000 in OCF is a bit spammy)
Consistently log # of records, bytes, channel length (correlated with memory consumed by that pipe/partition), whether we're waiting for commit
Tabulate start/end for long running operations
Unify names of some properties so we can do a column in grafana
Rename CH qrep_avro_sync.go to avro_sync.go as it's actually shared with CDC