### PR TITLE
[snowflake] Feature Flag for skipping Avro compression algorithm

### DIFF
--- a/flow/connectors/utils/avro_writer.go
+++ b/flow/connectors/utils/avro_writer.go
@@ -239,7 +239,8 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(
 		logger.Info("written records to OCF",
 			slog.Int64("records", numRows.Load()),
 			slog.Int("channelLen", len(p.stream.Records)),
-			slog.Float64("elapsedMinutes", time.Since(writeStart).Minutes()))
+			slog.Float64("elapsedMinutes", time.Since(writeStart).Minutes()),
+			slog.String("compression", string(p.avroCompressionCodec)))
 	})
 	defer shutdown()
 
@@ -269,7 +270,9 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(
 
 	logger.Info("finished writing records to OCF",
 		slog.Int64("records", numRows.Load()),
-		slog.Float64("elapsedMinutes", time.Since(writeStart).Minutes()))
+		slog.Float64("elapsedMinutes", time.Since(writeStart).Minutes()),
+		slog.String("compression", string(p.avroCompressionCodec)),
+	)
 
 	if err := p.stream.Err(); err != nil {
 		logger.Error("Failed to get record from stream", slog.Any("error", err))

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -136,6 +136,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_SNOWFLAKE,
 	},
 	{
+		Name:             "PEERDB_SNOWFLAKE_SKIP_COMPRESSION",
+		Description:      "Use `NULL` compression when creating Avro files to be uploaded to Snowflake directly",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
+		TargetForSetting: protos.DynconfTarget_SNOWFLAKE,
+	},
+	{
 		Name:             "PEERDB_CLICKHOUSE_BINARY_FORMAT",
 		Description:      "Binary field encoding on clickhouse destination; either raw, hex, or base64",
 		DefaultValue:     "raw",
@@ -627,6 +635,10 @@ func PeerDBEnableClickHouseJSON(ctx context.Context, env map[string]string) (boo
 
 func PeerDBSnowflakeMergeParallelism(ctx context.Context, env map[string]string) (int64, error) {
 	return dynamicConfSigned[int64](ctx, env, "PEERDB_SNOWFLAKE_MERGE_PARALLELISM")
+}
+
+func PeerDBSnowflakeSkipCompression(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_SNOWFLAKE_SKIP_COMPRESSION")
 }
 
 func PeerDBSnowflakeAutoCompress(ctx context.Context, env map[string]string) (bool, error) {


### PR DESCRIPTION
We are observing a return of the Snowflake errors: `COPY INTO command: 100079 (22000): Invalid data encountered during decompression for file: 'not_file',compression type used: 'ZSTD', cause: 'Data corruption detected'`

These were previously resolved by using `AUTO_COMPRESS=false`; however it seems that in the meantime further changes make the `zst` compression applied to Avro files to no longer be in compliance with Snowflake, leading to failures to decode the files.

This change introduces a feature flag that allows for the skipping of the `zstd` compression on Avro files, making the files that land in Snowflake fully uncompressed.

---

**NB:**
We are successfully running v0.30.9 in production w/o this error happening, however on updating to v0.34.8 the error returns. I have attempted to find out where between v0.30.9 and v0.34.8 there was the breaking change which led to this issue returning however I was not successful and ran out of allocated time - so I'm suggesting this alternative which would allow us to move to a more recent version of `peerdb`.