### PR TITLE
Last offset fetch: prevent destination connection by returning early

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -144,7 +144,8 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	lastOffset, err := func() (model.CdcCheckpoint, error) {
 		// special case pg-pg replication, where offsets are stored on destination instead of catalog
 		if _, isPg := any(srcConn).(*connpostgres.PostgresConnector); isPg {
-			dstPgConn, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, config.Env, a.CatalogPool, config.DestinationName)
+			dstPgConn, err := connectors.GetByNameAndForPeerAs[*connpostgres.PostgresConnector](
+				ctx, config.Env, a.CatalogPool, config.DestinationName, protos.DBType_POSTGRES)
 			if err != nil {
 				if !errors.Is(err, errors.ErrUnsupported) {
 					return model.CdcCheckpoint{}, fmt.Errorf("failed to get destination connector to get last offset: %w", err)

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -143,9 +143,8 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 
 	lastOffset, err := func() (model.CdcCheckpoint, error) {
 		// special case pg-pg replication, where offsets are stored on destination instead of catalog
-		if _, isPg := any(srcConn).(*connpostgres.PostgresConnector); isPg {
-			dstPgConn, err := connectors.GetByNameAndForPeerAs[*connpostgres.PostgresConnector](
-				ctx, config.Env, a.CatalogPool, config.DestinationName, protos.DBType_POSTGRES)
+		if _, isSourcePg := any(srcConn).(*connpostgres.PostgresConnector); isSourcePg {
+			dstPgConn, err := connectors.GetPostgresConnectorByName(ctx, config.Env, a.CatalogPool, config.DestinationName)
 			if err != nil {
 				if !errors.Is(err, errors.ErrUnsupported) {
 					return model.CdcCheckpoint{}, fmt.Errorf("failed to get destination connector to get last offset: %w", err)

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -485,7 +485,12 @@ func GetByNameAs[T Connector](ctx context.Context, env map[string]string, catalo
 	return GetAs[T](ctx, env, peer)
 }
 
-func GetPostgresConnectorByName(ctx context.Context, env map[string]string, catalogPool shared.CatalogPool, name string) (*connpostgres.PostgresConnector, error) {
+func GetPostgresConnectorByName(
+	ctx context.Context,
+	env map[string]string,
+	catalogPool shared.CatalogPool,
+	name string,
+) (*connpostgres.PostgresConnector, error) {
 	peer, err := LoadPeer(ctx, catalogPool, name)
 	if err != nil {
 		return nil, err

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -485,17 +485,15 @@ func GetByNameAs[T Connector](ctx context.Context, env map[string]string, catalo
 	return GetAs[T](ctx, env, peer)
 }
 
-func GetByNameAndForPeerAs[T Connector](ctx context.Context, env map[string]string, catalogPool shared.CatalogPool, name string, expectedType protos.DBType) (T, error) {
+func GetPostgresConnectorByName(ctx context.Context, env map[string]string, catalogPool shared.CatalogPool, name string) (*connpostgres.PostgresConnector, error) {
 	peer, err := LoadPeer(ctx, catalogPool, name)
 	if err != nil {
-		var none T
-		return none, err
+		return nil, err
 	}
-	if peer.Type != expectedType {
-		var none T
-		return none, errors.ErrUnsupported
+	if peer.Type != protos.DBType_POSTGRES {
+		return nil, errors.ErrUnsupported
 	}
-	return GetAs[T](ctx, env, peer)
+	return GetAs[*connpostgres.PostgresConnector](ctx, env, peer)
 }
 
 func CloseConnector(ctx context.Context, conn Connector) {

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -485,6 +485,19 @@ func GetByNameAs[T Connector](ctx context.Context, env map[string]string, catalo
 	return GetAs[T](ctx, env, peer)
 }
 
+func GetByNameAndForPeerAs[T Connector](ctx context.Context, env map[string]string, catalogPool shared.CatalogPool, name string, expectedType protos.DBType) (T, error) {
+	peer, err := LoadPeer(ctx, catalogPool, name)
+	if err != nil {
+		var none T
+		return none, err
+	}
+	if peer.Type != expectedType {
+		var none T
+		return none, errors.ErrUnsupported
+	}
+	return GetAs[T](ctx, env, peer)
+}
+
 func CloseConnector(ctx context.Context, conn Connector) {
 	if err := conn.Close(); err != nil {
 		internal.LoggerFromCtx(ctx).Error("error closing connector", slog.Any("error", err))


### PR DESCRIPTION
Implementation in https://github.com/PeerDB-io/peerdb/pull/3367 misses the fact that GetConnector which we call under the hood opens a destination connection, and only after we successfully get a connector do we assert that the connector supports T.

This PR clones GetByNameAs and passes in an `expectedType` parameter which is used to error out with unsupported early 