### PR TITLE
mongo: shorten _full_document to doc

### DIFF
--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -26,7 +26,8 @@ import (
 
 const (
 	DefaultDocumentKeyColumnName  = "_id"
-	DefaultFullDocumentColumnName = "_full_document"
+	DefaultFullDocumentColumnName = "doc"
+	LegacyFullDocumentColumnName  = "_full_document"
 )
 
 type MongoConnector struct {

--- a/flow/e2e/mongo/mongo.go
+++ b/flow/e2e/mongo/mongo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/e2e"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
 type MongoSource struct {
@@ -62,7 +63,7 @@ func (s *MongoSource) GetRows(ctx context.Context, suffix, table, cols string) (
 	}
 
 	recordBatch := &model.QRecordBatch{
-		Schema:  connmongo.GetDefaultSchema(),
+		Schema:  connmongo.GetDefaultSchema(shared.IntervalVersion_MongoDBFullDocumentColumnToDoc),
 		Records: nil,
 	}
 

--- a/flow/e2e/mongo/mongo_test.go
+++ b/flow/e2e/mongo/mongo_test.go
@@ -114,7 +114,7 @@ func (s MongoClickhouseSuite) Test_Simple_Flow() {
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t, tc, flowConnConfig)
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load to match", srcTable, dstTable, "_id,doc")
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
 	// insert 10 rows into the source table for cdc
@@ -126,7 +126,7 @@ func (s MongoClickhouseSuite) Test_Simple_Flow() {
 		require.True(t, res.Acknowledged)
 	}
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "cdc events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "cdc events to match", srcTable, dstTable, "_id,doc")
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
 }
@@ -161,7 +161,7 @@ func (s MongoClickhouseSuite) Test_Simple_Flow_Partitioned() {
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t, tc, flowConnConfig)
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load to match", srcTable, dstTable, "_id,doc")
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
 	// insert 10 rows into the source table for cdc
@@ -173,7 +173,7 @@ func (s MongoClickhouseSuite) Test_Simple_Flow_Partitioned() {
 		require.True(t, res.Acknowledged)
 	}
 
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "cdc events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "cdc events to match", srcTable, dstTable, "_id,doc")
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
 }
@@ -210,7 +210,7 @@ func (s MongoClickhouseSuite) Test_Inconsistent_Schema() {
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t, tc, flowConnConfig)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load to match", srcTable, dstTable, "_id,doc")
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
 
@@ -224,7 +224,7 @@ func (s MongoClickhouseSuite) Test_Inconsistent_Schema() {
 		require.NoError(t, err)
 		require.True(t, res.Acknowledged)
 	}
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "cdc events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "cdc events to match", srcTable, dstTable, "_id,doc")
 
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
@@ -255,7 +255,7 @@ func (s MongoClickhouseSuite) Test_CDC() {
 	insertRes, err := collection.InsertOne(t.Context(), bson.D{bson.E{Key: "key", Value: 1}}, options.InsertOne())
 	require.NoError(t, err)
 	require.True(t, insertRes.Acknowledged)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable, dstTable, "_id,doc")
 
 	updateRes, err := collection.UpdateOne(
 		t.Context(),
@@ -264,7 +264,7 @@ func (s MongoClickhouseSuite) Test_CDC() {
 		options.UpdateOne())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), updateRes.ModifiedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "update event", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "update event", srcTable, dstTable, "_id,doc")
 
 	replaceRes, err := collection.ReplaceOne(
 		t.Context(),
@@ -273,12 +273,12 @@ func (s MongoClickhouseSuite) Test_CDC() {
 		options.Replace())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), replaceRes.ModifiedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "replace event", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "replace event", srcTable, dstTable, "_id,doc")
 
 	deleteRes, err := collection.DeleteOne(t.Context(), bson.D{bson.E{Key: "key", Value: 3}}, options.DeleteOne())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), deleteRes.DeletedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "delete event", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "delete event", srcTable, dstTable, "_id,doc")
 
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
@@ -317,7 +317,7 @@ func (s MongoClickhouseSuite) Test_Nested_Document_At_Limit() {
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t, tc, flowConnConfig)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable, dstTable, "_id,doc")
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
 
