### PR TITLE
Add more detailed logging for strict vs lax nullable mismatches

### DIFF
--- a/flow/shared/types/qschema.go
+++ b/flow/shared/types/qschema.go
@@ -79,6 +79,9 @@ type NullableSchemaDebug struct {
 	// Per-field: would this column be nullable under strict mode?
 	// Index matches qfields order. True = nullable, False = NOT nullable under strict
 	StrictNullable []bool
+	// Per-field: did we find a matching row in pg_attribute?
+	// Index matches qfields order. False means lookup failed (table OID or attnum mismatch)
+	MatchFound []bool
 	// Table metadata including names, schemas, and inheritance chain
 	Tables []TableDebug
 }


### PR DESCRIPTION
Just in case. Took another look over the area and hamba/qvalue conversion/our handling of pgx responses can't seem to possibly be the issue, so only pgx-PG interactions are left.