### PR TITLE
Redesign applySchemaDeltas to only apply added columns to catalog

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 	"sync/atomic"
 	"time"
 
@@ -64,31 +63,57 @@ func (a *FlowableActivity) getTableNameSchemaMapping(ctx context.Context, flowNa
 
 func (a *FlowableActivity) applySchemaDeltas(
 	ctx context.Context,
-	config *protos.FlowConnectionConfigsCore,
-	options *protos.SyncFlowOptions,
+	flowJobName string,
 	schemaDeltas []*protos.TableSchemaDelta,
 ) error {
-	filteredTableMappings := make([]*protos.TableMapping, 0, len(schemaDeltas))
-	for _, tableMapping := range options.TableMappings {
-		if slices.ContainsFunc(schemaDeltas, func(schemaDelta *protos.TableSchemaDelta) bool {
-			return schemaDelta.SrcTableName == tableMapping.SourceTableIdentifier &&
-				schemaDelta.DstTableName == tableMapping.DestinationTableIdentifier
-		}) {
-			filteredTableMappings = append(filteredTableMappings, tableMapping)
-		}
+	logger := internal.LoggerFromCtx(ctx)
+	destinationNameListInDeltas := make([]string, 0, len(schemaDeltas))
+	for _, tableSchemaDelta := range schemaDeltas {
+		destinationNameListInDeltas = append(destinationNameListInDeltas, tableSchemaDelta.DstTableName)
 	}
+	logger.Info("loading table schemas from catalog for applying schema deltas",
+		slog.Int("numDeltas", len(schemaDeltas)),
+		slog.String("flowJobName", flowJobName),
+	)
+	schemasInCatalog, err := internal.LoadTableSchemasFromCatalog(ctx, a.CatalogPool, flowJobName, destinationNameListInDeltas)
+	if err != nil {
+		return fmt.Errorf("failed to load table schemas from catalog for applying schema deltas: %w", err)
+	}
+	for _, tableSchemaDelta := range schemaDeltas {
+		columnsInCatalog := schemasInCatalog[tableSchemaDelta.DstTableName].GetColumns()
+		addedColumns := tableSchemaDelta.GetAddedColumns()
 
-	if len(schemaDeltas) > 0 {
-		if err := a.SetupTableSchema(ctx, &protos.SetupTableSchemaBatchInput{
-			PeerName:      config.SourceName,
-			TableMappings: filteredTableMappings,
-			FlowName:      config.FlowJobName,
-			System:        config.System,
-			Env:           config.Env,
-			Version:       config.Version,
-		}); err != nil {
-			return a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to execute schema update at source: %w", err))
+		// Create a map to track existing column names to avoid duplicates
+		existingColumnNames := make(map[string]bool)
+		for _, col := range columnsInCatalog {
+			existingColumnNames[col.Name] = true
 		}
+
+		// Only add columns that don't already exist
+		var newColumnsToAdd []*protos.FieldDescription
+		for _, addedCol := range addedColumns {
+			if !existingColumnNames[addedCol.Name] {
+				newColumnsToAdd = append(newColumnsToAdd, addedCol)
+				existingColumnNames[addedCol.Name] = true
+			}
+		}
+		updatedColumnsInCatalog := append(columnsInCatalog, newColumnsToAdd...)
+		schemasInCatalog[tableSchemaDelta.DstTableName].Columns = updatedColumnsInCatalog
+	}
+	logger.Info("applying schema deltas to catalog",
+		slog.Int("numTables", len(schemasInCatalog)),
+		slog.Int("numDeltas", len(schemaDeltas)),
+		slog.String("flowJobName", flowJobName),
+	)
+	err = internal.UpdateTableSchemasInCatalog(
+		ctx,
+		a.CatalogPool,
+		logger,
+		flowJobName,
+		schemasInCatalog,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update table schemas in catalog: %w", err)
 	}
 	return nil
 }
@@ -223,7 +248,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 			return nil, fmt.Errorf("failed to sync schema: %w", err)
 		}
 
-		return nil, a.applySchemaDeltas(ctx, config, options, recordBatchSync.SchemaDeltas)
+		return nil, a.applySchemaDeltas(ctx, config.FlowJobName, recordBatchSync.SchemaDeltas)
 	}
 
 	var res *model.SyncResponse
@@ -319,7 +344,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	a.OtelManager.Metrics.CurrentBatchIdGauge.Record(ctx, res.CurrentSyncBatchID)
 
 	syncState.Store(shared.Ptr("updating schema"))
-	if err := a.applySchemaDeltas(ctx, config, options, res.TableSchemaDeltas); err != nil {
+	if err := a.applySchemaDeltas(ctx, config.FlowJobName, res.TableSchemaDeltas); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Why

Let's say you have a Postgres mirror running and it is in CDC. 
The pull batch size is 1.
On source for a table t1, the following operations are performed at the same time:
```sql
ALTER TABLE t1 ADD COLUMN good_column TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
INSERT INTO t1 DEFAULT VALUES;
ALTER TABLE t1 ADD COLUMN lost_column TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
```

The way PeerDB syncs the above operations is:
1) Receives the relation message for the addition of `good_column` and the INSERT.
1.1) Checks the schema of this table as stored in catalog, sees that `good_column` is not present and marks `good_column` as a delta to be synced.
2) Does not receive the column addition for `lost_column` because there was no subsequent DML (Postgres behaviour).
3) Syncs the INSERT to destination and adds `good_column` to destination.
4) Performs `applySchemaDelta` which gets the schema of the table t1 from Postgres and stores this schema in catalog. Note that lost_column will be stored here as it is part of the source table at this time.

Now, when another insert is performed:
```sql
INSERT INTO t1 DEFAULT VALUES;
```
PeerDB now:
1) Receives the relation message for the addition of `lost_column` and the INSERT.
1.1) Checks the schema of this table as stored in catalog, sees that `lost_column` is present and moves on.
2) Errors out when inserting to target tables with some message resembling `column "lost_column" not found in destination`.

Because we never identified `lost_column` as a delta to be added to destination.

## What

This PR changes the implementation of `applySchemaDeltas` where we do not touch Postgres, and instead simply do:
```
updated columns for t1 in catalog = current columns of t1 in catalog + added columns in delta of this batch
```

This way, when the second INSERT comes along in the example above, PeerDB will see that lost_column is not present in catalog and will add it to the list of schema deltas to be synced.

Note: Refactors the table OID migration code so that we can share a common function to update table schemas in catalog.

- E2E tests pending
- Functional reproduction pending
