### PR TITLE
deprecate PEERDB_CLICKHOUSE_NORMALIZATION_PARTS

### DIFF
--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -219,8 +219,6 @@ func TestBuildQuery_Basic(t *testing.T) {
 	ctx := t.Context()
 	tableName := "my_table"
 	rawTableName := "raw_my_table"
-	part := uint64(0)
-	numParts := uint64(1)
 	endBatchID := int64(10)
 	lastNormBatchID := int64(5)
 	enablePrimaryUpdate := false
@@ -248,12 +246,10 @@ func TestBuildQuery_Basic(t *testing.T) {
 
 	g := NewNormalizeQueryGenerator(
 		tableName,
-		part,
 		tableNameSchemaMapping,
 		tableMappings,
 		endBatchID,
 		lastNormBatchID,
-		numParts,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,
 		env,
@@ -279,8 +275,6 @@ func TestBuildQuery_WithPrimaryUpdate(t *testing.T) {
 	ctx := t.Context()
 	tableName := "my_table"
 	rawTableName := "raw_my_table"
-	part := uint64(0)
-	numParts := uint64(1)
 	endBatchID := int64(10)
 	lastNormBatchID := int64(5)
 	enablePrimaryUpdate := true
@@ -306,12 +300,10 @@ func TestBuildQuery_WithPrimaryUpdate(t *testing.T) {
 
 	g := NewNormalizeQueryGenerator(
 		tableName,
-		part,
 		tableNameSchemaMapping,
 		tableMappings,
 		endBatchID,
 		lastNormBatchID,
-		numParts,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,
 		env,
@@ -334,8 +326,6 @@ func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {
 	ctx := t.Context()
 	tableName := "my_table"
 	rawTableName := "raw_my_table"
-	part := uint64(0)
-	numParts := uint64(1)
 	endBatchID := int64(10)
 	lastNormBatchID := int64(5)
 	enablePrimaryUpdate := false
@@ -361,12 +351,10 @@ func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {
 
 	g := NewNormalizeQueryGenerator(
 		tableName,
-		part,
 		tableNameSchemaMapping,
 		tableMappings,
 		endBatchID,
 		lastNormBatchID,
-		numParts,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,
 		env,
@@ -381,58 +369,6 @@ func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, query, " AS `_peerdb_source_schema`")
 	require.Contains(t, query, "parallel_distributed_insert_select=0")
-}
-
-func TestBuildQuery_WithNumParts(t *testing.T) {
-	ctx := t.Context()
-	tableName := "my_table"
-	rawTableName := "raw_my_table"
-	part := uint64(2)
-	numParts := uint64(4)
-	endBatchID := int64(10)
-	lastNormBatchID := int64(5)
-	enablePrimaryUpdate := false
-	sourceSchemaAsDestinationColumn := false
-	env := map[string]string{}
-
-	tableSchema := &protos.TableSchema{
-		Columns: []*protos.FieldDescription{
-			{Name: "id", Type: string(types.QValueKindInt64)},
-		},
-		NullableEnabled: false,
-	}
-	tableNameSchemaMapping := map[string]*protos.TableSchema{
-		tableName: tableSchema,
-	}
-
-	tableMappings := []*protos.TableMapping{
-		{
-			SourceTableIdentifier:      "public.my_table",
-			DestinationTableIdentifier: tableName,
-		},
-	}
-
-	g := NewNormalizeQueryGenerator(
-		tableName,
-		part,
-		tableNameSchemaMapping,
-		tableMappings,
-		endBatchID,
-		lastNormBatchID,
-		numParts,
-		enablePrimaryUpdate,
-		sourceSchemaAsDestinationColumn,
-		env,
-		rawTableName,
-		nil,
-		false,
-		"",
-		shared.InternalVersion_Latest,
-	)
-
-	query, err := g.BuildQuery(ctx)
-	require.NoError(t, err)
-	require.Contains(t, query, "cityHash64(_peerdb_uid) % 4 = 2")
 }
 
 func TestGetOrderedPartitionByColumns(t *testing.T) {

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -368,10 +368,10 @@ func (s ClickHouseSuite) Test_Update_PKey_Env_Enabled() {
 	RequireEnvCanceled(s.t, env)
 }
 
-func (s ClickHouseSuite) Test_Chunking_Normalize() {
-	srcTableName := "test_update_pkey_chunking_enabled"
+func (s ClickHouseSuite) Test_Chunking_Initial_Load_Parts_Per_Partition() {
+	srcTableName := "test_update_pkey_chunking_initial_load_enabled"
 	srcFullName := s.attachSchemaSuffix(srcTableName)
-	dstTableName := "test_update_pkey_chunking_enabled_dst"
+	dstTableName := "test_update_pkey_chunking_initial_load_enabled_dst"
 
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
@@ -393,7 +393,6 @@ func (s ClickHouseSuite) Test_Chunking_Normalize() {
 	flowConnConfig.Env = map[string]string{
 		"PEERDB_CLICKHOUSE_ENABLE_PRIMARY_UPDATE":            "true",
 		"PEERDB_CLICKHOUSE_INITIAL_LOAD_PARTS_PER_PARTITION": "2",
-		"PEERDB_CLICKHOUSE_NORMALIZATION_PARTS":              "3",
 		"PEERDB_S3_BYTES_PER_AVRO_FILE":                      "1",
 	}
 

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -304,6 +304,11 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		ValueType:        protos.DynconfValueType_UINT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
+		Deprecated:       true,
+		DeprecateReason: "This introduced a race condition that could result in data loss during replication if used " +
+			"in conjunction with PEERDB_CLICKHOUSE_PARALLEL_NORMALIZE, since 1 or more partitions can fail but offset " +
+			"still can get recorded if the last partition succeeded. This settings is also redundant, instead of tuning " +
+			"this config, use PEERDB_S3_BYTES_PER_AVRO_FILE to manage OOM issues.",
 	},
 	{
 		Name:             "PEERDB_CLICKHOUSE_INITIAL_LOAD_PARTS_PER_PARTITION",
@@ -674,10 +679,6 @@ func UpdatePeerDBMaintenanceModeEnabled(ctx context.Context, pool shared.Catalog
 
 func PeerDBPKMEmptyBatchThrottleThresholdSeconds(ctx context.Context, env map[string]string) (int64, error) {
 	return dynamicConfSigned[int64](ctx, env, "PEERDB_PKM_EMPTY_BATCH_THROTTLE_THRESHOLD_SECONDS")
-}
-
-func PeerDBClickHouseNormalizationParts(ctx context.Context, env map[string]string) (uint64, error) {
-	return dynamicConfUnsigned[uint64](ctx, env, "PEERDB_CLICKHOUSE_NORMALIZATION_PARTS")
 }
 
 func PeerDBClickHouseInitialLoadPartsPerPartition(ctx context.Context, env map[string]string) (uint64, error) {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -44,6 +44,8 @@ message DynamicSetting {
   peerdb_flow.DynconfValueType value_type = 5;
   peerdb_flow.DynconfApplyMode apply_mode = 6;
   peerdb_flow.DynconfTarget target_for_setting = 7;
+  bool deprecated = 8;
+  string deprecate_reason = 9;
 }
 message GetDynamicSettingsRequest {}
 message GetDynamicSettingsResponse { repeated DynamicSetting settings = 1; }


### PR DESCRIPTION
- Deprecate `PEERDB_CLICKHOUSE_NORMALIZATION_PARTS` to address a race condition identified [here](https://github.com/PeerDB-io/peerdb/pull/3640#discussion_r2484605220). We are currently not using this FF.
- Introduce a mechanism to deprecate settings

Follow-up: 
- highlight this in the next peerdb release notes. 
- will address a separate race condition where parallel batches (enabled with `PEERDB_CLICKHOUSE_PARALLEL_NORMALIZE`) within a table can also cause data loss