### PR TITLE
patch: bring back previous updateFlowStatusInCatalogActivity function

### DIFF
--- a/flow/workflows/local_activities.go
+++ b/flow/workflows/local_activities.go
@@ -1,0 +1,21 @@
+package peerflow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
+)
+
+func updateFlowStatusInCatalogActivity(
+	ctx context.Context,
+	workflowID string,
+	status protos.FlowStatus,
+) (protos.FlowStatus, error) {
+	pool, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
+	if err != nil {
+		return status, fmt.Errorf("failed to get catalog connection pool: %w", err)
+	}
+	return internal.UpdateFlowStatusInCatalog(ctx, pool, workflowID, status)
+}

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -15,7 +15,6 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
-	"github.com/PeerDB-io/peerdb/flow/workflows/cdc_state"
 )
 
 type QRepFlowExecution struct {
@@ -488,7 +487,7 @@ func updateStatus(ctx workflow.Context, logger log.Logger, state *protos.QRepFlo
 	state.CurrentFlowStatus = status
 	// update the status in the catalog only if this is the root workflow
 	if workflow.GetInfo(ctx).ParentWorkflowExecution == nil {
-		cdc_state.SyncStatusToCatalog(ctx, logger, status)
+		syncStatusToCatalog(ctx, logger, status)
 	}
 }
 


### PR DESCRIPTION
One-off patch to unblock a Temporal history change error in QRepFlowWorkflow. 