### PR TITLE
retry transient tcp error

### DIFF
--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -80,7 +80,6 @@ const (
 	UnchangedToastValuesCounterName      = "unchanged_toast_values"
 	CodeNotificationCounterName          = "code_notification"
 	ServerWalEndLagGaugeName             = "wal_end_lag"
-	ClickHouseDDLExecutionGaugeName      = "clickhouse_ddl_execution_duration"
 )
 
 type Metrics struct {

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -80,6 +80,7 @@ const (
 	UnchangedToastValuesCounterName      = "unchanged_toast_values"
 	CodeNotificationCounterName          = "code_notification"
 	ServerWalEndLagGaugeName             = "wal_end_lag"
+	ClickHouseDDLExecutionGaugeName      = "clickhouse_ddl_execution_duration"
 )
 
 type Metrics struct {

--- a/flow/pkg/clickhouse/query_retry.go
+++ b/flow/pkg/clickhouse/query_retry.go
@@ -36,13 +36,30 @@ var retryableExceptions = map[chproto.Error]struct{}{
 	chproto.ErrKeeperException:            {},
 }
 
+// conditionallyRetryableExceptions are error codes that are only retryable
+// when the error message contains one of the specified substrings
+var conditionallyRetryableExceptions = map[chproto.Error][]string{
+	chproto.ErrStdException: {"unspecified iostream_category error"},
+}
+
 func isRetryableException(err error) bool {
-	if ex, ok := err.(*clickhouse.Exception); ok {
+	if ex, ok := errors.AsType[*clickhouse.Exception](err); ok {
 		if ex == nil {
 			return false
 		}
-		_, yes := retryableExceptions[chproto.Error(ex.Code)]
-		return yes
+		code := chproto.Error(ex.Code)
+		if _, ok := retryableExceptions[code]; ok {
+			return true
+		}
+		if substr, ok := conditionallyRetryableExceptions[code]; ok {
+			msg := ex.Error()
+			for _, s := range substr {
+				if strings.Contains(msg, s) {
+					return true
+				}
+			}
+		}
+		return false
 	}
 	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNRESET)
 }
@@ -61,8 +78,8 @@ func Exec(ctx context.Context, logger log.Logger,
 			time.Sleep(time.Second * time.Duration(i*5+1))
 		}
 	}
-	if ex, ok := err.(*clickhouse.Exception); ok {
-		isMV := strings.Contains(ex.Message, "while pushing to view")
+	if ex, ok := errors.AsType[*clickhouse.Exception](err); ok {
+		isMV := strings.Contains(ex.Error(), "while pushing to view")
 		if chproto.Error(ex.Code) == chproto.ErrIncorrectData {
 			ex.Message = "REDACTED"
 		}

--- a/flow/pkg/clickhouse/query_retry.go
+++ b/flow/pkg/clickhouse/query_retry.go
@@ -36,9 +36,7 @@ var retryableExceptions = map[chproto.Error]struct{}{
 	chproto.ErrKeeperException:            {},
 }
 
-// conditionallyRetryableExceptions are error codes that are only retryable
-// when the error message contains one of the specified substrings
-var conditionallyRetryableExceptions = map[chproto.Error][]string{
+var retryableExceptionSubstrings = map[chproto.Error][]string{
 	chproto.ErrStdException: {"unspecified iostream_category error"},
 }
 
@@ -51,7 +49,7 @@ func isRetryableException(err error) bool {
 		if _, ok := retryableExceptions[code]; ok {
 			return true
 		}
-		if substr, ok := conditionallyRetryableExceptions[code]; ok {
+		if substr, ok := retryableExceptionSubstrings[code]; ok {
 			msg := ex.Error()
 			for _, s := range substr {
 				if strings.Contains(msg, s) {


### PR DESCRIPTION
This PR fix two things:
- handle error `code: 1001, message: std::__1::ios_base::failure: ios_base::clear: unspecified iostream_category error`. This is a transient networking error that can happen in s3 during read and usually recovers on single retry. We want to also categorize it as retryable to avoid starting over the snapshot after a single error.
- when checking for VM substring, use error.Message() so we can search substring in all the wrapped error messages as well. The current behavior is we would classify as Normalization Error which would also notify, but ViewError is more direct here.