### PR TITLE
drop completed mirror: just delete flow entry

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -211,6 +211,36 @@ func (h *FlowRequestHandler) CreateQRepFlow(
 	}, nil
 }
 
+func (h *FlowRequestHandler) dropFlow(
+	ctx context.Context,
+	flowJobName string,
+	deleteStats bool,
+) error {
+	logs := slog.Group("shutdown-log", slog.String(string(shared.FlowNameKey), flowJobName))
+
+	dropFlowWorkflowID := fmt.Sprintf("%s-dropflow-%s", flowJobName, uuid.New())
+	workflowOptions := client.StartWorkflowOptions{
+		ID:                    dropFlowWorkflowID,
+		TaskQueue:             h.peerflowTaskQueueID,
+		TypedSearchAttributes: shared.NewSearchAttributes(flowJobName),
+	}
+
+	if dropFlowHandle, err := h.temporalClient.ExecuteWorkflow(ctx, workflowOptions, peerflow.DropFlowWorkflow, &protos.DropFlowInput{
+		FlowJobName:           flowJobName,
+		DropFlowStats:         deleteStats,
+		FlowConnectionConfigs: nil,
+		SkipDestinationDrop:   true,
+	}); err != nil {
+		slog.ErrorContext(ctx, "unable to start DropFlow workflow", logs, slog.Any("error", err))
+		return fmt.Errorf("unable to start DropFlow workflow: %w", err)
+	} else if err := dropFlowHandle.Get(ctx, nil); err != nil {
+		slog.ErrorContext(ctx, "DropFlow workflow did not execute successfully", logs, slog.Any("error", err))
+		return fmt.Errorf("DropFlow workflow did not execute successfully: %w", err)
+	}
+
+	return nil
+}
+
 func (h *FlowRequestHandler) shutdownFlow(
 	ctx context.Context,
 	flowJobName string,
@@ -369,7 +399,9 @@ func (h *FlowRequestHandler) FlowStateChange(
 			}
 		case protos.FlowStatus_STATUS_TERMINATING, protos.FlowStatus_STATUS_TERMINATED:
 			if currState != protos.FlowStatus_STATUS_TERMINATED && currState != protos.FlowStatus_STATUS_TERMINATING {
-				if currState == protos.FlowStatus_STATUS_COMPLETED || currState == protos.FlowStatus_STATUS_FAILED {
+				if currState == protos.FlowStatus_STATUS_COMPLETED {
+					changeErr = h.dropFlow(ctx, req.FlowJobName, req.DropMirrorStats)
+				} else if currState == protos.FlowStatus_STATUS_FAILED {
 					changeErr = h.shutdownFlow(ctx, req.FlowJobName, req.DropMirrorStats, req.SkipDestinationDrop)
 				} else {
 					changeErr = model.FlowSignalStateChange.SignalClientWorkflow(ctx, h.temporalClient, workflowID, "", req)


### PR DESCRIPTION
bypasses mess of shutdowFlow logic, in particular doesn't try connect to source/destination, avoiding issues when those are unavailable