### PR TITLE
better logging around mysql versioning

### DIFF
--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -12,15 +12,16 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-mysql-org/go-mysql/client"
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"go.temporal.io/sdk/log"
+	"google.golang.org/protobuf/proto"
+
 	metadataStore "github.com/PeerDB-io/peerdb/flow/connectors/external_metadata"
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/shared"
-	"github.com/go-mysql-org/go-mysql/client"
-	"github.com/go-mysql-org/go-mysql/mysql"
-	"go.temporal.io/sdk/log"
-	"google.golang.org/protobuf/proto"
 )
 
 type MySqlConnector struct {


### PR DESCRIPTION
- Log the version and command running
- Log a warning when `compareServerVersion` fails 

For debugging potential issue where `CompareServerVersion` is silently failing.