### PR TITLE
Ensure exceptions are matched as pointers

### DIFF
--- a/flow/shared/exceptions/constructor_test.go
+++ b/flow/shared/exceptions/constructor_test.go
@@ -1,0 +1,47 @@
+package exceptions
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+func TestErrorConstructorsShouldReturnPointers(t *testing.T) {
+	cfg := &packages.Config{
+		Mode: packages.NeedFiles | packages.NeedSyntax,
+		Dir:  ".",
+	}
+
+	pkgs, err := packages.Load(cfg, ".")
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1, "Expected exactly one package")
+
+	pkg := pkgs[0]
+
+	for _, file := range pkg.Syntax {
+		ast.Inspect(file, func(n ast.Node) bool {
+			if fn, ok := n.(*ast.FuncDecl); ok {
+				// Check if function name starts with "New" and ends with "Error"
+				if strings.HasPrefix(fn.Name.Name, "New") && strings.HasSuffix(fn.Name.Name, "Error") {
+					// Check return type
+					if fn.Type.Results != nil && len(fn.Type.Results.List) > 0 {
+						returnType := fn.Type.Results.List[0].Type
+						// If it's not a pointer (*Ident), it's a violation
+						if _, isPointer := returnType.(*ast.StarExpr); !isPointer {
+							pos := pkg.Fset.Position(fn.Pos())
+							assert.Fail(
+								t, "Error constructor should return pointer",
+								"%s:%s should return *%s",
+								pos.Filename, fn.Name.Name, strings.TrimPrefix(fn.Name.Name, "New"))
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+}

--- a/flow/shared/exceptions/mysql.go
+++ b/flow/shared/exceptions/mysql.go
@@ -11,8 +11,8 @@ type MySQLIncompatibleColumnTypeError struct {
 
 func NewIncompatibleColumnTypeError(
 	tableName string, columnName string, columnType byte, dataType string,
-) MySQLIncompatibleColumnTypeError {
-	return MySQLIncompatibleColumnTypeError{
+) *MySQLIncompatibleColumnTypeError {
+	return &MySQLIncompatibleColumnTypeError{
 		TableName:  tableName,
 		ColumnName: columnName,
 		dataType:   dataType,


### PR DESCRIPTION
When we classify an error, it's very often hard to reproduce so you can't really test it.

Add an AST-based test that makes sure all of them are declared properly.