### PR TITLE
[classifier] move net error classifications above per-db

### DIFF
--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -32,8 +32,8 @@ func TestPostgresDNSErrorShouldBeConnectivity(t *testing.T) {
 	errorClass, errInfo := GetErrorClass(t.Context(), err)
 	assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
-		Source: ErrorSourcePostgres,
-		Code:   "UNKNOWN",
+		Source: ErrorSourceNet,
+		Code:   "net.DNSError",
 	}, errInfo, "Unexpected error info")
 }
 
@@ -426,8 +426,8 @@ func TestPostgresConnectionRefusedErrorShouldBeConnectivity(t *testing.T) {
 			errorClass, errInfo := GetErrorClass(t.Context(), err)
 			assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
 			assert.Equal(t, ErrorInfo{
-				Source: ErrorSourcePostgres,
-				Code:   "UNKNOWN",
+				Source: ErrorSourceNet,
+				Code:   "connect: connection refused",
 			}, errInfo, "Unexpected error info")
 		})
 	}


### PR DESCRIPTION
These errors are independent of databases, and should be returned as the underlying error instead of being wrapped by a database library-specific error and classified there.