### PR TITLE
reduce channel sizes to 1024

### DIFF
--- a/flow/connectors/utils/stream.go
+++ b/flow/connectors/utils/stream.go
@@ -16,7 +16,7 @@ import (
 func RecordsToRawTableStream[Items model.Items](
 	req *model.RecordsToStreamRequest[Items], numericTruncator model.StreamNumericTruncator,
 ) (*model.QRecordStream, error) {
-	recordStream := model.NewQRecordStream(1 << 17)
+	recordStream := model.NewQRecordStream(1024)
 	recordStream.SetSchema(types.QRecordSchema{
 		Fields: []types.QField{
 			{

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -57,7 +57,7 @@ const (
 	RequestIdKey     ContextKey = "x-peerdb-request-id"
 )
 
-const FetchAndChannelSize = 128 * 1024
+const FetchAndChannelSize = 1024
 
 func Ptr[T any](x T) *T {
 	return &x


### PR DESCRIPTION
based on https://github.com/PeerDB-io/ab-scale-testing there was no benefit

this optimization was made for a particular usecase before other optimizations were made

these channel sizes become particularly painful when multiple mirrors are spun up