### PR TITLE
normalize grouping: be int64, not bool

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -418,9 +418,10 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	groupBatches, err := internal.PeerDBGroupNormalize(ctx, req.Env)
 	if err != nil {
 		c.logger.Error("failed to lookup PEERDB_GROUP_NORMALIZE, only normalizing 1 batch")
+		groupBatches = 1
 	}
-	if !groupBatches {
-		endBatchID = min(endBatchID, normBatchID+1)
+	if groupBatches > 0 {
+		endBatchID = min(endBatchID, normBatchID+groupBatches)
 	}
 
 	if err := c.copyAvroStagesToDestination(ctx, req.FlowJobName, normBatchID, endBatchID, req.Env, req.Version); err != nil {

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -43,8 +43,8 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 	{
 		Name:             "PEERDB_GROUP_NORMALIZE",
 		Description:      "Controls whether normalize applies to one batch at a time, or all pending batches",
-		DefaultValue:     "false",
-		ValueType:        protos.DynconfValueType_BOOL,
+		DefaultValue:     "1",
+		ValueType:        protos.DynconfValueType_INT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
@@ -528,8 +528,8 @@ func PeerDBNormalizeBufferSize(ctx context.Context, env map[string]string) (int6
 	return dynamicConfSigned[int64](ctx, env, "PEERDB_NORMALIZE_CHANNEL_BUFFER_SIZE")
 }
 
-func PeerDBGroupNormalize(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_GROUP_NORMALIZE")
+func PeerDBGroupNormalize(ctx context.Context, env map[string]string) (int64, error) {
+	return dynamicConfSigned[int64](ctx, env, "PEERDB_GROUP_NORMALIZE")
 }
 
 func PeerDBQueueFlushTimeoutSeconds(ctx context.Context, env map[string]string) (time.Duration, error) {


### PR DESCRIPTION
grouping was originally disabled because of a pathological scenario:
normalizing all pending batches would grow until the number of pending batches began OOMing

this allows capping the number of batches to normalize at once