### PR TITLE
pin clickhouse to a specific version

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -238,11 +238,10 @@ jobs:
         env:
           PGPASSWORD: postgres
 
-      - name: get latest version of ClickHouse
+      - name: set ClickHouse version
         id: ch-version
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/ClickHouse/ClickHouse/releases/latest | jq -r .tag_name)
-          echo "ch_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "ch_version=v25.11.1.558-stable" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-clickhouse


### PR DESCRIPTION
`latest` is not a reliable tag for downloading ClickHouse, we hit issues where latest release is for an older version under LTS.
<img width="2374" height="488" alt="Screenshot 2025-12-10 at 22 52 33@2x" src="https://github.com/user-attachments/assets/8eac1d17-b7ea-4053-94e4-63eaf9826beb" />

Pin to a specific version to unblock CI for now. Need a better solution long-term.