### PR TITLE
Query replication mirrors UI: change upsert key columns input to textfield

### DIFF
--- a/ui/app/mirrors/create/qrep/qrep.tsx
+++ b/ui/app/mirrors/create/qrep/qrep.tsx
@@ -64,9 +64,6 @@ export default function QRepConfigForm({
   const [sourceTables, setSourceTables] = useState<
     { value: string; label: string }[]
   >([]);
-  const [allColumns, setAllColumns] = useState<
-    { value: string; label: string }[]
-  >([]);
   const [watermarkColumns, setWatermarkColumns] = useState<
     { value: string; label: string }[]
   >([]);
@@ -122,12 +119,6 @@ export default function QRepConfigForm({
           const types = allowedTypesForWatermarkColumn.get(sourceType);
           return !types || types.has(col.type);
         });
-        setAllColumns(
-          cols.map((col) => ({
-            value: col.name,
-            label: `${col.name} (${col.type})`,
-          }))
-        );
         setWatermarkColumns(
           filteredCols.map((col) => ({
             value: col.name,
@@ -218,7 +209,6 @@ export default function QRepConfigForm({
                         />
                       ) : setting.label === 'Upsert Key Columns' ? (
                         <UpsertColsDisplay
-                          columns={allColumns}
                           loading={loading}
                           setter={setter}
                           setting={setting}

--- a/ui/app/mirrors/create/qrep/upsertcols.tsx
+++ b/ui/app/mirrors/create/qrep/upsertcols.tsx
@@ -9,14 +9,12 @@ import {
 import { MirrorSetting } from '../helpers/common';
 
 interface UpsertColsProps {
-  columns: { value: string; label: string }[];
   loading: boolean;
   setter: Dispatch<SetStateAction<QRepConfig>>;
   setting: MirrorSetting;
 }
 
 export default function UpsertColsDisplay({
-  columns,
   loading,
   setter,
   setting,


### PR DESCRIPTION
In a query where they are having aliases for columns (i.e column A in source maps to column B in target), the upsert key columns for upsert qrep mode need to column B (i,e the destination columns).
Currently we list source columns in the UI, this PR changes this to allow typing whatever columns are needed