### PR TITLE
improve ddl logging

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -910,6 +910,10 @@ func processMessage[Items model.Items](
 			return nil, err
 		}
 
+		if _, exists := p.srcTableIDNameMapping[msg.RelationID]; !exists {
+			return nil, nil
+		}
+
 		logger.Info("processing RelationMessage",
 			slog.Any("LSN", currentClientXlogPos),
 			slog.Uint64("RelationID", uint64(msg.RelationID)),


### PR DESCRIPTION
We came across scenarios where we were seeing consecutive add column DDLs for same column; would be good to get more details on the original relation message.

This PR:
- ~relation id existence is checked in the `processRelationMessage` with warn logging, so remove duplicated check~ nvm, realizing this might make the log a bit more noisy than needed since all relationMessage that we do not care about would log.
- log processing relation message with more details (we are already logging every relation message)