### PR TITLE
Change 30 min retry policies to 20 min

### DIFF
--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -78,7 +78,7 @@ func (q *QRepFlowExecution) SetupMetadataTables(ctx workflow.Context) error {
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,
 			BackoffCoefficient:     2.,
-			MaximumInterval:        30 * time.Minute,
+			MaximumInterval:        20 * time.Minute,
 			MaximumAttempts:        0,
 			NonRetryableErrorTypes: nil,
 		},
@@ -100,7 +100,7 @@ func (q *QRepFlowExecution) setupTableSchema(ctx workflow.Context, tableName str
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,
 			BackoffCoefficient:     2.,
-			MaximumInterval:        30 * time.Minute,
+			MaximumInterval:        20 * time.Minute,
 			MaximumAttempts:        0,
 			NonRetryableErrorTypes: nil,
 		},
@@ -132,7 +132,7 @@ func (q *QRepFlowExecution) setupWatermarkTableOnDestination(ctx workflow.Contex
 			RetryPolicy: &temporal.RetryPolicy{
 				InitialInterval:        time.Minute,
 				BackoffCoefficient:     2.,
-				MaximumInterval:        30 * time.Minute,
+				MaximumInterval:        20 * time.Minute,
 				MaximumAttempts:        0,
 				NonRetryableErrorTypes: nil,
 			},
@@ -293,7 +293,7 @@ func (q *QRepFlowExecution) consolidatePartitions(ctx workflow.Context) error {
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,
 			BackoffCoefficient:     2.,
-			MaximumInterval:        30 * time.Minute,
+			MaximumInterval:        20 * time.Minute,
 			MaximumAttempts:        0,
 			NonRetryableErrorTypes: nil,
 		},
@@ -358,7 +358,7 @@ func (q *QRepFlowExecution) handleTableCreationForResync(ctx workflow.Context, s
 			RetryPolicy: &temporal.RetryPolicy{
 				InitialInterval:        time.Minute,
 				BackoffCoefficient:     2.,
-				MaximumInterval:        30 * time.Minute,
+				MaximumInterval:        20 * time.Minute,
 				MaximumAttempts:        0,
 				NonRetryableErrorTypes: nil,
 			},
@@ -404,7 +404,7 @@ func (q *QRepFlowExecution) handleTableRenameForResync(ctx workflow.Context, sta
 			RetryPolicy: &temporal.RetryPolicy{
 				InitialInterval:        time.Minute,
 				BackoffCoefficient:     2.,
-				MaximumInterval:        30 * time.Minute,
+				MaximumInterval:        20 * time.Minute,
 				MaximumAttempts:        0,
 				NonRetryableErrorTypes: nil,
 			},
@@ -445,7 +445,7 @@ func QRepWaitForNewRowsWorkflow(ctx workflow.Context, config *protos.QRepConfig,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,
 			BackoffCoefficient:     2.,
-			MaximumInterval:        30 * time.Minute,
+			MaximumInterval:        20 * time.Minute,
 			MaximumAttempts:        0,
 			NonRetryableErrorTypes: nil,
 		},

--- a/flow/workflows/xmin_flow.go
+++ b/flow/workflows/xmin_flow.go
@@ -77,7 +77,7 @@ func XminFlowWorkflow(
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:        time.Minute,
 			BackoffCoefficient:     2.,
-			MaximumInterval:        30 * time.Minute,
+			MaximumInterval:        20 * time.Minute,
 			MaximumAttempts:        0,
 			NonRetryableErrorTypes: nil,
 		},


### PR DESCRIPTION
We've changed the recoverable monitor to anticipate ~20 minute max gaps between errors. Accommodating in the code before the upgrades.