### PR TITLE
classification: pg replica identity index dropped error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -921,6 +921,18 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
+	var postgresReplicaIdentityIndexError *exceptions.ReplicaIdentityIndexError
+	if errors.As(err, &postgresReplicaIdentityIndexError) {
+		return ErrorUnsupportedSchemaChange, ErrorInfo{
+			Source: ErrorSourcePostgres,
+			Code:   "UNSUPPORTED_SCHEMA_CHANGE",
+			AdditionalAttributes: map[AdditionalErrorAttributeKey]string{
+				ErrorAttributeKeyTable:  postgresReplicaIdentityIndexError.Table,
+				ErrorAttributeKeyColumn: "n\a",
+			},
+		}
+	}
+
 	return ErrorOther, ErrorInfo{
 		Source: ErrorSourceOther,
 		Code:   "UNKNOWN",

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -182,9 +182,9 @@ func (c *PostgresConnector) getReplicaIdentityIndexColumns(
 		relID).Scan(&indexRelID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("no replica identity index for table %s", schemaTable)
+			return nil, exceptions.NewReplicaIdentityIndexError(schemaTable.String())
 		}
-		return nil, fmt.Errorf("error finding replica identity index for table %s: %w", schemaTable, err)
+		return nil, fmt.Errorf("error querying replica identity index for table %s: %w", schemaTable, err)
 	}
 
 	return c.getColumnNamesForIndex(ctx, indexRelID)

--- a/flow/shared/exceptions/primary_key_and_replica_identity.go
+++ b/flow/shared/exceptions/primary_key_and_replica_identity.go
@@ -20,6 +20,18 @@ func (e *PrimaryKeyModifiedError) Error() string {
 	return fmt.Sprintf("cannot locate primary key column '%s' value for table '%s': %v", e.ColumnName, e.TableName, e.error.Error())
 }
 
+type ReplicaIdentityIndexError struct {
+	Table string
+}
+
+func NewReplicaIdentityIndexError(table string) error {
+	return &ReplicaIdentityIndexError{Table: table}
+}
+
+func (e *ReplicaIdentityIndexError) Error() string {
+	return fmt.Sprintf("table %s has no replica identity index", e.Table)
+}
+
 type ReplicaIdentityNothingError struct {
 	Table string
 }


### PR DESCRIPTION
This came up a few times. Can happen when user drops the index used for replica identity.  Should notify.