### PR TITLE
MySQL: Perform binlog_row_metadata guard only if table is in mirror

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -489,16 +489,16 @@ func (c *MySqlConnector) PullRecords(
 				}
 			}
 		case *replication.RowsEvent:
-			if len(ev.Table.ColumnName) == 0 && len(ev.Table.ColumnType) > 0 {
-				e := exceptions.NewMySQLUnsupportedBinlogRowMetadataError(string(ev.Table.Schema), string(ev.Table.Table))
-				c.logger.Error(e.Error())
-				return e
-			}
 			sourceTableName := string(ev.Table.Schema) + "." + string(ev.Table.Table) // TODO this is fragile
 			destinationTableName := req.TableNameMapping[sourceTableName].Name
 			exclusion := req.TableNameMapping[sourceTableName].Exclude
 			schema := req.TableNameSchemaMapping[destinationTableName]
 			if schema != nil {
+				if len(ev.Table.ColumnName) == 0 && len(ev.Table.ColumnType) > 0 {
+					e := exceptions.NewMySQLUnsupportedBinlogRowMetadataError(string(ev.Table.Schema), string(ev.Table.Table))
+					c.logger.Error(e.Error())
+					return e
+				}
 				otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(event.RawData)))
 				fetchedBytes.Add(int64(len(event.RawData)))
 				totalFetchedBytes.Add(int64(len(event.RawData)))


### PR DESCRIPTION
This avoids mirrors being unnecessarily blocked on tables which are not in the mirror, and I believe binlog_row_metadata being FULL is not necessarily critical to CDC's functioning