### PR TITLE
Revert change stream creation timeout

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -325,6 +325,8 @@ func (c *MongoConnector) PullRecords(
 				if err := recreateChangeStream(false); err != nil {
 					return fmt.Errorf("failed to recreate change stream: %w", err)
 				}
+				c.logger.Info("[mongo] recreated change stream because context deadline exceeded",
+					slog.Duration("elapsed", time.Since(pullStart)))
 				continue
 			}
 
@@ -332,6 +334,7 @@ func (c *MongoConnector) PullRecords(
 				if err := recreateChangeStream(true); err != nil {
 					return fmt.Errorf("failed to recreate change stream: %w", err)
 				}
+				c.logger.Info("[mongo] recreated change stream because resume token not found", slog.Duration("elapsed", time.Since(pullStart)))
 				continue
 			}
 

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -87,8 +87,7 @@ func (c *MongoConnector) SetupReplication(ctx context.Context, input *protos.Set
 	if err != nil {
 		return model.SetupReplicationResult{}, fmt.Errorf("failed to create changestream pipeline: %w", err)
 	}
-
-	changeStream, err := createChangeStream(c.client, ctx, pipeline, changeStreamOpts)
+	changeStream, err := c.client.Watch(ctx, pipeline, changeStreamOpts)
 	if err != nil {
 		return model.SetupReplicationResult{}, fmt.Errorf("failed to start change stream for storing initial resume token: %w", err)
 	}
@@ -157,7 +156,7 @@ func (c *MongoConnector) PullRecords(
 		return err
 	}
 
-	changeStream, err := createChangeStream(c.client, ctx, pipeline, changeStreamOpts)
+	changeStream, err := c.client.Watch(ctx, pipeline, changeStreamOpts)
 	if err != nil {
 		if isResumeTokenNotFoundError(err) && resumeToken != nil {
 			timestamp, err := decodeTimestampFromResumeToken(resumeToken)
@@ -166,7 +165,7 @@ func (c *MongoConnector) PullRecords(
 			}
 			changeStreamOpts.SetStartAtOperationTime(&timestamp)
 			changeStreamOpts.SetResumeAfter(nil)
-			changeStream, err = createChangeStream(c.client, ctx, pipeline, changeStreamOpts)
+			changeStream, err = c.client.Watch(ctx, pipeline, changeStreamOpts)
 			if err != nil {
 				return fmt.Errorf("failed to recreate change stream: %w", err)
 			}
@@ -300,7 +299,7 @@ func (c *MongoConnector) PullRecords(
 			changeStreamOpts.SetStartAtOperationTime(nil)
 		}
 
-		changeStream, err = createChangeStream(c.client, ctx, pipeline, changeStreamOpts)
+		changeStream, err = c.client.Watch(ctx, pipeline, changeStreamOpts)
 		if err != nil {
 			return err
 		}
@@ -326,8 +325,6 @@ func (c *MongoConnector) PullRecords(
 				if err := recreateChangeStream(false); err != nil {
 					return fmt.Errorf("failed to recreate change stream: %w", err)
 				}
-				c.logger.Info("[mongo] recreated change stream because context deadline exceeded",
-					slog.Duration("elapsed", time.Since(pullStart)))
 				continue
 			}
 
@@ -335,7 +332,6 @@ func (c *MongoConnector) PullRecords(
 				if err := recreateChangeStream(true); err != nil {
 					return fmt.Errorf("failed to recreate change stream: %w", err)
 				}
-				c.logger.Info("[mongo] recreated change stream because resume token not found", slog.Duration("elapsed", time.Since(pullStart)))
 				continue
 			}
 
@@ -463,20 +459,6 @@ func createPipeline(tableNameMapping map[string]model.NameAndExclude) (mongo.Pip
 	)
 
 	return pipeline, nil
-}
-
-// createChangeStream calls client.Watch with a 5 minute context deadline
-// so the driver sends it as maxTimeMS over the wire. Otherwise, server-side
-// default maxTimeMS is used which can sometimes be too short.
-func createChangeStream(
-	client *mongo.Client,
-	parent context.Context,
-	pipeline mongo.Pipeline,
-	opts *options.ChangeStreamOptionsBuilder,
-) (*mongo.ChangeStream, error) {
-	watchCtx, cancel := context.WithTimeout(parent, 5*time.Minute)
-	defer cancel()
-	return client.Watch(watchCtx, pipeline, opts)
 }
 
 // This can happen if the resumeToken we are attempting to `ResumeAfter` refers to a table that has been


### PR DESCRIPTION
Need to revert this change because there's a scenario with change stream creation where a busy write-heavy database + an idle table can result in a long change stream creation duration. 

Turns out change stream creation will implicitly read the oplog forward from the resume point until it populate the first batch. It will stop and return only when one of the following criteria is hit:
(1) batchSize is reached (defaults is 101 events when not explicitly set)
(2) maxTimeMs is reached (defaults to 0 on the server when not explicitly set, meaning no timeout)
(3) pipeline is exhausted at the oplog tail

Validated locally that change stream creation has linear complexity when trying to resume from resume token to the latest with an increasing number of records in-between:

```
  ┌────────────┬─────────────────┬──────────┐                                                                                               
  │ busyWrites │ aggregateOpenMs │ μs/entry │                                                                                               
  ├────────────┼─────────────────┼──────────┤                                                                                               
  │     10,000 │              21 │     2.10 │               
  ├────────────┼─────────────────┼──────────┤
  │    100,000 │             234 │     2.34 │
  ├────────────┼─────────────────┼──────────┤                                                                                               
  │    500,000 │             913 │     1.83 │
  ├────────────┼─────────────────┼──────────┤                                                                                               
  │  1,000,000 │           1,839 │     1.84 │               
  ├────────────┼─────────────────┼──────────┤
  │ 10,000,000 │          20,905 │     2.09 │
  └────────────┴─────────────────┴──────────┘    
```

Related upstream issue: https://jira.mongodb.org/browse/SERVER-44110, which recommends setting batchSize to 0 which would allow change stream creation to return immediately and offload the scan work to `cs.Next()`. 

Fixes: DBI-691