### PR TITLE
drop table should disable max_table_size_to_drop

### DIFF
--- a/flow/connectors/clickhouse/setting_util.go
+++ b/flow/connectors/clickhouse/setting_util.go
@@ -19,6 +19,7 @@ const (
 	SettingTypeJsonSkipDuplicatedPaths        CHSetting = "type_json_skip_duplicated_paths"
 	SettingThrowOnMaxPartitionsPerInsertBlock CHSetting = "throw_on_max_partitions_per_insert_block"
 	SettingParallelDistributedInsertSelect    CHSetting = "parallel_distributed_insert_select"
+	SettingMaxTableSizeToDrop                 CHSetting = "max_table_size_to_drop"
 )
 
 // CHSettingMinVersions maps setting names to their minimum required ClickHouse versions
@@ -26,6 +27,7 @@ const (
 var CHSettingMinVersions = map[CHSetting]chproto.Version{
 	SettingJsonTypeEscapeDotsInKeys:    {Major: 25, Minor: 8, Patch: 0},
 	SettingTypeJsonSkipDuplicatedPaths: {Major: 24, Minor: 8, Patch: 0},
+	SettingMaxTableSizeToDrop:          {Major: 23, Minor: 12, Patch: 0},
 }
 
 type CHSetting string


### PR DESCRIPTION
Drop table query is used during resync (as well as during pipe deletion) to:
- drop the raw table
- drop the *_resync table after swapping tables at the end of resync, if swap succeeds
- drop the original table before renaming resync table to original table, if swap fails

By default `max_table_size_to_drop` on ClickHouse Cloud is set to 1TB,  bypass this config to prevent resync failure caused by this config. The config was introduced in 23.12 [[changelog](https://github.com/ClickHouse/clickhouse-docs/blob/main/docs/whats-new/changelog/2023.md#2312)]:
> Allow to overwrite max_partition_size_to_drop and max_table_size_to_drop server settings in query time. https://github.com/ClickHouse/ClickHouse/pull/57452 ([Jordi Villar](https://github.com/jrdi)).
