### PR TITLE
Classify Postgres error : has no primary keys and does not have REPLICA IDENTITY FULL

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -284,6 +284,14 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
+	var missingPrimaryKeyErr *exceptions.MissingPrimaryKeyError
+	if errors.As(err, &missingPrimaryKeyErr) {
+		return ErrorNotifyBadSourceTableReplicaIdentity, ErrorInfo{
+			Source: ErrorSourcePostgres,
+			Code:   "MISSING_PRIMARY_KEY",
+		}
+	}
+
 	var temporalErr *temporal.ApplicationError
 	if errors.As(err, &temporalErr) {
 		switch exceptions.ApplicationErrorType(temporalErr.Type()) {

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -132,7 +132,7 @@ func (c *PostgresConnector) getReplicaIdentityType(
 		return ReplicaIdentityDefault, fmt.Errorf("error getting replica identity for table %s: %w", schemaTable, err)
 	}
 	if replicaIdentity == rune(ReplicaIdentityNothing) {
-		return ReplicaIdentityType(replicaIdentity), exceptions.NewErrReplicaIdentityNothing(schemaTable.String(), nil)
+		return ReplicaIdentityType(replicaIdentity), exceptions.NewReplicaIdentityNothingError(schemaTable.String(), nil)
 	}
 
 	return ReplicaIdentityType(replicaIdentity), nil

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1192,7 +1192,7 @@ func (c *PostgresConnector) EnsurePullability(
 		// we only allow no primary key if the table has REPLICA IDENTITY FULL
 		// this is ok for replica identity index as we populate the primary key columns
 		if len(pKeyCols) == 0 && replicaIdentity != ReplicaIdentityFull {
-			return nil, fmt.Errorf("table %s has no primary keys and does not have REPLICA IDENTITY FULL", schemaTable)
+			return nil, exceptions.NewMissingPrimaryKeyError(schemaTable.String())
 		}
 	}
 

--- a/flow/shared/exceptions/primary_key_and_replica_identity.go
+++ b/flow/shared/exceptions/primary_key_and_replica_identity.go
@@ -24,10 +24,22 @@ type ReplicaIdentityNothingError struct {
 	Table string
 }
 
-func NewErrReplicaIdentityNothing(table string, cause error) error {
+func NewReplicaIdentityNothingError(table string, cause error) error {
 	return &ReplicaIdentityNothingError{Table: table}
 }
 
 func (e *ReplicaIdentityNothingError) Error() string {
 	return fmt.Sprintf("table %s has replica identity 'n'/NOTHING", e.Table)
+}
+
+type MissingPrimaryKeyError struct {
+	Table string
+}
+
+func NewMissingPrimaryKeyError(table string) error {
+	return &MissingPrimaryKeyError{Table: table}
+}
+
+func (e *MissingPrimaryKeyError) Error() string {
+	return fmt.Sprintf("table %s has no primary keys and does not have REPLICA IDENTITY FULL", e.Table)
 }


### PR DESCRIPTION
In some cases where a Postgres table could have a primary key during validation but removed later, we would wish to notify the user so they can grant replica identity full (one of the options)