### PR TITLE
Downgrade min required mongo version to 4.4

### DIFF
--- a/flow/shared/mongo/validation.go
+++ b/flow/shared/mongo/validation.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	MinSupportedVersion    = "5.1.0"
+	MinSupportedVersion    = "4.4.0"
 	MinOplogRetentionHours = 24
 
 	ReplicaSet     = "ReplicaSet"


### PR DESCRIPTION
I don't see any reason so far to require Mongo higher than version 5.1