### PR TITLE
quote watermark column with non-zero NumPartitionsOverride

### DIFF
--- a/flow/connectors/postgres/qrep.go
+++ b/flow/connectors/postgres/qrep.go
@@ -265,7 +265,7 @@ func (c *PostgresConnector) getNumRowsPartitions(
 		return partitionHelper.GetPartitions(), nil
 	} else {
 		minmaxQuery := fmt.Sprintf("SELECT MIN(%[2]s),MAX(%[2]s) FROM %[1]s %[3]s",
-			parsedWatermarkTable.String(), config.WatermarkColumn, whereClause)
+			parsedWatermarkTable.String(), quotedWatermarkColumn, whereClause)
 		var row pgx.Row
 		var minVal any
 		if last != nil && last.Range != nil {


### PR DESCRIPTION
Fix an issue of using PostgreSQL watermark column that contain uppercase letters for example
```
  "watermarkColumn": "rowInsertedAt",
```
and setting snapshotNumPartitionsOverride > 0, **GetQRepPartitions** fails with

```
{
  "message": "failed to get partitions from source: ERROR: column \"rowinsertedat\" does not exist (SQLSTATE 42703)",
  "source": "GoSDK",
  "cause": {
    "message": "ERROR: column \"rowinsertedat\" does not exist (SQLSTATE 42703)",
    "source": "GoSDK",
    "applicationFailureInfo": {
      "type": "PgError"
    }
  },
  "applicationFailureInfo": {
    "type": "wrapError"
  }
}
```