### PR TITLE
Log errors from export tx commit

### DIFF
--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -133,7 +133,11 @@ func (a *SnapshotActivity) MaintainTx(ctx context.Context, sessionID string, flo
 			a.SnapshotStatesMutex.Lock()
 			delete(a.TxSnapshotStates, sessionID)
 			a.SnapshotStatesMutex.Unlock()
-			return conn.FinishExport(tx)
+			if err := conn.FinishExport(tx); err != nil {
+				logger.Error("finish export error", slog.Any("error", err))
+				return err
+			}
+			return nil
 		}
 		time.Sleep(time.Minute)
 	}


### PR DESCRIPTION
When the exported snapshot identifier is lost, partition workflows notice it first and cancel the parent workflow activity that's holding the transaction. Only the first error is logged, so we know that the snapshot expired but don't know why. Adding a log when committing that transaction errors out.