### PR TITLE
pg/mysql cdc: report fetched bytes metric with interval

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1031,7 +1031,7 @@ func (a *FlowableActivity) emitLogRetentionHours(
 
 var activeFlowStatuses = map[protos.FlowStatus]struct{}{
 	protos.FlowStatus_STATUS_RUNNING:   {},
-	protos.FlowStatus_STATUS_PAUSED: {},
+	protos.FlowStatus_STATUS_PAUSED:    {},
 	protos.FlowStatus_STATUS_PAUSING:   {},
 	protos.FlowStatus_STATUS_SETUP:     {},
 	protos.FlowStatus_STATUS_SNAPSHOT:  {},

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -410,7 +410,7 @@ func (c *MySqlConnector) PullRecords(
 				} else if inTx {
 					c.logger.Info("[mysql] timeout reached, but still in transaction, waiting for inTx false",
 						slog.Uint64("records", uint64(recordCount)),
-						slog.Int64("bytes", fetchedBytes.Load()),
+						slog.Int64("bytes", totalFetchedBytes.Load()),
 						slog.Int("channelLen", req.RecordStream.ChannelLen()))
 					// reset timeoutCtx to a low value and wait for inTx to become false
 					cancelTimeout()


### PR DESCRIPTION
@ilidemi noticed 10% of cpu usage in pg/mysql was attributed to metrics

reuse pattern used by qrep where we add to atomic counters & regularly empty those counters

mongo cdc already does this