### PR TITLE
UI: Make column box aware of replica identity index

### DIFF
--- a/protos/route.proto
+++ b/protos/route.proto
@@ -191,6 +191,7 @@ message ColumnsItem {
   string type = 2;
   bool is_key = 3;
   string qkind = 4;
+  bool is_replica_identity = 5;
 }
 
 message TableColumnsResponse {

--- a/ui/app/mirrors/create/cdc/columnbox.tsx
+++ b/ui/app/mirrors/create/cdc/columnbox.tsx
@@ -53,6 +53,19 @@ export default function ColumnBox({
     const includedColumnCount = columns.length - tableRow.exclude.size;
     const isLastIncludedColumn = includedColumnCount === 1 && isIncluded;
 
+    // For replica identity columns, ensure at least one remains included
+    const replicaIdentityColumns = columns.filter(
+      (col) => col.isReplicaIdentity
+    );
+    const includedReplicaIdentityCount = replicaIdentityColumns.filter(
+      (col) => !tableRow.exclude.has(col.name)
+    ).length;
+    const isLastIncludedReplicaIdentity =
+      !tableRow.isReplicaIdentityFull &&
+      column.isReplicaIdentity &&
+      includedReplicaIdentityCount === 1 &&
+      isIncluded;
+
     return (
       <RowWithCheckbox
         key={column.name}
@@ -82,7 +95,7 @@ export default function ColumnBox({
           <Checkbox
             style={{ cursor: 'pointer' }}
             disabled={
-              (!tableRow.isReplicaIdentityFull && column.isKey) ||
+              isLastIncludedReplicaIdentity ||
               disabled ||
               partOfOrderingKey ||
               isLastIncludedColumn


### PR DESCRIPTION
Follow up to #3894, now column exclusion in UI is allowed as long as there is atleast one replica identity column included in case of default replica identity tables. If the replica identity full, the behaviour is unchanged

Adds an E2E test for a scenario where a default replica identity table has a PKey and also a replica identity index column, and a mirror is kicked off with the PKey excluded.