### PR TITLE
make PEERDB_APPLY_SCHEMA_DELTA_TO_CATALOG=true the default

### DIFF
--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -422,7 +422,7 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 	{
 		Name:             "PEERDB_APPLY_SCHEMA_DELTA_TO_CATALOG",
 		Description:      "Apply schema deltas to catalog instead of fetching latest schema from source",
-		DefaultValue:     "false",
+		DefaultValue:     "true",
 		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,


### PR DESCRIPTION
Now that we have validated the diff log for applying schemaDeltasV2, it's safe to set default value to true and roll it out for all services. Leaving the old schemaDeltasV1 around for a bit longer before removing the old code, so we have a mechanism to rollback dynamically if needed for whatever reason.
