### PR TITLE
Log user activity when config update is initiated

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -460,7 +460,7 @@ func (h *FlowRequestHandler) FlowStateChange(
 			slog.ErrorContext(ctx, "unable to signal workflow update", logs, slog.Any("error", err))
 			return nil, NewInternalApiError(fmt.Errorf("unable to signal workflow update: %w", err))
 		}
-		telemetry.LogActivityStartFlowConfigUpdate(ctx, req.FlowJobName)
+		telemetry.LogActivityStartFlowConfigUpdate(ctx, req.FlowJobName, req.FlowConfigUpdate.GetCdcFlowConfigUpdate())
 	}
 
 	slog.InfoContext(ctx, "[flow-state-change] received request", logs,

--- a/flow/shared/telemetry/activity_logging.go
+++ b/flow/shared/telemetry/activity_logging.go
@@ -51,10 +51,6 @@ func LogActivityTerminateFlow(ctx context.Context, flowName string) {
 	logActivity(ctx, ActionTerminateFlow, slog.String("flowName", flowName))
 }
 
-func LogActivityStartFlowConfigUpdate(ctx context.Context, flowName string) {
-	logActivity(ctx, ActionStartFlowConfigUpdate, slog.String("flowName", flowName))
-}
-
 func LogActivityStartMaintenance(ctx context.Context) {
 	logActivity(ctx, ActionStartMaintenance)
 }
@@ -73,6 +69,31 @@ func LogActivityCreatePeer(ctx context.Context) {
 
 func LogActivityDropPeer(ctx context.Context) {
 	logActivity(ctx, ActionDropPeer)
+}
+
+func LogActivityStartFlowConfigUpdate(ctx context.Context, flowName string, update *protos.CDCFlowConfigUpdate) {
+	var changes []string
+
+	// Only logging fields that don't need old values to compare to
+	if len(update.AdditionalTables) > 0 {
+		var addedTables []string
+		for _, t := range update.AdditionalTables {
+			addedTables = append(addedTables, t.SourceTableIdentifier)
+		}
+		changes = append(changes, fmt.Sprintf("tables added: %v", addedTables))
+	}
+
+	if len(update.RemovedTables) > 0 {
+		var removedTables []string
+		for _, t := range update.RemovedTables {
+			removedTables = append(removedTables, t.SourceTableIdentifier)
+		}
+		changes = append(changes, fmt.Sprintf("tables removed: %v", removedTables))
+	}
+
+	logActivity(ctx, ActionStartFlowConfigUpdate,
+		slog.String("flowName", flowName),
+		slog.String("activityDetails", strings.Join(changes, ", ")))
 }
 
 type OldCDCFlowValues struct {


### PR DESCRIPTION
Table addition right now looks like mirror resumed -> extended wait -> flow config updated. Add a log in the handler indicating an update was initiated