### PR TITLE
Classify CH SUPPORT_IS_DISABLED

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -208,6 +208,9 @@ var (
 	ErrorNotifyPostgresLogicalMessageProcessing = ErrorClass{
 		Class: "NOTIFY_POSTGRES_LOGICAL_MESSAGE_PROCESSING_ERROR", action: NotifyUser,
 	}
+	ErrorNotifyClickHouseSupportIsDisabledError = ErrorClass{
+		Class: "NOTIFY_CLICKHOUSE_SUPPORT_IS_DISABLED_ERROR", action: NotifyUser,
+	}
 	// Catch-all for unclassified errors
 	ErrorOther = ErrorClass{
 		// These are unclassified and should not be exposed
@@ -861,6 +864,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			if strings.Contains(chException.Message, "Replicated DDL queries are disabled") {
 				return ErrorRetryRecoverable, chErrorInfo
 			}
+		case chproto.ErrSupportIsDisabled:
+			return ErrorNotifyClickHouseSupportIsDisabledError, chErrorInfo
 		}
 		var normalizationErr *exceptions.NormalizationError
 		if isClickHouseMvError(chException) {


### PR DESCRIPTION
Based on the [source code search](https://github.com/search?q=repo%3AClickHouse%2FClickHouse%20SUPPORT_IS_DISABLED&type=code), this code is all about features getting disabled.

The error that triggered this was `failed to add column my_column for table my_table: code: 344, message: Experimental text index feature is not enabled (turn on setting 'allow_experimental_full_text_index')`