### PR TITLE
Classify: MySQL multi-source GTID conflict

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -472,9 +472,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		case 1146: // ER_NO_SUCH_TABLE
 			return ErrorNotifySourceTableMissing, myErrorInfo
 		case 1943:
-			if myErr.State == "HY000" && strings.Contains(myErr.Message, "duplicate domain id") {
-				return ErrorNotifyBadGTIDSetup, myErrorInfo
-			}
+			return ErrorNotifyBadGTIDSetup, myErrorInfo
 		default:
 			return ErrorOther, myErrorInfo
 		}


### PR DESCRIPTION
Error encountered was:
```
ERROR 1943 (HY000): GTID 0-4294967295-115345509 and 0-1-115345510 conflict (duplicate domain id 0)
```

Relevant material:
https://mariadb.com/docs/server/ha-and-performance/standard-replication/gtid#use-with-multi-source-replication-and-other-multi-primary-setups