### PR TITLE
Revert "improve schema validations gaps (#3752)"

### DIFF
--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -2,7 +2,6 @@ package connclickhouse
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -67,9 +66,6 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 
 	for _, tableMapping := range cfg.TableMappings {
 		dstTableName := tableMapping.DestinationTableIdentifier
-		if dstTableName == "" {
-			return errors.New("destination table identifier is empty")
-		}
 		if _, ok := processedMapping[dstTableName]; !ok {
 			// if destination table is not a key, that means source table was not a key in the original schema mapping(?)
 			return fmt.Errorf("source table %s not found in schema mapping", tableMapping.SourceTableIdentifier)

--- a/flow/connectors/mongo/validate.go
+++ b/flow/connectors/mongo/validate.go
@@ -28,13 +28,5 @@ func (c *MongoConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.F
 		return err
 	}
 
-	sourceTableIdentifiers := make([]string, 0, len(cfg.TableMappings))
-	for _, tm := range cfg.TableMappings {
-		sourceTableIdentifiers = append(sourceTableIdentifiers, tm.SourceTableIdentifier)
-	}
-	if err := shared_mongo.ValidateCollections(ctx, c.client, sourceTableIdentifiers); err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/flow/connectors/utils/identifiers.go
+++ b/flow/connectors/utils/identifiers.go
@@ -23,7 +23,7 @@ func (t *SchemaTable) MySQL() string {
 // ParseSchemaTable parses a table name into schema and table name.
 func ParseSchemaTable(tableName string) (*SchemaTable, error) {
 	schema, table, hasDot := strings.Cut(tableName, ".")
-	if !hasDot || schema == "" || table == "" || strings.ContainsRune(table, '.') {
+	if !hasDot || strings.ContainsRune(table, '.') {
 		return nil, fmt.Errorf("invalid table name: %s", tableName)
 	}
 

--- a/flow/e2e/flow_status_test.go
+++ b/flow/e2e/flow_status_test.go
@@ -100,7 +100,7 @@ func (s APITestSuite) TestFlowStatusUpdate() {
 		cols = "id,val"
 	case *MongoSource:
 		res, err := s.Source().(*MongoSource).AdminClient().
-			Database(Schema(s)).Collection("status_test").
+			Database(Schema(s)).Collection("valid").
 			InsertOne(s.t.Context(), bson.D{bson.E{Key: "id", Value: 1}, bson.E{Key: "val", Value: "first"}}, options.InsertOne())
 		require.NoError(s.t, err)
 		require.True(s.t, res.Acknowledged)

--- a/flow/e2e/mongo_test.go
+++ b/flow/e2e/mongo_test.go
@@ -209,9 +209,6 @@ func (s MongoClickhouseSuite) Test_CDC() {
 	flowConnConfig.DoInitialSnapshot = true
 
 	adminClient := s.Source().(*MongoSource).AdminClient()
-	err := adminClient.Database(srcDatabase).CreateCollection(t.Context(), srcTable)
-	require.NoError(t, err)
-
 	collection := adminClient.Database(srcDatabase).Collection(srcTable)
 
 	tc := NewTemporalClient(t)
@@ -646,10 +643,6 @@ func (s MongoClickhouseSuite) Test_Mongo_Can_Resume_After_Delete_Table() {
 	flowConnConfig.DoInitialSnapshot = true
 
 	db := s.Source().(*MongoSource).AdminClient().Database(srcDatabase)
-	err := db.CreateCollection(t.Context(), srcTable1)
-	require.NoError(t, err)
-	err = db.CreateCollection(t.Context(), srcTable2)
-	require.NoError(t, err)
 
 	tc := NewTemporalClient(t)
 	env := ExecutePeerflow(t, tc, flowConnConfig)

--- a/flow/pkg/mongo/validation.go
+++ b/flow/pkg/mongo/validation.go
@@ -107,31 +107,6 @@ func ValidateOplogRetention(ctx context.Context, client *mongo.Client) error {
 	}
 }
 
-func ValidateCollections(ctx context.Context, client *mongo.Client, sourceTableIdentifiers []string) error {
-	databaseCollectionsMapping := make(map[string][]string)
-
-	for _, sourceTableIdentifier := range sourceTableIdentifiers {
-		database, collection, hasDot := strings.Cut(sourceTableIdentifier, ".")
-		if !hasDot || database == "" || collection == "" || strings.ContainsRune(collection, '.') {
-			return fmt.Errorf("invalid source table identifier: %s", sourceTableIdentifier)
-		}
-		databaseCollectionsMapping[database] = append(databaseCollectionsMapping[database], collection)
-	}
-
-	for database, collections := range databaseCollectionsMapping {
-		allCollections, err := GetCollectionNames(ctx, client, database)
-		if err != nil {
-			return fmt.Errorf("failed to get collections: %w", err)
-		}
-		for _, col := range collections {
-			if !slices.Contains(allCollections, col) {
-				return fmt.Errorf("collection %s.%s does not exist", database, col)
-			}
-		}
-	}
-	return nil
-}
-
 func GetTopologyType(ctx context.Context, client *mongo.Client) (string, error) {
 	hello, err := GetHelloResponse(ctx, client)
 	if err != nil {


### PR DESCRIPTION
This reverts commit ecc358c68b8e7d9135d7751d20032923784642bf.

Seeing following error on main since last commit:
> "Normalization Error: failed to normalize records: error while inserting into target clickhouse table test_coalescing: code: 49, message: Too large size (18446744062280095870) passed to allocator. It indicates an error."

seems unrelated to the code, revert and test to see if it is fixed.