### PR TITLE
ECONNRESET should be retried

### DIFF
--- a/flow/pkg/clickhouse/query_retry.go
+++ b/flow/pkg/clickhouse/query_retry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"syscall"
 	"time"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -42,7 +43,7 @@ func isRetryableException(err error) bool {
 		_, yes := retryableExceptions[chproto.Error(ex.Code)]
 		return yes
 	}
-	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNRESET)
 }
 
 func Exec(ctx context.Context, logger log.Logger,


### PR DESCRIPTION
We are only retrying ECONNRESET on the workflow level, despite this being a retryable error. This is expensive for initial snapshot which ends up starting over the workflow. Retry on the query execution level instead. 