### PR TITLE
Heartbeat in Postgres: Make pg_logical_emit_message transactional

### DIFF
--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -98,7 +98,7 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 	},
 	{
 		Name:             "PEERDB_WAL_HEARTBEAT_QUERY",
-		DefaultValue:     "SELECT pg_logical_emit_message(false,'peerdb_heartbeat','')",
+		DefaultValue:     "SELECT pg_logical_emit_message(true,'peerdb_heartbeat','')",
 		ValueType:        protos.DynconfValueType_STRING,
 		Description:      "SQL to run during each WAL heartbeat",
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,


### PR DESCRIPTION
We have noticed cases where in freshly spun up Postgres instances which have a replication slot and without having a single transaction performed on them by the user, our logical decoding messages emitted via the heartbeat workflow can cause WAL files to accumulate over time, taking up disk space, even though the slot size is low.

This is due to a Postgres issue where non-transactional changes in the WAL do not trigger recomputation of global required LSN across all slots. Thus this PR makes a change where it changes the first parameter in pg_emit_logical_message to true. The first parameter denotes whether the messages are transactional (i.e increment xid):
https://pgpedia.info/p/pg_logical_emit_message.html