### PR TITLE
[postgres] classify slot read failing due to inactive sync standby

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -438,7 +438,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			}
 
 			if strings.Contains(pgErr.Message,
-				"specified in parameter \"synchronized_standby_slots\" does not have active_pid") {
+				`specified in parameter "synchronized_standby_slots" does not have active_pid`) {
 				return ErrorRetryRecoverable, pgErrorInfo
 			}
 


### PR DESCRIPTION
Still figuring out exactly when this can happen, but classify regardless