### PR TITLE
classification: logical decoding not supported

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -167,6 +167,9 @@ var (
 	ErrorNotifyReplicationStandbySetup = ErrorClass{
 		Class: "NOTIFY_REPLICATION_STANDBY_SETUP", action: NotifyUser,
 	}
+	ErrorNotifyLogicalDecodingStandbyNotSupported = ErrorClass{
+		Class: "NOTIFY_LOGICAL_DECODING_STANDBY_NOT_SUPPORTED", action: NotifyUser,
+	}
 	ErrorInternal = ErrorClass{
 		Class: "INTERNAL", action: NotifyTelemetry,
 	}
@@ -605,6 +608,11 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 
 		case pgerrcode.QueryCanceled:
 			return ErrorNotifyConnectivity, pgErrorInfo
+
+		case pgerrcode.FeatureNotSupported:
+			if strings.Contains(pgErr.Message, "logical decoding cannot be used while in recovery") {
+				return ErrorNotifyLogicalDecodingStandbyNotSupported, pgErrorInfo
+			}
 
 		case pgerrcode.DeadlockDetected,
 			pgerrcode.SerializationFailure,

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -326,6 +326,20 @@ func TestPostgresInvalidValueForSynchronizedStandbySlots(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresLogicalDecodingNotSupportedOnStandby(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.FeatureNotSupported,
+		Message:  "logical decoding cannot be used while in recovery",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("error starting replication at startLsn - 11763874329649: %w", err))
+	assert.Equal(t, ErrorNotifyLogicalDecodingStandbyNotSupported, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.FeatureNotSupported,
+	}, errInfo)
+}
+
 func TestPostgresCreatingSlotOnReader(t *testing.T) {
 	err := &pgconn.PgError{
 		Severity: "ERROR",


### PR DESCRIPTION
While we do check for logical decoding on standby during validation, it's possible for a failover to occur where the primary that succeeded validation became the standby. Notify user when this happens. 

(not explicitly checking PG version, as this error only occurs on PG15 or older)