### PR TITLE
Renovate config: Skip generated and deprecated packages.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,22 @@
       "matchUpdateTypes": ["pinDigest"],
       "matchFileNames": ["docker-compose.yml"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/pingcap/tidb",
+        "github.com/pingcap/tidb/pkg/parser",
+        "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/PeerDB-io/peerdb/flow/generated/**"
+      ],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
This pull request adds two packages rules to Renovate configuration to:

1. Skip updates on generated packages.
2. Skip updates on deprecated packages.