### PR TITLE
Add configurable normalisation threshold for alerting

### DIFF
--- a/flow/alerting/alert_sender_test.go
+++ b/flow/alerting/alert_sender_test.go
@@ -1,0 +1,74 @@
+package alerting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlackAlertSenderThresholds(t *testing.T) {
+	t.Parallel()
+
+	config := &slackAlertConfig{
+		AuthToken:                                  "test-token",
+		ChannelIDs:                                 []string{"channel1"},
+		Members:                                    []string{"user1"},
+		SlotLagMBAlertThreshold:                    1000,
+		OpenConnectionsAlertThreshold:              10,
+		IntervalSinceLastNormalizeMinutesThreshold: 120,
+	}
+
+	sender := newSlackAlertSender(config)
+
+	assert.Equal(t, uint32(1000), sender.getSlotLagMBAlertThreshold())
+	assert.Equal(t, uint32(10), sender.getOpenConnectionsAlertThreshold())
+	assert.Equal(t, uint32(120), sender.getIntervalSinceLastNormalizeMinutesThreshold())
+}
+
+func TestSlackAlertSenderDefaultThresholds(t *testing.T) {
+	t.Parallel()
+
+	// Test with zero values (use global default)
+	config := &slackAlertConfig{
+		AuthToken:  "test-token",
+		ChannelIDs: []string{"channel1"},
+	}
+
+	sender := newSlackAlertSender(config)
+
+	assert.Equal(t, uint32(0), sender.getSlotLagMBAlertThreshold())
+	assert.Equal(t, uint32(0), sender.getOpenConnectionsAlertThreshold())
+	assert.Equal(t, uint32(0), sender.getIntervalSinceLastNormalizeMinutesThreshold())
+}
+
+func TestEmailAlertSenderThresholds(t *testing.T) {
+	t.Parallel()
+
+	config := &EmailAlertSenderConfig{
+		EmailAddresses:                             []string{"test@example.com"},
+		SlotLagMBAlertThreshold:                    2000,
+		OpenConnectionsAlertThreshold:              20,
+		IntervalSinceLastNormalizeMinutesThreshold: 180,
+	}
+
+	sender := NewEmailAlertSender(nil, config)
+
+	assert.Equal(t, uint32(2000), sender.getSlotLagMBAlertThreshold())
+	assert.Equal(t, uint32(20), sender.getOpenConnectionsAlertThreshold())
+	assert.Equal(t, uint32(180), sender.getIntervalSinceLastNormalizeMinutesThreshold())
+}
+
+func TestEmailAlertSenderDefaultThresholds(t *testing.T) {
+	t.Parallel()
+
+	// Test with zero values (use global default)
+	config := &EmailAlertSenderConfig{
+		EmailAddresses: []string{"test@example.com"},
+	}
+
+	sender := NewEmailAlertSender(nil, config)
+
+	assert.Equal(t, uint32(0), sender.getSlotLagMBAlertThreshold())
+	assert.Equal(t, uint32(0), sender.getOpenConnectionsAlertThreshold())
+	assert.Equal(t, uint32(0), sender.getIntervalSinceLastNormalizeMinutesThreshold())
+}

