### PR TITLE
feat(bigquery): add retry for intermittent GCS 401 errors

### DIFF
--- a/flow/connectors/bigquery/gcs_header_provider.go
+++ b/flow/connectors/bigquery/gcs_header_provider.go
@@ -45,3 +45,9 @@ func (p *GCSHeaderProvider) GetHeaders(ctx context.Context) (http.Header, error)
 	headers.Set("Authorization", "Bearer "+p.token.Value)
 	return headers, nil
 }
+
+func (p *GCSHeaderProvider) InvalidateToken() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.token = nil
+}

--- a/flow/connectors/clickhouse/gcs_retry.go
+++ b/flow/connectors/clickhouse/gcs_retry.go
@@ -1,0 +1,36 @@
+package connclickhouse
+
+import (
+	"strings"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// isRetryableGCSError checks if the error is a retryable GCS authentication error.
+// This handles intermittent 401 Unauthorized errors that can occur due to
+// Google Cloud's eventual consistency with newly minted downscoped OAuth2 tokens.
+//
+// The error must be:
+// 1. A ClickHouse exception with code ErrReceivedErrorFromRemoteIOServer (86)
+// 2. From storage.googleapis.com
+// 3. An HTTP 401 Unauthorized error
+func isRetryableGCSError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	ex, ok := err.(*clickhouse.Exception)
+	if !ok || ex == nil {
+		return false
+	}
+
+	// Check for error code 86: RECEIVED_ERROR_FROM_REMOTE_IO_SERVER
+	if chproto.Error(ex.Code) != chproto.ErrReceivedErrorFromRemoteIOServer {
+		return false
+	}
+
+	msg := ex.Message
+	return strings.Contains(msg, "storage.googleapis.com") &&
+		strings.Contains(msg, "HTTP status code: 401")
+}

--- a/flow/connectors/clickhouse/gcs_retry_test.go
+++ b/flow/connectors/clickhouse/gcs_retry_test.go
@@ -1,0 +1,59 @@
+package connclickhouse
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRetryableGCSError(t *testing.T) {
+	t.Run("nil error returns false", func(t *testing.T) {
+		require.False(t, isRetryableGCSError(nil))
+	})
+
+	t.Run("non-clickhouse error returns false", func(t *testing.T) {
+		require.False(t, isRetryableGCSError(errors.New("some random error")))
+	})
+
+	t.Run("clickhouse error with wrong code returns false", func(t *testing.T) {
+		err := &clickhouse.Exception{
+			Code:    60, // Unknown table error
+			Message: "Table does not exist",
+		}
+		require.False(t, isRetryableGCSError(err))
+	})
+
+	t.Run("clickhouse error code 86 but not GCS returns false", func(t *testing.T) {
+		err := &clickhouse.Exception{
+			Code:    86,
+			Message: "Received error from remote server https://example.com/data.parquet. HTTP status code: 401 'Unauthorized'",
+		}
+		require.False(t, isRetryableGCSError(err))
+	})
+
+	t.Run("clickhouse error code 86 GCS but not 401 returns false", func(t *testing.T) {
+		err := &clickhouse.Exception{
+			Code:    86,
+			Message: "Received error from remote server https://storage.googleapis.com/bucket/file.parquet. HTTP status code: 403 'Forbidden'",
+		}
+		require.False(t, isRetryableGCSError(err))
+	})
+
+	t.Run("GCS 401 error returns true", func(t *testing.T) {
+		err := &clickhouse.Exception{
+			Code:    86,
+			Message: `Received error from remote server https://storage.googleapis.com/xxxx/dddd%2Fccc.53bc2bcae41e2d9c662e1ba7%2F000000163894.parquet. HTTP status code: 401 'Unauthorized', body length: 131 bytes, body: '<?xml version='1.0' encoding='UTF-8'?><Error><Code>AuthenticationRequired</Code><Message>Authentication required.</Message></Error>': (in file/uri https://storage.googleapis.com/xxxx/dddd%2Fccc.53bc2bcae41e2d9c662e1ba7%2F000000163894.parquet): While executing ParquetBlockInputFormat: While executing URL`,
+		}
+		require.True(t, isRetryableGCSError(err))
+	})
+
+	t.Run("GCS 401 error with different bucket returns true", func(t *testing.T) {
+		err := &clickhouse.Exception{
+			Code:    86,
+			Message: "Received error from remote server https://storage.googleapis.com/another-bucket/path/to/file.parquet. HTTP status code: 401 'Unauthorized'",
+		}
+		require.True(t, isRetryableGCSError(err))
+	})
+}

