### PR TITLE
support ctid parititioning as override

### DIFF
--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -427,6 +427,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
+	{
+		Name:             "PEERDB_POSTGRES_APPLY_CTID_BLOCK_PARTITIONING_OVERRIDE",
+		Description:      "Use CTID block partitioning for initial snapshot if watermark column is ctid",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
+		TargetForSetting: protos.DynconfTarget_ALL,
+	},
 }
 
 var DynamicIndex = func() map[string]int {
@@ -774,4 +782,8 @@ func PeerDBMetricsRecordAggregatesEnabled(ctx context.Context, env map[string]st
 
 func PeerDBApplySchemaDeltaToCatalogEnabled(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_APPLY_SCHEMA_DELTA_TO_CATALOG")
+}
+
+func PeerDBPostgresApplyCtidBlockPartitioning(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_POSTGRES_APPLY_CTID_BLOCK_PARTITIONING_OVERRIDE")
 }


### PR DESCRIPTION
Make it possible to support CTID partitioning as an override via dynamic config.

Previously this was determined by numPartitionOverrides, but there's no reason the two configs needs to be tied together. This PR respect backwards compatibility while introducing a way to override with ctid partitioning using the computed number of partitions. 

Testing: ran smoke test locally