### PR TITLE
reduce flakiness

### DIFF
--- a/flow/e2e/api/api_test.go
+++ b/flow/e2e/api/api_test.go
@@ -184,9 +184,6 @@ func TestApiPg(t *testing.T) {
 }
 
 func TestApiMy(t *testing.T) {
-	// need to sequence this suite to run before all other MySQL tests
-	// because other tests fail due to invalid mysql.rds_configuration table settings
-	testMySQLRDSBinlog(t)
 	testApi(t, e2e.SetupMySQL)
 }
 

--- a/flow/e2e/api/mysql_rds_binlog_test.go
+++ b/flow/e2e/api/mysql_rds_binlog_test.go
@@ -49,8 +49,7 @@ func (s MySQLRDSBinlogAPITestSuite) Connector() *connpostgres.PostgresConnector 
 	return s.pg.PostgresConnector
 }
 
-func testMySQLRDSBinlog(t *testing.T) {
-	t.Helper()
+func TestMySQLRDSBinlog(t *testing.T) {
 	e2eshared.RunSuiteNoParallel(t, func(t *testing.T) MySQLRDSBinlogAPITestSuite {
 		t.Helper()
 


### PR DESCRIPTION
recent fix (#3472) to make api tests parallel has subtests mixed with suite calling t.Parallel on top level,
allowing other mysql non-api e2e tests to run in parallel, which is bad