### PR TITLE
Automatic dependency updates: Stubbed generated modules

### DIFF
--- a/.github/actions/genprotos/action.yml
+++ b/.github/actions/genprotos/action.yml
@@ -21,6 +21,4 @@ runs:
         github_token: ${{ github.token }}
     - if: steps.cache.outputs.cache-hit != 'true'
       shell: sh
-      run: |
-        buf generate protos
-        cd flow && go generate
+      run: ./generate-protos.sh

--- a/flow/generated/grpc_handler/stub.go
+++ b/flow/generated/grpc_handler/stub.go
@@ -1,0 +1,10 @@
+// Stub file so `go mod tidy` can resolve this package without running
+// codegen. Its presence doesn't interfere with the generated code.
+// Blank imports must mirror what the generator emits, otherwise tidy
+// will prune required modules from go.sum.
+package grpc_handler
+
+import (
+	_ "google.golang.org/grpc/codes"
+	_ "google.golang.org/grpc/status"
+)

--- a/flow/generated/proto_conversions/stub.go
+++ b/flow/generated/proto_conversions/stub.go
@@ -1,0 +1,3 @@
+// Stub file so `go mod tidy` can resolve this package without running
+// codegen. Its presence doesn't interfere with the generated code.
+package proto_conversions

--- a/flow/generated/protos/stub.go
+++ b/flow/generated/protos/stub.go
@@ -1,0 +1,22 @@
+// Stub file so `go mod tidy` can resolve this package without running
+// `buf generate`. Its presence doesn't interfere with the generated code.
+// Blank imports must mirror what the generator emits, otherwise tidy
+// will prune required modules from go.sum.
+package protos
+
+import (
+	_ "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	_ "github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
+	_ "google.golang.org/genproto/googleapis/api/annotations"
+	_ "google.golang.org/grpc"
+	_ "google.golang.org/grpc/codes"
+	_ "google.golang.org/grpc/grpclog"
+	_ "google.golang.org/grpc/metadata"
+	_ "google.golang.org/grpc/status"
+	_ "google.golang.org/protobuf/proto"
+	_ "google.golang.org/protobuf/reflect/protoreflect"
+	_ "google.golang.org/protobuf/runtime/protoimpl"
+	_ "google.golang.org/protobuf/types/descriptorpb"
+	_ "google.golang.org/protobuf/types/known/durationpb"
+	_ "google.golang.org/protobuf/types/known/timestamppb"
+)


### PR DESCRIPTION
This PR adds stubs for the packages to be generated by `generate-protos.sh` . 
This way the script is not required for  `go get -t ./...` finish successfully.

That command is used by Renovate to explore the dependencies it needs to update. Prior to this PR, it was failing leaving the update PRs in inconsistent states and crashing before tidy was even invoked.
Any dependency update bot invoking `go mod tidy` must detect theses packages in order to avoid removing entries.

The stubs are transparent to the proto generated files with no collisions and imports replicating their dependencies. 
Not running the protocol generation script will lead to failed compilations even with the stubs in.

Follows up: https://github.com/PeerDB-io/peerdb/pull/4246 and https://github.com/PeerDB-io/peerdb/pull/4248 in the series of changes fixing automatic updates.