### PR TITLE
handle error code 40 as retryable

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -786,6 +786,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorNotifyConnectivity, mongoErrorInfo
 		case 18: // AuthenticationFailed
 			return ErrorNotifyConnectivity, mongoErrorInfo
+		case 40: // ConflictingUpdateOperators
+			return ErrorRetryRecoverable, mongoErrorInfo
 		case 43: // CursorNotFound
 			return ErrorRetryRecoverable, mongoErrorInfo
 		case 91: // ShutdownInProgress


### PR DESCRIPTION
Recovered by itself. Seems like something internal in MongoDB because change stream should be read-only operations and does not perform any updates. 
