### PR TITLE
bugfix: fix id redundant quotes in mongodb connector

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -226,7 +226,7 @@ func (c *MongoConnector) PullRecords(
 			if idValue == nil {
 				return errors.New("document key _id not found")
 			}
-			qValue, err := qValueStringFromKey(idValue)
+			qValue, err := qValueStringFromKey(idValue, req.InternalVersion)
 			if err != nil {
 				return fmt.Errorf("failed to convert _id to string: %w", err)
 			}

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -203,7 +203,7 @@ func (c *MongoConnector) PullQRepRecords(
 			return 0, 0, fmt.Errorf("failed to decode record: %w", err)
 		}
 
-		record, err := QValuesFromDocument(doc)
+		record, err := QValuesFromDocument(doc, config.Version)
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to convert record: %w", err)
 		}
@@ -282,14 +282,14 @@ func toRangeFilter(watermarkColumn string, partitionRange *protos.PartitionRange
 	}
 }
 
-func QValuesFromDocument(doc bson.D) ([]types.QValue, error) {
+func QValuesFromDocument(doc bson.D, version uint32) ([]types.QValue, error) {
 	var qValues []types.QValue
 
 	var qvalueId types.QValueString
 	var err error
 	for _, v := range doc {
 		if v.Key == DefaultDocumentKeyColumnName {
-			qvalueId, err = qValueStringFromKey(v.Value)
+			qvalueId, err = qValueStringFromKey(v.Value, version)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert key %s: %w", DefaultDocumentKeyColumnName, err)
 			}

--- a/flow/connectors/mongo/qvalue_convert.go
+++ b/flow/connectors/mongo/qvalue_convert.go
@@ -3,12 +3,24 @@ package connmongo
 import (
 	"fmt"
 
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
 var API = CreateExtendedJSONMarshaler()
 
-func qValueStringFromKey(key any) (types.QValueString, error) {
+func qValueStringFromKey(key any, version uint32) (types.QValueString, error) {
+	// For new mirrors, store ObjectID and string keys without redundant quotes
+	if version >= shared.InternalVersion_MongoDBIdWithoutRedundantQuotes {
+		switch v := key.(type) {
+		case bson.ObjectID:
+			return types.QValueString{Val: v.Hex()}, nil
+		case string:
+			return types.QValueString{Val: v}, nil
+		}
+	}
 	jsonb, err := API.Marshal(key)
 	if err != nil {
 		return types.QValueString{}, fmt.Errorf("error marshalling key: %w", err)

--- a/flow/e2e/mongo.go
+++ b/flow/e2e/mongo.go
@@ -76,7 +76,7 @@ func (s *MongoSource) GetRows(ctx context.Context, suffix, table, cols string) (
 		if err != nil {
 			return nil, err
 		}
-		record, err := connmongo.QValuesFromDocument(doc)
+		record, err := connmongo.QValuesFromDocument(doc, shared.InternalVersion_Latest)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -40,6 +40,8 @@ const (
 	InternalVersion_MongoDBFullDocumentColumnToDoc
 	// All: setting json_type_escape_dots_in_keys = true when inserting JSON column to ClickHouse (only impacts MongoDB today)
 	InternalVersion_JsonEscapeDotsInKeys
+	// MongoDB: `_id` column values stored as-is without redundant quotes
+	InternalVersion_MongoDBIdWithoutRedundantQuotes
 
 	TotalNumberOfInternalVersions
 	InternalVersion_Latest = TotalNumberOfInternalVersions - 1


### PR DESCRIPTION
Currently the `_id` column is replicated with an additional set of quoted in ClickHouse. 

This change could probably be introduced without a new version, as this change is more semantic and would not break existing pipes. However, to be strictly backwards-compatible, this would mean existing pipes would replicate in a consistent manner, and new pipes will have this bug fixed.
