### PR TITLE
Postgres: Classify replica identity nothing error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -118,6 +118,9 @@ var (
 	ErrorNotifySourceTableMissing = ErrorClass{
 		Class: "NOTIFY_SOURCE_TABLE_MISSING", action: NotifyUser,
 	}
+	ErrorNotifyBadSourceTableReplicaIdentity = ErrorClass{
+		Class: "NOTIFY_BAD_POSTGRES_TABLE_REPLICA_IDENTITY", action: NotifyUser,
+	}
 	ErrorNotifyPublicationMissing = ErrorClass{
 		Class: "NOTIFY_PUBLICATION_MISSING", action: NotifyUser,
 	}
@@ -259,6 +262,13 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		return ErrorNotifySourceTableMissing, ErrorInfo{
 			Source: ErrorSourcePostgres,
 			Code:   "TABLE_DOES_NOT_EXIST",
+		}
+	}
+
+	if errors.Is(err, shared.ErrReplicaIdentityNothing) {
+		return ErrorNotifyBadSourceTableReplicaIdentity, ErrorInfo{
+			Source: ErrorSourcePostgres,
+			Code:   "REPLICA_IDENTITY_NOTHING",
 		}
 	}
 

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -130,7 +130,7 @@ func (c *PostgresConnector) getReplicaIdentityType(
 		return ReplicaIdentityDefault, fmt.Errorf("error getting replica identity for table %s: %w", schemaTable, err)
 	}
 	if replicaIdentity == rune(ReplicaIdentityNothing) {
-		return ReplicaIdentityType(replicaIdentity), fmt.Errorf("table %s has replica identity 'n'/NOTHING", schemaTable)
+		return ReplicaIdentityType(replicaIdentity), shared.ErrReplicaIdentityNothing
 	}
 
 	return ReplicaIdentityType(replicaIdentity), nil

--- a/flow/shared/err_types.go
+++ b/flow/shared/err_types.go
@@ -8,8 +8,9 @@ import (
 )
 
 var (
-	ErrSlotAlreadyExists error = temporal.NewNonRetryableApplicationError("slot already exists", "snapshot", nil)
-	ErrTableDoesNotExist error = temporal.NewNonRetryableApplicationError("table does not exist", "snapshot", nil)
+	ErrSlotAlreadyExists      error = temporal.NewNonRetryableApplicationError("slot already exists", "snapshot", nil)
+	ErrTableDoesNotExist      error = temporal.NewNonRetryableApplicationError("table does not exist", "snapshot", nil)
+	ErrReplicaIdentityNothing error = errors.New("table has replica identity 'n'/NOTHING")
 )
 
 type ErrType string


### PR DESCRIPTION
If a table has replica identity nothing then we currently error out wherever we get table schema. This PR makes sure to emit this error. It will notify users