### PR TITLE
Update cargo-chef tag, update golang-ci used in GH actions

### DIFF
--- a/.github/workflows/golang-lint.yml
+++ b/.github/workflows/golang-lint.yml
@@ -29,12 +29,12 @@ jobs:
       - name: golangci-lint flow
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: v2.7.2
+          version: v2.9.0
           working-directory: ./flow
           args: --timeout=10m
       - name: golangci-lint e2e_cleanup
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: v2.7.2
+          version: v2.9.0
           working-directory: ./e2e_cleanup
           args: --timeout=10m

--- a/stacks/peerdb-server.Dockerfile
+++ b/stacks/peerdb-server.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1@sha256:b6afd42430b15f2d2a4c5a02b919e98a525b785b1aaff16747d2f623364e39b6
 
-FROM lukemathwalker/cargo-chef:latest-rust-alpine@sha256:8bfc93575a1216a3be4501651d4b8119be4ba10cdb02e212eb51a1e387e87039 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.93.0-alpine@sha256:fcba0c09eda0e520f545903cdfc595267261785eec3b2c60a20292634360a749 AS chef
 
 WORKDIR /root
 


### PR DESCRIPTION
unversioned cargo-chef tag hasn't been updated in half a year, causing trouble in #3933

I forgot to include golangci version bump in #3944