### PR TITLE
Test mysql 9.5 (gtid) and 8.4 (filepos)

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-latest-16-cores]
-        db-version: [{pg: 16, mysql: 'mysql-gtid', mongo: '6.0'}, {pg: 17, mysql: 'mysql-pos', mongo: '7.0'}, {pg: 18, mysql: 'maria', mongo: '8.0'}]
+        db-version: [{pg: 16, mysql: '8.4', mongo: '6.0'}, {pg: 17, mysql: '9.5', mongo: '7.0'}, {pg: 18, mysql: 'maria', mongo: '8.0'}]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     services:
@@ -42,7 +42,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mysql:
-        image: ${{ startsWith(matrix.db-version.mysql, 'mysql') && 'mysql:oracle@sha256:0596fa224cdf3b3355ce3ddbfd7ce77be27ec9e51841dfc5d2e1c8b81eea69d2' || '' }}
+        image: ${{ matrix.db-version.mysql != 'maria' && format('mysql:{0}', matrix.db-version.mysql) || '' }}
         ports:
           - 3306:3306
         env:
@@ -501,15 +501,3 @@ jobs:
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  finish:
-    needs: [flow_test]
-    if: needs.flow_test.result != 'skipped'
-    runs-on: ubuntu-latest
-    steps:
-      - name: check all tests passed
-        run: |
-          if [[ "${{ needs.flow_test.result }}" != "success" ]]; then
-            echo "One or more tests failed"
-            exit 1
-          fi

