### PR TITLE
UI: Fix table deselection upon schema expand and showing of hard delete

### DIFF
--- a/ui/app/mirrors/create/cdc/cdc.tsx
+++ b/ui/app/mirrors/create/cdc/cdc.tsx
@@ -119,7 +119,7 @@ export default function CDCConfigForm({
     isPostgresDestination() ||
     isBigQueryDestination() ||
     isSnowflakeDestination();
-  const supportsHardDelete = () => !isClickhouseDestination();
+  const supportsHardDelete = () => isClickhouseDestination();
 
   const shouldHidePublicationName = (label: string) => {
     return label === 'publication name' && !isPostgresSource();
@@ -163,7 +163,7 @@ export default function CDCConfigForm({
   };
 
   const shoudlHideHardDelete = (label: string) => {
-    return label.includes('soft delete') && !supportsHardDelete();
+    return label.includes('hard delete') && !supportsHardDelete();
   };
 
   const shouldHideClickhouseScript = (label: string) => {
@@ -197,6 +197,7 @@ export default function CDCConfigForm({
       shouldHideTypeSystem(label),
       shouldHideColumnName(label),
       shouldHideSoftDelete(label),
+      shoudlHideHardDelete(label),
       shouldHideClickhouseScript(label),
       shouldHideBigQuerySourceIncompatibleFields(label),
     ];

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -69,6 +69,7 @@ export default function SchemaBox({
   const [tablesLoading, setTablesLoading] = useState(false);
   const [columnsLoading, setColumnsLoading] = useState(false);
   const [expandedSchemas, setExpandedSchemas] = useState<string[]>([]);
+  const [fetchedSchemas, setFetchedSchemas] = useState<Set<string>>(new Set());
   const [tableQuery, setTableQuery] = useState<string>('');
   const [defaultTargetSchema, setDefaultTargetSchema] =
     useState<string>(schema);
@@ -244,6 +245,8 @@ export default function SchemaBox({
           );
           return [...filteredRows, ...newRows];
         });
+
+        setFetchedSchemas((prev) => new Set(prev).add(schemaName));
       } catch (error) {
         // Handle error if needed
         console.error('Error fetching tables:', error);
@@ -270,10 +273,16 @@ export default function SchemaBox({
   ];
 
   useEffect(() => {
-    if (schemaIsExpanded(schema)) {
+    if (schemaIsExpanded(schema) && !fetchedSchemas.has(schema)) {
       fetchTablesForSchema(schema);
     }
-  }, [schema, fetchTablesForSchema, schemaIsExpanded, initialLoadOnly]);
+  }, [
+    schema,
+    fetchTablesForSchema,
+    schemaIsExpanded,
+    fetchedSchemas,
+    initialLoadOnly,
+  ]);
 
   return (
     <div style={schemaBoxStyle}>


### PR DESCRIPTION
- Makes sure expanding schema, selecting all tables, collapsing and expanding schema again still results in all table checkboxes being checked
- Makes sure Hard delete is only shown for ClickHouse destination mirrors

- [x] Functionally tested