--- a/flow/alerting/email_alert_sender.go
+++ b/flow/alerting/email_alert_sender.go
@@ -13,34 +13,37 @@ import (
 )
 
 type EmailAlertSenderConfig struct {
-	sourceEmail                   string
-	configurationSetName          string
-	replyToAddresses              []string
-	EmailAddresses                []string `json:"email_addresses"`
-	SlotLagMBAlertThreshold       uint32   `json:"slot_lag_mb_alert_threshold"`
-	OpenConnectionsAlertThreshold uint32   `json:"open_connections_alert_threshold"`
+	sourceEmail                                string
+	configurationSetName                       string
+	replyToAddresses                           []string
+	EmailAddresses                             []string `json:"email_addresses"`
+	SlotLagMBAlertThreshold                    uint32   `json:"slot_lag_mb_alert_threshold"`
+	OpenConnectionsAlertThreshold              uint32   `json:"open_connections_alert_threshold"`
+	IntervalSinceLastNormalizeMinutesThreshold uint32   `json:"interval_since_last_normalize_minutes_threshold"`
 }
 
 type EmailAlertSender struct {
 	AlertSender
-	client                        *ses.Client
-	sourceEmail                   string
-	configurationSetName          string
-	replyToAddresses              []string
-	emailAddresses                []string
-	slotLagMBAlertThreshold       uint32
-	openConnectionsAlertThreshold uint32
+	client                                     *ses.Client
+	sourceEmail                                string
+	configurationSetName                       string
+	replyToAddresses                           []string
+	emailAddresses                             []string
+	slotLagMBAlertThreshold                    uint32
+	openConnectionsAlertThreshold              uint32
+	intervalSinceLastNormalizeMinutesThreshold uint32
 }
 
 func NewEmailAlertSender(client *ses.Client, config *EmailAlertSenderConfig) *EmailAlertSender {
 	return &EmailAlertSender{
-		client:                        client,
-		sourceEmail:                   config.sourceEmail,
-		configurationSetName:          config.configurationSetName,
-		replyToAddresses:              config.replyToAddresses,
-		emailAddresses:                config.EmailAddresses,
-		slotLagMBAlertThreshold:       config.SlotLagMBAlertThreshold,
-		openConnectionsAlertThreshold: config.OpenConnectionsAlertThreshold,
+		client:                                     client,
+		sourceEmail:                                config.sourceEmail,
+		configurationSetName:                       config.configurationSetName,
+		replyToAddresses:                           config.replyToAddresses,
+		emailAddresses:                             config.EmailAddresses,
+		slotLagMBAlertThreshold:                    config.SlotLagMBAlertThreshold,
+		openConnectionsAlertThreshold:              config.OpenConnectionsAlertThreshold,
+		intervalSinceLastNormalizeMinutesThreshold: config.IntervalSinceLastNormalizeMinutesThreshold,
 	}
 }
 
