### PR TITLE
Emit error text as a metric label

### DIFF
--- a/flow/alerting/alerting.go
+++ b/flow/alerting/alerting.go
@@ -515,11 +515,16 @@ func (a *Alerter) logFlowErrorInternal(
 		slog.Any("stack", inErrWithStack),
 		slog.String("flowErrorType", errorType.String()),
 	)
+	errorText := errError
+	if len(errorText) > 256 {
+		errorText = errorText[:256]
+	}
 	errorAttributes := []attribute.KeyValue{
 		attribute.Stringer(otel_metrics.ErrorClassKey, errorClass),
 		attribute.Stringer(otel_metrics.ErrorActionKey, errorClass.ErrorAction()),
 		attribute.Stringer(otel_metrics.ErrorSourceKey, errInfo.Source),
 		attribute.String(otel_metrics.ErrorCodeKey, errInfo.Code),
+		attribute.String(otel_metrics.ErrorTextKey, errorText),
 	}
 	if len(errInfo.AdditionalAttributes) != 0 {
 		for k, v := range errInfo.AdditionalAttributes {

--- a/flow/otel_metrics/attributes.go
+++ b/flow/otel_metrics/attributes.go
@@ -9,6 +9,7 @@ const (
 	ErrorActionKey             = "errorAction"
 	ErrorSourceKey             = "errorSource"
 	ErrorCodeKey               = "errorCode"
+	ErrorTextKey               = "errorText"
 	InstanceStatusKey          = "instanceStatus"
 	PeerDBVersionKey           = "peerDBVersion"
 	DeploymentVersionKey       = "deploymentVersion"


### PR DESCRIPTION
Emit error text as a metric label which allows to match it with regex for silencing before classification is deployed.

The main concern is series cardinality.
In Prometheus, the most it's going to spike in 6h is hundreds, at 10x scale thousands, which is fine.
In Thanos, the unique series would be 5.2K/7 days, 18K/30days, 45K/90 days, or 52K - 180K - 450K at 10x scale. All of these are fine (as long as we don't query on that label there regularly). We'll be able to have better config infrastructure before any of it becomes a problem.