### PR TITLE
Classify PG IdleInTransactionSessionTimeout as recoverable

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -533,7 +533,10 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		case pgerrcode.QueryCanceled:
 			return ErrorNotifyConnectivity, pgErrorInfo
 
-		case pgerrcode.DuplicateFile, pgerrcode.DeadlockDetected, pgerrcode.SerializationFailure:
+		case pgerrcode.DuplicateFile,
+			pgerrcode.DeadlockDetected,
+			pgerrcode.SerializationFailure,
+			pgerrcode.IdleInTransactionSessionTimeout:
 			return ErrorRetryRecoverable, pgErrorInfo
 		default:
 			return ErrorOther, pgErrorInfo


### PR DESCRIPTION
`[pg_query_executor] row iteration failed 'SELECT * FROM "public"."call" WHERE "created_at" BETWEEN $1 AND $2': FATAL: terminating connection due to idle-in-transaction timeout (SQLSTATE 25P03)`

Snapshotting a partition, lost connection, 12 minutes of silence, then this error, then restart and continue on
