### PR TITLE
make required check generic

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -501,15 +501,15 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  flow_test_complete:
+  finish:
     name: Flow Tests Complete
     needs: [flow_test]
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: Check all tests passed
+      - name: check all tests passed
         run: |
-          if [[ "${{ needs.test.result }}" != "success" ]]; then
-            echo "One or more required test jobs failed"
+          if [[ "${{ needs.flow_test.result }}" != "success" ]]; then
+            echo "One or more tests failed"
             exit 1
           fi


### PR DESCRIPTION
Create a single required check for CI that depends on required jobs -- to be able to dynamically evolve CI matrix without having to modify required checks in admin panel.

This means update required checks to just include the finish job, so that we no longer need to modify it every time matrix changed (we might also add more required tests in the future other than flow_test, this makes it flexible)