### PR TITLE
report flow status metric at start of drop flow

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1420,7 +1420,7 @@ func (a *FlowableActivity) PeerDBFullRefreshOverwriteMode(ctx context.Context, e
 	return internal.PeerDBFullRefreshOverwriteMode(ctx, env)
 }
 
-func (a *FlowableActivity) ReportStatusMetric(ctx context.Context, flowJobName string, status protos.FlowStatus) error {
+func (a *FlowableActivity) ReportStatusMetric(ctx context.Context, status protos.FlowStatus) error {
 	_, isActive := activeFlowStatuses[status]
 	a.OtelManager.Metrics.FlowStatusGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
 		attribute.String(otel_metrics.FlowStatusKey, status.String()),

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -164,7 +164,7 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 	_ = workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: time.Minute,
 		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
-	}), flowable.ReportStatusMetric, input.FlowJobName, status).Get(ctx, nil)
+	}), flowable.ReportStatusMetric, status).Get(ctx, nil)
 
 	if input.FlowConnectionConfigs != nil {
 		if input.DropFlowStats {


### PR DESCRIPTION
avoids race where drop would happen before RecordMetrics could move flow out of running

followup to #3465