### PR TITLE
mongo: use bson.Unmarshal consistently

### DIFF
--- a/flow/e2e/mongo.go
+++ b/flow/e2e/mongo.go
@@ -72,7 +72,7 @@ func (s *MongoSource) GetRows(ctx context.Context, suffix, table, cols string) (
 
 	for cursor.Next(ctx) {
 		var doc bson.D
-		err := cursor.Decode(&doc)
+		err := bson.Unmarshal(cursor.Current, &doc)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously we've used `cursor.Decode` in some places and this has resulted in the error:
> '[qrep] failed to pull records: failed to decode record: bufio: buffer full

This is because of the decoder implementation:
```
func (c *Cursor) Decode(val any) error {
	dec := getDecoder(c.Current, c.bsonOpts, c.registry)
	return dec.Decode(val)
}
```
`getDecoder` returns a decoder as follows:
```
dec := bson.NewDecoder(bson.NewDocumentReader(bytes.NewReader(data)))
```
and:
```
func NewReader(rd io.Reader) *Reader {
	return NewReaderSize(rd, defaultBufSize)
}
```
`defaultBufSize` hard-coded to 4096, so it's possible to hit this limit when the document reader is calling `readSlice(delim byte)`, where it tries to read until the first occurrence of the delimiter. 

Was able to repro this locally, see snippet.

Switching to `bson.Unmarshal` which does not have this issue (i.e. allocates buffer based on actual size of the data). 

Ran the following test to validate:
```
func TestBufioBufferFullError(t *testing.T) {
	longFieldName := strings.Repeat("x", 5000)
	doc := bson.D{{Key: longFieldName, Value: "test"}}
	raw, err := bson.Marshal(doc)
	require.NoError(t, err)

	// Test 1: cursor.Decode() approach fails
	t.Run("cursor.Decode approach fails", func(t *testing.T) {
		reader := bson.NewDocumentReader(bytes.NewReader(raw))
		decoder := bson.NewDecoder(reader)

		var decoded bson.D
		err := decoder.Decode(&decoded)

		require.Error(t, err)
		require.Contains(t, err.Error(), "bufio: buffer full")
	})

	// Test 2: bson.Unmarshal() approach succeeds
	t.Run("bson.Unmarshal approach works", func(t *testing.T) {
		var decoded bson.D
		err := bson.Unmarshal(raw, &decoded)

		require.NoError(t, err)
		require.Len(t, decoded, 1)
		require.Equal(t, longFieldName, decoded[0].Key)
	})
}

```


Will separately report an issue upstream.  (edit: bug report created [here](https://jira.mongodb.org/browse/GODRIVER-3809))
