### PR TITLE
fix(validate): apply force internal version on cdc validate

### DIFF
--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -35,6 +35,13 @@ var FlagConstraints = map[string]flagConstraint{
 func (h *FlowRequestHandler) ValidateCDCMirror(
 	ctx context.Context, req *protos.CreateCDCFlowRequest,
 ) (*protos.ValidateCDCMirrorResponse, APIError) {
+	if req.ConnectionConfigs != nil {
+		if internalVersion, err := internal.PeerDBForceInternalVersion(ctx, req.ConnectionConfigs.Env); err != nil {
+			return nil, NewInternalApiError(err)
+		} else {
+			req.ConnectionConfigs.Version = internalVersion
+		}
+	}
 	flowConnectionConfigsCore := proto_conversions.FlowConnectionConfigsToCore(req.ConnectionConfigs, 0)
 	return h.validateCDCMirrorImpl(ctx, flowConnectionConfigsCore, false)
 }


### PR DESCRIPTION
ValidateCDCMirror was not bumping cfg.Version like CreateCDCFlow does, so source GetTableSchema returned legacy column names (e.g. mongo `_full_document` vs renamed `doc`), causing destination validation to fail with "field _full_document not found in destination table" even though create succeeded.