### PR TITLE
Mitigate blank oids in catalog

### DIFF
--- a/flow/internal/schema_helpers.go
+++ b/flow/internal/schema_helpers.go
@@ -68,6 +68,7 @@ func BuildProcessedSchemaMapping(
 						NullableEnabled:       tableSchema.NullableEnabled,
 						System:                tableSchema.System,
 						Columns:               columns,
+						TableOid:              tableSchema.TableOid,
 					}
 				}
 				break

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -633,7 +633,8 @@ message GetDefaultPartitionKeyForTablesOutput {
   map<string, string> table_default_partition_key_mapping = 1;
 }
 
-message GetFlowConfigAndWorkflowIdFromCatalogOutput {
+message GetFlowInfoToCancelFromCatalogOutput {
   FlowConnectionConfigsCore flow_connection_configs = 1;
   string workflow_id = 2;
+  peerdb_peers.DBType source_peer_type = 3;
 }


### PR DESCRIPTION
When a table has excluded columns, its oid doesn't get propagated and becomes zero. This makes table addition cancellation unsafe to run.
Fix the miss and add a check in the workflow to error out in such cases. After this change there won't be any new oids missed and the cancellation workflow will be safe to use, at most erroring out preemptively.

Repairing the existing mappings will be a separate change.