@@ -58,6 +61,10 @@ func (e *EmailAlertSender) getSlotLagMBAlertThreshold() uint32 {
 
 func (e *EmailAlertSender) getOpenConnectionsAlertThreshold() uint32 {
 	return e.openConnectionsAlertThreshold
+}
+
+func (e *EmailAlertSender) getIntervalSinceLastNormalizeMinutesThreshold() uint32 {
+	return e.intervalSinceLastNormalizeMinutesThreshold
 }
 
 func (e *EmailAlertSender) sendAlert(ctx context.Context, alertTitle string, alertMessage string) error {

--- a/flow/alerting/interface.go
+++ b/flow/alerting/interface.go
@@ -6,4 +6,5 @@ type AlertSender interface {
 	sendAlert(ctx context.Context, alertTitle string, alertMessage string) error
 	getSlotLagMBAlertThreshold() uint32
 	getOpenConnectionsAlertThreshold() uint32
+	getIntervalSinceLastNormalizeMinutesThreshold() uint32
 }

--- a/flow/alerting/slack_alert_sender.go
+++ b/flow/alerting/slack_alert_sender.go
@@ -10,11 +10,12 @@ import (
 
 type SlackAlertSender struct {
 	AlertSender
-	client                        *slack.Client
-	channelIDs                    []string
-	members                       []string
-	slotLagMBAlertThreshold       uint32
-	openConnectionsAlertThreshold uint32
+	client                                     *slack.Client
+	channelIDs                                 []string
+	members                                    []string
+	slotLagMBAlertThreshold                    uint32
+	openConnectionsAlertThreshold              uint32
+	intervalSinceLastNormalizeMinutesThreshold uint32
 }
 
 func (s *SlackAlertSender) getSlotLagMBAlertThreshold() uint32 {
@@ -25,12 +26,17 @@ func (s *SlackAlertSender) getOpenConnectionsAlertThreshold() uint32 {
 	return s.openConnectionsAlertThreshold
 }
 
+func (s *SlackAlertSender) getIntervalSinceLastNormalizeMinutesThreshold() uint32 {
+	return s.intervalSinceLastNormalizeMinutesThreshold
+}
+
 type slackAlertConfig struct {
-	AuthToken                     string   `json:"auth_token"`
-	ChannelIDs                    []string `json:"channel_ids"`
-	Members                       []string `json:"members"`
-	SlotLagMBAlertThreshold       uint32   `json:"slot_lag_mb_alert_threshold"`
-	OpenConnectionsAlertThreshold uint32   `json:"open_connections_alert_threshold"`
+	AuthToken                                  string   `json:"auth_token"`
+	ChannelIDs                                 []string `json:"channel_ids"`
+	Members                                    []string `json:"members"`
+	SlotLagMBAlertThreshold                    uint32   `json:"slot_lag_mb_alert_threshold"`
+	OpenConnectionsAlertThreshold              uint32   `json:"open_connections_alert_threshold"`
+	IntervalSinceLastNormalizeMinutesThreshold uint32   `json:"interval_since_last_normalize_minutes_threshold"`
 }
 
 func newSlackAlertSender(config *slackAlertConfig) *SlackAlertSender {
@@ -39,7 +45,8 @@ func newSlackAlertSender(config *slackAlertConfig) *SlackAlertSender {
 		channelIDs:                    config.ChannelIDs,
 		slotLagMBAlertThreshold:       config.SlotLagMBAlertThreshold,
 		openConnectionsAlertThreshold: config.OpenConnectionsAlertThreshold,
-		members:                       config.Members,
+		intervalSinceLastNormalizeMinutesThreshold: config.IntervalSinceLastNormalizeMinutesThreshold,
+		members: config.Members,
 	}
 }
 

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -966,9 +966,9 @@ func (c *PostgresConnector) GetTablesFromPublication(
 			tables[i] = schemaTable.Table
 		}
 		getTablesSQL = `
-            SELECT schemaname, tablename 
-            FROM pg_publication_tables 
-            WHERE pubname = $1 
+            SELECT schemaname, tablename
+            FROM pg_publication_tables
+            WHERE pubname = $1
             AND (schemaname, tablename) NOT IN (
                 SELECT a.val AS schemaname, b.val AS tablename
                 FROM unnest($2::text[]) WITH ORDINALITY AS a(val, idx)
@@ -1592,6 +1592,8 @@ func (c *PostgresConnector) HandleSlotInfo(
 				attribute.String(otel_metrics.PeerNameKey, alertKeys.PeerName),
 			)),
 		)
+		logger.Info(fmt.Sprintf("Checking normalize interval for %s", alertKeys.FlowName),
+			slog.String("intervalSinceLastNormalize", intervalSinceLastNormalize.String()))
 		alerter.AlertIfTooLongSinceLastNormalize(ctx, alertKeys, *intervalSinceLastNormalize)
 	}
 

--- a/ui/app/alert-config/new.tsx
+++ b/ui/app/alert-config/new.tsx
@@ -306,6 +306,28 @@ export function NewConfig(alertProps: AlertConfigProps) {
         />
       </div>
       <div>
+        <p>Interval Since Last Normalize Alert Threshold (in minutes)</p>
+        <Label as='label' style={{ fontSize: 14 }}>
+          Alert if data hasn&apos;t been normalized for longer than this
+          duration. Set to 0 to use global default.
+        </Label>
+        <TextField
+          key={'interval_since_last_normalize_minutes_threshold'}
+          style={{ height: '2.5rem', marginTop: '0.5rem' }}
+          variant='simple'
+          type={'number'}
+          placeholder='optional (0 = use global default)'
+          value={config.interval_since_last_normalize_minutes_threshold}
+          onChange={(e) =>
+            setConfig((previous) => ({
+              ...previous,
+              interval_since_last_normalize_minutes_threshold:
+                e.target.valueAsNumber,
+            }))
+          }
+        />
+      </div>
+      <div>
         <p>
           Alert only for these mirrors (leave empty to alert for all mirrors)
         </p>

--- a/ui/app/alert-config/new.tsx
+++ b/ui/app/alert-config/new.tsx
@@ -279,11 +279,11 @@ export function NewConfig(alertProps: AlertConfigProps) {
           variant='simple'
           type={'number'}
           placeholder='optional'
-          value={config.slot_lag_mb_alert_threshold / 1000}
+          value={(config.slot_lag_mb_alert_threshold ?? 0) / 1000 || ''}
           onChange={(e) =>
             setConfig((previous) => ({
               ...previous,
-              slot_lag_mb_alert_threshold: e.target.valueAsNumber * 1000,
+              slot_lag_mb_alert_threshold: (isNaN(e.target.valueAsNumber) ? 0 : e.target.valueAsNumber) * 1000,
             }))
           }
         />
@@ -296,11 +296,11 @@ export function NewConfig(alertProps: AlertConfigProps) {
           variant='simple'
           type={'number'}
           placeholder='optional'
-          value={config.open_connections_alert_threshold}
+          value={config.open_connections_alert_threshold || ''}
           onChange={(e) =>
             setConfig((previous) => ({
               ...previous,
-              open_connections_alert_threshold: e.target.valueAsNumber,
+              open_connections_alert_threshold: isNaN(e.target.valueAsNumber) ? 0 : e.target.valueAsNumber,
             }))
           }
         />
@@ -316,13 +316,13 @@ export function NewConfig(alertProps: AlertConfigProps) {
           style={{ height: '2.5rem', marginTop: '0.5rem' }}
           variant='simple'
           type={'number'}
-          placeholder='optional (0 = use global default)'
-          value={config.interval_since_last_normalize_minutes_threshold}
+          placeholder='minutes (default: 240)'
+          value={config.interval_since_last_normalize_minutes_threshold || ''}
           onChange={(e) =>
             setConfig((previous) => ({
               ...previous,
               interval_since_last_normalize_minutes_threshold:
-                e.target.valueAsNumber,
+                isNaN(e.target.valueAsNumber) ? 0 : e.target.valueAsNumber,
             }))
           }
         />

--- a/ui/app/alert-config/page.tsx
+++ b/ui/app/alert-config/page.tsx
@@ -49,7 +49,7 @@ export default function AlertConfigPage() {
       channel_ids: [''],
       open_connections_alert_threshold: 20,
       slot_lag_mb_alert_threshold: 5000,
-      interval_since_last_normalize_minutes_threshold: 0,
+      interval_since_last_normalize_minutes_threshold: 240,
     },
     alertForMirrors: [],
     forEdit: false,

--- a/ui/app/alert-config/page.tsx
+++ b/ui/app/alert-config/page.tsx
@@ -49,6 +49,7 @@ export default function AlertConfigPage() {
       channel_ids: [''],
       open_connections_alert_threshold: 20,
       slot_lag_mb_alert_threshold: 5000,
+      interval_since_last_normalize_minutes_threshold: 0,
     },
     alertForMirrors: [],
     forEdit: false,

--- a/ui/app/alert-config/validation.ts
+++ b/ui/app/alert-config/validation.ts
@@ -9,6 +9,9 @@ const baseServiceConfigSchema = z.object({
   open_connections_alert_threshold: z
     .int({ error: () => 'Threshold must be an integer' })
     .min(0, 'Connections threshold must be non-negative'),
+  interval_since_last_normalize_minutes_threshold: z
+    .int({ error: () => 'Normalize threshold must be an integer' })
+    .min(0, 'Normalize threshold must be non-negative'),
 });
 
 export const slackServiceConfigSchema = z.intersection(

--- a/ui/components/AlertDropdown.tsx
+++ b/ui/components/AlertDropdown.tsx
@@ -20,7 +20,7 @@ export default function AlertDropdown({
 
   return (
     <DropdownMenu.Root>
-      <DropdownMenu.Trigger>
+      <DropdownMenu.Trigger asChild>
         <Button
           aria-controls={open ? 'menu-list-grow' : undefined}
           aria-haspopup='true'


### PR DESCRIPTION
resolves #3921


<img width="1371" height="989" alt="image" src="https://github.com/user-attachments/assets/ec30d5df-b32e-49ab-9464-2924c4657912" />

<img width="1975" height="215" alt="image" src="https://github.com/user-attachments/assets/d21bd7d8-fba5-4c53-8f13-886bc8f155e1" />

create a local test mirror and fire off an update
```
testdb=# update users set name = 'Alice' where id = 1;
UPDATE 1
testdb=# select * from users;
 id |  name   |           email           |        created_at         
----+---------+---------------------------+---------------------------
  2 | Bob     | bob@example.com           | 2026-01-28 01:50:34.35945
  3 | Charlie | charlie@example.com       | 2026-01-28 01:50:34.35945
  1 | Alice   | alice.updated@example.com | 2026-01-28 01:50:34.35945
(3 rows)
```

wait until threshold is hit and wait for alert

```
Alert: Too long since last data normalize for PeerDB mirror test_mirrorData hasn't been synced to the target for mirror test_mirror since the last 15m30.791347s. This could indicate an issue with the pipeline — please check the UI and logs to confirm. Alternatively, it might be that the source database is idle and not receiving new updates. (threshold: 5 minutes)cc: ```
