### PR TITLE
Minor: improve CDC logging

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -176,6 +176,7 @@ func (c *MongoConnector) PullRecords(
 	defer changeStream.Close(ctx)
 
 	var recordCount uint32
+	pullStart := time.Now()
 	defer func() {
 		if recordCount == 0 {
 			req.RecordStream.SignalAsEmpty()
@@ -183,7 +184,8 @@ func (c *MongoConnector) PullRecords(
 		c.logger.Info("[mongo] PullRecords finished streaming",
 			slog.Uint64("records", uint64(recordCount)),
 			slog.Int64("bytes", c.totalBytesRead.Load()),
-			slog.Int("channelLen", req.RecordStream.ChannelLen()))
+			slog.Int("channelLen", req.RecordStream.ChannelLen()),
+			slog.Float64("elapsedMinutes", time.Since(pullStart).Minutes()))
 	}()
 	// before the first record arrives, we wait for up to an hour before resetting context timeout
 	// after the first record arrives, we switch to configured idleTimeout
@@ -263,7 +265,8 @@ func (c *MongoConnector) PullRecords(
 			c.logger.Info("[mongo] PullRecords streaming",
 				slog.Uint64("records", uint64(recordCount)),
 				slog.Int64("bytes", c.totalBytesRead.Load()),
-				slog.Int("channelLen", req.RecordStream.ChannelLen()))
+				slog.Int("channelLen", req.RecordStream.ChannelLen()),
+				slog.Float64("elapsedMinutes", time.Since(pullStart).Minutes()))
 		}
 		return nil
 	}

--- a/flow/connectors/utils/avro_writer.go
+++ b/flow/connectors/utils/avro_writer.go
@@ -246,11 +246,13 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(
 		slog.Int("channelLen", len(p.stream.Records)))
 
 	numRows := atomic.Int64{}
+	writeStart := time.Now()
 
 	shutdown := shared.Interval(ctx, time.Minute, func() {
 		logger.Info("written records to OCF",
 			slog.Int64("records", numRows.Load()),
-			slog.Int("channelLen", len(p.stream.Records)))
+			slog.Int("channelLen", len(p.stream.Records)),
+			slog.Float64("elapsedMinutes", time.Since(writeStart).Minutes()))
 	})
 	defer shutdown()
 
@@ -278,7 +280,9 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(
 		}
 	}
 
-	logger.Info("finished writing records to OCF", slog.Int64("records", numRows.Load()))
+	logger.Info("finished writing records to OCF",
+		slog.Int64("records", numRows.Load()),
+		slog.Float64("elapsedMinutes", time.Since(writeStart).Minutes()))
 
 	if err := p.stream.Err(); err != nil {
 		logger.Error("Failed to get record from stream", slog.Any("error", err))


### PR DESCRIPTION
A neon peer was pulling records for longer than the batch timeout but unclear why
Also their batch time was 3 hours so hard to browse through the logs