### PR TITLE
fix(ui): optimize SchemaBox avoid fetch table schema when collapsed

### DIFF
--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -195,17 +195,10 @@ export default function SchemaBox({
     setRows(newRows);
   };
 
-  const rowsDoNotHaveSchemaTables = (schema: string) => {
-    return !rows.some((row) => row.schema === schema);
-  };
 
   const handleSchemaClick = (schemaName: string) => {
     if (!schemaIsExpanded(schemaName)) {
       setExpandedSchemas((curr) => [...curr, schemaName]);
-
-      if (rowsDoNotHaveSchemaTables(schemaName)) {
-        fetchTablesForSchema(schemaName);
-      }
     } else {
       setExpandedSchemas((curr) =>
         curr.filter((expandedSchema) => expandedSchema != schemaName)
@@ -270,8 +263,10 @@ export default function SchemaBox({
   ];
 
   useEffect(() => {
-    fetchTablesForSchema(schema);
-  }, [schema, fetchTablesForSchema, initialLoadOnly]);
+    if (schemaIsExpanded(schema)) {
+      fetchTablesForSchema(schema);
+    }
+  }, [schema, fetchTablesForSchema, schemaIsExpanded, initialLoadOnly]);
 
   return (
     <div style={schemaBoxStyle}>


### PR DESCRIPTION
SchemaBox component is used for table mapping in mirror creation flow. When component is mounted, all the schemas are collapsed. However, what is currently observed, regardless of box is collapsed, `fetchTablesForSchema` is always executed causing overhead requests being sent to API.

Desired behaviour would be tables are fetched only if box is being expanded. This PR fixes it, trying to keep the functionality of reloading results when the `initialLoadOnly` prop is changed. It has a side effect of retried request if we collapse and expand box again, but I think it's an edge case.

It's not a pain in most cases (it's less likely to have that many schemas it overloads API), but for my testing I had a peer source that consisted of >100 schemas.
