### PR TITLE
Limit max byte length for PG handshake

### DIFF
--- a/flow/connectors/postgres/ssh_wrapped_conn.go
+++ b/flow/connectors/postgres/ssh_wrapped_conn.go
@@ -58,7 +58,7 @@ func NewPostgresConnFromConfig(
 	// crash the process. Avoid that by limiting the max body length just for the initial handshake.
 	connConfig.BuildFrontend = func(r io.Reader, w io.Writer) *pgproto3.Frontend {
 		frontend := pgproto3.NewFrontend(r, w)
-		frontend.SetMaxBodyLen(1024 * 1024)
+		frontend.SetMaxBodyLen(16 * 1024 * 1024)
 		return frontend
 	}
 	conn, err := pgx.ConnectConfig(ctx, connConfig)


### PR DESCRIPTION
When the endpoint is misbehaved (e.g. a TCP tunnel started pointing at something new), the random initial sequence of bytes may be misinterpreted as a multi-GB message and crash the process. Avoid that by limiting the max body length just for the initial handshake. The param used here is meant exactly for that.