### PR TITLE
make sure dst connection is closed after use

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -576,6 +576,7 @@ func (a *FlowableActivity) ReplicateQRepPartitions(ctx context.Context,
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to get qrep destination connector: %w", err))
 	}
+	defer qRepSyncCoreConn.Close()
 
 	var replicatePartition func(partition *protos.QRepPartition) error
 


### PR DESCRIPTION
Make sure clickhouse connection is closed after we call `LoadPeerAndGetByNameAs`