### PR TITLE
Fix incorrect Zookeeper path formatting for ReplicatedMergeTree

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -32,7 +32,7 @@ const (
 		_peerdb_batch_id Int64,
 		_peerdb_unchanged_toast_columns String
 	)`
-	zooPathPrefix = "/clickhouse/tables/{uuid}/{shard}/{database}/%s"
+	zooPathPrefix = "/clickhouse/tables/{uuid}/{shard}/{database}/"
 )
 
 // GetRawTableName returns the raw table name for the given table identifier.


### PR DESCRIPTION
- Remove extraneous `%s` from `zooPathPrefix` constant in [cdc.go]
- This fixes an issue where the table name was incorrectly prefixed with `%s` in the Zookeeper path (e.g., `.../mydb/%sanjul_test3_log`) when using Replicated table engines.
- Resolves #3783.