### PR TITLE
dynamic required job v3

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -503,28 +503,12 @@ jobs:
 
   finish:
     needs: [flow_test]
+    if: needs.flow_test.result != 'skipped'
     runs-on: ubuntu-latest
-    if: always()
     steps:
       - name: check all tests passed
         run: |
-          if [[ "${{ github.event_name }}" != "pull_request_target" ]]; then
-            if [[ "${{ needs.flow_test.result }}" != "success" && "${{ needs.flow_test.result }}" != "skipped" ]]; then
-              echo "One or more tests failed"
-              exit 1
-            fi
-          fi
-
-  finish_pull_request_target:
-    needs: [flow_test]
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: check all tests passed (pull_request_target)
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            if [[ "${{ needs.flow_test.result }}" != "success" && "${{ needs.flow_test.result }}" != "skipped" ]]; then
-              echo "One or more tests failed"
-              exit 1
-            fi
+          if [[ "${{ needs.flow_test.result }}" != "success" ]]; then
+            echo "One or more tests failed"
+            exit 1
           fi


### PR DESCRIPTION
Overcomplicated this problem previously, turns out `needs.flow_test.result` was evaluated to `skipped` right away (there's no way to differentiate between `needs.flow_test.result` from pull_request vs from pull_request_target, and the latter was skipped), so the required jobs `finish` and `finish_pull_request_target` completed right way, which is not what we want. 

The simpler solution is only run `finish` on _unskipped_ flow_test job (so there is only one `finish` job).

Test:
- Verified there is only one `Flow build and test / finish (pull_request)` created in this PR, and only after flow_test jobs are completed.
- Expect `Flow build and test / finish (pull_request_target)` and `Flow build and test / finish_pull_request_target (pull_request_target)` will disappear once this PR is merged to main.
