### PR TITLE
minor: fix React key on PostgresForm

### DIFF
--- a/ui/components/PeerForms/PostgresForm.tsx
+++ b/ui/components/PeerForms/PostgresForm.tsx
@@ -92,11 +92,11 @@ export default function PostgresForm({
             (config.authType === PostgresAuthType.POSTGRES_IAM_AUTH &&
               setting.field === 'awsAuth.authType')) ? (
           <RowWithSelect
+            key={id}
             label={<Label>{setting.label}</Label>}
             action={
               <div>
                 <ReactSelect
-                  key={id}
                   defaultValue={setting.options?.find(
                     ({ value }) => value === setting.default
                   )}


### PR DESCRIPTION
## Error Type
Console Error

## Error Message
Each child in a list should have a unique "key" prop.

Check the render method of `PostgresForm`. See https://react.dev/link/warning-keys for more information.


    at eval (components/PeerForms/PostgresForm.tsx:94:11)
    at Array.map (<anonymous>:null:null)
    at PostgresForm (components/PeerForms/PostgresForm.tsx:58:17)
    at configComponentMap (app/peers/create/[peerType]/page.tsx:82:11)
    at CreateConfig (app/peers/create/[peerType]/page.tsx:217:44)

## Code Frame
  92 |             (config.authType === PostgresAuthType.POSTGRES_IAM_AUTH &&
  93 |               setting.field === 'awsAuth.authType')) ? (
> 94 |           <RowWithSelect
     |           ^
  95 |             label={<Label>{setting.label}</Label>}
  96 |             action={
  97 |               <div>

Next.js version: 16.0.2 (Webpack)
