### PR TITLE
drop flow: use same workflow id as peerflow

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -283,7 +283,7 @@ func (h *FlowRequestHandler) dropFlow(
 		}
 	}
 
-	dropFlowWorkflowID := fmt.Sprintf("%s-dropflow-%s", flowJobName, uuid.New())
+	dropFlowWorkflowID := flowJobName + "-peerflow"
 	workflowOptions := client.StartWorkflowOptions{
 		ID:                    dropFlowWorkflowID,
 		TaskQueue:             h.peerflowTaskQueueID,
@@ -341,7 +341,7 @@ func (h *FlowRequestHandler) shutdownFlow(
 			return fmt.Errorf("unable to get cdc config from catalog: %w", err)
 		}
 	}
-	dropFlowWorkflowID := fmt.Sprintf("%s-dropflow-%s", flowJobName, uuid.New())
+	dropFlowWorkflowID := flowJobName + "-peerflow"
 	workflowOptions := client.StartWorkflowOptions{
 		ID:                    dropFlowWorkflowID,
 		TaskQueue:             h.peerflowTaskQueueID,


### PR DESCRIPTION
alternative to #3549, fixes drop flow failing to update status in catalog when workflow id doesn't match cdc workflow id