--- a/flow/e2e/clickhouse_mysql_test.go
+++ b/flow/e2e/clickhouse_mysql_test.go
@@ -264,8 +264,15 @@ func (s ClickHouseSuite) Test_MySQL_Enum() {
 }
 
 func (s ClickHouseSuite) Test_MySQL_Vector() {
-	if mysource, ok := s.source.(*MySqlSource); !ok || mysource.Config.Flavor != protos.MySqlFlavor_MYSQL_MYSQL {
+	mysource, ok := s.source.(*MySqlSource)
+	if !ok || mysource.Config.Flavor != protos.MySqlFlavor_MYSQL_MYSQL {
 		s.t.Skip("only applies to mysql")
+	}
+
+	if cmp, err := mysource.CompareServerVersion(s.t.Context(), "9.0.0"); err != nil {
+		s.t.Fatal(err)
+	} else if cmp < 0 {
+		s.t.Skip("VECTOR type is only supported in MySQL 9.0+")
 	}
 
 	srcTableName := "test_vector"

--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -27,20 +27,26 @@ func SetupMySQL(t *testing.T, suffix string) (*MySqlSource, error) {
 	if myVersion == "" {
 		t.Skip()
 	}
-	mode, isMySQL := strings.CutPrefix(myVersion, "mysql-")
-	replicationMode := protos.MySqlReplicationMechanism_MYSQL_GTID
-	if mode == "pos" {
+	var replicationMode protos.MySqlReplicationMechanism
+	var mysqlFlavor protos.MySqlFlavor
+	switch myVersion {
+	case "9.5":
+		replicationMode = protos.MySqlReplicationMechanism_MYSQL_GTID
+		mysqlFlavor = protos.MySqlFlavor_MYSQL_MYSQL
+	case "8.4":
 		replicationMode = protos.MySqlReplicationMechanism_MYSQL_FILEPOS
+		mysqlFlavor = protos.MySqlFlavor_MYSQL_MYSQL
+	case "maria":
+		replicationMode = protos.MySqlReplicationMechanism_MYSQL_GTID
+		mysqlFlavor = protos.MySqlFlavor_MYSQL_MARIA
+	default:
+		t.Error("unexpected mysql version", myVersion)
 	}
-	if !isMySQL && myVersion != "maria" {
-		t.Error("unknown mysql version", myVersion)
-	}
-	return SetupMyCore(t, suffix, !isMySQL, replicationMode)
+	return SetupMyCore(t, suffix, replicationMode, mysqlFlavor)
 }
 
-func SetupMyCore(t *testing.T, suffix string, isMaria bool, replicationMechanism protos.MySqlReplicationMechanism) (*MySqlSource, error) {
+func SetupMyCore(t *testing.T, suffix string, replication protos.MySqlReplicationMechanism, flavor protos.MySqlFlavor) (*MySqlSource, error) {
 	t.Helper()
-
 	config := &protos.MySqlConfig{
 		Host:                 "localhost",
 		Port:                 3306,
@@ -50,11 +56,8 @@ func SetupMyCore(t *testing.T, suffix string, isMaria bool, replicationMechanism
 		Setup:                nil,
 		Compression:          0,
 		DisableTls:           true,
-		Flavor:               protos.MySqlFlavor_MYSQL_MYSQL,
-		ReplicationMechanism: replicationMechanism,
-	}
-	if isMaria {
-		config.Flavor = protos.MySqlFlavor_MYSQL_MARIA
+		Flavor:               flavor,
+		ReplicationMechanism: replication,
 	}
 
 	connector, err := connmysql.NewMySqlConnector(t.Context(), config)
@@ -76,11 +79,14 @@ func SetupMyCore(t *testing.T, suffix string, isMaria bool, replicationMechanism
 		return nil, err
 	}
 
-	if !isMaria {
-		if _, err := connector.Execute(t.Context(), "select get_lock('settings',-1)"); err != nil {
-			connector.Close()
-			return nil, err
-		}
+	setupSql := []string{
+		"set global binlog_format=row",
+		"set global binlog_row_image=full",
+		"set global binlog_row_metadata=full",
+		"set global max_connections=500",
+	}
+
+	if flavor != protos.MySqlFlavor_MYSQL_MARIA {
 		rs, err := connector.Execute(t.Context(), "select @@gtid_mode")
 		if err != nil {
 			connector.Close()
@@ -91,36 +97,41 @@ func SetupMyCore(t *testing.T, suffix string, isMaria bool, replicationMechanism
 			connector.Close()
 			return nil, err
 		}
-		if !strings.EqualFold(gtidMode, "on") {
-			for _, sql := range []string{
-				"set global binlog_row_metadata=full",
-				"set global enforce_gtid_consistency=on",
-				"set global gtid_mode=off_permissive",
-				"set global gtid_mode=on_permissive",
-				"set global gtid_mode=on",
-				"set global max_connections=500",
-			} {
-				if _, err := connector.Execute(t.Context(), sql); err != nil {
-					connector.Close()
-					return nil, err
-				}
+		if replication == protos.MySqlReplicationMechanism_MYSQL_GTID {
+			if strings.EqualFold(gtidMode, "off") {
+				// The value of @@GLOBAL.GTID_MODE can only be changed one step at a time:
+				// OFF <-> OFF_PERMISSIVE <-> ON_PERMISSIVE <-> ON
+				setupSql = append(setupSql,
+					"select get_lock('settings',-1)",
+					"set global enforce_gtid_consistency=on",
+					"set global gtid_mode=off_permissive",
+					"set global gtid_mode=on_permissive",
+					"set global gtid_mode=on",
+					"do release_lock('settings')",
+				)
 			}
+		} else if replication == protos.MySqlReplicationMechanism_MYSQL_FILEPOS {
+			if strings.EqualFold(gtidMode, "on") {
+				// The value of @@GLOBAL.GTID_MODE can only be changed one step at a time:
+				// ON <-> ON_PERMISSIVE <-> OFF_PERMISSIVE <-> OFF
+				setupSql = append(setupSql,
+					"select get_lock('settings',-1)",
+					"set global enforce_gtid_consistency=off",
+					"set global gtid_mode=on_permissive",
+					"set global gtid_mode=off_permissive",
+					"set global gtid_mode=off",
+					"do release_lock('settings')",
+				)
+			}
+		} else {
+			return nil, fmt.Errorf("unexpected replication mechanism: %v", replication)
 		}
-		if _, err := connector.Execute(t.Context(), "do release_lock('settings')"); err != nil {
+	}
+
+	for _, sql := range setupSql {
+		if _, err := connector.Execute(t.Context(), sql); err != nil {
 			connector.Close()
-			return nil, err
-		}
-	} else {
-		for _, sql := range []string{
-			"set global binlog_format=row",
-			"set binlog_format=row",
-			"set global binlog_row_metadata=full",
-			"set global max_connections=500",
-		} {
-			if _, err := connector.Execute(t.Context(), sql); err != nil {
-				connector.Close()
-				return nil, err
-			}
+			return nil, fmt.Errorf("error executing %s: %v", sql, err)
 		}
 	}
 


### PR DESCRIPTION
Turns out getting mysql 5.7 to play well with our CI was not a trivial feat.

5.7 requires passing in `--log_bin` to explicitly enable binary logging, but there is no way to pass this into the image as an argument with github-action service configs (`options` are docker args, not application args).  And there's no environment variables to pass it in either. So first downside is we can't run it as a service.

Then tried to do something similar to Maria where we just spin up the container with `docker run` but was blocked by networking issues.  `mysql` no longer works for ssh_keepalive_tests for some reason, but even `localhost` did not work for them. For the other e2e tests, was seeing 'connection refused'  errors due to ipv6 not supported by default on mysql 5,  tried passing in `--bind-address="::"` but still getting the same error so i suspect it has to do with docker network connectivity issues that i am not understanding. 

Fallback to 8.4 for now (with some small refactoring around test setups) until i am motivated to look into this again. 