### PR TITLE
handle partition min/max being null

### DIFF
--- a/flow/connectors/utils/partition.go
+++ b/flow/connectors/utils/partition.go
@@ -286,6 +286,8 @@ func (p *PartitionHelper) AddPartitionsWithRange(start any, end any, numPartitio
 	partition, err := p.getPartitionForStartAndEnd(start, end)
 	if err != nil {
 		return err
+	} else if partition == nil {
+		return nil
 	}
 
 	switch r := partition.Range.Range.(type) {

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -2386,6 +2386,51 @@ func (s ClickHouseSuite) Test_Partition_Key_Timestamp() {
 	e2e.RequireEnvCanceled(s.t, env)
 }
 
+// tests where panic happened when using custom partition key on empty table
+func (s ClickHouseSuite) Test_Partition_Key_Empty() {
+	srcTableName := "test_partition_key_empty"
+	srcFullName := s.attachSchemaSuffix(srcTableName)
+	dstTableName := "test_partition_key_empty"
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		id INT PRIMARY KEY,
+		myname TEXT NOT NULL,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)`, srcFullName)))
+
+	connectionGen := e2e.FlowConnectionGenerationConfig{
+		FlowJobName: s.attachSuffix("clickhouse_partition_key_empty"),
+		TableMappings: []*protos.TableMapping{{
+			SourceTableIdentifier:      srcFullName,
+			DestinationTableIdentifier: dstTableName,
+			PartitionKey:               "id",
+			ShardingKey:                "id",
+		}},
+		Destination: s.Peer().Name,
+	}
+
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.SnapshotMaxParallelWorkers = 4
+	flowConnConfig.SnapshotNumRowsPerPartition = 10
+	tc := e2e.NewTemporalClient(s.t)
+	env := e2e.ExecutePeerflow(s.t, tc, flowConnConfig)
+	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	e2e.EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,myname,updated_at")
+
+	countRow := s.Conn().QueryRow(s.t.Context(),
+		`SELECT COUNT(*) FROM peerdb_stats.qrep_partitions WHERE parent_mirror_name = $1`,
+		flowConnConfig.FlowJobName)
+
+	var partitionCount int
+	require.NoError(s.t, countRow.Scan(&partitionCount), "failed to get partition count")
+	require.GreaterOrEqual(s.t, partitionCount, 0, "expected no partitions to be created")
+
+	env.Cancel(s.t.Context())
+	e2e.RequireEnvCanceled(s.t, env)
+}
+
 func (s ClickHouseSuite) Test_PartitionBy() {
 	srcTableName := "test_partition_by"
 	srcFullName := s.attachSchemaSuffix(srcTableName)


### PR DESCRIPTION
previously we would bypass this when count returned 0,
but with mysql estimate we don't trust 0 & still have 1 partition