### PR TITLE
Add `gocache` to speed up local Docker builds

### DIFF
--- a/stacks/flow.Dockerfile
+++ b/stacks/flow.Dockerfile
@@ -20,7 +20,8 @@ WORKDIR /root/flow
 ENV CGO_ENABLED=1
 # Generate the typed handler wrapper
 RUN go generate
-RUN go build -o /root/peer-flow
+ENV GOCACHE=/root/.cache/go-build
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -o /root/peer-flow
 
 FROM alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS flow-base
 ENV TZ=UTC


### PR DESCRIPTION
Caching link from Go documentation:
https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching

Locally, when re-running `docker build` commands this take the build from ~260-290s down to 20-26s.