### PR TITLE
Add time limit for get variant to be 10s

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1747,7 +1747,9 @@ func (a *FlowableActivity) GetFlowMetadata(
 		// Use a short timeout for optional variant detection to avoid consuming entire activity timeout
 		variantCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		if srcConn, err := connectors.GetByNameAs[connectors.DatabaseVariantConnector](variantCtx, nil, a.CatalogPool, input.SourceName); err == nil {
+		if srcConn, err := connectors.GetByNameAs[connectors.DatabaseVariantConnector](
+			variantCtx, nil, a.CatalogPool, input.SourceName,
+		); err == nil {
 			if variant, variantErr := srcConn.GetDatabaseVariant(variantCtx); variantErr == nil {
 				sourcePeer.Variant = variant
 			} else {


### PR DESCRIPTION
During DropFlow we have get flow metadata, there is a 1 min timeout. But the failure can take longer.