### PR TITLE
feat(bigquery): add PEERDB_BIGQUERY_GEO_MAKE_VALID

### DIFF
--- a/flow/connectors/bigquery/avro_transform_test.go
+++ b/flow/connectors/bigquery/avro_transform_test.go
@@ -33,8 +33,40 @@ func TestAvroTransform(t *testing.T) {
 		"`camelCol4`",
 		"CURRENT_TIMESTAMP AS `sync_col`",
 	}
-	transformedCols := getTransformedColumns(dstSchema, "sync_col", "del_col")
+	transformedCols := getTransformedColumns(dstSchema, "sync_col", "del_col", false)
 	if !reflect.DeepEqual(transformedCols, expectedTransformCols) {
 		t.Errorf("Transform SQL is not correct. Got: %v", transformedCols)
+	}
+}
+
+func TestAvroTransformGeoMakeValid(t *testing.T) {
+	dstSchema := &bigquery.Schema{
+		&bigquery.FieldSchema{
+			Name: "col1",
+			Type: bigquery.GeographyFieldType,
+		},
+		&bigquery.FieldSchema{
+			Name: "col2",
+			Type: bigquery.JSONFieldType,
+		},
+		&bigquery.FieldSchema{
+			Name: "camelCol4",
+			Type: bigquery.StringFieldType,
+		},
+		&bigquery.FieldSchema{
+			Name: "sync_col",
+			Type: bigquery.TimestampFieldType,
+		},
+	}
+
+	expectedTransformCols := []string{
+		"ST_GEOGFROMTEXT(`col1`, make_valid => TRUE) AS `col1`",
+		"PARSE_JSON(`col2`,wide_number_mode=>'round') AS `col2`",
+		"`camelCol4`",
+		"CURRENT_TIMESTAMP AS `sync_col`",
+	}
+	transformedCols := getTransformedColumns(dstSchema, "sync_col", "del_col", true)
+	if !reflect.DeepEqual(transformedCols, expectedTransformCols) {
+		t.Errorf("Transform SQL with make_valid is not correct. Got: %v", transformedCols)
 	}
 }

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -434,6 +434,12 @@ func (c *BigQueryConnector) NormalizeRecords(ctx context.Context, req *model.Nor
 		unchangedToastMergeChunking = 8
 	}
 
+	geoMakeValid, err := internal.PeerDBBigQueryGeoMakeValid(ctx, req.Env)
+	if err != nil {
+		c.logger.Warn("failed to load PEERDB_BIGQUERY_GEO_MAKE_VALID, continuing with false", slog.Any("error", err))
+		geoMakeValid = false
+	}
+
 	rawTableName := c.getRawTableName(req.FlowJobName)
 
 	normBatchID, err := c.GetLastNormalizeBatchID(ctx, req.FlowJobName)
@@ -453,6 +459,7 @@ func (c *BigQueryConnector) NormalizeRecords(ctx context.Context, req *model.Nor
 		if err := c.mergeTablesInThisBatch(ctx, batchId,
 			req.FlowJobName, rawTableName, req.TableNameSchemaMapping, unchangedToastMergeChunking,
 			&protos.PeerDBColumns{SoftDeleteColName: req.SoftDeleteColName, SyncedAtColName: req.SyncedAtColName},
+			geoMakeValid,
 		); err != nil {
 			return model.NormalizeResponse{}, err
 		}
@@ -486,6 +493,7 @@ func (c *BigQueryConnector) mergeTablesInThisBatch(
 	tableToSchema map[string]*protos.TableSchema,
 	unchangedToastMergeChunking uint32,
 	peerdbColumns *protos.PeerDBColumns,
+	geoMakeValid bool,
 ) error {
 	tableNames, err := c.getDistinctTableNamesInBatch(
 		ctx,
@@ -516,6 +524,7 @@ func (c *BigQueryConnector) mergeTablesInThisBatch(
 		mergeBatchId:       batchId,
 		peerdbCols:         peerdbColumns,
 		shortColumn:        map[string]string{},
+		geoMakeValid:       geoMakeValid,
 	}
 
 	for _, tableName := range tableNames {

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -427,6 +427,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
+	{
+		Name:             "PEERDB_BIGQUERY_GEO_MAKE_VALID",
+		Description:      "BigQuery only: use make_valid parameter in ST_GEOGFROMTEXT to repair geometries that are invalid under S2 during merge and initial load",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
+		TargetForSetting: protos.DynconfTarget_BIGQUERY,
+	},
 }
 
 var DynamicIndex = func() map[string]int {
@@ -574,6 +582,10 @@ func PeerDBBigQueryEnableSyncedAtPartitioning(ctx context.Context, env map[strin
 
 func PeerDBBigQueryToastMergeChunking(ctx context.Context, env map[string]string) (uint32, error) {
 	return dynamicConfUnsigned[uint32](ctx, env, "PEERDB_BIGQUERY_TOAST_MERGE_CHUNKING")
+}
+
+func PeerDBBigQueryGeoMakeValid(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_BIGQUERY_GEO_MAKE_VALID")
 }
 
 func PeerDBCDCChannelBufferSize(ctx context.Context, env map[string]string) (int, error) {


### PR DESCRIPTION
Resolves #3920 

feat(bigquery): add `PEERDB_BIGQUERY_GEO_MAKE_VALID` dynamic setting for `ST_GEOGFROMTEXT`

BigQuery uses S2 geometry which has stricter validity rules than GEOS/PostGIS. Geometries that are valid in PostGIS can fail to load into BigQuery due to S2 edge intersection checks.

This adds a configurable setting that passes make_valid => TRUE to `ST_GEOGFROMTEXT` during CDC merge and initial load, allowing BigQuery's S2 engine to repair geometries on ingest.

Defaults to false (no behaviour change for existing mirrors).