### PR TITLE
dynamic required job v2

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -502,14 +502,29 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   finish:
-    name: Flow Tests Complete
     needs: [flow_test]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: check all tests passed
         run: |
-          if [[ "${{ needs.flow_test.result }}" != "success" && "${{ needs.flow_test.result }}" != "skipped" ]]; then
-            echo "One or more tests failed"
-            exit 1
+          if [[ "${{ github.event_name }}" != "pull_request_target" ]]; then
+            if [[ "${{ needs.flow_test.result }}" != "success" && "${{ needs.flow_test.result }}" != "skipped" ]]; then
+              echo "One or more tests failed"
+              exit 1
+            fi
+          fi
+
+  finish_pull_request_target:
+    needs: [flow_test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: check all tests passed (pull_request_target)
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            if [[ "${{ needs.flow_test.result }}" != "success" && "${{ needs.flow_test.result }}" != "skipped" ]]; then
+              echo "One or more tests failed"
+              exit 1
+            fi
           fi


### PR DESCRIPTION
Have two required jobs: `finished` and `finished_pull_request_target` , one on `pull_request` and one on `pull_request_target` to avoid the scenario where the skipped job with same name bypass required checks.

Thought about handling this directly in the "if" clause, but having these jobs run `always` (and having "event == pull_request_target" and "event != pull_request_target") is more future-proof in case we change flow_test's `if` clause and this gets overlooked.