### PR TITLE
Make safe_wal_size metric optional

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -375,7 +375,7 @@ func getSlotInfo(ctx context.Context, conn *pgx.Conn, slotName string, database 
 		var restartLSN pgtype.Text
 		var currentLSN pgtype.Text
 		var walStatus pgtype.Text
-		var safeWalSize pgtype.Int8
+		var safeWalSize *int64
 		var confirmedFlushLSN pgtype.Text
 		var sentLSN *string
 		var active pgtype.Bool
@@ -429,7 +429,7 @@ func getSlotInfo(ctx context.Context, conn *pgx.Conn, slotName string, database 
 			RestartToConfirmedMb:     restartToConfirmedMB.Float32,
 			ConfirmedToCurrentMb:     confirmedToCurrentMB.Float32,
 			WalStatus:                walStatus.String,
-			SafeWalSize:              safeWalSize.Int64,
+			SafeWalSize:              safeWalSize,
 			WaitEventType:            waitEventType.String,
 			WaitEvent:                waitEvent.String,
 			BackendState:             backendState.String,

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -1445,7 +1445,9 @@ func (c *PostgresConnector) HandleSlotInfo(
 	}
 	slotMetricGauges.RestartLSNGauge.Record(ctx, int64(restartLSN), attributeSet)
 
-	slotMetricGauges.SafeWalSizeGauge.Record(ctx, slotInfo.SafeWalSize, attributeSet)
+	if slotInfo.SafeWalSize != nil {
+		slotMetricGauges.SafeWalSizeGauge.Record(ctx, *slotInfo.SafeWalSize, attributeSet)
+	}
 
 	var activeValue int64
 	if slotInfo.Active {
@@ -1462,12 +1464,14 @@ func (c *PostgresConnector) HandleSlotInfo(
 		attribute.String(otel_metrics.BackendStateKey, slotInfo.BackendState),
 	)))
 
-	slotMetricGauges.WalStatusGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
-		attribute.String(otel_metrics.FlowNameKey, alertKeys.FlowName),
-		attribute.String(otel_metrics.PeerNameKey, alertKeys.PeerName),
-		attribute.String(otel_metrics.SlotNameKey, alertKeys.SlotName),
-		attribute.String(otel_metrics.WalStatusKey, slotInfo.WalStatus),
-	)))
+	if slotInfo.WalStatus != "" {
+		slotMetricGauges.WalStatusGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+			attribute.String(otel_metrics.FlowNameKey, alertKeys.FlowName),
+			attribute.String(otel_metrics.PeerNameKey, alertKeys.PeerName),
+			attribute.String(otel_metrics.SlotNameKey, alertKeys.SlotName),
+			attribute.String(otel_metrics.WalStatusKey, slotInfo.WalStatus),
+		)))
+	}
 
 	slotMetricGauges.LogicalDecodingWorkMemGauge.Record(ctx, slotInfo.LogicalDecodingWorkMemMb, attributeSet)
 

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -234,6 +234,7 @@ message ListPeersResponse {
 }
 
 message SlotInfo {
+  reserved 12;
   string slot_name = 1;
   string redo_lSN = 2;
   string restart_lSN = 3;
@@ -245,7 +246,6 @@ message SlotInfo {
   string current_lSN = 9;
   float restart_to_confirmed_mb = 10;
   float confirmed_to_current_mb = 11;
-  int64 safe_wal_size = 12;
   string wait_event_type = 13;
   string wait_event = 14;
   string backend_state = 15;
@@ -254,6 +254,7 @@ message SlotInfo {
   optional int64 spill_txns = 18;
   optional int64 spill_count = 19;
   optional int64 spill_bytes = 20;
+  optional int64 safe_wal_size = 21;
 }
 
 message SlotLagPoint {


### PR DESCRIPTION
Making zeros informative for the purposes of monitoring/potential alerting. These should be all the changes to make #3685 additions explicitly optional where applicable (`wal_status` stays as empty label but that's easy to distinguish)