### PR TITLE
Support empty GTID set

### DIFF
--- a/flow/connectors/mysql/replication_mechanism.go
+++ b/flow/connectors/mysql/replication_mechanism.go
@@ -18,10 +18,6 @@ type parsedReplicationOffset struct {
 }
 
 func parseReplicationOffsetText(flavor string, offsetText string) (parsedReplicationOffset, error) {
-	if offsetText == "" {
-		return parsedReplicationOffset{}, nil
-	}
-
 	if rest, isFilePos := strings.CutPrefix(offsetText, "!f:"); isFilePos {
 		comma := strings.LastIndexByte(rest, ',')
 		if comma == -1 {

--- a/flow/connectors/mysql/replication_mechanism_test.go
+++ b/flow/connectors/mysql/replication_mechanism_test.go
@@ -66,7 +66,7 @@ func TestReplicationMechanismInUseFromOffsetText(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		mechanism, err := replicationMechanismInUseFromOffsetText("mysql", "")
 		require.NoError(t, err)
-		require.Empty(t, mechanism)
+		require.Equal(t, protos.MySqlReplicationMechanism_MYSQL_GTID.String(), mechanism)
 	})
 
 	t.Run("invalid", func(t *testing.T) {

--- a/flow/connectors/mysql/replication_mechanism_test.go
+++ b/flow/connectors/mysql/replication_mechanism_test.go
@@ -10,12 +10,6 @@ import (
 )
 
 func TestParseReplicationOffsetText(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		parsedOffset, err := parseReplicationOffsetText("mysql", "")
-		require.NoError(t, err)
-		require.Equal(t, parsedReplicationOffset{}, parsedOffset)
-	})
-
 	t.Run("filepos", func(t *testing.T) {
 		parsedOffset, err := parseReplicationOffsetText("mysql", "!f:mysql-bin.000001,4d2")
 		require.NoError(t, err)
@@ -39,6 +33,14 @@ func TestParseReplicationOffsetText(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, protos.MySqlReplicationMechanism_MYSQL_GTID.String(), parsedOffset.mechanism)
 		require.Equal(t, "3e11fa47-71ca-11e1-9e33-c80aa9429562:23", parsedOffset.gset.String())
+		require.Equal(t, mysql.Position{}, parsedOffset.pos)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		parsedOffset, err := parseReplicationOffsetText("mysql", "")
+		require.NoError(t, err)
+		require.Equal(t, protos.MySqlReplicationMechanism_MYSQL_GTID.String(), parsedOffset.mechanism)
+		require.True(t, parsedOffset.gset.IsEmpty())
 		require.Equal(t, mysql.Position{}, parsedOffset.pos)
 	})
 


### PR DESCRIPTION
Happens when the MySQL instance didn't execute any GTID transactions (restored from a backup or GTID recently enabled) or got reset. Was supported before, regressed in #4051

Validated on the real mirror that was failing

Closes DBI-685