### PR TITLE
CH: reject system databases as destination

### DIFF
--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -18,6 +18,10 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 	cfg *protos.FlowConnectionConfigsCore,
 	tableNameSchemaMapping map[string]*protos.TableSchema,
 ) error {
+	if err := chvalidate.CheckNotSystemDatabase(c.Config.Database); err != nil {
+		return err
+	}
+
 	if internal.PeerDBOnlyClickHouseAllowed() {
 		err := chvalidate.CheckIfClickHouseCloudHasSharedMergeTreeEnabled(ctx, c.logger, c.database)
 		if err != nil {

--- a/flow/pkg/clickhouse/validation.go
+++ b/flow/pkg/clickhouse/validation.go
@@ -12,6 +12,14 @@ import (
 	"go.temporal.io/sdk/log"
 )
 
+func CheckNotSystemDatabase(database string) error {
+	switch database {
+	case "system", "information_schema", "INFORMATION_SCHEMA":
+		return fmt.Errorf("database %q is a system database and cannot be used as a destination", database)
+	}
+	return nil
+}
+
 var acceptableTableEngines = []string{
 	"ReplacingMergeTree", "MergeTree", "ReplicatedReplacingMergeTree", "ReplicatedMergeTree", "CoalescingMergeTree", "Null",
 }


### PR DESCRIPTION
Current error is cryptic:

`failed to create validation table peerdb_validation_9my2: code: 36, message: Macro 'uuid' and empty arguments of ReplicatedMergeTree are supported only for ON CLUSTER queries with Atomic database engine`