### PR TITLE
fix: typo in minio service entrypoint in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,7 @@ services:
       mc alias set myminiopeerdb http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD;
       mc mb myminiopeerdb/$$PEERDB_CLICKHOUSE_AWS_S3_BUCKET_NAME;
       wait
+      "
 
 volumes:
   pgdata:


### PR DESCRIPTION
There's just a missing double quote in the minio entrypoint in the docker-compose preventing the run-peerdb.sh script to run.

```bash
decoding failed due to the following error(s):

error decoding 'services[minio].entrypoint': invalid command line string
```