### PR TITLE
Add TEMPORAL_TLS_SERVER_NAME for custom SNI in Temporal client TLS

### DIFF
--- a/flow/cmd/cert.go
+++ b/flow/cmd/cert.go
@@ -31,21 +31,21 @@ func parseTemporalCertAndKeyFromEnvironment(ctx context.Context) ([]tls.Certific
 }
 
 func setupTemporalClient(ctx context.Context, clientOptions client.Options) (client.Client, error) {
+	var tlsConfig *tls.Config
+
 	if certPath := internal.PeerDBTemporalClientCertPath(); certPath != "" {
 		slog.InfoContext(ctx, "Using temporal certificate/key from paths for authentication")
 		keyPath := internal.PeerDBTemporalClientKeyPath()
 
-		clientOptions.ConnectionOptions = client.ConnectionOptions{
-			TLS: &tls.Config{
-				GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-					keyPairValue, err := tls.LoadX509KeyPair(certPath, keyPath)
-					if err != nil {
-						return nil, fmt.Errorf("unable to obtain temporal key pair: %w", err)
-					}
-					return &keyPairValue, nil
-				},
-				MinVersion: tls.VersionTLS13,
+		tlsConfig = &tls.Config{
+			GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				keyPairValue, err := tls.LoadX509KeyPair(certPath, keyPath)
+				if err != nil {
+					return nil, fmt.Errorf("unable to obtain temporal key pair: %w", err)
+				}
+				return &keyPairValue, nil
 			},
+			MinVersion: tls.VersionTLS13,
 		}
 	} else if internal.PeerDBTemporalEnableCertAuth() {
 		slog.InfoContext(ctx, "Using temporal certificate/key from environment for authentication")
@@ -55,12 +55,17 @@ func setupTemporalClient(ctx context.Context, clientOptions client.Options) (cli
 			return nil, fmt.Errorf("unable to base64 decode certificate and key: %w", err)
 		}
 
-		clientOptions.ConnectionOptions = client.ConnectionOptions{
-			TLS: &tls.Config{
-				Certificates: certs,
-				MinVersion:   tls.VersionTLS13,
-			},
+		tlsConfig = &tls.Config{
+			Certificates: certs,
+			MinVersion:   tls.VersionTLS13,
 		}
+	}
+
+	if tlsConfig != nil {
+		if serverName := internal.PeerDBTemporalTLSServerName(); serverName != "" {
+			tlsConfig.ServerName = serverName
+		}
+		clientOptions.ConnectionOptions = client.ConnectionOptions{TLS: tlsConfig}
 	}
 
 	tc, err := client.Dial(clientOptions)

--- a/flow/internal/config.go
+++ b/flow/internal/config.go
@@ -158,13 +158,13 @@ func PeerDBTemporalClientKeyPath() string {
 	return GetEnvString("TEMPORAL_CLIENT_KEY_PATH", "")
 }
 
-// PeerDBTemporalTLSServerName returns the value used as the SNI / hostname
+// PeerDBTemporalTLSServerName allows to override the value used as the SNI / hostname
 // verification target in the TLS handshake with the Temporal frontend. Set
 // this when the dial address (TEMPORAL_HOST_PORT) differs from the hostname
 // the server's certificate is issued for — e.g. connecting to Temporal Cloud
 // via an AWS PrivateLink VPC endpoint, whose hostname will not match the
 // namespace's wildcard cert. When empty, Go's TLS stack derives ServerName
-// from the dial address (existing behavior).
+// from TEMPORAL_HOST_PORT.
 func PeerDBTemporalTLSServerName() string {
 	return GetEnvString("TEMPORAL_TLS_SERVER_NAME", "")
 }

--- a/flow/internal/config.go
+++ b/flow/internal/config.go
@@ -158,6 +158,17 @@ func PeerDBTemporalClientKeyPath() string {
 	return GetEnvString("TEMPORAL_CLIENT_KEY_PATH", "")
 }
 
+// PeerDBTemporalTLSServerName returns the value used as the SNI / hostname
+// verification target in the TLS handshake with the Temporal frontend. Set
+// this when the dial address (TEMPORAL_HOST_PORT) differs from the hostname
+// the server's certificate is issued for — e.g. connecting to Temporal Cloud
+// via an AWS PrivateLink VPC endpoint, whose hostname will not match the
+// namespace's wildcard cert. When empty, Go's TLS stack derives ServerName
+// from the dial address (existing behavior).
+func PeerDBTemporalTLSServerName() string {
+	return GetEnvString("TEMPORAL_TLS_SERVER_NAME", "")
+}
+
 func PeerDBGetIncidentIoUrl() string {
 	return GetEnvString("PEERDB_INCIDENTIO_URL", "")
 }


### PR DESCRIPTION
## Summary

Add a new optional environment variable, `TEMPORAL_TLS_SERVER_NAME`, that lets operators override the SNI / hostname-verification target used by the Temporal gRPC client's TLS handshake. When unset, behavior is unchanged.

## Motivation

Today `setupTemporalClient` in `flow/cmd/cert.go` builds `tls.Config` without setting `ServerName`. Per Go's TLS defaults this causes the stack to derive SNI (and the hostname for server-cert verification) from the hostname portion of the dial address — i.e. whatever is in `TEMPORAL_HOST_PORT`.

That works for direct Temporal Cloud (`<ns>.<account>.tmprl.cloud`) and for self-hosted Temporal behind a DNS name that matches its server cert. It **breaks** any deployment where the dial address differs from the hostname the server's certificate is issued for. The canonical case is Temporal Cloud reached via an AWS PrivateLink VPC endpoint:

- `TEMPORAL_HOST_PORT` has to be the VPCE hostname: `vpce-XXXX.vpce-svc-YYYY.<region>.vpce.amazonaws.com:7233`.
- Temporal Cloud serves a wildcard cert for `*.<account>.tmprl.cloud`.
- The Go client sends SNI = VPCE hostname → Temporal's frontend does not match, and closes the connection during the handshake.

On the client this surfaces as:

```
unable to create Temporal client: failed reaching server: connection error:
desc = "transport: authentication handshake failed: read tcp X:51906->Y:7233: read: connection reset by peer"
```

Verified: the cert, key, chain, and server-side client-CA allowlist are all correct — the only thing keeping the handshake from succeeding is the SNI mismatch. Running `openssl s_client -connect <VPCE>:7233 -cert ... -key ... -servername <ns>.<account>.tmprl.cloud` completes successfully; removing `-servername` reproduces the reset. Today the only workaround is DNS-side (Route53 PHZ or pod `hostAliases`) to make the dial address be the namespace hostname — awkward operationally.

This PR provides a direct knob for the common case.

## Change

- **`flow/internal/config.go`**: add `PeerDBTemporalTLSServerName()` reading `TEMPORAL_TLS_SERVER_NAME` (default `""`).
- **`flow/cmd/cert.go`**: refactor `setupTemporalClient` to build `tlsConfig` up front, then apply `ServerName` from the new env var when non-empty. Both cert-auth branches (path-based and env-based) benefit. When `TEMPORAL_TLS_SERVER_NAME` is empty the `ServerName` field stays zero-valued and Go falls back to the dial-address hostname — existing behavior preserved.

## Usage

For Temporal Cloud via PrivateLink:

```
TEMPORAL_HOST_PORT=vpce-xxxxxx.vpce-svc-xxxxxx.us-east-1.vpce.amazonaws.com:7233
TEMPORAL_TLS_SERVER_NAME=<namespace>.<account>.tmprl.cloud
TEMPORAL_CLIENT_CERT=<base64-encoded PEM>
TEMPORAL_CLIENT_KEY=<base64-encoded PEM>
```

## Testing

- Existing behavior preserved when `TEMPORAL_TLS_SERVER_NAME` is unset (the `ServerName` field stays zero).
- With the env var set, `tls.Config.ServerName` is populated, which Go's TLS stack uses for both SNI and hostname verification.

No new tests — there are no existing unit tests covering `setupTemporalClient` or the `PeerDBTemporal*` env getters; happy to add some if maintainers prefer.

## Related

A companion change to `peerdb-enterprise` (helm chart) to expose this env var via a values field can follow once this lands — I can open that PR next if you're open to the approach here.