### PR TITLE
Fix rerun of local tests

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -2,10 +2,13 @@ allow_k8s_contexts(k8s_context()) # to unblock local() in local set-ups with a K
 
 docker_compose('./docker-compose-dev.yml')
 
+flow_ignore = ['flow/e2e/', 'flow/**/*_test.go']
+
 docker_build('flow-api', '.',
     dockerfile='stacks/flow.Dockerfile',
     target='flow-api',
     only=['flow/', 'stacks/flow.Dockerfile'],
+    ignore=flow_ignore,
     build_args={'PEERDB_VERSION_SHA_SHORT': os.getenv('PEERDB_VERSION_SHA_SHORT', 'unknown')},
 )
 
@@ -13,12 +16,14 @@ docker_build('flow-worker', '.',
     dockerfile='stacks/flow.Dockerfile',
     target='flow-worker',
     only=['flow/', 'stacks/flow.Dockerfile'],
+    ignore=flow_ignore,
 )
 
 docker_build('flow-snapshot-worker', '.',
     dockerfile='stacks/flow.Dockerfile',
     target='flow-snapshot-worker',
     only=['flow/', 'stacks/flow.Dockerfile'],
+    ignore=flow_ignore,
 )
 
 docker_build('peerdb', '.',

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -129,7 +129,7 @@ func (s APITestSuite) checkMetadataLastSyncStateValues(
 }
 
 func (s APITestSuite) waitForActiveSlotForPostgresMirror(env WorkflowRun, mirrorName string) {
-	slotName := "peerflow_slot_" + mirrorName
+	slotName := connpostgres.GetDefaultSlotName(mirrorName)
 	EnvWaitFor(s.t, env, 3*time.Minute, "waiting for replication to become active", func() bool {
 		var active pgtype.Bool
 		err := s.pg.PostgresConnector.Conn().QueryRow(s.t.Context(),
@@ -1546,16 +1546,10 @@ func (s APITestSuite) TestDropCompletedAndUnavailable() {
 	pgWithProxy, proxy, err := SetupPostgresWithToxiproxy(s.t, suffix, 9903)
 	require.NoError(s.t, err)
 	defer func() {
-		require.NoError(s.t, proxy.Enable())
-		connectionString := internal.GetPGConnectionString(proxyConfig, "")
-		connConfig, err := connpostgres.ParseConfig(connectionString, proxyConfig)
-		require.NoError(s.t, err)
-		conn, err := connpostgres.NewPostgresConnFromConfig(s.t.Context(), connConfig, "", nil, nil)
-		if err != nil {
-			s.t.Logf("failed to connect for teardown: %v", err)
-		} else if err := cleanPostgres(s.t.Context(), conn, suffix); err != nil {
-			s.t.Logf("failed to teardown: %v", err)
+		if err := cleanPostgres(s.t.Context(), s.pg.Conn(), suffix); err != nil {
+			s.t.Logf("failed to clean proxy schema: %v", err)
 		}
+		require.NoError(s.t, proxy.Delete())
 	}()
 
 	require.NoError(s.t, pgWithProxy.Exec(s.t.Context(),
@@ -1578,7 +1572,7 @@ func (s APITestSuite) TestDropCompletedAndUnavailable() {
 	}()
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName: "create_concurrent_toxi_" + suffix,
+		FlowJobName: "concurrent_toxi_" + suffix,
 		TableNameMapping: map[string]string{
 			AttachSchema(s, "valid"): "valid",
 		},
@@ -2471,7 +2465,7 @@ func (s APITestSuite) TestCreateCDCFlowAttachConcurrentRequestsToxi() {
 	}()
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName: "create_concurrent_toxi_" + suffix,
+		FlowJobName: "concurrent_toxi_" + suffix,
 		TableNameMapping: map[string]string{
 			fmt.Sprintf("e2e_test_%s.%s", suffix, tableName): tableName,
 		},

--- a/flow/e2e/bigquery_test.go
+++ b/flow/e2e/bigquery_test.go
@@ -99,7 +99,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Complete_Flow_No_Data() {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix("test_complete_flow_no_data"),
+		FlowJobName:      s.attachSuffix("complete_flow_no_data"),
 		TableNameMapping: map[string]string{srcTableName: dstTableName},
 		Destination:      s.Peer().Name,
 	}
@@ -499,7 +499,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Invalid_Geo_Avro_CDC() {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix("test_invalid_geo_bq_avro_cdc"),
+		FlowJobName:      s.attachSuffix("invalid_geo_bq_avro_cdc"),
 		TableNameMapping: map[string]string{srcTableName: dstTableName},
 		Destination:      s.Peer().Name,
 	}
@@ -629,7 +629,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Simple_Schema_Changes() {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix(tableName),
+		FlowJobName:      s.attachSuffix("simple_schema_changes"),
 		TableNameMapping: map[string]string{srcTableName: tableName},
 		Destination:      s.Peer().Name,
 	}
@@ -707,7 +707,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_All_Types_Schema_Changes() {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix(tableName),
+		FlowJobName:      s.attachSuffix("all_types_schema_changes"),
 		TableNameMapping: map[string]string{srcTableName: tableName},
 		Destination:      s.Peer().Name,
 	}
@@ -989,7 +989,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_Multi_Table_Multi_Dataset() {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName: s.attachSuffix("test_multi_table_multi_dataset_bq"),
+		FlowJobName: s.attachSuffix("multi_table_multi_ds_bq"),
 		TableNameMapping: map[string]string{
 			srcTable1Name: dstTable1Name,
 			srcTable2Name: fmt.Sprintf("%s.%s", secondDataset, dstTable2Name),

--- a/flow/e2e/bigquery_test.go
+++ b/flow/e2e/bigquery_test.go
@@ -707,7 +707,7 @@ func (s PeerFlowE2ETestSuiteBQ) Test_All_Types_Schema_Changes() {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix("all_types_schema_changes"),
+		FlowJobName:      s.attachSuffix("all_types_schema_chg"),
 		TableNameMapping: map[string]string{srcTableName: tableName},
 		Destination:      s.Peer().Name,
 	}

--- a/flow/e2e/cancel_table_addition_test.go
+++ b/flow/e2e/cancel_table_addition_test.go
@@ -325,14 +325,13 @@ func (s APITestSuite) testCancelTableAddition(
 		require.Fail(s.t, fmt.Sprintf("unknown source type %T", s.source))
 	}
 
-	flowName := "cancel_table_addition_test_flow"
-	// based on the two inputs
+	flowName := "cancel_tbl_add"
 	if assumeTableRemovalWillNotHappen && !withRemoval {
-		flowName += "_no_removal_assumed"
+		flowName += "_no_rm_assumed"
 	} else if !assumeTableRemovalWillNotHappen && withRemoval {
-		flowName += "_with_removal"
+		flowName += "_with_rm"
 	} else if assumeTableRemovalWillNotHappen && withRemoval {
-		flowName += "_no_removal_assumed_with_removal"
+		flowName += "_no_rm_assumed_with_rm"
 	} else {
 		flowName += "_normal"
 	}
@@ -1143,7 +1142,7 @@ func (s APITestSuite) TestCancelTableAdditionDuringSetupFlow() {
 	}
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      "cancel_table_addition_test_" + s.suffix,
+		FlowJobName:      "cancel_tbl_add_" + s.suffix,
 		TableNameMapping: map[string]string{AttachSchema(s, "original"): "original"},
 		Destination:      s.ch.Peer().Name,
 	}

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -387,7 +387,7 @@ func (s ClickHouseSuite) Test_Chunking_Initial_Load_Parts_Per_Partition() {
 		fmt.Sprintf(`INSERT INTO %s (id,"key") VALUES (1,'init'),(2,'two'),(3,'tri'),(4,'cry')`, srcFullName)))
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix("clickhouse_pkey_update_chunking_enabled"),
+		FlowJobName:      s.attachSuffix("ch_pkey_update_chunking_enabled"),
 		TableNameMapping: map[string]string{srcFullName: dstTableName},
 		Destination:      s.Peer().Name,
 	}
@@ -487,7 +487,7 @@ func (s ClickHouseSuite) WeirdTable(tableName string) {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName: s.attachSuffix("clickhouse_test_weird_table_" + strings.ToLower(qvalue.ConvertToAvroCompatibleName(tableName))),
+		FlowJobName: s.attachSuffix("ch_weird_table_" + strings.ToLower(qvalue.ConvertToAvroCompatibleName(tableName))),
 		TableMappings: []*protos.TableMapping{{
 			SourceTableIdentifier:      s.attachSchemaSuffix(tableName),
 			DestinationTableIdentifier: dstTableName,
@@ -557,7 +557,7 @@ func (s ClickHouseSuite) Test_WeirdTable_Question() {
 }
 
 func (s ClickHouseSuite) Test_WeirdTable_Dash() {
-	s.WeirdTable("table-group%c%i%t%i%z%e%n")
+	s.WeirdTable("table-group%a%b%c")
 }
 
 // large NUMERICs (precision >76) are mapped to String on CH, test
@@ -758,7 +758,7 @@ func (s ClickHouseSuite) testNumericFF(ffValue bool) {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix(fmt.Sprintf("clickhouse_test_unbounded_numerics_ff_%v", ffValue)),
+		FlowJobName:      s.attachSuffix(fmt.Sprintf("ch_unbounded_numerics_ff_%v", ffValue)),
 		TableNameMapping: map[string]string{srcFullName: dstTableName},
 		Destination:      s.Peer().Name,
 	}

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -432,7 +432,7 @@ func (s ClickHouseSuite) Test_Replident_Full_Unchanged_TOAST_Updates() {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      s.attachSuffix("clickhouse_test_replident_full_toast"),
+		FlowJobName:      s.attachSuffix("ch_replident_full_toast"),
 		TableNameMapping: map[string]string{srcFullName: dstTableName},
 		Destination:      s.Peer().Name,
 	}
@@ -2094,7 +2094,7 @@ func (s ClickHouseSuite) Test_Unprivileged_Postgres_Columns() {
 	require.NoError(s.t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName: s.attachSuffix("clickhouse_test_unprivileged_columns"),
+		FlowJobName: s.attachSuffix("ch_unprivileged_columns"),
 		TableMappings: []*protos.TableMapping{{
 			SourceTableIdentifier:      srcFullName,
 			DestinationTableIdentifier: dstTableName,

--- a/flow/e2e/congen.go
+++ b/flow/e2e/congen.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/PeerDB-io/peerdb/flow/connectors"
+	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
@@ -68,6 +69,12 @@ func (c *FlowConnectionGenerationConfig) GenerateFlowConnectionConfigs(s Suite) 
 				ShardingKey:                "id",
 			})
 		}
+	}
+
+	if _, ok := s.Source().(*PostgresSource); ok {
+		slotName := connpostgres.GetDefaultSlotName(c.FlowJobName)
+		require.LessOrEqual(t, len(slotName), 64,
+			"slot name %q is %d chars, PostgreSQL limit is 64 and may cause conflicts on test rerun", slotName, len(slotName))
 	}
 
 	ret := &protos.FlowConnectionConfigs{

--- a/flow/e2e/generic_test.go
+++ b/flow/e2e/generic_test.go
@@ -1088,7 +1088,7 @@ func (s Generic) Test_Inheritance_Table_With_Dynamic_Setting() {
 	require.NoError(t, err)
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:   AddSuffix(s, "test_inheritance_dynconf"),
+		FlowJobName:   AddSuffix(s, "test_inheritance_dyncnf"),
 		TableMappings: TableMappings(s, srcTable, dstTable),
 		Destination:   s.Peer().Name,
 	}


### PR DESCRIPTION
- Cleanup of a toxi test to avoid port conflict on the next run
- Limit PG slot names as they silently get truncated and chop off the suffix, enforce that for future tests
- QoL improvement to not rebuild flow services on test file changes