### PR TITLE
fix(e2e): use CI_MYSQL_VERSION as MySQL peer name

### DIFF
--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -181,7 +181,7 @@ func (s *MySqlSource) GeneratePeer(t *testing.T) *protos.Peer {
 	t.Helper()
 
 	peer := &protos.Peer{
-		Name: "mysql",
+		Name: os.Getenv("CI_MYSQL_VERSION"),
 		Type: protos.DBType_MYSQL,
 		Config: &protos.Peer_MysqlConfig{
 			MysqlConfig: s.Config,

--- a/flow/e2e/mysql_rds_binlog_test.go
+++ b/flow/e2e/mysql_rds_binlog_test.go
@@ -72,6 +72,11 @@ func TestMySQLRDSBinlog(t *testing.T) {
 }
 
 func (s MySQLRDSBinlogAPITestSuite) TestMySQLRDSBinlogValidation() {
+	// Register cleanup before creating the table so it is always dropped even if the test fails early.
+	s.t.Cleanup(func() {
+		_ = s.source.Exec(context.Background(), "DROP TABLE IF EXISTS mysql.rds_configuration")
+	})
+
 	require.NoError(s.t, s.source.Exec(s.t.Context(),
 		fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", AttachSchema(s, "valid"))))
 
@@ -109,6 +114,4 @@ func (s MySQLRDSBinlogAPITestSuite) TestMySQLRDSBinlogValidation() {
 	res, err = s.ValidateCDCMirror(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
 	require.NoError(s.t, err)
 	require.NotNil(s.t, res)
-
-	require.NoError(s.t, s.source.Exec(s.t.Context(), "DROP TABLE IF EXISTS mysql.rds_configuration;"))
 }

--- a/flow/e2e/mysql_rds_binlog_test.go
+++ b/flow/e2e/mysql_rds_binlog_test.go
@@ -92,7 +92,7 @@ func (s MySQLRDSBinlogAPITestSuite) TestMySQLRDSBinlogValidation() {
 	st, ok := status.FromError(err)
 	require.True(s.t, ok)
 	require.Equal(s.t, codes.FailedPrecondition, st.Code())
-	require.Equal(s.t, "failed to validate source connector mysql: binlog configuration error: "+
+	require.Equal(s.t, "failed to validate source connector "+flowConnConfig.SourceName+": binlog configuration error: "+
 		"RDS/Aurora setting 'binlog retention hours' should be at least 24, currently unset", st.Message())
 
 	require.NoError(s.t, s.source.Exec(s.t.Context(), "UPDATE mysql.rds_configuration SET value = '1' WHERE name = 'binlog retention hours'"))
@@ -102,7 +102,7 @@ func (s MySQLRDSBinlogAPITestSuite) TestMySQLRDSBinlogValidation() {
 	st, ok = status.FromError(err)
 	require.True(s.t, ok)
 	require.Equal(s.t, codes.FailedPrecondition, st.Code())
-	require.Equal(s.t, "failed to validate source connector mysql: binlog configuration error: "+
+	require.Equal(s.t, "failed to validate source connector "+flowConnConfig.SourceName+": binlog configuration error: "+
 		"RDS/Aurora setting 'binlog retention hours' should be at least 24, currently 1", st.Message())
 
 	require.NoError(s.t, s.source.Exec(s.t.Context(), "UPDATE mysql.rds_configuration SET value = '24' WHERE name = 'binlog retention hours';"))


### PR DESCRIPTION
## Summary
- All MySQL e2e tests shared a hardcoded peer name `"mysql"`. With `ON CONFLICT DO NOTHING` on peer creation, whichever flavor ran first (mysql-gtid, mysql-pos, maria) won and subsequent flavors silently used the wrong connection config.
- This caused schema fetches against the wrong MySQL instance, resulting in empty table schemas and `ORDER BY tuple()` errors on ClickHouse `ReplacingMergeTree` tables.
- Fix: use `CI_MYSQL_VERSION` env var as the peer name so each flavor gets a unique peer.
