### PR TITLE
Alert log flow error for failure in CheckConnection

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -84,7 +84,11 @@ func (a *FlowableActivity) CheckConnection(
 	}
 	defer connClose(ctx)
 
-	return conn.ConnectionActive(ctx)
+	if err = conn.ConnectionActive(ctx); err != nil {
+		return a.Alerter.LogFlowError(ctx, config.FlowName, fmt.Errorf("connection not active: %w", err))
+	}
+
+	return nil
 }
 
 func (a *FlowableActivity) CheckMetadataTables(


### PR DESCRIPTION
Adds an `LogFlowError` call in the `CheckConnection` activity so that an error there goes through our alerting flows