### PR TITLE
Log paging errors on data migration failure

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1880,7 +1880,7 @@ func (a *FlowableActivity) MigratePostgresTableOIDs(
 
 		return nil
 	}); err != nil {
-		a.Alerter.LogFlowError(ctx, flowName, err)
+		return a.Alerter.LogFlowError(ctx, flowName, err)
 	}
 
 	return nil


### PR DESCRIPTION
This migration is good, but for the sake of potential copy-pasting in the future the errors should go through the alerter