### PR TITLE
Don't retry DropFlowSource on auth errors

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -827,10 +827,14 @@ func (a *FlowableActivity) DropFlowSource(ctx context.Context, req *protos.DropF
 	ctx = context.WithValue(ctx, shared.FlowNameKey, req.FlowJobName)
 	srcConn, srcClose, err := connectors.GetByNameAs[connectors.CDCPullConnectorCore](ctx, nil, a.CatalogPool, req.PeerName)
 	if err != nil {
-		var notFound *exceptions.NotFoundError
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*exceptions.NotFoundError](err); ok {
 			logger := internal.LoggerFromCtx(ctx)
 			logger.Warn("peer missing, skipping", slog.String("peer", req.PeerName))
+			return nil
+		}
+		if _, ok := errors.AsType[*exceptions.AuthError](err); ok {
+			logger := internal.LoggerFromCtx(ctx)
+			logger.Warn("auth error, skipping to avoid triggering security tools", slog.String("peer", req.PeerName))
 			return nil
 		}
 		return a.Alerter.LogFlowError(ctx, req.FlowJobName,
@@ -840,8 +844,7 @@ func (a *FlowableActivity) DropFlowSource(ctx context.Context, req *protos.DropF
 	defer srcClose(ctx)
 
 	if err := srcConn.PullFlowCleanup(ctx, req.FlowJobName); err != nil {
-		var dnsErr *net.DNSError
-		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+		if dnsErr, ok := errors.AsType[*net.DNSError](err); ok && dnsErr.IsNotFound {
 			a.Alerter.LogFlowWarning(ctx, req.FlowJobName, fmt.Errorf("[DropFlowSource] hostname not found, skipping: %w", err))
 			return nil
 		} else {

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -100,6 +101,15 @@ func NewPostgresConnector(ctx context.Context, env map[string]string, pgConfig *
 	conn, err := NewPostgresConnFromConfig(ctx, connConfig, pgConfig.TlsHost, rdsAuth, tunnel)
 	if err != nil {
 		tunnel.Close()
+
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+			switch pgErr.Code {
+			case pgerrcode.InvalidAuthorizationSpecification,
+				pgerrcode.InvalidPassword,
+				pgerrcode.InsufficientPrivilege:
+				err = exceptions.NewAuthError(err)
+			}
+		}
 		logger.Error("failed to create connection", slog.Any("error", err))
 		return nil, fmt.Errorf("failed to create connection: %w", err)
 	}

--- a/flow/connectors/postgres/postgres_test.go
+++ b/flow/connectors/postgres/postgres_test.go
@@ -1,0 +1,21 @@
+package connpostgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/internal"
+	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
+)
+
+func TestNewPostgresConnectorAuthError(t *testing.T) {
+	t.Parallel()
+	config := internal.GetCatalogPostgresConfigFromEnv(t.Context())
+	config.Password = "wrong_password"
+	_, err := NewPostgresConnector(t.Context(), nil, config)
+	require.Error(t, err)
+
+	var authErr *exceptions.AuthError
+	require.ErrorAs(t, err, &authErr)
+}

--- a/flow/shared/exceptions/common.go
+++ b/flow/shared/exceptions/common.go
@@ -15,3 +15,19 @@ func (e *NotFoundError) Error() string {
 func (e *NotFoundError) Unwrap() error {
 	return e.error
 }
+
+type AuthError struct {
+	error
+}
+
+func NewAuthError(err error) *AuthError {
+	return &AuthError{err}
+}
+
+func (e *AuthError) Error() string {
+	return "auth error: " + e.error.Error()
+}
+
+func (e *AuthError) Unwrap() error {
+	return e.error
+}


### PR DESCRIPTION
DropFlow retries source cleanup for many hours if it can't connect, in case the db is just turned off for the night and cleanup can still be done after. As these attempts and also ScheduledTasks are also running for a long time, it looks like an attack to external security tools. If our user was revoked, we shouldn't expect to successfully clean up anyway.

Closes DBI-670