### PR TITLE
CI Tests results ingestion: Follow-up improvements

### DIFF
--- a/.github/scripts/test-results.sh
+++ b/.github/scripts/test-results.sh
@@ -45,7 +45,8 @@ yq -p=xml -o=json \
     "workflow_run_link": strenv(WORKFLOW_RUN_LINK),
     "workflow_head_branch": strenv(WORKFLOW_HEAD_BRANCH),
     "workflow_retry_number": (strenv(WORKFLOW_RUN_NUMBER) | tonumber),
-    "commit_sha": strenv(COMMIT_SHA)
+    "commit_sha": strenv(COMMIT_SHA),
+    "compatibility_matrix_id": (strenv(COMBINATION_ID) | select(. != "") // null)
   } |
   select(.suite_name != null)
   ' \

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -563,6 +563,7 @@ jobs:
           WORKFLOW_RUN_NUMBER: ${{ github.run_attempt }}
           COMMIT_SHA: ${{ github.sha }}
           SUMMARY_HEADER: "x-clickhouse-summary"
+          COMBINATION_ID: "pg${{ matrix.db-version.pg }}-my${{ matrix.db-version.mysql }}-mo${{ matrix.db-version.mongo }}"
         run: |
           if [ -z "${{ secrets.CI_O11Y_TARGET_API_KEY_ID }}" ] \
             || [ -z "${{ secrets.CI_O11Y_TARGET_API_KEY_SECRET }}" ] \

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -563,7 +563,7 @@ jobs:
           WORKFLOW_RUN_NUMBER: ${{ github.run_attempt }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           SUMMARY_HEADER: "x-clickhouse-summary"
-          COMBINATION_ID: "pg${{ matrix.db-version.pg }}-my${{ matrix.db-version.mysql }}-mo${{ matrix.db-version.mongo }}"
+          COMBINATION_ID: "pg${{ matrix.db-version.pg }}-my${{ matrix.db-version.mysql }}-mo${{ matrix.db-version.mongo }}-ch${{ matrix.db-version.ch }}"
         run: |
           if [ -z "${{ secrets.CI_O11Y_TARGET_API_KEY_ID }}" ] \
             || [ -z "${{ secrets.CI_O11Y_TARGET_API_KEY_SECRET }}" ] \

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -561,7 +561,7 @@ jobs:
           WORKFLOW_RUN_LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW_HEAD_BRANCH: ${{ github.head_ref || github.ref_name }}
           WORKFLOW_RUN_NUMBER: ${{ github.run_attempt }}
-          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           SUMMARY_HEADER: "x-clickhouse-summary"
           COMBINATION_ID: "pg${{ matrix.db-version.pg }}-my${{ matrix.db-version.mysql }}-mo${{ matrix.db-version.mongo }}"
         run: |


### PR DESCRIPTION
Two improvements following up https://github.com/PeerDB-io/peerdb/pull/4191

1. Include information on the sources versions matrix combination.
2. For PRs, the commit information is now the last commit pushed by the author rather than the resulting commit from the automatic merge from main.