### PR TITLE
Temporal: Set MaxHeartbeatThrottleInterval to 10 seconds

### DIFF
--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -92,7 +92,7 @@ func WorkerSetup(ctx context.Context, opts *WorkerSetupOptions) (*WorkerSetupRes
 		OnFatalError: func(err error) {
 			slog.Error("Peerflow Worker failed", slog.Any("error", err))
 		},
-		MaxHeartbeatThrottleInterval: 15 * time.Second,
+		MaxHeartbeatThrottleInterval: 10 * time.Second,
 	})
 	peerflow.RegisterFlowWorkerWorkflows(w)
 


### PR DESCRIPTION
Cause for slow pausing was that cancellation requests were being acted upon only after 0.8 times heartbeat timeout had passed.

This PR lowers the interval of pending heartbeats being sent. This is a worker-level setting so affects all our activities. More info here:
https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling

It might also mean higher network traffic from our worker to Temporal