### PR TITLE
use bson.Unmarshal everywhere

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -345,7 +345,7 @@ func (c *MongoConnector) PullRecords(
 		cumulativeBytesProcessed.Add(changeEventSize)
 
 		var changeEvent ChangeEvent
-		if err := changeStream.Decode(&changeEvent); err != nil {
+		if err := bson.Unmarshal(changeStream.Current, &changeEvent); err != nil {
 			return fmt.Errorf("failed to decode change stream document: %w", err)
 		}
 


### PR DESCRIPTION
Missed the CDC case in https://github.com/PeerDB-io/peerdb/pull/3898