@@ -325,7 +325,7 @@ func (s MongoClickhouseSuite) Test_Nested_Document_At_Limit() {
 	res, err = collection.InsertOne(t.Context(), nestedDoc("X"), options.InsertOne())
 	require.NoError(t, err)
 	require.True(t, res.Acknowledged)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert events to match", srcTable, dstTable, "_id,doc")
 
 	oid := bson.D{bson.E{Key: "_id", Value: res.InsertedID}}
 
@@ -333,19 +333,19 @@ func (s MongoClickhouseSuite) Test_Nested_Document_At_Limit() {
 	updateRes, err := collection.UpdateOne(t.Context(), oid, bson.D{bson.E{Key: "$set", Value: nestedDoc("Y")}}, options.UpdateOne())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), updateRes.ModifiedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "update events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "update events to match", srcTable, dstTable, "_id,doc")
 
 	// replace nested doc for cdc
 	replaceRes, err := collection.ReplaceOne(t.Context(), oid, nestedDoc("Z"), options.Replace())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), replaceRes.ModifiedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "replace events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "replace events to match", srcTable, dstTable, "_id,doc")
 
 	// delete nested doc for cdc
 	deleteRes, err := collection.DeleteOne(t.Context(), oid, options.DeleteOne())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), deleteRes.DeletedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "delete events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "delete events to match", srcTable, dstTable, "_id,doc")
 
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
@@ -384,7 +384,7 @@ func (s MongoClickhouseSuite) Test_Large_Document_At_Limit() {
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t, tc, flowConnConfig)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable, dstTable, "_id,doc")
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
 
@@ -392,7 +392,7 @@ func (s MongoClickhouseSuite) Test_Large_Document_At_Limit() {
 	res, err = collection.InsertOne(t.Context(), largeDoc("X"), options.InsertOne())
 	require.NoError(t, err)
 	require.True(t, res.Acknowledged)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert events to match", srcTable, dstTable, "_id,doc")
 
 	oid := bson.D{bson.E{Key: "_id", Value: res.InsertedID}}
 
@@ -400,19 +400,19 @@ func (s MongoClickhouseSuite) Test_Large_Document_At_Limit() {
 	updateRes, err := collection.UpdateOne(t.Context(), oid, bson.D{bson.E{Key: "$set", Value: largeDoc("Y")}}, options.UpdateOne())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), updateRes.ModifiedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "update events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "update events to match", srcTable, dstTable, "_id,doc")
 
 	// replace large doc for cdc
 	replaceRes, err := collection.ReplaceOne(t.Context(), oid, largeDoc("Z"), options.Replace())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), replaceRes.ModifiedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "replace events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "replace events to match", srcTable, dstTable, "_id,doc")
 
 	// delete large doc for cdc
 	deleteRes, err := collection.DeleteOne(t.Context(), oid, options.DeleteOne())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), deleteRes.DeletedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "delete events to match", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "delete events to match", srcTable, dstTable, "_id,doc")
 
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
@@ -457,8 +457,8 @@ func (s MongoClickhouseSuite) Test_Transactions_Across_Collections() {
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t, tc, flowConnConfig)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable1, dstTable1, "_id,_full_document")
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable2, dstTable2, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable1, dstTable1, "_id,doc")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable2, dstTable2, "_id,doc")
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
 
