### PR TITLE
Mongo error classification: Add classification for FailedToSatisfyReadPreference

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -699,6 +699,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorRetryRecoverable, mongoErrorInfo
 		case 13436: // NotPrimaryOrSecondary
 			return ErrorNotifyConnectivity, mongoErrorInfo
+		case 133: // FailedToSatisfyReadPreference
+			return ErrorNotifyConnectivity, mongoErrorInfo
 		default:
 			return ErrorOther, mongoErrorInfo
 		}


### PR DESCRIPTION
Encountered:
```
change stream error: (FailedToSatisfyReadPreference) 
Could not find host matching read preference { mode: "nearest" } for set cfg
```