### PR TITLE
Enable utf8mb4 setting when server supports it

### DIFF
--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -229,6 +229,11 @@ func (c *MySqlConnector) setSessionSettings() error {
 		}
 	}
 
+	// MariaDB <= 11.5 defaults to latin1, which can result in Unicode to not be replicated correctly
+	if _, err := conn.Execute("SET NAMES utf8mb4"); err != nil {
+		c.logger.Warn("utf8mb4 not supported, ignoring", slog.Any("error", err))
+	}
+
 	switch c.Flavor() {
 	case mysql.MySQLFlavor:
 		// set max_execution_time to unlimited


### PR DESCRIPTION
Support Unicode if table contains unicode, even if server has `utf8/utf8_general_ci` for charset/collation set. 

All modern MySQL and MariaDB defaults to `utf8mb4/utf8mb4_0900_ai_ci `, but in older versions of MariaDB [[ref](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/installing-mariadb/troubleshooting-installation-issues/installation-issues-on-debian-and-ubuntu/differences-in-mariadb-in-debian-and-ubuntu#system-variables)] it is possible for user's instance to have `character_set_server/collation_server` set to `utf8/utf8_general_ci` by default. 

When this happens our Golang client, despite [defaulting](https://github.com/go-mysql-org/go-mysql/blob/4dea9fec1aeb19916d9358a8fffb20d094733b2c/mysql/const.go#L194-L196) to `utf8mb4/utf8mb4_0900_ai_ci`, ends up resolving to `utf8/utf8_general_ci` based on server-side config.

Updating these variables on mysql server to support utf8mb4 requires restart, but on the client it can be handled on the session-level. 

Verified that when server has  `--character-set-server=utf8` and `--collation-server=utf8_general_ci`, client can still override it with `SET NAMES utf8mb4`, which has the following effect[[ref](https://dev.mysql.com/doc/refman/8.4/en/set-names.html)]:

> This statement sets the three session system variables [character_set_client](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_character_set_client), [character_set_connection](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_character_set_connection), and [character_set_results](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_character_set_results) to the given character set. Setting [character_set_connection](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_character_set_connection) to charset_name also sets [collation_connection](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_collation_connection) to the default collation for charset_name. See [Section 12.4, “Connection Character Sets and Collations”](https://dev.mysql.com/doc/refman/8.4/en/charset-connection.html).

