### PR TITLE
classify mysql client transient error

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -467,7 +467,7 @@ func (c *MySqlConnector) PullRecords(
 			} else {
 				c.logger.Error("[mysql] PullRecords failed to get event", slog.Any("error", err))
 			}
-			return err
+			return exceptions.NewMySQLStreamingError(err)
 		}
 
 		allFetchedBytes.Add(int64(len(event.RawData)))

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -12,7 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"go.temporal.io/sdk/log"
@@ -25,6 +24,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 	mysql_validation "github.com/PeerDB-io/peerdb/flow/pkg/mysql"
 	"github.com/PeerDB-io/peerdb/flow/shared"
+	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 )
 
 type MySqlConnector struct {

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"go.temporal.io/sdk/log"
@@ -299,20 +300,23 @@ func (c *MySqlConnector) ExecuteNoRetry(ctx context.Context, cmd string, args ..
 }
 
 func (c *MySqlConnector) Execute(ctx context.Context, cmd string, args ...any) (*mysql.Result, error) {
-	var connectionErr error
+	var retryableErr error
 	for conn, err := range c.withRetries(ctx) {
 		if err != nil {
 			return nil, err
 		}
 
-		rs, err := conn.Execute(cmd, args...)
-		if err != nil && mysql.ErrorEqual(err, mysql.ErrBadConn) {
-			connectionErr = err
-			continue
+		if rs, err := conn.Execute(cmd, args...); err != nil {
+			if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
+				retryableErr = err
+				continue
+			}
+			return nil, err
+		} else {
+			return rs, nil
 		}
-		return rs, err
 	}
-	return nil, connectionErr
+	return nil, retryableErr
 }
 
 func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string, result *mysql.Result,
@@ -320,7 +324,7 @@ func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string,
 	resultCb client.SelectPerResultCallback,
 	args ...any,
 ) error {
-	var connectionErr error
+	var retryableErr error
 	for conn, err := range c.withRetries(ctx) {
 		if err != nil {
 			return err
@@ -328,8 +332,8 @@ func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string,
 
 		if len(args) == 0 {
 			if err := conn.ExecuteSelectStreaming(cmd, result, rowCb, resultCb); err != nil {
-				if mysql.ErrorEqual(err, mysql.ErrBadConn) {
-					connectionErr = err
+				if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
+					retryableErr = err
 					continue
 				}
 				return err
@@ -337,8 +341,8 @@ func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string,
 		} else {
 			stmt, err := conn.Prepare(cmd)
 			if err != nil {
-				if mysql.ErrorEqual(err, mysql.ErrBadConn) {
-					connectionErr = err
+				if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
+					retryableErr = err
 					continue
 				}
 				return err
@@ -346,8 +350,8 @@ func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string,
 			err = stmt.ExecuteSelectStreaming(result, rowCb, resultCb, args...)
 			_ = stmt.Close()
 			if err != nil {
-				if mysql.ErrorEqual(err, mysql.ErrBadConn) {
-					connectionErr = err
+				if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
+					retryableErr = err
 					continue
 				}
 				return err
@@ -355,7 +359,7 @@ func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string,
 		}
 		return nil
 	}
-	return connectionErr
+	return retryableErr
 }
 
 func (c *MySqlConnector) GetGtidModeOn(ctx context.Context) (bool, error) {

--- a/flow/shared/exceptions/mysql.go
+++ b/flow/shared/exceptions/mysql.go
@@ -5,10 +5,15 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 )
+
+// InvalidSequenceRe go-mysql-org returns "invalid sequence X != Y" when the TCP packet sequence
+// is out of sync — always transient, safe to retry.
+var InvalidSequenceRe = regexp.MustCompile(`invalid sequence \d+ != \d+`)
 
 type MySQLIncompatibleColumnTypeError struct {
 	TableName  string
@@ -72,14 +77,17 @@ func NewMySQLStreamingError(err error) *MySQLStreamingError {
 		return &MySQLStreamingError{err, true}
 	}
 
-	var recordHeaderError tls.RecordHeaderError
-	if errors.As(err, &recordHeaderError) {
+	if recordHeaderError, ok := errors.AsType[tls.RecordHeaderError](err); ok {
 		if recordHeaderError.Msg == "first record does not look like a TLS handshake" {
 			return &MySQLStreamingError{err, true}
 		}
 	}
 
 	if strings.Contains(err.Error(), mysql.ErrBadConn.Error()) {
+		return &MySQLStreamingError{err, true}
+	}
+
+	if InvalidSequenceRe.MatchString(err.Error()) {
 		return &MySQLStreamingError{err, true}
 	}
 


### PR DESCRIPTION
Retry transient auth error that can happen occasionally when creating a binlogSyncer:

> MySQL streaming error: handleAuthResult: readAuthResult: ReadPacket: invalid sequence 2 != 3

MySQL client received package with sequence number `2` when it expected `3` during auth handshake, then succeeds on retry.  Suggest a bug in the auth handshake code in go-mysql-org client. 

We've seen similar issue in the past with `invalid sequence 4 != 5` that also succeeded on retry 

Fixes: DBI-414
