### PR TITLE
mongo: measure event size instead of metered dialer

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -37,8 +37,6 @@ x-flow-worker-env: &flow-worker-env
   # enables worker profiling using Go's pprof
   ENABLE_PROFILING: "true"
   PPROF_PORT: "6060"
-  # Uncomment to enable logging mongodb CDC commands
-  # MONGO_COMMAND_MONITOR: "true"
 
 services:
   catalog:

--- a/flow/connectors/mongo/command_monitor.go
+++ b/flow/connectors/mongo/command_monitor.go
@@ -9,12 +9,11 @@ import (
 	"go.temporal.io/sdk/log"
 )
 
-// NewCommandMonitor creates a command monitor for debugging MongoDB operations.
-// To enable, set the environment variable MONGO_COMMAND_MONITOR=true
+// NewCommandMonitor creates a command monitor for debugging MongoDB server/client communication.
 func NewCommandMonitor(logger log.Logger) *event.CommandMonitor {
 	return &event.CommandMonitor{
 		Started: func(ctx context.Context, evt *event.CommandStartedEvent) {
-			logger.Info(fmt.Sprintf("[CommandMonitor] started: command=%s database=%s requestID=%d",
+			logger.Debug(fmt.Sprintf("[CommandMonitor] started: command=%s database=%s requestID=%d",
 				evt.CommandName,
 				evt.DatabaseName,
 				evt.RequestID,
@@ -27,10 +26,10 @@ func NewCommandMonitor(logger log.Logger) *event.CommandMonitor {
 			if err := bson.Unmarshal(evt.Reply, &reply); err == nil {
 				logline += fmt.Sprintf(" reply=%+v", reply)
 			}
-			logger.Info(logline)
+			logger.Debug(logline)
 		},
 		Failed: func(ctx context.Context, evt *event.CommandFailedEvent) {
-			logger.Warn(fmt.Sprintf("[CommandMonitor] failed: command=%s duration=%v error=%v",
+			logger.Debug(fmt.Sprintf("[CommandMonitor] failed: command=%s duration=%v error=%v",
 				evt.CommandName,
 				evt.Duration,
 				evt.Failure,

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -168,8 +168,7 @@ func parseAsClientOptions(config *protos.MongoConfig, meteredDialer utils.Metere
 		clientOptions.SetTLSConfig(tlsConfig)
 	}
 
-	// For debugging only: set env var MONGO_COMMAND_MONITOR to "true" to log all change stream commands
-	if os.Getenv("MONGO_COMMAND_MONITOR") == "true" {
+	if level, ok := os.LookupEnv("PEERDB_LOG_LEVEL"); ok && level == "DEBUG" {
 		clientOptions.SetMonitor(NewCommandMonitor(logger))
 	}
 


### PR DESCRIPTION
For Postgres/MySQL, we were manually tracking bytes processed for cdc, but for MongoDB we were using metered dialer for cdc. This PR updates MongoDB to use the same mechanism as Postgres/MySQL for CDC -- we explicitly measure and track cdc bytes as well as overall change stream bytes. Since Mongo provides server-side change stream filtering, these two  metrics are represented by the same `deltaBytesProcessed` variable.

#### Testing
Tested locally before and after this change to make sure that bytes reported only reflect when CDC events are processed. 

#### Follow-up
Prior to this PR, the metric was reflecting application traffic in raw bytes. And after some investigation, it turns out change stream was generate 400 bytes of traffic every seconds (which equates to ~35MB / day), mainly due to change stream's internal mechanism where it calls `GetMore` every second to look for new records.

I looked into configuring the `GetMore` frequency with [`setMaxAwaitTime`](https://www.mongodb.com/docs/manual/reference/method/cursor.maxAwaitTimeMS/#mongodb-method-cursor.maxAwaitTimeMS) to reduce network traffic, however this introduces a different error: `MaxAwaitTime must be less than the operation timeout`.  This requires more investigations as I was not able to determine how "operation timeout" is set.  Note the CommandMonitor was added in this PR to support further debugging.

To avoids confusion on data ingestion volume, use the change stream event size for now.