### PR TITLE
mongo error clean up

### DIFF
--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -576,7 +576,8 @@ func TestTemporalUnknownErrorShouldBeOther(t *testing.T) {
 func TestMongoShutdownInProgressErrorShouldBeRecoverable(t *testing.T) {
 	// Simulate a MongoDB shutdown in progress error (quiesce mode)
 	de := driver.Error{
-		Code:    91,
+		Code: 0,
+		//nolint:lll
 		Message: "connection pool for <host>:<port> was cleared because another operation failed with: (ShutdownInProgress) The server is in quiesce mode and will shut down",
 	}
 	err := mongo.CommandError{
@@ -588,6 +589,6 @@ func TestMongoShutdownInProgressErrorShouldBeRecoverable(t *testing.T) {
 	assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceMongoDB,
-		Code:   "91",
+		Code:   "0",
 	}, errInfo, "Unexpected error info")
 }


### PR DESCRIPTION
`changestream.Err()` calls [`wrapErrors`](https://github.com/mongodb/mongo-go-driver/blob/1e7cea0fc96b08059915a3d1b0903be2c7c1ed0c/mongo/change_stream.go#L569-L579) which [_attempts_ to wraps errors in one of CommandError, MarshalError, MongocryptError, etc.](https://github.com/mongodb/mongo-go-driver/blob/1e7cea0fc96b08059915a3d1b0903be2c7c1ed0c/mongo/errors.go#L90-L106), but errors can fall thru if it doesn't match one of the known error targets, and the original error is returned. This PR updates driver.Error matching with the wrapped errors. 

There's also been a few iterations of this error handling such that this section no longer makes sense (comment says we retry, but code has since been changed to notify, but notify to all retryable errors seems too aggressive):
```
		// some error codes are defined to be retryable by the driver, so we retry them
		var retryableError RetryableError
		if errors.As(mongoErr, &retryableError) && retryableError.Retryable() {
			return ErrorNotifyConnectivity, mongoErrorInfo
		}
```

So instead notify on the errors we've seen so far: ShutdownInProgress (which has code=91). Would be better if we are more explicit about which one to retry and which one to notify, as they come up in practice.

Finally, fixes https://linear.app/clickhouse/issue/DBI-111/classify-connection-pool-error-with-mongodb-cluster by making it retryable when "connection reset by peers" is detected.