### PR TITLE
Feat: Add dynamic schema and index migration support for Postgres→Postgres CDC mirrors

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -207,6 +207,68 @@ func (c *PostgresConnector) getColumnNamesForIndex(ctx context.Context, indexOID
 	return cols, nil
 }
 
+// getIndexesForTable returns all non-primary indexes for the given table.
+func (c *PostgresConnector) getIndexesForTable(
+	ctx context.Context,
+	relID uint32,
+	schemaTable *utils.SchemaTable,
+) ([]*protos.IndexDescription, error) {
+	query := `
+		SELECT
+			ci.relname AS index_name,
+			am.amname AS method,
+			i.indisunique AS is_unique,
+			pg_get_expr(i.indpred, i.indrelid) AS predicate,
+			(
+				SELECT array_agg(a.attname ORDER BY u.nr)
+				FROM unnest(i.indkey) WITH ORDINALITY AS u(attnum, nr)
+				JOIN pg_attribute AS a ON a.attrelid = i.indrelid AND a.attnum = u.attnum
+			) as column_names
+		FROM pg_index i
+		JOIN pg_class ct ON ct.oid = i.indrelid
+		JOIN pg_namespace ns ON ns.oid = ct.relnamespace
+		JOIN pg_class ci ON ci.oid = i.indexrelid
+		JOIN pg_am am ON am.oid = ci.relam
+		WHERE i.indrelid = $1
+		  AND ns.nspname = $2
+		  AND ct.relname = $3
+		  AND NOT i.indisprimary`
+
+	rows, err := c.conn.Query(ctx, query, relID, schemaTable.Schema, schemaTable.Table)
+	if err != nil {
+		return nil, fmt.Errorf("error querying indexes for table %s: %w", schemaTable, err)
+	}
+
+	var indexes []*protos.IndexDescription
+	var (
+		name        string
+		method      string
+		isUnique    bool
+		whereClause pgtype.Text
+		columnNames []string
+	)
+	_, err = pgx.ForEachRow(rows, []any{&name, &method, &isUnique, &whereClause, &columnNames}, func() error {
+		where := ""
+		if whereClause.Valid {
+			where = whereClause.String
+		}
+		indexes = append(indexes, &protos.IndexDescription{
+			Name:           name,
+			ColumnNames:    columnNames,
+			Method:         method,
+			IsUnique:       isUnique,
+			Where:          where,
+			IncludeColumns: nil, // can be filled later if you also query INCLUDE columns
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error iterating index rows for table %s: %w", schemaTable, err)
+	}
+
+	return indexes, nil
+}
+
 func (c *PostgresConnector) getNullableColumns(ctx context.Context, relID uint32) (map[string]struct{}, error) {
 	rows, err := c.conn.Query(ctx, "SELECT a.attname FROM pg_attribute a WHERE a.attrelid = $1 AND NOT a.attnotnull", relID)
 	if err != nil {
@@ -523,6 +585,27 @@ func generateCreateTableSQLForNormalizedTable(
 	}
 
 	return fmt.Sprintf(createNormalizedTableSQL, dstSchemaTable.String(), strings.Join(createTableSQLArray, ","))
+}
+
+func generateCreateIndexesSQLForNormalizedTable(
+	dstSchemaTable *utils.SchemaTable,
+	tableSchema *protos.TableSchema,
+) []string {
+	if tableSchema == nil || len(tableSchema.Indexes) == 0 {
+		return nil
+	}
+	stmts := make([]string, 0, len(tableSchema.Indexes))
+	for _, idx := range tableSchema.Indexes {
+		if idx == nil || len(idx.ColumnNames) == 0 || idx.Name == "" {
+			continue
+		}
+
+		stmt, _ := buildCreateIndexStmt(dstSchemaTable.String(), idx)
+
+		stmts = append(stmts, stmt)
+	}
+
+	return stmts
 }
 
 func (c *PostgresConnector) GetLastSyncBatchID(ctx context.Context, jobName string) (int64, error) {

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -395,6 +395,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
+	{
+		Name:             "PEERDB_POSTGRES_CDC_SCHEMA_MIGRATION_INDEX_ENABLED",
+		Description:      "Enable/disable schema migration (add and drop indexes) for Postgres CDC",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_ALL,
+	},
 }
 
 var DynamicIndex = func() map[string]int {
@@ -726,4 +734,8 @@ func PeerDBMetricsRecordAggregatesEnabled(ctx context.Context, env map[string]st
 
 func PeerDBPostgresCDCMigrationEnabled(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_POSTGRES_CDC_SCHEMA_MIGRATION_ENABLED")
+}
+
+func PeerDBPostgresCDCMigrationIndexEnabled(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_POSTGRES_CDC_SCHEMA_MIGRATION_INDEX_ENABLED")
 }

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -233,6 +233,7 @@ message TableSchema {
   TypeSystem system = 4;
   bool nullable_enabled = 5;
   repeated FieldDescription columns = 6;
+  repeated IndexDescription indexes = 7;
 }
 
 message FieldDescription {
@@ -240,6 +241,21 @@ message FieldDescription {
   string type = 2;
   int32 type_modifier = 3;
   bool nullable = 4;
+}
+
+message IndexDescription {
+  // index name on source
+  string name = 1;
+  // key columns in order
+  repeated string column_names = 2;
+  // index method, e.g. "btree", "gin", "gist", "hash"
+  string method = 3;
+  // whether index is UNIQUE
+  bool is_unique = 4;
+  // WHERE predicate for partial indexes, empty if not partial
+  string where = 5;
+  // INCLUDE columns (Postgres INCLUDE clause)
+  repeated string include_columns = 6;
 }
 
 message SetupTableSchemaBatchInput {
@@ -433,6 +449,8 @@ message TableSchemaDelta {
   bool nullable_enabled = 5;
   repeated string dropped_columns = 6;
   repeated FieldDescription altered_columns = 7;
+  repeated IndexDescription added_indexes = 8;
+  repeated IndexDescription dropped_indexes = 9;
 }
 
 message QRepFlowState {


### PR DESCRIPTION
This PR adds end‑to‑end support for propagating schema and index changes from Postgres sources to Postgres destinations during CDC, gated behind new dynamic configuration flags.

Added `PEERDB_POSTGRES_CDC_SCHEMA_MIGRATION_ENABLED` to control column-level schema migration (add/drop/alter) for Postgres CDC mirrors.
Added `PEERDB_POSTGRES_CDC_SCHEMA_MIGRATION_INDEX_ENABLED` to control index-level migration (create/drop) for Postgres CDC mirrors.

For column-level schema migration:
There was already the support to detect the column drop and type change but it was just getting logged.

For index-level migration:
Existing support was only present for primary key index and not the column level indexes. 
On every relation record similar to column level changes, added logic to compare current schema indexes with previous schema indexes. If there is a diff then apply it to target and update previous schema to current.