### PR TITLE
fix distributed resync

### DIFF
--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -672,6 +672,17 @@ func (s Suite) TestResyncCompleted() {
 	env, err = e2e.GetPeerflow(s.t.Context(), s.pg.PostgresConnector.Conn(), tc, flowConnConfig.FlowJobName)
 	require.NoError(s.t, err)
 	e2e.EnvWaitForFinished(s.t, env, time.Minute)
+
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
+	})
+	require.NoError(s.t, err)
+
+	e2e.EnvWaitForEqualTables(env, s.ch, "resync 2", tableName, cols)
+	env, err = e2e.GetPeerflow(s.t.Context(), s.pg.PostgresConnector.Conn(), tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	e2e.EnvWaitForFinished(s.t, env, time.Minute)
 }
 
 func (s Suite) TestDropCompleted() {


### PR DESCRIPTION
would fail on 2nd time around since rename only applies to Distributed table, not its backing table

put timestamp on backing table to avoid name conflict