### PR TITLE
classification: handle mysql ErrBadConn bubble up as a tls error 

### DIFF
--- a/flow/shared/exceptions/mysql.go
+++ b/flow/shared/exceptions/mysql.go
@@ -5,6 +5,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
 type MySQLIncompatibleColumnTypeError struct {
@@ -74,6 +77,10 @@ func NewMySQLStreamingError(err error) *MySQLStreamingError {
 		if recordHeaderError.Msg == "first record does not look like a TLS handshake" {
 			return &MySQLStreamingError{err, true}
 		}
+	}
+
+	if strings.Contains(err.Error(), mysql.ErrBadConn.Error()) {
+		return &MySQLStreamingError{err, true}
 	}
 
 	return &MySQLStreamingError{err, false}


### PR DESCRIPTION
Handle the following error (which can bubble up as a tls error)

> MySQL streaming error: failed to set @slave_gtid_strict_mode=1: io.ReadFull(header) failed. err remote error: tls: error decoding message: connection was bad
