### PR TITLE
lift binlog_row_metadata for azure

### DIFF
--- a/flow/connectors/mysql/validate.go
+++ b/flow/connectors/mysql/validate.go
@@ -68,7 +68,7 @@ func (c *MySqlConnector) CheckBinlogSettings(ctx context.Context, requireRowMeta
 				c.logger.Warn("Falling back to MySQL 5.7 check")
 				return mysql_validation.CheckMySQL5BinlogSettings(conn, c.logger)
 			} else {
-				return mysql_validation.CheckMySQL8BinlogSettings(conn, c.logger)
+				return mysql_validation.CheckMySQL8BinlogSettings(conn, c.logger, requireRowMetadata)
 			}
 		default:
 			return fmt.Errorf("unsupported MySQL flavor: %s", c.config.Flavor.String())


### PR DESCRIPTION
[azure_server_name](https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-server-parameters)  indicates  Azure Database for MySQL - Flexible Server instance. So we can use this variable to determine if we can lift the validation for `binlog_row_metadata`, given users of this db can't edit this config. However, if user has column exclusion selected, it would still block. 