### PR TITLE
Reduce QRep channel size

### DIFF
--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -51,7 +51,7 @@ const (
 	DeploymentUIDKey ContextKey = "deploymentUid"
 )
 
-const FetchAndChannelSize = 256 * 1024
+const FetchAndChannelSize = 128 * 1024
 
 func Ptr[T any](x T) *T {
 	return &x


### PR DESCRIPTION
Quick and dirty way to reduce memory usage when snapshot parallelism is too big for the node. Current channel size is 256K, previous value (#315) was 16K, so going to 128K should help with memory but not be too low.