### PR TITLE
Add Test_SS_Types_PG for comprehensive PG-to-PG type replication

### DIFF
--- a/flow/e2e/postgres_test.go
+++ b/flow/e2e/postgres_test.go
@@ -1354,6 +1354,18 @@ func (s PeerFlowE2ETestSuitePG) Test_SS_Types_PG() {
 		)`, srcTableName))
 	require.NoError(s.t, err)
 
+	// Row 3b: NaN and Infinity values for numeric/double precision
+	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
+		INSERT INTO %s (
+			id, col_numeric, col_double_precision,
+			created_at, updated_at
+		) VALUES
+			('33333333-3333-3333-3333-33333333333a', 'NaN', 'NaN', '2024-01-01 00:00:00+00', '2024-01-01 00:00:00+00'),
+			('33333333-3333-3333-3333-33333333333b', NULL, '+Infinity', '2024-01-01 00:00:00+00', '2024-01-01 00:00:00+00'),
+			('33333333-3333-3333-3333-33333333333c', NULL, '-Infinity', '2024-01-01 00:00:00+00', '2024-01-01 00:00:00+00')
+		`, srcTableName))
+	require.NoError(s.t, err)
+
 	// Row 4: Unicode text (Chinese, Arabic, Russian, Emoji), special chars
 	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
 		INSERT INTO %s (
@@ -1386,7 +1398,7 @@ func (s PeerFlowE2ETestSuitePG) Test_SS_Types_PG() {
 		)`, srcTableName))
 	require.NoError(s.t, err)
 
-	s.t.Log("Inserted 5 edge case rows for initial snapshot")
+	s.t.Log("Inserted 8 edge case rows for initial snapshot")
 
 	env := ExecutePeerflow(s.t, tc, flowConnConfig)
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)


### PR DESCRIPTION
## Summary
- Adds `Test_SS_Types_PG` test for comprehensive PostgreSQL-to-PostgreSQL CDC replication
- Tests various data types: text, varchar, numeric, date/time, interval, json, arrays, enums, UUIDs
- Uses `TypeSystem_PG` to preserve native PostgreSQL types during replication

## Test Coverage
- Initial snapshot with 5 edge case rows (NULLs, empty values, min values, unicode, boundary timestamps)
- CDC inserts with 5 more rows (max values, nested JSON, complex intervals)
- CDC updates (NULL to values, unicode changes, JSON changes)
- CDC deletes

## Key Detail
Uses `flowConnConfig.System = protos.TypeSystem_PG` which preserves native PostgreSQL column types (like `interval`) instead of converting through the Q type system.