### PR TITLE
Catch missing slot / publication for alerting in PullRecords

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -213,7 +213,8 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		// wait for the pull goroutine to finish
 		if err := errGroup.Wait(); err != nil {
 			// don't log flow error for "replState changed" and "slot is already active"
-			if !(temporal.IsApplicationError(err) || shared.IsSQLStateError(err, pgerrcode.ObjectInUse)) {
+			var applicationError *temporal.ApplicationError
+			if !((errors.As(err, &applicationError) && applicationError.Type() == "desync") || shared.IsSQLStateError(err, pgerrcode.ObjectInUse)) {
 				_ = a.Alerter.LogFlowError(ctx, flowName, err)
 			}
 			if temporal.IsApplicationError(err) {

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -214,7 +214,8 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		if err := errGroup.Wait(); err != nil {
 			// don't log flow error for "replState changed" and "slot is already active"
 			var applicationError *temporal.ApplicationError
-			if !((errors.As(err, &applicationError) && applicationError.Type() == "desync") || shared.IsSQLStateError(err, pgerrcode.ObjectInUse)) {
+			if !((errors.As(err, &applicationError) && applicationError.Type() == "desync") ||
+				shared.IsSQLStateError(err, pgerrcode.ObjectInUse)) {
 				_ = a.Alerter.LogFlowError(ctx, flowName, err)
 			}
 			if temporal.IsApplicationError(err) {


### PR DESCRIPTION
Missed a code path in https://github.com/PeerDB-io/peerdb/pull/3296

This PR catches non-desync temporal app errors which includes missing slot and publication in PullRecords. Functionally tested