### PR TITLE
support specifying x509 auth mechanism for mongodb

### DIFF
--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net"
 	"os"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -127,9 +126,7 @@ func parseAsClientOptions(config *protos.MongoConfig, meteredDialer utils.Metere
 		return nil, fmt.Errorf("error parsing uri: %w", err)
 	}
 
-	if connStr.Username != "" || connStr.Password != "" ||
-		// handle the edge case where '@' or ':@' in uri but no username/password provided
-		strings.Contains(connStr.Original[len(connStr.Scheme+"://"):len(connStr.Scheme+"://")+2], "@") {
+	if connStr.UsernameSet {
 		return nil, errors.New("connection string should not contain username and password")
 	}
 


### PR DESCRIPTION
support MONGODB-X509 (TLS) authentication. Only checks to make sure username/password are not specified. previous check `HasAuthParameters` will block if authMechanism is specified in the connection string, but that should be allowed. 