### PR TITLE
Notify on ECONNRESET during peer creation

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -351,7 +351,23 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
-	// Connection reset errors can mostly be ignored
+	var peerCreateError *exceptions.PeerCreateError
+	if errors.As(err, &peerCreateError) {
+		if errors.Is(peerCreateError, context.DeadlineExceeded) {
+			return ErrorNotifyConnectivity, ErrorInfo{
+				Source: ErrorSourceOther,
+				Code:   "CONTEXT_DEADLINE_EXCEEDED",
+			}
+		}
+		if errors.Is(peerCreateError, syscall.ECONNRESET) {
+			return ErrorNotifyConnectivity, ErrorInfo{
+				Source: ErrorSourceNet,
+				Code:   syscall.ECONNRESET.Error(),
+			}
+		}
+	}
+
+	// Other connection reset errors can mostly be ignored
 	if errors.Is(err, syscall.ECONNRESET) {
 		return ErrorIgnoreConnTemporary, ErrorInfo{
 			Source: ErrorSourceNet,
@@ -909,17 +925,6 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorNotifyMVOrView, chErrorInfo
 		}
 		return ErrorOther, chErrorInfo
-	}
-
-	var peerCreateError *exceptions.PeerCreateError
-	if errors.As(err, &peerCreateError) {
-		// Check for context deadline exceeded error
-		if errors.Is(peerCreateError, context.DeadlineExceeded) {
-			return ErrorNotifyConnectivity, ErrorInfo{
-				Source: ErrorSourceOther,
-				Code:   "CONTEXT_DEADLINE_EXCEEDED",
-			}
-		}
 	}
 
 	var numericOutOfRangeError *exceptions.NumericOutOfRangeError

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"syscall"
 	"testing"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -442,6 +443,31 @@ func TestPeerCreateTimeoutErrorShouldBeConnectivity(t *testing.T) {
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceOther,
 		Code:   "CONTEXT_DEADLINE_EXCEEDED",
+	}, errInfo, "Unexpected error info")
+}
+
+func TestConnectionResetDuringPeerCreateShouldBeConnectivity(t *testing.T) {
+	t.Parallel()
+
+	err := exceptions.NewPeerCreateError(
+		fmt.Errorf("failed to open connection to ClickHouse peer: failed to ping to ClickHouse peer: read: %w", syscall.ECONNRESET))
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed to recreate destination connector: %w", err))
+	assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceNet,
+		Code:   syscall.ECONNRESET.Error(),
+	}, errInfo, "Unexpected error info")
+}
+
+func TestConnectionResetFromSourceShouldBeIgnored(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("failed to pull records: read tcp 10.0.0.1:5432: %w", syscall.ECONNRESET)
+	errorClass, errInfo := GetErrorClass(t.Context(), err)
+	assert.Equal(t, ErrorIgnoreConnTemporary, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceNet,
+		Code:   syscall.ECONNRESET.Error(),
 	}, errInfo, "Unexpected error info")
 }
 


### PR DESCRIPTION
ECONNRESET is currently ignored because it often happens on idle connections. However, if we get it during peer creation, we know it's because the peer is completely unavailable and that's worthy of notifying.