### PR TITLE
Reduce CI MySQL warnings

### DIFF
--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -67,14 +67,14 @@ func SetupMyCore(t *testing.T, suffix string, replication protos.MySqlReplicatio
 	}
 
 	if _, err := connector.Execute(
-		t.Context(), fmt.Sprintf("DROP DATABASE IF EXISTS \"e2e_test_%s\"", suffix),
+		t.Context(), fmt.Sprintf("DROP DATABASE IF EXISTS `e2e_test_%s`", suffix),
 	); err != nil {
 		connector.Close()
 		return nil, err
 	}
 
 	if _, err := connector.Execute(
-		t.Context(), fmt.Sprintf("CREATE DATABASE \"e2e_test_%s\"", suffix),
+		t.Context(), fmt.Sprintf("CREATE DATABASE `e2e_test_%s`", suffix),
 	); err != nil {
 		connector.Close()
 		return nil, err


### PR DESCRIPTION
Quote cleanup query properly - PG-style quoting produces 8812 warnings per run
```
"msg":"failed to parse QueryEvent",
"query":"DROP DATABASE IF EXISTS \"e2e_test_mychclg_nq7h7zy5\"",
"error":"line 1 column 51 near \"\"e2e_test_mychclg_nq7h7zy5\"\"
```