--- a/flow/internal/backoff.go
+++ b/flow/internal/backoff.go
@@ -1,0 +1,85 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// backoffConfig holds configuration for exponential backoff retry logic.
+type backoffConfig struct {
+	maxAttempts  int
+	initialDelay time.Duration
+	isRetryable  func(error) bool
+}
+
+// BackoffOption configures exponential backoff behavior.
+type BackoffOption func(*backoffConfig)
+
+// WithBackoffMaxAttempts sets the maximum number of retry attempts.
+// Default is 3 if not specified.
+func WithBackoffMaxAttempts(n int) BackoffOption {
+	return func(c *backoffConfig) {
+		c.maxAttempts = n
+	}
+}
+
+// WithBackoffInitialDelay sets the initial delay before the first retry.
+// The delay doubles with each subsequent attempt (e.g., 2s, 4s, 8s).
+// Default is 1 second if not specified.
+func WithBackoffInitialDelay(d time.Duration) BackoffOption {
+	return func(c *backoffConfig) {
+		c.initialDelay = d
+	}
+}
+
+// WithBackoffRetryable sets the function that determines if an error is retryable.
+// If not specified, no errors are retried.
+func WithBackoffRetryable(fn func(error) bool) BackoffOption {
+	return func(c *backoffConfig) {
+		c.isRetryable = fn
+	}
+}
+
+// ExponentialBackoff executes the given function with exponential backoff retry logic.
+// It retries when isRetryable returns true for the error, up to maxAttempts times.
+// The delay between retries follows: initialDelay * 2^attempt (e.g., 2s, 4s, 8s)
+// Returns the result of fn on success, or the last error after all attempts are exhausted.
+func ExponentialBackoff[T any](ctx context.Context, fn func() (T, error), opts ...BackoffOption) (T, error) {
+	config := backoffConfig{
+		maxAttempts:  3,
+		initialDelay: time.Second,
+		isRetryable:  func(error) bool { return false },
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	var zero T
+	var lastErr error
+
+	for attempt := range config.maxAttempts {
+		result, err := fn()
+		if err == nil {
+			return result, nil
+		}
+
+		if !config.isRetryable(err) {
+			return zero, err
+		}
+
+		lastErr = err
+
+		// Don't sleep after the last attempt
+		if attempt < config.maxAttempts-1 {
+			delay := config.initialDelay * time.Duration(1<<attempt)
+			select {
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+
+	return zero, fmt.Errorf("failed after %d attempts: %w", config.maxAttempts, lastErr)
+}

--- a/flow/internal/backoff_test.go
+++ b/flow/internal/backoff_test.go
@@ -1,0 +1,126 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExponentialBackoff(t *testing.T) {
+	t.Run("succeeds on first attempt", func(t *testing.T) {
+		ctx := context.Background()
+		attempts := 0
+
+		result, err := ExponentialBackoff(ctx, func() (int, error) {
+			attempts++
+			return 42, nil
+		},
+			WithBackoffMaxAttempts(3),
+			WithBackoffInitialDelay(time.Millisecond),
+			WithBackoffRetryable(func(err error) bool { return true }),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, 42, result)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("retries on retryable error", func(t *testing.T) {
+		ctx := context.Background()
+		attempts := 0
+		retryableErr := errors.New("retryable error")
+
+		result, err := ExponentialBackoff(ctx, func() (int, error) {
+			attempts++
+			if attempts < 3 {
+				return 0, retryableErr
+			}
+			return 42, nil
+		},
+			WithBackoffMaxAttempts(3),
+			WithBackoffInitialDelay(time.Millisecond),
+			WithBackoffRetryable(func(err error) bool { return errors.Is(err, retryableErr) }),
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, 42, result)
+		require.Equal(t, 3, attempts)
+	})
+
+	t.Run("does not retry on non-retryable error", func(t *testing.T) {
+		ctx := context.Background()
+		attempts := 0
+		nonRetryableErr := errors.New("non-retryable error")
+
+		_, err := ExponentialBackoff(ctx, func() (int, error) {
+			attempts++
+			return 0, nonRetryableErr
+		},
+			WithBackoffMaxAttempts(3),
+			WithBackoffInitialDelay(time.Millisecond),
+			WithBackoffRetryable(func(err error) bool { return false }),
+		)
+
+		require.ErrorIs(t, err, nonRetryableErr)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("returns error after max attempts", func(t *testing.T) {
+		ctx := context.Background()
+		attempts := 0
+		retryableErr := errors.New("always fails")
+
+		_, err := ExponentialBackoff(ctx, func() (int, error) {
+			attempts++
+			return 0, retryableErr
+		},
+			WithBackoffMaxAttempts(3),
+			WithBackoffInitialDelay(time.Millisecond),
+			WithBackoffRetryable(func(err error) bool { return true }),
+		)
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, retryableErr)
+		require.Contains(t, err.Error(), "failed after 3 attempts")
+		require.Equal(t, 3, attempts)
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		attempts := 0
+
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}()
+
+		_, err := ExponentialBackoff(ctx, func() (int, error) {
+			attempts++
+			return 0, errors.New("error")
+		},
+			WithBackoffMaxAttempts(3),
+			WithBackoffInitialDelay(time.Hour), // Long delay to ensure we hit context cancellation
+			WithBackoffRetryable(func(err error) bool { return true }),
+		)
+
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("uses defaults when no options provided", func(t *testing.T) {
+		ctx := context.Background()
+		attempts := 0
+
+		// With no options, isRetryable defaults to always returning false
+		_, err := ExponentialBackoff(ctx, func() (int, error) {
+			attempts++
+			return 0, errors.New("error")
+		})
+
+		require.Error(t, err)
+		require.Equal(t, 1, attempts) // No retries because default isRetryable returns false
+	})
+}

--- a/flow/model/qobject_stream.go
+++ b/flow/model/qobject_stream.go
@@ -19,6 +19,7 @@ const (
 // HeaderProvider provides HTTP headers for authenticating object requests.
 type HeaderProvider interface {
 	GetHeaders(ctx context.Context) (http.Header, error)
+	InvalidateToken()
 }
 
 type Object struct {


### PR DESCRIPTION
Add exponential backoff retry logic to handle intermittent HTTP 401
Unauthorized errors from GCS when fetching files via ClickHouse's
URL table function during BigQuery source ingestion.

The retry logic:
- Detects GCS 401 errors (ClickHouse error code 86)
- Invalidates cached token before retry
- Uses exponential backoff (2s, 4s delays)
- Retries up to 3 times
