### PR TITLE
fix(bigquery): fix down-scoped token prefix path

### DIFF
--- a/flow/connectors/bigquery/gcp.go
+++ b/flow/connectors/bigquery/gcp.go
@@ -71,8 +71,13 @@ func (p *gcsPath) Bucket() string {
 // It is used as the prefix to query objects in the bucket.
 // For example, if the path is "folder/subfolder", it returns "folder/subfolder/".
 // If the path is "folder/subfolder/", it also returns "folder/subfolder/".
+// If the path is empty or just "/", it returns an empty string.
 func (p *gcsPath) QueryPrefix() string {
-	return strings.TrimPrefix(p.Path, "/") + "/"
+	path := strings.TrimPrefix(p.Path, "/")
+	if path == "" {
+		return ""
+	}
+	return path + "/"
 }
 
 func (p *gcsPath) JoinPath(elem ...string) *gcsPath {

--- a/flow/e2e/bigquery_source_test.go
+++ b/flow/e2e/bigquery_source_test.go
@@ -428,7 +428,7 @@ func (s BigQueryClickhouseSuite) Test_Trips_Flow() {
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
 	flowConnConfig.DoInitialSnapshot = true
 	flowConnConfig.InitialSnapshotOnly = true
-	flowConnConfig.SnapshotStagingPath = stagingTestBucket + "/test"
+	flowConnConfig.SnapshotStagingPath = stagingTestBucket
 
 	tc := NewTemporalClient(t)
 	env := ExecutePeerflow(t, tc, flowConnConfig)


### PR DESCRIPTION
When a root path of bucket is provided `gs://my_bucket/` as a staging bucket, a GCP down scoped token contains wrong bucket filter expression.

See `storageDownScopedToken`:

https://github.com/PeerDB-io/peerdb/blob/a6da92fc3839342e7e0cc67794d05e97fa6c2131/flow/connectors/bigquery/gcp.go#L15-L36

The reason is when path is empty, condition is produced like:

`resource.name.startsWith('projects/_/buckets/my_bucket/objects//')`

but it should be:

`resource.name.startsWith('projects/_/buckets/my_bucket/objects/')`

It's an easy fix and comes with a test change to ensure we cover that case in future.
