### PR TITLE
skip pubviaroot query if postgres version is less than 13

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -93,12 +93,18 @@ func (c *PostgresConnector) NewPostgresCDCSource(ctx context.Context, cdcConfig 
 	}
 
 	var publishViaPartitionRoot bool
-	if err := c.conn.QueryRow(ctx,
-		"SELECT COALESCE(pubviaroot, false) FROM pg_publication WHERE pubname=$1",
-		cdcConfig.Publication,
-	).Scan(&publishViaPartitionRoot); err != nil {
-		return nil, fmt.Errorf("error checking publish_via_partition_root for publication %s: %w",
-			cdcConfig.Publication, err)
+	majorVersion, err := c.MajorVersion(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting major version: %w", err)
+	}
+	if majorVersion >= shared.POSTGRES_13 {
+		if err := c.conn.QueryRow(ctx,
+			"SELECT COALESCE(pubviaroot, false) FROM pg_publication WHERE pubname=$1",
+			cdcConfig.Publication,
+		).Scan(&publishViaPartitionRoot); err != nil {
+			return nil, fmt.Errorf("error checking publish_via_partition_root for publication %s: %w",
+				cdcConfig.Publication, err)
+		}
 	}
 
 	var schemaNameForRelID map[uint32]string

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -38,6 +38,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
+//nolint:govet // fieldalignment: fields grouped by purpose for readability
 type PostgresCDCSource struct {
 	*PostgresConnector
 	srcTableIDNameMapping  map[uint32]string
@@ -51,6 +52,8 @@ type PostgresCDCSource struct {
 
 	// for partitioned tables, maps child relid to parent relid
 	childToParentRelIDMapping map[uint32]uint32
+	idToRelKindMap            map[uint32]byte
+	publishViaPartitionRoot   bool
 
 	// for storing schema delta audit logs to catalog
 	catalogPool                              shared.CatalogPool
@@ -82,11 +85,20 @@ type PostgresCDCConfig struct {
 
 // Create a new PostgresCDCSource
 func (c *PostgresConnector) NewPostgresCDCSource(ctx context.Context, cdcConfig *PostgresCDCConfig) (*PostgresCDCSource, error) {
-	childToParentRelIDMap, err := getChildToParentRelIDMap(ctx,
+	childToParentRelIDMap, idToRelKindMap, err := getChildToParentRelIDMap(ctx,
 		c.conn, slices.Collect(maps.Keys(cdcConfig.SrcTableIDNameMapping)),
 		cdcConfig.HandleInheritanceForNonPartitionedTables)
 	if err != nil {
 		return nil, fmt.Errorf("error getting child to parent relid map: %w", err)
+	}
+
+	var publishViaPartitionRoot bool
+	if err := c.conn.QueryRow(ctx,
+		"SELECT COALESCE(pubviaroot, false) FROM pg_publication WHERE pubname=$1",
+		cdcConfig.Publication,
+	).Scan(&publishViaPartitionRoot); err != nil {
+		return nil, fmt.Errorf("error checking publish_via_partition_root for publication %s: %w",
+			cdcConfig.Publication, err)
 	}
 
 	var schemaNameForRelID map[uint32]string
@@ -107,6 +119,8 @@ func (c *PostgresConnector) NewPostgresCDCSource(ctx context.Context, cdcConfig 
 		publication:                              cdcConfig.Publication,
 		commitLock:                               nil,
 		childToParentRelIDMapping:                childToParentRelIDMap,
+		idToRelKindMap:                           idToRelKindMap,
+		publishViaPartitionRoot:                  publishViaPartitionRoot,
 		catalogPool:                              cdcConfig.CatalogPool,
 		otelManager:                              cdcConfig.OtelManager,
 		hushWarnUnhandledMessageType:             make(map[pglogrepl.MessageType]struct{}),
@@ -136,14 +150,14 @@ func (p *PostgresCDCSource) getSourceSchemaForDestinationColumn(relID uint32, ta
 
 func getChildToParentRelIDMap(ctx context.Context,
 	conn *pgx.Conn, parentTableOIDs []uint32, handleInheritanceForNonPartitionedTables bool,
-) (map[uint32]uint32, error) {
+) (map[uint32]uint32, map[uint32]byte, error) {
 	relkinds := "'p'"
 	if handleInheritanceForNonPartitionedTables {
 		relkinds = "'p', 'r'"
 	}
 
 	query := fmt.Sprintf(`
-		SELECT parent.oid AS parentrelid, child.oid AS childrelid
+		SELECT parent.oid AS parentrelid, child.oid AS childrelid, parent.relkind
 		FROM pg_inherits
 		JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 		JOIN pg_class child ON pg_inherits.inhrelid = child.oid
@@ -152,19 +166,22 @@ func getChildToParentRelIDMap(ctx context.Context,
 
 	rows, err := conn.Query(ctx, query, parentTableOIDs)
 	if err != nil {
-		return nil, fmt.Errorf("error querying for child to parent relid map: %w", err)
+		return nil, nil, fmt.Errorf("error querying for child to parent relid map: %w", err)
 	}
 
 	childToParentRelIDMap := make(map[uint32]uint32)
+	idToRelKindMap := make(map[uint32]byte)
 	var parentRelID, childRelID pgtype.Uint32
-	if _, err := pgx.ForEachRow(rows, []any{&parentRelID, &childRelID}, func() error {
+	var relkind byte
+	if _, err := pgx.ForEachRow(rows, []any{&parentRelID, &childRelID, &relkind}, func() error {
 		childToParentRelIDMap[childRelID.Uint32] = parentRelID.Uint32
+		idToRelKindMap[parentRelID.Uint32] = relkind
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("error iterating over child to parent relid map: %w", err)
+		return nil, nil, fmt.Errorf("error iterating over child to parent relid map: %w", err)
 	}
 
-	return childToParentRelIDMap, nil
+	return childToParentRelIDMap, idToRelKindMap, nil
 }
 
 // replProcessor implements ingesting PostgreSQL logical replication tuples into items.
@@ -917,13 +934,23 @@ func processMessage[Items model.Items](
 		p.otelManager.Metrics.CommitLagGauge.Record(ctx, time.Now().UTC().Sub(msg.CommitTime).Microseconds())
 		p.commitLock = nil
 	case *pglogrepl.RelationMessage:
+		originalRelID := msg.RelationID
+		var parentRelKind byte
 		// treat all relation messages as corresponding to parent if partitioned.
-		msg.RelationID, err = p.checkIfUnknownTableInherits(ctx, msg.RelationID)
+		msg.RelationID, parentRelKind, err = p.checkIfUnknownTableInherits(ctx, msg.RelationID)
 		if err != nil {
 			return nil, err
 		}
 
 		if _, exists := p.srcTableIDNameMapping[msg.RelationID]; !exists {
+			return nil, nil
+		}
+
+		// With publish_via_partition_root = true, PG emits a parent RelationMessage
+		// followed by a child RelationMessage for each partition. The parent's
+		// column list matches the tuple data wire format, so skip the child's
+		// to avoid overwriting with a potentially reordered column definition.
+		if originalRelID != msg.RelationID && parentRelKind == 'p' && p.publishViaPartitionRoot {
 			return nil, nil
 		}
 
@@ -1299,7 +1326,7 @@ func (p *PostgresCDCSource) getParentRelIDIfPartitioned(relID uint32) uint32 {
 // filtered by relkind; parent needs to be a partitioned table by default
 func (p *PostgresCDCSource) checkIfUnknownTableInherits(ctx context.Context,
 	relID uint32,
-) (uint32, error) {
+) (uint32, byte, error) {
 	relID = p.getParentRelIDIfPartitioned(relID)
 	relkinds := "'p'"
 	if p.handleInheritanceForNonPartitionedTables {
@@ -1316,9 +1343,9 @@ func (p *PostgresCDCSource) checkIfUnknownTableInherits(ctx context.Context,
 			relID,
 		).Scan(&parentRelID); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return relID, nil
+				return relID, 0, nil
 			}
-			return 0, fmt.Errorf("failed to query pg_inherits: %w", err)
+			return 0, 0, fmt.Errorf("failed to query pg_inherits: %w", err)
 		}
 		p.childToParentRelIDMapping[relID] = parentRelID
 		p.hushWarnUnknownTableDetected[relID] = struct{}{}
@@ -1326,8 +1353,8 @@ func (p *PostgresCDCSource) checkIfUnknownTableInherits(ctx context.Context,
 			slog.Uint64("childRelID", uint64(relID)),
 			slog.Uint64("parentRelID", uint64(parentRelID)),
 			slog.String("parentTableName", p.srcTableIDNameMapping[parentRelID]))
-		return parentRelID, nil
+		return parentRelID, p.idToRelKindMap[parentRelID], nil
 	}
 
-	return relID, nil
+	return relID, p.idToRelKindMap[relID], nil
 }

--- a/flow/e2e/generic_test.go
+++ b/flow/e2e/generic_test.go
@@ -452,6 +452,107 @@ func (s Generic) Test_Partitioned_Table() {
 	RequireEnvCanceled(t, env)
 }
 
+func (s Generic) Test_Partitioned_Table_With_Different_Column_Ordering() {
+	t := s.T()
+
+	pgSource, ok := s.Source().(*PostgresSource)
+	if !ok {
+		t.Skip("test only applies to postgres")
+	}
+	conn := pgSource.PostgresConnector
+
+	srcTable := "test_partition_reorder"
+	dstTable := "test_partition_reorder_dst"
+	srcSchemaTable := AttachSchema(s, srcTable)
+
+	// Parent: column ordering: id, key, value, created_at
+	// p1: uses parent column ordering
+	// p2: attaches partitioned table with different column ordering from parent
+	// p3: attaches partitioned table with same column ordering as parent
+	_, err := conn.Conn().Exec(t.Context(), fmt.Sprintf(`
+		CREATE TABLE %[1]s(
+			id INT NOT NULL,
+			key TEXT,
+			value INT,
+			created_at TIMESTAMP DEFAULT now(),
+			PRIMARY KEY (created_at, id)
+		) PARTITION BY RANGE(created_at);
+		CREATE TABLE %[1]s_p1
+			PARTITION OF %[1]s
+			FOR VALUES FROM ('2024-01-01') TO ('2024-05-01');
+		CREATE TABLE %[1]s_p2(
+			value INT,
+			created_at TIMESTAMP DEFAULT now(),
+			key TEXT,
+			id INT NOT NULL,
+			PRIMARY KEY (created_at, id)
+		);
+		ALTER TABLE %[1]s ATTACH PARTITION %[1]s_p2
+			FOR VALUES FROM ('2024-05-01') TO ('2024-09-01');
+		CREATE TABLE %[1]s_p3(
+			id INT NOT NULL,
+			key TEXT,
+			value INT,
+			created_at TIMESTAMP DEFAULT now(),
+			PRIMARY KEY (created_at, id)
+		);
+		ALTER TABLE %[1]s ATTACH PARTITION %[1]s_p3
+			FOR VALUES FROM ('2024-09-01') TO ('2025-01-01');
+	`, srcSchemaTable))
+	require.NoError(t, err)
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:   AddSuffix(s, srcTable),
+		TableMappings: TableMappings(s, srcTable, dstTable),
+		Destination:   s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+
+	tc := NewTemporalClient(t)
+	env := ExecutePeerflow(t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(t, env, flowConnConfig)
+
+	// Batch 1: insert into all 3 partitions, verify correctness
+	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(
+		`INSERT INTO %s(id, key, value, created_at) VALUES
+			(1, 'a', 10, '2024-02-15'),
+			(2, 'b', 20, '2024-06-15'),
+			(3, 'c', 30, '2024-10-15')`, srcSchemaTable))
+	EnvNoError(t, env, err)
+
+	EnvWaitForEqualTablesWithNames(env, s, "first batch 3 rows",
+		srcTable, dstTable, `id,key,value,created_at`)
+
+	// Batch 2: insert into all 3 partitions, verify correctness across batches
+	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(
+		`INSERT INTO %s(id, key, value, created_at) VALUES
+			(4, 'd', 40, '2024-11-15'),
+			(5, 'e', 50, '2024-03-15'),
+			(6, 'f', 60, '2024-07-15')`, srcSchemaTable))
+	EnvNoError(t, env, err)
+
+	EnvWaitForEqualTablesWithNames(env, s, "all 6 rows",
+		srcTable, dstTable, `id,key,value,created_at`)
+
+	// DDL: add a new column to the parent, should propagate to all children
+	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(
+		`ALTER TABLE %s ADD COLUMN extra TEXT`, srcSchemaTable))
+	EnvNoError(t, env, err)
+
+	// Batch 3: insert into all 3 partitions, verify correctness with new column addition
+	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(
+		`INSERT INTO %s(id, key, value, created_at, extra) VALUES
+			(7, 'g', 70, '2024-08-15', 'x1'),
+			(8, 'h', 80, '2024-12-15', 'x2'),
+			(9, 'i', 90, '2024-04-15', 'x3')`, srcSchemaTable))
+	EnvNoError(t, env, err)
+
+	EnvWaitForEqualTablesWithNames(env, s, "all 9 rows with new column",
+		srcTable, dstTable, `id,key,value,created_at,extra`)
+	env.Cancel(t.Context())
+	RequireEnvCanceled(t, env)
+}
+
 func (s Generic) Test_Schema_Changes_Cutoff_Bug() {
 	t := s.T()
 

--- a/flow/e2e/generic_test.go
+++ b/flow/e2e/generic_test.go
@@ -523,15 +523,30 @@ func (s Generic) Test_Partitioned_Table_With_Different_Column_Ordering() {
 	EnvWaitForEqualTablesWithNames(env, s, "first batch 3 rows",
 		srcTable, dstTable, `id,key,value,created_at`)
 
-	// Batch 2: insert into all 3 partitions, verify correctness across batches
+	// DDL: add a new partition dynamically while CDC is running
+	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(`
+		CREATE TABLE %[1]s_p4(
+			value INT,
+			created_at TIMESTAMP DEFAULT now(),
+			key TEXT,
+			id INT NOT NULL,
+			PRIMARY KEY (created_at, id)
+		);
+		ALTER TABLE %[1]s ATTACH PARTITION %[1]s_p4
+			FOR VALUES FROM ('2025-01-01') TO ('2025-05-01');
+	`, srcSchemaTable))
+	EnvNoError(t, env, err)
+
+	// Batch 2: insert into all 4 partitions, verify correctness
 	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(
 		`INSERT INTO %s(id, key, value, created_at) VALUES
 			(4, 'd', 40, '2024-11-15'),
 			(5, 'e', 50, '2024-03-15'),
-			(6, 'f', 60, '2024-07-15')`, srcSchemaTable))
+			(6, 'f', 60, '2024-07-15'),
+			(7, 'g', 70, '2025-02-15')`, srcSchemaTable))
 	EnvNoError(t, env, err)
 
-	EnvWaitForEqualTablesWithNames(env, s, "all 6 rows",
+	EnvWaitForEqualTablesWithNames(env, s, "all 7 rows",
 		srcTable, dstTable, `id,key,value,created_at`)
 
 	// DDL: add a new column to the parent, should propagate to all children
@@ -539,16 +554,18 @@ func (s Generic) Test_Partitioned_Table_With_Different_Column_Ordering() {
 		`ALTER TABLE %s ADD COLUMN extra TEXT`, srcSchemaTable))
 	EnvNoError(t, env, err)
 
-	// Batch 3: insert into all 3 partitions, verify correctness with new column addition
+	// Batch 3: insert into all 4 partitions, verify correctness with new column addition
 	_, err = conn.Conn().Exec(t.Context(), fmt.Sprintf(
 		`INSERT INTO %s(id, key, value, created_at, extra) VALUES
-			(7, 'g', 70, '2024-08-15', 'x1'),
-			(8, 'h', 80, '2024-12-15', 'x2'),
-			(9, 'i', 90, '2024-04-15', 'x3')`, srcSchemaTable))
+			(8, 'h', 80, '2024-08-15', 'x1'),
+			(9, 'l', 90, '2024-12-15', 'x2'),
+			(10, 'j', 100, '2024-04-15', 'x3'),
+			(11, 'k', 110, '2025-01-15', 'x4')`, srcSchemaTable))
 	EnvNoError(t, env, err)
 
-	EnvWaitForEqualTablesWithNames(env, s, "all 9 rows with new column",
+	EnvWaitForEqualTablesWithNames(env, s, "all 11 rows with new column",
 		srcTable, dstTable, `id,key,value,created_at,extra`)
+
 	env.Cancel(t.Context())
 	RequireEnvCanceled(t, env)
 }


### PR DESCRIPTION
- Bring back https://github.com/PeerDB-io/peerdb/pull/4035, optionally query for pubviaroot only if pg version >= 13, otherwise default to false since pubviaroot is not supported anyways
- Add e2e coverage to check that a dynamically added partition with out-of-order columns works
- Validate that cdc continue to work on pg 12

Fixes: https://github.com/PeerDB-io/peerdb/issues/3544