### PR TITLE
Support very long numbers as strings in PG JSON

### DIFF
--- a/flow/connectors/mongo/codec.go
+++ b/flow/connectors/mongo/codec.go
@@ -16,31 +16,7 @@ import (
 // by converting them to JSON strings. Decoders are implemented to satisfy json-iterator's
 // extension interface requirements, even though decoding is not used by MongoDB Connector.
 type BsonExtension struct {
-	jsoniter.Extension
-}
-
-func (extension *BsonExtension) UpdateStructDescriptor(structDescriptor *jsoniter.StructDescriptor) {
-	// not used (bson documents does not contain struct)
-}
-
-func (extension *BsonExtension) CreateEncoder(typ reflect2.Type) jsoniter.ValEncoder {
-	// use default
-	return nil
-}
-
-func (extension *BsonExtension) CreateDecoder(typ reflect2.Type) jsoniter.ValDecoder {
-	// use default
-	return nil
-}
-
-func (extension *BsonExtension) CreateMapKeyEncoder(typ reflect2.Type) jsoniter.ValEncoder {
-	// use default
-	return nil
-}
-
-func (extension *BsonExtension) CreateMapKeyDecoder(typ reflect2.Type) jsoniter.ValDecoder {
-	// use default
-	return nil
+	jsoniter.DummyExtension
 }
 
 func (extension *BsonExtension) DecorateEncoder(typ reflect2.Type, encoder jsoniter.ValEncoder) jsoniter.ValEncoder {
@@ -52,17 +28,6 @@ func (extension *BsonExtension) DecorateEncoder(typ reflect2.Type, encoder jsoni
 	}
 	// use default
 	return encoder
-}
-
-func (extension *BsonExtension) DecorateDecoder(typ reflect2.Type, decoder jsoniter.ValDecoder) jsoniter.ValDecoder {
-	if typ.Type1() == reflect.TypeFor[bson.D]() {
-		return &BsonDCodec{}
-	}
-	if typ.Type1() == reflect.TypeFor[bson.A]() {
-		return &BsonACodec{}
-	}
-	// use default
-	return decoder
 }
 
 type BsonDCodec struct{}

--- a/flow/connectors/postgres/json.go
+++ b/flow/connectors/postgres/json.go
@@ -1,0 +1,41 @@
+package connpostgres
+
+import (
+	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
+)
+
+type relaxedNumberDecoder struct{}
+
+func (d *relaxedNumberDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	switch iter.WhatIsNext() {
+	case jsoniter.NumberValue:
+		numberToken := iter.ReadNumber()
+		if val, err := numberToken.Float64(); err == nil {
+			*(*any)(ptr) = val
+		} else {
+			*(*any)(ptr) = numberToken.String()
+		}
+	default:
+		*(*any)(ptr) = iter.Read()
+	}
+}
+
+type RelaxedNumberExtension struct {
+	jsoniter.DummyExtension
+}
+
+func (extension *RelaxedNumberExtension) CreateDecoder(typ reflect2.Type) jsoniter.ValDecoder {
+	if typ == reflect2.TypeOfPtr((*any)(nil)).Elem() {
+		return &relaxedNumberDecoder{}
+	}
+	return nil
+}
+
+func createExtendedJSONUnmarshaler() jsoniter.API {
+	config := jsoniter.ConfigCompatibleWithStandardLibrary
+	config.RegisterExtension(&RelaxedNumberExtension{})
+	return config
+}

--- a/flow/connectors/postgres/json.go
+++ b/flow/connectors/postgres/json.go
@@ -10,16 +10,17 @@ import (
 type relaxedNumberDecoder struct{}
 
 func (d *relaxedNumberDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	anyPtr := (*any)(ptr)
 	switch iter.WhatIsNext() {
 	case jsoniter.NumberValue:
 		numberToken := iter.ReadNumber()
 		if val, err := numberToken.Float64(); err == nil {
-			*(*any)(ptr) = val
+			*anyPtr = val
 		} else {
-			*(*any)(ptr) = numberToken.String()
+			*anyPtr = numberToken.String()
 		}
 	default:
-		*(*any)(ptr) = iter.Read()
+		*anyPtr = iter.Read()
 	}
 }
 

--- a/flow/connectors/postgres/json_test.go
+++ b/flow/connectors/postgres/json_test.go
@@ -1,0 +1,106 @@
+package connpostgres
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelaxedNumberExtension(t *testing.T) {
+	relaxedNumberStr := "1" + strings.Repeat("0", 1000)
+	negRelaxedNumberStr := "-" + relaxedNumberStr
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected any
+	}{
+		{
+			name:     "integer",
+			input:    `{"value": 42}`,
+			expected: float64(42),
+		},
+		{
+			name:     "float",
+			input:    `{"value": 3.14159}`,
+			expected: float64(3.14159),
+		},
+		{
+			name:     "large integer",
+			input:    `{"value": 1` + strings.Repeat("0", 308) + `}`,
+			expected: float64(1e308),
+		},
+		{
+			name:     "negative large integer",
+			input:    `{"value": -1` + strings.Repeat("0", 308) + `}`,
+			expected: float64(-1e308),
+		},
+		{
+			name:     "scientific notation",
+			input:    `{"value": 1.23e10}`,
+			expected: float64(1.23e10),
+		},
+		{
+			name:     "relaxed integer",
+			input:    `{"value": ` + relaxedNumberStr + `}`,
+			expected: relaxedNumberStr,
+		},
+		{
+			name:     "negative relaxed integer",
+			input:    `{"value": ` + negRelaxedNumberStr + `}`,
+			expected: negRelaxedNumberStr,
+		},
+		{
+			name:     "string",
+			input:    `{"value": "not a number"}`,
+			expected: "not a number",
+		},
+		{
+			name:     "boolean",
+			input:    `{"value": true}`,
+			expected: true,
+		},
+		{
+			name:     "null",
+			input:    `{"value": null}`,
+			expected: nil,
+		},
+		{
+			name:     "array with numbers",
+			input:    `{"value": [1, 2.5, ` + relaxedNumberStr + `]}`,
+			expected: []any{float64(1), float64(2.5), relaxedNumberStr},
+		},
+		{
+			name:     "nested object with numbers",
+			input:    `{"value": {"a": 123, "b": ` + relaxedNumberStr + `}}`,
+			expected: map[string]any{"a": float64(123), "b": relaxedNumberStr},
+		},
+	}
+
+	jsonApi := createExtendedJSONUnmarshaler()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result map[string]any
+			err := jsonApi.UnmarshalFromString(tc.input, &result)
+			require.NoError(t, err)
+
+			actual := result["value"]
+
+			// For arrays and maps, need to compare deeply
+			switch expected := tc.expected.(type) {
+			case []any:
+				actualArr, ok := actual.([]any)
+				require.True(t, ok, "expected array type")
+				require.Equal(t, expected, actualArr)
+			case map[string]any:
+				actualMap, ok := actual.(map[string]any)
+				require.True(t, ok, "expected map type")
+				require.Equal(t, expected, actualMap)
+			default:
+				require.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}

--- a/flow/connectors/postgres/json_test.go
+++ b/flow/connectors/postgres/json_test.go
@@ -11,6 +11,7 @@ func TestRelaxedNumberExtension(t *testing.T) {
 	relaxedNumberStr := "1" + strings.Repeat("0", 1000)
 	negRelaxedNumberStr := "-" + relaxedNumberStr
 
+	//nolint:govet // it's a test, no need for fieldalignment
 	testCases := []struct {
 		name     string
 		input    string

--- a/flow/connectors/postgres/qrep_query_executor_test.go
+++ b/flow/connectors/postgres/qrep_query_executor_test.go
@@ -101,8 +101,10 @@ func TestSupportedDataTypes(t *testing.T) {
 		col_jsonb JSONB,
 		col_jsonb_null JSONB,
 		col_json_arr JSON[],
+		col_json_arr_empty JSON[],
 		col_json_arr_null JSON[],
 		col_jsonb_arr JSONB[],
+		col_jsonb_arr_empty JSONB[],
 		col_jsonb_arr_null JSONB[]
 	);`, utils.QuoteIdentifier(schemaName))
 
@@ -132,10 +134,12 @@ func TestSupportedDataTypes(t *testing.T) {
 		col_jsonb,
 		col_jsonb_null,
 		col_json_arr,
+		col_json_arr_empty,
 		col_json_arr_null,
 		col_jsonb_arr,
+		col_jsonb_arr_empty,
 		col_jsonb_arr_null
-	) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23)`, utils.QuoteIdentifier(schemaName))
+	) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)`, utils.QuoteIdentifier(schemaName))
 
 	savedTime := time.Now().UTC()
 	savedUUID := uuid.New()
@@ -163,8 +167,10 @@ func TestSupportedDataTypes(t *testing.T) {
 		jsonPayload,             // col_jsonb
 		nil,                     // col_jsonb_null
 		[]any{jsonPayload, nil}, // col_json_arr
+		[]any{},                 // col_json_arr_empty
 		nil,                     // col_json_arr_null
 		[]any{jsonPayload, nil}, // col_jsonb_arr
+		[]any{},                 // col_jsonb_arr_empty
 		nil,                     // col_jsonb_arr_null
 	)
 	require.NoError(t, err, "error while inserting into test table")
@@ -258,15 +264,21 @@ func TestSupportedDataTypes(t *testing.T) {
 	require.Contains(t, actualJsonArr, `"relaxedNumber":"`+relaxedNumberStr+`"`)
 	require.True(t, strings.HasSuffix(actualJsonArr, `},null]`))
 
-	require.Nil(t, record[20].Value(), "expected null for col_json_arr_null")
+	actualJsonArrEmpty := record[20].Value().(string)
+	require.Equal(t, "[]", actualJsonArrEmpty, "expected empty JSON array for col_json_arr_empty")
 
-	actualJsonbArr := record[21].Value().(string)
+	require.Nil(t, record[21].Value(), "expected null for col_json_arr_null")
+
+	actualJsonbArr := record[22].Value().(string)
 	require.True(t, strings.HasPrefix(actualJsonbArr, "[{"))
 	require.Contains(t, actualJsonbArr, `"key":"value"`)
 	require.Contains(t, actualJsonbArr, `"relaxedNumber":"`+relaxedNumberStr+`"`)
 	require.True(t, strings.HasSuffix(actualJsonbArr, `},null]`))
 
-	require.Nil(t, record[22].Value(), "expected null for col_jsonb_arr_null")
+	actualJsonbArrEmpty := record[23].Value().(string)
+	require.Equal(t, "[]", actualJsonbArrEmpty, "expected empty JSONB array for col_jsonb_arr_empty")
+
+	require.Nil(t, record[24].Value(), "expected null for col_jsonb_arr_null")
 }
 
 func TestStringDataTypes(t *testing.T) {

--- a/flow/connectors/postgres/qrep_query_executor_test.go
+++ b/flow/connectors/postgres/qrep_query_executor_test.go
@@ -223,7 +223,7 @@ func TestSupportedDataTypes(t *testing.T) {
 	expectedDuration := time.Duration(savedTime.Hour())*time.Hour +
 		time.Duration(savedTime.Minute())*time.Minute +
 		time.Duration(savedTime.Second())*time.Second +
-		time.Duration(savedTime.Nanosecond())*time.Nanosecond
+		time.Duration(savedTime.Nanosecond()/1000)*time.Microsecond
 	require.Equal(t, expectedDuration, actualTz2)
 
 	actualTz3 := record[12].Value().(time.Duration)

--- a/flow/e2e/clickhouse/peer_flow_ch_test.go
+++ b/flow/e2e/clickhouse/peer_flow_ch_test.go
@@ -1092,20 +1092,24 @@ func (s ClickHouseSuite) Test_Types_CH() {
 		require.NoError(s.t, err)
 	}
 
+	relaxedNumberStr := "1" + strings.Repeat("0", 1000)
+	jsonPayload := fmt.Sprintf(`{"key": 123, "relaxedNumber": %s}`, relaxedNumberStr)
+
 	_, err := s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
 	CREATE TABLE IF NOT EXISTS %[1]s(id serial PRIMARY KEY,c1 BIGINT,c2 BIT,c3 VARBIT,c4 BOOLEAN,
 		c6 BYTEA,c7 CHARACTER,c8 varchar,c9 CIDR,c11 DATE,c12 FLOAT,c13 DOUBLE PRECISION,
-		c14 INET,c15 INTEGER,c16 INTERVAL,c17 JSON,c18 JSONB,c21 MACADDR,c22 MONEY,
+		c14 INET,c15 INTEGER,c16 INTERVAL,c21 MACADDR,c22 MONEY,
 		c23 NUMERIC,c24 OID,c28 REAL,c29 SMALLINT,c30 SMALLSERIAL,c31 SERIAL,c32 TEXT,
 		c33 TIMESTAMP,c34 TIMESTAMPTZ,c35 TIME,c36 TIMETZ,c37 TSQUERY,c38 TSVECTOR,
 		c39 TXID_SNAPSHOT,c40 UUID, c41 mood[], c42 INT[], c43 FLOAT[], c44 TEXT[], c45 mood, c46 HSTORE,
 		c47 DATE[], c48 TIMESTAMPTZ[], c49 TIMESTAMP[], c50 BOOLEAN[], c51 SMALLINT[], c52 UUID[],
-		c53 NUMERIC(16,2)[], c54 NUMERIC[], c55 NUMERIC(16,2)[], c56 NUMERIC[], c57 INTERVAL[]);
+		c53 NUMERIC(16,2)[], c54 NUMERIC[], c55 NUMERIC(16,2)[], c56 NUMERIC[], c57 INTERVAL[],
+		c58 JSON, c59 JSON, c60 JSONB, c61 JSONB, c62 JSON[], c63 JSON[], c64 JSONB[], c65 JSONB[]);
 		INSERT INTO %[1]s SELECT 2,2,b'1',b'101',
 		true,random_bytes(32),'s','test','1.1.10.2'::cidr,
 		CURRENT_DATE,1.23,1.234,'10.0.0.0/32'::inet,1,
 		'5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds'::interval,
-		'{"sai":-8.02139037433155}'::json,'{"sai":1}'::jsonb,'08:00:2b:01:02:03'::macaddr,
+		'08:00:2b:01:02:03'::macaddr,
 		1.2,123456789012345678901234567890.123456789012345678901234567890,
 		4::oid,1.23,1,1,1,'test',now(),now(),now()::time,now()::timetz,
 		'fat & rat'::tsquery,'a fat cat sat on a mat and ate a fat rat'::tsvector,
@@ -1123,8 +1127,11 @@ func (s ClickHouseSuite) Test_Types_CH() {
 		'{1, 2}'::smallint[],
 		'{"66073c38-b8df-4bdb-bbca-1c97596b8940","66073c38-b8df-4bdb-bbca-1c97596b8940"}'::uuid[],
 		'{1.2, 1.23, null}'::numeric(16,2)[], '{1.2, 1.23, null}'::numeric[], null::numeric(16,2)[], null::numeric[],
-		'{1 second, 5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds}'::interval[];`,
-		srcFullName))
+		'{1 second, 5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds}'::interval[],
+		'%[2]s'::json, null::json, '%[2]s'::jsonb, null::jsonb,
+		ARRAY['%[2]s'::json, null]::json[], null::json[],
+		ARRAY['%[2]s'::jsonb, null]::jsonb[], null::jsonb[];`,
+		srcFullName, jsonPayload))
 	require.NoError(s.t, err)
 
 	connectionGen := e2e.FlowConnectionGenerationConfig{
@@ -1140,14 +1147,33 @@ func (s ClickHouseSuite) Test_Types_CH() {
 	e2e.SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 	e2e.EnvWaitForCount(env, s, "waiting for initial snapshot count", dstTableName, "id", 1)
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "check comparable types 1", srcTableName, dstTableName,
-		"id,c1,c4,c7,c8,c11,c12,c13,c15,c23,c28,c29,c30,c31,c32,c33,c34,c35,c36,c40,c41,c42,c43,c44,c45,c48,c49,c52,c53,c54,c55,c56,c57")
+		"id,c1,c4,c7,c8,c11,c12,c13,c15,c23,c28,c29,c30,c31,c32,c33,c34,c35,c36,c40,c41,c42,c43,c44,c45,c48,c49,c52,c53,c54,c55,c56,c57,c59,c61,c63,c65")
+
+	// Verify JSON values  
+	expectedJSON := fmt.Sprintf(`{"key":123,"relaxedNumber":"%s"}`, relaxedNumberStr)
+	expectedJSONArray := fmt.Sprintf(`[{"key":123,"relaxedNumber":"%s"},null]`, relaxedNumberStr)
+	rows, err := s.GetRows(dstTableName, "c58,c60,c62,c64")
+	require.NoError(s.t, err)
+	require.Len(s.t, rows.Records, 1, "expected 1 row")
+	c58Str, ok := rows.Records[0][0].Value().(string)
+	require.True(s.t, ok, "c58 should be a string")
+	require.Equal(s.t, expectedJSON, c58Str, "c58 should have exact JSON with quoted number")
+	c60Str, ok := rows.Records[0][1].Value().(string)
+	require.True(s.t, ok, "c60 should be a string")
+	require.Equal(s.t, expectedJSON, c60Str, "c60 should have exact JSON with quoted number")
+	c62Str, ok := rows.Records[0][2].Value().(string)
+	require.True(s.t, ok, "c62 should be a string")
+	require.Equal(s.t, expectedJSONArray, c62Str, "c62 should have exact JSON array with quoted number")
+	c64Str, ok := rows.Records[0][3].Value().(string)
+	require.True(s.t, ok, "c64 should be a string")
+	require.Equal(s.t, expectedJSONArray, c64Str, "c64 should have exact JSON array with quoted number")
 
 	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
-		INSERT INTO %s SELECT 3,2,b'1',b'101',
+		INSERT INTO %[1]s SELECT 3,2,b'1',b'101',
 		true,random_bytes(32),'s','test','1.1.10.2'::cidr,
 		CURRENT_DATE,1.23,1.234,'10.0.0.0/32'::inet,1,
 		'5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds'::interval,
-		'{"sai":-8.02139037433155}'::json,'{"sai":1}'::jsonb,'08:00:2b:01:02:03'::macaddr,
+		'08:00:2b:01:02:03'::macaddr,
 		1.2,123456789012345678901234567890.123456789012345678901234567890,
 		4::oid,1.23,1,1,1,'test',now(),now(),now()::time,now()::timetz,
 		'fat & rat'::tsquery,'a fat cat sat on a mat and ate a fat rat'::tsvector,
@@ -1165,11 +1191,36 @@ func (s ClickHouseSuite) Test_Types_CH() {
 		'{1, 2}'::smallint[],
 		'{"86073c38-b8df-4bdb-bbca-1c97596b8940","66073c38-b8df-4bdb-bbca-1c97596b8940"}'::uuid[],
 		'{2.2, 2.23, null}'::numeric(16,2)[], '{2.2, 2.23, null}'::numeric[], null::numeric(16,2)[], null::numeric[],
-		'{1 second, 5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds}'::interval[];`, srcFullName))
+		'{1 second, 5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds}'::interval[],
+		'%[2]s'::json, null::json, '%[2]s'::jsonb, null::jsonb,
+		ARRAY['%[2]s'::json, null]::json[], null::json[],
+		ARRAY['%[2]s'::jsonb, null]::jsonb[], null::jsonb[];`, srcFullName, jsonPayload))
 	require.NoError(s.t, err)
 	e2e.EnvWaitForCount(env, s, "waiting for CDC count", dstTableName, "id", 2)
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "check comparable types 2", srcTableName, dstTableName,
-		"id,c1,c4,c7,c8,c11,c12,c13,c15,c23,c28,c29,c30,c31,c32,c33,c34,c35,c36,c40,c41,c42,c43,c44,c45,c48,c49,c52,c53,c54,c55,c56,c57")
+		"id,c1,c4,c7,c8,c11,c12,c13,c15,c23,c28,c29,c30,c31,c32,c33,c34,c35,c36,c40,c41,c42,c43,c44,c45,c48,c49,c52,c53,c54,c55,c56,c57,c59,c61,c63,c65")
+
+	// Verify JSON values after CDC
+	rows, err = s.GetRows(dstTableName, "c58,c60,c62,c64")
+	require.NoError(s.t, err)
+	require.Len(s.t, rows.Records, 2, "expected 2 rows after CDC")
+	for i := range 2 {
+		c58Str, ok := rows.Records[i][0].Value().(string)
+		require.True(s.t, ok, "c58 should be a string in row %d", i)
+		require.Equal(s.t, expectedJSON, c58Str, "c58 should have exact JSON with quoted number in row %d", i)
+
+		c60Str, ok := rows.Records[i][1].Value().(string)
+		require.True(s.t, ok, "c60 should be a string in row %d", i)
+		require.Equal(s.t, expectedJSON, c60Str, "c60 should have exact JSON with quoted number in row %d", i)
+
+		c62Str, ok := rows.Records[i][2].Value().(string)
+		require.True(s.t, ok, "c62 should be a string in row %d", i)
+		require.Equal(s.t, expectedJSONArray, c62Str, "c62 should have exact JSON array with quoted number in row %d", i)
+
+		c64Str, ok := rows.Records[i][3].Value().(string)
+		require.True(s.t, ok, "c64 should be a string in row %d", i)
+		require.Equal(s.t, expectedJSONArray, c64Str, "c64 should have exact JSON array with quoted number in row %d", i)
+	}
 
 	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
 		UPDATE %[1]s SET c1=3,c32='testery' WHERE id=2;
@@ -1178,7 +1229,7 @@ func (s ClickHouseSuite) Test_Types_CH() {
 		true,random_bytes(32),'s','test','1.1.10.2'::cidr,
 		CURRENT_DATE,1.23,1.234,'10.0.0.0/32'::inet,1,
 		'5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds'::interval,
-		'{"sai":-8.02139037433155}'::json,'{"sai":1}'::jsonb,'08:00:2b:01:02:03'::macaddr,
+		'08:00:2b:01:02:03'::macaddr,
 		1.2,123456789012345678901234567890.123456789012345678901234567890,
 		4::oid,1.23,1,1,1,'test',now(),now(),now()::time,now()::timetz,
 		'fat & rat'::tsquery,'a fat cat sat on a mat and ate a fat rat'::tsvector,
@@ -1196,12 +1247,37 @@ func (s ClickHouseSuite) Test_Types_CH() {
 		'{1, 2}'::smallint[],
 		'{"66073c38-b8df-4bdb-bbca-1c97596b8940","66073c38-b8df-4bdb-bbca-1c97596b8940"}'::uuid[],
 		'{1.2, 1.23, null}'::numeric(16,2)[], '{1.2, 1.23, null}'::numeric[], null::numeric(16,2)[], null::numeric[],
-		'{1 second, 5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds}'::interval[];`, srcFullName))
+		'{1 second, 5 years 2 months 29 days 1 minute 2 seconds 200 milliseconds 20000 microseconds}'::interval[],
+		'%[2]s'::json, null::json, '%[2]s'::jsonb, null::jsonb,
+		ARRAY['%[2]s'::json, null]::json[], null::json[],
+		ARRAY['%[2]s'::jsonb, null]::jsonb[], null::jsonb[];`, srcFullName, jsonPayload))
 
 	require.NoError(s.t, err)
 	e2e.EnvWaitForCount(env, s, "waiting for CDC count again", dstTableName, "id", 3)
 	e2e.EnvWaitForEqualTablesWithNames(env, s, "check comparable types 3", srcTableName, dstTableName,
-		"id,c1,c4,c7,c8,c11,c12,c13,c15,c23,c28,c29,c30,c31,c32,c33,c34,c35,c36,c40,c41,c42,c43,c44,c45,c48,c49,c52,c53,c54,c55,c56,c57")
+		"id,c1,c4,c7,c8,c11,c12,c13,c15,c23,c28,c29,c30,c31,c32,c33,c34,c35,c36,c40,c41,c42,c43,c44,c45,c48,c49,c52,c53,c54,c55,c56,c57,c59,c61,c63,c65")
+
+	// Verify JSON values after final updates
+	rows, err = s.GetRows(dstTableName, "c58,c60,c62,c64")
+	require.NoError(s.t, err)
+	require.Len(s.t, rows.Records, 3, "expected 3 rows after final updates")
+	for i := range 3 {
+		c58Str, ok := rows.Records[i][0].Value().(string)
+		require.True(s.t, ok, "c58 should be a string in row %d", i)
+		require.Equal(s.t, expectedJSON, c58Str, "c58 should have exact JSON with quoted number in row %d", i)
+
+		c60Str, ok := rows.Records[i][1].Value().(string)
+		require.True(s.t, ok, "c60 should be a string in row %d", i)
+		require.Equal(s.t, expectedJSON, c60Str, "c60 should have exact JSON with quoted number in row %d", i)
+
+		c62Str, ok := rows.Records[i][2].Value().(string)
+		require.True(s.t, ok, "c62 should be a string in row %d", i)
+		require.Equal(s.t, expectedJSONArray, c62Str, "c62 should have exact JSON array with quoted number in row %d", i)
+
+		c64Str, ok := rows.Records[i][3].Value().(string)
+		require.True(s.t, ok, "c64 should be a string in row %d", i)
+		require.Equal(s.t, expectedJSONArray, c64Str, "c64 should have exact JSON array with quoted number in row %d", i)
+	}
 
 	env.Cancel(s.t.Context())
 	e2e.RequireEnvCanceled(s.t, env)


### PR DESCRIPTION
Python transparently makes ints bigints, serializes to JSON as is, PG accepts that JSON, then we and CH can't consume that JSON. Go can produce such JSON too if you put a big.Int in there

The software that hit this is https://github.com/JudgmentLabs/judgeval and we're The leading database for AI

Add a custom decoder so that we replace what we can't parse into float64 with strings. This is backcompatible because only the values that were previously failing would see the new behavior and succeed