### PR TITLE
Add heartbeat for add tables to publication activity

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1584,6 +1584,11 @@ func (a *FlowableActivity) ReplicateXminPartition(ctx context.Context,
 func (a *FlowableActivity) AddTablesToPublication(ctx context.Context, cfg *protos.FlowConnectionConfigsCore,
 	additionalTableMappings []*protos.TableMapping,
 ) error {
+	shutdown := common.HeartbeatRoutine(ctx, func() string {
+		return "adding tables to publication"
+	})
+	defer shutdown()
+
 	ctx = context.WithValue(ctx, shared.FlowNameKey, cfg.FlowJobName)
 	srcConn, srcClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, cfg.Env, a.CatalogPool, cfg.SourceName)
 	if err != nil {

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -212,7 +212,8 @@ func processTableAdditions(
 
 	logger.Info("altering publication for additional tables")
 	alterPublicationAddAdditionalTablesCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 5 * time.Minute,
+		StartToCloseTimeout: 1 * time.Hour,
+		HeartbeatTimeout:    5 * time.Minute,
 	})
 	alterPublicationAddAdditionalTablesFuture := workflow.ExecuteActivity(
 		alterPublicationAddAdditionalTablesCtx,


### PR DESCRIPTION
Similar to #3825, this PR adds a Temporal heartbeat timeout and longer close timeout to the AddTablesToPublication activity as it has been noticed that when Postgres is bottlenecked, this can take an unusually long time.