### PR TITLE
fix: trigger GetSourceVariant only during ScheduledTasks

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1232,9 +1232,10 @@ func (a *FlowableActivity) recordSlotInformation(
 ) error {
 	logger := internal.LoggerFromCtx(ctx)
 	flowMetadata, err := a.GetFlowMetadata(ctx, &protos.FlowContextMetadataInput{
-		FlowName:        info.config.FlowJobName,
-		SourceName:      info.config.SourceName,
-		DestinationName: info.config.DestinationName,
+		FlowName:           info.config.FlowJobName,
+		SourceName:         info.config.SourceName,
+		DestinationName:    info.config.DestinationName,
+		FetchSourceVariant: true,
 	})
 	if err != nil {
 		logger.Error("Failed to get flow metadata", slog.Any("error", err))
@@ -1279,9 +1280,10 @@ func (a *FlowableActivity) emitLogRetentionHours(
 ) error {
 	logger := internal.LoggerFromCtx(ctx)
 	flowMetadata, err := a.GetFlowMetadata(ctx, &protos.FlowContextMetadataInput{
-		FlowName:        info.config.FlowJobName,
-		SourceName:      info.config.SourceName,
-		DestinationName: info.config.DestinationName,
+		FlowName:           info.config.FlowJobName,
+		SourceName:         info.config.SourceName,
+		DestinationName:    info.config.DestinationName,
+		FetchSourceVariant: true,
 	})
 	if err != nil {
 		logger.Error("Failed to get flow metadata", slog.Any("error", err))
@@ -1743,7 +1745,7 @@ func (a *FlowableActivity) GetFlowMetadata(
 	}
 
 	// Detect source database variant
-	if input.SourceName != "" {
+	if input.FetchSourceVariant && input.SourceName != "" {
 		// Use a short timeout for optional variant detection to avoid consuming entire activity timeout
 		variantCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -3,6 +3,7 @@ package conns3
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -41,7 +42,7 @@ func NewS3Connector(
 	}
 	pgMetadata, err := metadataStore.NewPostgresMetadata(ctx)
 	if err != nil {
-		logger.Error("failed to create postgres metadata store", "error", err)
+		logger.Error("failed to create postgres metadata store", slog.Any("error", err))
 		return nil, err
 	}
 	return &S3Connector{
@@ -102,7 +103,7 @@ func (c *S3Connector) SyncRecords(ctx context.Context, req *model.SyncRecordsReq
 
 	lastCheckpoint := req.Records.GetLastCheckpoint()
 	if err := c.FinishBatch(ctx, req.FlowJobName, req.SyncBatchID, lastCheckpoint); err != nil {
-		c.logger.Error("failed to increment id", "error", err)
+		c.logger.Error("failed to increment id", slog.Any("error", err))
 		return nil, err
 	}
 

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -608,11 +608,12 @@ func CDCFlowWorkflow(
 
 		var err error
 		ctx, err = GetFlowMetadataContext(ctx, &protos.FlowContextMetadataInput{
-			FlowName:        cfg.FlowJobName,
-			SourceName:      cfg.SourceName,
-			DestinationName: cfg.DestinationName,
-			Status:          state.CurrentFlowStatus,
-			IsResync:        cfg.Resync,
+			FlowName:           cfg.FlowJobName,
+			SourceName:         cfg.SourceName,
+			DestinationName:    cfg.DestinationName,
+			Status:             state.CurrentFlowStatus,
+			IsResync:           cfg.Resync,
+			FetchSourceVariant: false,
 		})
 		if err != nil {
 			logger.Error("failed to GetFlowMetadataContext", slog.Any("error", err))

--- a/flow/workflows/drop_flow.go
+++ b/flow/workflows/drop_flow.go
@@ -148,9 +148,10 @@ func DropFlowWorkflow(ctx workflow.Context, input *protos.DropFlowInput) error {
 	logger.Info("performing cleanup for flow",
 		slog.String(string(shared.FlowNameKey), input.FlowJobName))
 	contextMetadataInput := &protos.FlowContextMetadataInput{
-		FlowName: input.FlowJobName,
-		Status:   status,
-		IsResync: false,
+		FlowName:           input.FlowJobName,
+		Status:             status,
+		IsResync:           false,
+		FetchSourceVariant: false,
 	}
 	if input.FlowConnectionConfigs != nil {
 		contextMetadataInput.SourceName = input.FlowConnectionConfigs.SourceName

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -598,6 +598,7 @@ message FlowContextMetadataInput {
   string destination_name = 3;
   FlowStatus status = 4;
   bool is_resync = 5;
+  bool fetch_source_variant = 6;
 }
 
 enum FlowOperation {


### PR DESCRIPTION
GetFlowMetadata is in the critical path for both `CDCFlow` and `DropFlow`, making it rely on the source database due to variant determination is leading to weird failure modes

Only run it during ScheduledTasks to move it out of the critical path.