### PR TITLE
catalog pool: don't set MinConns to 1

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1031,7 +1031,7 @@ func (a *FlowableActivity) emitLogRetentionHours(
 
 var activeFlowStatuses = map[protos.FlowStatus]struct{}{
 	protos.FlowStatus_STATUS_RUNNING:   {},
-	protos.FlowStatus_STATUS_PAUSED: {},
+	protos.FlowStatus_STATUS_PAUSED:    {},
 	protos.FlowStatus_STATUS_PAUSING:   {},
 	protos.FlowStatus_STATUS_SETUP:     {},
 	protos.FlowStatus_STATUS_SNAPSHOT:  {},

--- a/flow/internal/catalog.go
+++ b/flow/internal/catalog.go
@@ -29,9 +29,8 @@ func GetCatalogConnectionPoolFromEnv(ctx context.Context) (shared.CatalogPool, e
 			return shared.CatalogPool{},
 				exceptions.NewCatalogError(fmt.Errorf("unable to parse catalog connection string: %w", err))
 		}
-		config.MinConns = 1
 		config.MaxConns = 3
-		config.MaxConnIdleTime = time.Second
+		config.MaxConnIdleTime = 90 * time.Second
 		pool, err = pgxpool.NewWithConfig(ctx, config)
 		if err != nil {
 			return shared.CatalogPool{Pool: pool},


### PR DESCRIPTION
health check only runs once a minute, so pool wasn't aggressively culled

meanwhile MinConns counterbalance keeps cold services lukewarm