### PR TITLE
drop flow: update status with flow name, not workflow id

### DIFF
--- a/flow/internal/workflow.go
+++ b/flow/internal/workflow.go
@@ -42,3 +42,13 @@ func UpdateFlowStatusInCatalog(ctx context.Context, pool shared.CatalogPool,
 	}
 	return status, nil
 }
+
+func UpdateFlowStatusWithNameInCatalog(ctx context.Context, pool shared.CatalogPool,
+	flowName string, status protos.FlowStatus,
+) (protos.FlowStatus, error) {
+	if _, err := pool.Exec(ctx, "UPDATE flows SET status=$1,updated_at=now() WHERE name=$2", status, flowName); err != nil {
+		slog.ErrorContext(ctx, "failed to update flow status", slog.Any("error", err), slog.String("flowName", flowName))
+		return status, fmt.Errorf("failed to update flow status: %w", err)
+	}
+	return status, nil
+}

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -142,7 +142,7 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 		status = protos.FlowStatus_STATUS_RESYNC
 	}
 	logger := workflow.GetLogger(ctx)
-	syncStatusToCatalog(ctx, logger, status)
+	syncStatusToCatalogWithFlowName(ctx, logger, status, input.FlowJobName)
 
 	ctx = workflow.WithValue(ctx, shared.FlowNameKey, input.FlowJobName)
 	logger.Info("performing cleanup for flow",

--- a/flow/workflows/local_activities.go
+++ b/flow/workflows/local_activities.go
@@ -25,3 +25,15 @@ func updateFlowStatusInCatalogActivity(
 	}
 	return internal.UpdateFlowStatusInCatalog(ctx, pool, workflowID, status)
 }
+
+func updateFlowStatusWithNameInCatalogActivity(
+	ctx context.Context,
+	flowName string,
+	status protos.FlowStatus,
+) (protos.FlowStatus, error) {
+	pool, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
+	if err != nil {
+		return status, fmt.Errorf("failed to get catalog connection pool: %w", err)
+	}
+	return internal.UpdateFlowStatusWithNameInCatalog(ctx, pool, flowName, status)
+}


### PR DESCRIPTION
when workflow is completed/failed & dropped, its status would be left as completed/failed

this would prevent logic which avoids creating drop flow when status is terminating,
creating situations where multiple drop flows are running concurrently