### PR TITLE
MySQL: explicitly set timezone at session to UTC

### DIFF
--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -205,7 +205,6 @@ func (c *MySqlConnector) setSessionSettings() error {
 		}
 	}
 
-	// Set session settings
 	switch c.Flavor() {
 	case mysql.MySQLFlavor:
 		// set max_execution_time to unlimited


### PR DESCRIPTION
## Risk

This PR is a breaking change across resyncs and new MySQL mirrors, as it changes the way we obtain timestamp values from source in initial load.

## Why

Fixes #3457 

### How timestamps are synced during initial load
When we do a SELECT in MySQL in initial load, timestamp column values are retrieved in wall-clock fashion which is then treated as UTC downstream and in ClickHouse.
For example if your ClickHouse server has its global timezone setting set to UTC + 7 and on MySQL server the timezone is UTC + 5:30, and on MySQL you have a timestamp value of 10am today, after initial load once you do a SELECT on the ClickHouse table you will see it as 5pm (17:00) today.
The source MySQL server timezone is not being accounted for here.

### How timestamps are synced during CDC
When we insert the same 10 am today row during CDC and inspect the binlog, we see something like:
```
### INSERT INTO `peerdb_test`.`ts_test`
### SET
###   @1=6
###   @2=1758007422
# at 753
#250916 12:53:42 server id 1  end_log_pos 784 CRC32 0xc171d0e7 	Xid = 1194
COMMIT/*!*/;
```

So it is recorded in the binlog (and we get it) as epoch, which is why CDC timestamp values are synced correctly. In the above setup if you run a SELECT on ClickHouse you will see 11:30 AM today which is correct. (Jakarta is 1.5 hours ahead of India)

## What
When we connect to MySQL, we now set our session's timezone to +00 (UTC) so that the above behavioural difference is removed. Initial load will now sync the 10 am row as 11:30 am in the above setup