### PR TITLE
explicit check for "use of closed network connection" suffix

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -539,7 +539,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
-	if errors.Is(err, net.ErrClosed) {
+	if errors.Is(err, net.ErrClosed) || strings.HasSuffix(err.Error(), "use of closed network connection") {
 		return ErrorIgnoreConnTemporary, ErrorInfo{
 			Source: ErrorSourceNet,
 			Code:   "net.ErrClosed",


### PR DESCRIPTION
many libraries create this error themselves, & check this way, as historically go did not expose net.ErrClosed type