### PR TITLE
feat(bigquery): verbose into flow info on GCS snapshot

### DIFF
--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -341,7 +341,11 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 			var apiErr *googleapi.Error
 			if errors.As(err, &apiErr) {
 				if apiErr.Code == 403 {
-					_ = c.LogFlowInfo(ctx, flowName, fmt.Sprintf("Permission denied error when starting export job for table %s: %s", tm.SourceTableIdentifier, apiErr.Message))
+					_ = c.LogFlowInfo(ctx, flowName, fmt.Sprintf(
+						"Permission denied error when starting export job for table %s: %s",
+						tm.SourceTableIdentifier,
+						apiErr.Message,
+					))
 				}
 			}
 


### PR DESCRIPTION
The idea is to give an insight on ongoing snapshot GCS export. For large datasets, it can take few minutes.
