### PR TITLE
Renovate configuration: Enable go mod tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
       ]
     },
     {
+      "matchManagers": ["gomod"],
+      "postUpdateOptions": ["gomodTidy"]
+    },
+    {
       "matchPackageNames": ["next", "react", "react-*", "@types/react", "@types/react-*", "eslint", "eslint-config-next"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Renovate configuration: Add a package rule making all go updates run `go mod tidy` after the dependency bump.

This happens as a post update step. That is, the dependency is bumped in the local branch created by Renovate, then `go mod tidy` is invoked thus guaranteeing synchronization between `go.mod` and `go.sum`  files. 