### PR TITLE
Allow to disable CDC store

### DIFF
--- a/flow/connectors/utils/cdc_store_test.go
+++ b/flow/connectors/utils/cdc_store_test.go
@@ -137,7 +137,7 @@ func TestNullKeyDoesntStore(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ok)
 
-	require.Equal(t, 1, cdcRecordsStore.Len())
+	require.Equal(t, 1, cdcRecordsStore.numRecords.Load())
 
 	require.NoError(t, cdcRecordsStore.Close())
 }

--- a/flow/connectors/utils/cdc_store_test.go
+++ b/flow/connectors/utils/cdc_store_test.go
@@ -137,7 +137,7 @@ func TestNullKeyDoesntStore(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ok)
 
-	require.Equal(t, 1, cdcRecordsStore.numRecords.Load())
+	require.Equal(t, 1, int(cdcRecordsStore.numRecords.Load()))
 
 	require.NoError(t, cdcRecordsStore.Close())
 }

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -65,6 +65,13 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_QUEUES,
 	},
 	{
+		Name:             "PEERDB_CDC_STORE_ENABLED",
+		Description:      "Controls whether to enable the store for recovering unchanged Postgres TOAST values within a CDC batch",
+		DefaultValue:     "true",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_ALL,
+	}, {
 		Name:             "PEERDB_CDC_DISK_SPILL_RECORDS_THRESHOLD",
 		Description:      "CDC: number of records beyond which records are written to disk instead",
 		DefaultValue:     "1000000",
@@ -542,6 +549,10 @@ func PeerDBQueueFlushTimeoutSeconds(ctx context.Context, env map[string]string) 
 
 func PeerDBQueueParallelism(ctx context.Context, env map[string]string) (int64, error) {
 	return dynamicConfSigned[int64](ctx, env, "PEERDB_QUEUE_PARALLELISM")
+}
+
+func PeerDBCDCStoreEnabled(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_CDC_STORE_ENABLED")
 }
 
 func PeerDBCDCDiskSpillRecordsThreshold(ctx context.Context, env map[string]string) (int64, error) {

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -71,7 +71,8 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
-	}, {
+	},
+	{
 		Name:             "PEERDB_CDC_DISK_SPILL_RECORDS_THRESHOLD",
 		Description:      "CDC: number of records beyond which records are written to disk instead",
 		DefaultValue:     "1000000",


### PR DESCRIPTION
Introduce a config that allows to disable the CDC store (default behavior doesn't change). Disabling it frees up 75% of RAM for CDC proper for the ClickHouse target on loaded services.

#3376 will give us data on whether the impact is small enough to merge this and flip the setting.