### PR TITLE
mongo connector sse error handling

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -619,7 +619,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
-	var mongoServerError *topology.ServerSelectionError
+	var mongoServerError topology.ServerSelectionError
 	if errors.As(err, &mongoServerError) {
 		return ErrorNotifyConnectivity, ErrorInfo{
 			Source: ErrorSourceMongoDB,


### PR DESCRIPTION
Mongo like to use value receiver for error implementations instead of pointer receiver. 