### PR TITLE
Security: Division-by-zero panic when computing EventHub partition key

### DIFF
--- a/flow/connectors/eventhub/partition_hash.go
+++ b/flow/connectors/eventhub/partition_hash.go
@@ -14,6 +14,10 @@ func hashString(s string) uint32 {
 }
 
 func HashedPartitionKey(s string, numPartitions uint32) string {
+	if numPartitions == 0 {
+		return "0"
+	}
+
 	partition := hashString(s) % numPartitions
 	return strconv.FormatUint(uint64(partition), 10)
 }


### PR DESCRIPTION
## Summary

Security: Division-by-zero panic when computing EventHub partition key

## Problem

**Severity**: `Medium` | **File**: `flow/connectors/eventhub/partition_hash.go:L17`

`HashedPartitionKey` performs `hash % numPartitions` without validating `numPartitions`. If `numPartitions` is 0 (from bad config or upstream input), this will panic and can crash the process (DoS).

## Solution

Validate `numPartitions > 0` before modulo. Prefer changing the function signature to return `(string, error)` and return a validation error for zero partitions.

## Changes

- `flow/connectors/eventhub/partition_hash.go` (modified)