@@ -480,8 +480,8 @@ func (s MongoClickhouseSuite) Test_Transactions_Across_Collections() {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), res.([]*mongo.UpdateResult)[0].ModifiedCount)
 	require.Equal(t, int64(1), res.([]*mongo.UpdateResult)[1].ModifiedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "t1 to match", srcTable1, dstTable1, "_id,_full_document")
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "t2 to match", srcTable2, dstTable2, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "t1 to match", srcTable1, dstTable1, "_id,doc")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "t2 to match", srcTable2, dstTable2, "_id,doc")
 
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
@@ -511,25 +511,25 @@ func (s MongoClickhouseSuite) Test_Enable_Json() {
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t, tc, flowConnConfig)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "initial load", srcTable, dstTable, "_id,doc")
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
 
 	insertRes, err := collection.InsertOne(t.Context(), bson.D{bson.E{Key: "key2", Value: "val2"}}, options.InsertOne())
 	require.NoError(t, err)
 	require.True(t, insertRes.Acknowledged)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable, dstTable, "_id,doc")
 	oid := bson.D{bson.E{Key: "_id", Value: res.InsertedID}}
 
 	replaceRes, err := collection.ReplaceOne(t.Context(), oid, bson.D{bson.E{Key: "key2", Value: "val2"}}, options.Replace())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), replaceRes.ModifiedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "replace event", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "replace event", srcTable, dstTable, "_id,doc")
 
 	deleteRes, err := collection.DeleteOne(t.Context(), oid, options.DeleteOne())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), deleteRes.DeletedCount)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "delete event", srcTable, dstTable, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "delete event", srcTable, dstTable, "_id,doc")
 
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
@@ -566,8 +566,8 @@ func (s MongoClickhouseSuite) Test_Mongo_Can_Resume_After_Delete_Table() {
 	insertRes, err = db.Collection(srcTable2).InsertOne(t.Context(), bson.D{bson.E{Key: "key", Value: "val"}}, options.InsertOne())
 	require.NoError(t, err)
 	require.True(t, insertRes.Acknowledged)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable1, dstTable1, "_id,_full_document")
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable2, dstTable2, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable1, dstTable1, "_id,doc")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable2, dstTable2, "_id,doc")
 
 	// pause workflow
 	e2e.SignalWorkflow(t.Context(), env, model.FlowSignal, model.PauseSignal)
@@ -590,7 +590,7 @@ func (s MongoClickhouseSuite) Test_Mongo_Can_Resume_After_Delete_Table() {
 	insertRes, err = db.Collection(srcTable1).InsertOne(t.Context(), bson.D{bson.E{Key: "key2", Value: "val2"}}, options.InsertOne())
 	require.NoError(t, err)
 	require.True(t, insertRes.Acknowledged)
-	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable1, dstTable1, "_id,_full_document")
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "insert event", srcTable1, dstTable1, "_id,doc")
 
 	env.Cancel(t.Context())
 	e2e.RequireEnvCanceled(t, env)
@@ -724,16 +724,16 @@ func (s MongoClickhouseSuite) Test_Json_Types() {
 
 	tc := e2e.NewTemporalClient(t)
 	env := e2e.ExecutePeerflow(t, tc, flowConnConfig)
-	e2e.EnvWaitForCount(env, s, "initial load", dstTable, "_id,_full_document", 1)
+	e2e.EnvWaitForCount(env, s, "initial load", dstTable, "_id,doc", 1)
 
 	e2e.SetupCDCFlowStatusQuery(t, env, flowConnConfig)
 
 	insertRes, err = collection.InsertOne(t.Context(), doc, options.InsertOne())
 	require.NoError(t, err)
 	require.True(t, insertRes.Acknowledged)
-	e2e.EnvWaitForCount(env, s, "cdc", dstTable, "_id,_full_document", 2)
+	e2e.EnvWaitForCount(env, s, "cdc", dstTable, "_id,doc", 2)
 
-	rows, err := s.GetRows(dstTable, "_id,_full_document")
+	rows, err := s.GetRows(dstTable, "_id,doc")
 	require.NoError(t, err)
 	require.Len(t, rows.Records, 2, "Expected 2 rows in destination table")
 

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -18,6 +18,7 @@ const (
 const (
 	InternalVersion_First uint32 = iota
 	InternalVersion_PgVectorAsFloatArray
+	IntervalVersion_MongoDBFullDocumentColumnToDoc
 
 	TotalNumberOfInternalVersions
 	InternalVersion_Latest = TotalNumberOfInternalVersions - 1


### PR DESCRIPTION
Shorten default name from `_full_document` to `doc`. 