### PR TITLE
NormalizeLoop: fix normalize race

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -728,58 +728,64 @@ func (a *FlowableActivity) normalizeLoop(
 	defer normalizeWaiting.Store(false)
 
 	for {
-		normalizeWaiting.Store(true)
-		ch := normalizeRequests.Wait()
-		if ch == nil {
-			logger.Info("[normalize-loop] lastChan closed")
-			return
-		}
-		select {
-		case <-syncDone:
-			logger.Info("[normalize-loop] syncDone closed")
-			return
-		case <-ctx.Done():
-			logger.Info("[normalize-loop] context closed")
-			return
-		case <-ch:
-			reqBatchID := normalizeRequests.Load()
-			lastNormalizedBatchID := normalizingBatchID.Load()
-			if reqBatchID <= lastNormalizedBatchID {
+		// Check for pending work before waiting on the channel.
+		// This avoids a race where Update() replaces the channel while we're
+		// processing, causing Wait() to return the new (unclosed) channel
+		// and missing the signal entirely until the next Update.
+		reqBatchID := normalizeRequests.Load()
+		lastNormalizedBatchID := normalizingBatchID.Load()
+		if reqBatchID <= lastNormalizedBatchID {
+			normalizeWaiting.Store(true)
+			ch := normalizeRequests.Wait()
+			if ch == nil {
+				logger.Info("[normalize-loop] lastChan closed")
+				return
+			}
+			select {
+			case <-syncDone:
+				logger.Info("[normalize-loop] syncDone closed")
+				return
+			case <-ctx.Done():
+				logger.Info("[normalize-loop] context closed")
+				return
+			case <-ch:
 				continue
 			}
-			retryInterval := time.Minute
-		retryLoop:
-			for {
-				normalizingBatchID.Store(reqBatchID)
-				if err := a.startNormalize(ctx, config, reqBatchID, normalizeResponses); err != nil {
-					_ = a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
-					for {
-						// update req to latest normalize request & retry
-						select {
-						case <-syncDone:
-							logger.Info("[normalize-loop] syncDone closed before retry")
-							return
-						case <-ctx.Done():
-							logger.Info("[normalize-loop] context closed before retry")
-							return
-						default:
-							time.Sleep(retryInterval)
-							retryInterval = min(retryInterval*2, 5*time.Minute)
-							// record the last normalized batch ID even if retry fails to populate metrics consistently
-							a.OtelManager.Metrics.LastNormalizedBatchIdGauge.Record(
-								ctx, lastNormalizedBatchID, metric.WithAttributeSet(attribute.NewSet(
-									attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
-								)))
-							reqBatchID = normalizeRequests.Load()
-							continue retryLoop
-						}
+		}
+		normalizeWaiting.Store(false)
+
+		retryInterval := time.Minute
+	retryLoop:
+		for {
+			normalizingBatchID.Store(reqBatchID)
+			if err := a.startNormalize(ctx, config, reqBatchID, normalizeResponses); err != nil {
+				_ = a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
+				for {
+					// update req to latest normalize request & retry
+					select {
+					case <-syncDone:
+						logger.Info("[normalize-loop] syncDone closed before retry")
+						return
+					case <-ctx.Done():
+						logger.Info("[normalize-loop] context closed before retry")
+						return
+					default:
+						time.Sleep(retryInterval)
+						retryInterval = min(retryInterval*2, 5*time.Minute)
+						// record the last normalized batch ID even if retry fails to populate metrics consistently
+						a.OtelManager.Metrics.LastNormalizedBatchIdGauge.Record(
+							ctx, lastNormalizedBatchID, metric.WithAttributeSet(attribute.NewSet(
+								attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
+							)))
+						reqBatchID = normalizeRequests.Load()
+						continue retryLoop
 					}
 				}
-				a.OtelManager.Metrics.LastNormalizedBatchIdGauge.Record(ctx, reqBatchID, metric.WithAttributeSet(attribute.NewSet(
-					attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
-				)))
-				break
 			}
+			a.OtelManager.Metrics.LastNormalizedBatchIdGauge.Record(ctx, reqBatchID, metric.WithAttributeSet(attribute.NewSet(
+				attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
+			)))
+			break
 		}
 	}
 }


### PR DESCRIPTION
There's a race condition in normalizeLoop with the LastChan signaling mechanism.

The race:

- `normalizeLoop` is inside `startNormalize` processing batch 346
- Sync thread completes batch 347 and calls `normRequests.Update(347)` — this stores value 347, creates a new channel, and closes the old channel
- `startNormalize` for 346 returns, normalizeLoop goes back to the top
- `normalizeRequests.Wait()` returns the new (unclosed) channel created in step 2
- `normalizeLoop` blocks on `<-ch` — but this channel will only be closed by the next `Update()` (batch 348)
- So the signal for batch 347 is missed. Normalize 347 won't start until batch 348 is synced (which may never happen if traffic is low)

Check for pending work via Load() before calling Wait(). Only block on the channel if there's genuinely nothing to process.