### PR TITLE
Classify more errors

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -171,9 +171,6 @@ var (
 	ErrorNotifyChangeStreamHistoryLost = ErrorClass{
 		Class: "NOTIFY_CHANGE_STREAM_HISTORY_LOST", action: NotifyUser,
 	}
-	ErrorNotifyWALSegmentRemoved = ErrorClass{
-		Class: "NOTIFY_WAL_SEGMENT_REMOVED", action: NotifyUser,
-	}
 	ErrorOther = ErrorClass{
 		// These are unclassified and should not be exposed
 		Class: "OTHER", action: NotifyTelemetry,
@@ -321,7 +318,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		case pgerrcode.UndefinedFile:
 			// Handle WAL segment removed errors
 			if PostgresWalSegmentRemovedRe.MatchString(pgErr.Message) {
-				return ErrorNotifyWALSegmentRemoved, pgErrorInfo
+				return ErrorRetryRecoverable, pgErrorInfo
 			}
 
 		case pgerrcode.InternalError:

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -464,6 +464,7 @@ func PullCdcRecords[Items model.Items](
 	}
 
 	var standByLastLogged time.Time
+	// Remove exceptions.PrimaryKeyModifiedError and its classification when this is removed
 	cdcRecordsStorage, err := utils.NewCDCStore[Items](ctx, req.Env, p.flowJobName)
 	if err != nil {
 		return err

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -3,7 +3,6 @@ package model
 import (
 	"context"
 	"crypto/sha256"
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/shared"
+	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 )
 
 type NameAndExclude struct {
@@ -127,7 +127,7 @@ func RecToTablePKey[T Items](
 	for _, pkeyCol := range tableNameSchemaMapping[tableName].PrimaryKeyColumns {
 		pkeyColBytes, err := rec.GetItems().GetBytesByColName(pkeyCol)
 		if err != nil {
-			return TableWithPkey{}, fmt.Errorf("error getting primary key column '%s' value for table '%s': %w", pkeyCol, tableName, err)
+			return TableWithPkey{}, exceptions.NewPrimaryKeyModifiedError(err, tableName, pkeyCol)
 		}
 		// cannot return an error
 		_, _ = hasher.Write(pkeyColBytes)

--- a/flow/shared/exceptions/primary_key_modfied.go
+++ b/flow/shared/exceptions/primary_key_modfied.go
@@ -1,0 +1,21 @@
+package exceptions
+
+import "fmt"
+
+type PrimaryKeyModifiedError struct {
+	error
+	TableName  string
+	ColumnName string
+}
+
+func NewPrimaryKeyModifiedError(err error, tableName, columnName string) *PrimaryKeyModifiedError {
+	return &PrimaryKeyModifiedError{err, tableName, columnName}
+}
+
+func (e *PrimaryKeyModifiedError) Unwrap() error {
+	return e.error
+}
+
+func (e *PrimaryKeyModifiedError) Error() string {
+	return fmt.Sprintf("cannot locate primary key column '%s' value for table '%s': %v", e.ColumnName, e.TableName, e.error.Error())
+}


### PR DESCRIPTION
~~PG requested WAL segment ... has already been removed with 58P01 seems to be non-retryable~~

Neon NeonWALPageRead is constantly reoccurring on one service and comes after we read 0 records for a while while the slot is growing

Our CDC store doesn't allow private key columns to be dropped so that's not recoverable but when we remove CDC store we could defer that to Postgres to decide