### PR TITLE
move quickstart to GitHub repo

### DIFF
--- a/quickstart_prepare_peers.sh
+++ b/quickstart_prepare_peers.sh
@@ -22,7 +22,7 @@ CREATE DATABASE target;
 \c source
 
 --- Create the test table on source database
-DROP TABLE IF EXISTS source CASCADE;
+DROP TABLE IF EXISTS test CASCADE;
 CREATE TABLE test (
     id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     c1 INT,


### PR DESCRIPTION
original location was deleted, linked from https://docs.peerdb.io/quickstart/quickstart#quickstart