### PR TITLE
remove DATABASE_URL from docker compose yaml

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -203,7 +203,6 @@ services:
         required: false
     environment:
       <<: *catalog-config
-      DATABASE_URL: postgres://postgres:postgres@catalog:5432/postgres
       PEERDB_FLOW_SERVER_HTTP: http://flow_api:8113
       PEERDB_PASSWORD:
       NEXTAUTH_SECRET: __changeme__

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,6 @@ services:
       - 3000:3000
     environment:
       <<: *catalog-config
-      DATABASE_URL: postgres://postgres:postgres@catalog:5432/postgres
       PEERDB_FLOW_SERVER_HTTP: http://flow_api:8113
       NEXTAUTH_SECRET: __changeme__
       NEXTAUTH_URL: http://localhost:3000


### PR DESCRIPTION
should've been removed when we removed prisma in #1920