### PR TITLE
classification: handle mongo cursor errors

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -707,6 +707,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorNotifyConnectivity, mongoErrorInfo
 		case 18: // AuthenticationFailed
 			return ErrorNotifyConnectivity, mongoErrorInfo
+		case 43: // CursorNotFound
+			return ErrorRetryRecoverable, mongoErrorInfo
 		case 91: // ShutdownInProgress
 			return ErrorIgnoreConnTemporary, mongoErrorInfo
 		case 202: // NetworkInterfaceExceededTimeLimit

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -670,7 +670,7 @@ func TestMongoPoolErrorShouldBeRecoverable(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
-func TestMongoHostUnreachableErrorShouldBeRecoverable(t *testing.T) {
+func TestMongoCursorErrors(t *testing.T) {
 	err := mongo.CommandError{
 		Code:    6,
 		Message: "(HostUnreachable) Error on remote shard test.mongodb.net:27017 :: caused by :: interrupted at shutdown",
@@ -680,6 +680,17 @@ func TestMongoHostUnreachableErrorShouldBeRecoverable(t *testing.T) {
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceMongoDB,
 		Code:   "6",
+	}, errInfo)
+
+	err = mongo.CommandError{
+		Code:    43,
+		Message: "cursor id 1234567890 not found",
+	}
+	errorClass, errInfo = GetErrorClass(t.Context(), fmt.Errorf("cursor error: %w", err))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMongoDB,
+		Code:   "43",
 	}, errInfo)
 }
 


### PR DESCRIPTION
Retry errors like:

> Emitting error/warning metric: '[qrep] failed to pull records: cursor error: (HostUnreachable) Error on remote shard <host>t:27017 :: caused by :: interrupted at shutdown'

The host observed recovered after 10 minutes. If we experience more HostUnreachable error in the future that don't auto-recover, it may be worth setting this to notify users instead.

Also retry errors liie:

> Emitting error/warning metric: '[qrep] failed to pull records: cursor error: (CursorNotFound) cursor id 3324504510164163118 not found'

This can happen if there is a server-side shutdown, failover while initial load is running. 