### PR TITLE
improve normalize logic readability

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -650,7 +650,7 @@ func (a *FlowableActivity) startNormalize(
 	}
 
 	for {
-		logger.Info("normalizing batch", slog.Int64("syncBatchID", batchID))
+		logger.Info("normalizing batches", slog.Int64("syncBatchID", batchID))
 		res, err := dstConn.NormalizeRecords(ctx, &model.NormalizeRecordsRequest{
 			FlowJobName:            config.FlowJobName,
 			Env:                    config.Env,

--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -221,8 +221,8 @@ func TestBuildQuery_Basic(t *testing.T) {
 	rawTableName := "raw_my_table"
 	part := uint64(0)
 	numParts := uint64(1)
-	syncBatchID := int64(10)
-	batchIDToLoadForTable := int64(5)
+	endBatchID := int64(10)
+	lastNormBatchID := int64(5)
 	enablePrimaryUpdate := false
 	sourceSchemaAsDestinationColumn := false
 	env := map[string]string{}
@@ -251,8 +251,8 @@ func TestBuildQuery_Basic(t *testing.T) {
 		part,
 		tableNameSchemaMapping,
 		tableMappings,
-		syncBatchID,
-		batchIDToLoadForTable,
+		endBatchID,
+		lastNormBatchID,
 		numParts,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,
@@ -281,8 +281,8 @@ func TestBuildQuery_WithPrimaryUpdate(t *testing.T) {
 	rawTableName := "raw_my_table"
 	part := uint64(0)
 	numParts := uint64(1)
-	syncBatchID := int64(10)
-	batchIDToLoadForTable := int64(5)
+	endBatchID := int64(10)
+	lastNormBatchID := int64(5)
 	enablePrimaryUpdate := true
 	sourceSchemaAsDestinationColumn := false
 	env := map[string]string{}
@@ -309,8 +309,8 @@ func TestBuildQuery_WithPrimaryUpdate(t *testing.T) {
 		part,
 		tableNameSchemaMapping,
 		tableMappings,
-		syncBatchID,
-		batchIDToLoadForTable,
+		endBatchID,
+		lastNormBatchID,
 		numParts,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,
@@ -336,8 +336,8 @@ func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {
 	rawTableName := "raw_my_table"
 	part := uint64(0)
 	numParts := uint64(1)
-	syncBatchID := int64(10)
-	batchIDToLoadForTable := int64(5)
+	endBatchID := int64(10)
+	lastNormBatchID := int64(5)
 	enablePrimaryUpdate := false
 	sourceSchemaAsDestinationColumn := true
 	env := map[string]string{}
@@ -364,8 +364,8 @@ func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {
 		part,
 		tableNameSchemaMapping,
 		tableMappings,
-		syncBatchID,
-		batchIDToLoadForTable,
+		endBatchID,
+		lastNormBatchID,
 		numParts,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,
@@ -389,8 +389,8 @@ func TestBuildQuery_WithNumParts(t *testing.T) {
 	rawTableName := "raw_my_table"
 	part := uint64(2)
 	numParts := uint64(4)
-	syncBatchID := int64(10)
-	batchIDToLoadForTable := int64(5)
+	endBatchID := int64(10)
+	lastNormBatchID := int64(5)
 	enablePrimaryUpdate := false
 	sourceSchemaAsDestinationColumn := false
 	env := map[string]string{}
@@ -417,8 +417,8 @@ func TestBuildQuery_WithNumParts(t *testing.T) {
 		part,
 		tableNameSchemaMapping,
 		tableMappings,
-		syncBatchID,
-		batchIDToLoadForTable,
+		endBatchID,
+		lastNormBatchID,
 		numParts,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,


### PR DESCRIPTION
The clickhouse normalize logic/metrics uses a mix of startBatchId/normBatchId, endBatchId/syncBatchId. This makes the code more confusing than it needs to be:
- `startBatchID` metric attribute can be misleading because StartBatchID should be inclusive according to `NormalizeResponse`, but it is used to represent last normalized batch ID -- changed metrics to always use `lastNormBatchID` instead.
- `syncBatchID` metric attribute can be misleading because of the GroupNormalize setting, since the `endBatchID` is determined by `lastNormBatchId + batchGroup`, and not necessarily `req.SyncBatchID` -- changed it to always use `endBatchID` instead.
- when executing per-table normalize queries, per-table metric attribute can be misleading, since individual queries can have different starting batchID (i.e. if previous iteration failed half way), so make sure the query-level metric attribute is used.
- removing a footgun where `NormalizeQueryGenerator` was created twice, once to generate query and another partially created to pass query info; this avoids accidentally using unset attributes.

Previously considered standardize on [startBatchID, endBatchID] throughout, but keeping (lastNormBatchID, endBatchID] to avoid introducing new concept.