### PR TITLE
classify 'Bad query specified' as retryable

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -803,6 +803,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorNotifyConnectivity, mongoErrorInfo
 		case 133: // FailedToSatisfyReadPreference
 			return ErrorNotifyConnectivity, mongoErrorInfo
+		case 17287: // Bad query specified (documentDB only)
+			return ErrorRetryRecoverable, mongoErrorInfo
 		default:
 			return ErrorOther, mongoErrorInfo
 		}


### PR DESCRIPTION
DocumentDB-only transient error that succeeds on retry.

Fixes: https://linear.app/clickhouse/issue/DBI-673/