### PR TITLE
mongo: improve error message users see

### DIFF
--- a/flow/connectors/mongo/validate.go
+++ b/flow/connectors/mongo/validate.go
@@ -8,11 +8,11 @@ import (
 )
 
 func (c *MongoConnector) ValidateCheck(ctx context.Context) error {
-	if err := shared_mongo.ValidateServerCompatibility(ctx, c.client); err != nil {
+	if err := shared_mongo.ValidateUserRoles(ctx, c.client); err != nil {
 		return err
 	}
 
-	if err := shared_mongo.ValidateUserRoles(ctx, c.client); err != nil {
+	if err := shared_mongo.ValidateServerCompatibility(ctx, c.client); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Moved ValidateUserRoles above validateServerCompatibility to avoid confusing user errors like:

> failed server compatibility validation: 'serverStatus' failed: (Unauthorized) not authorized on admin to execute command

which depends on clusterMonitor role. This way we get more useful error like:

> failed permissions validation: missing required role: clusterMonitor