### PR TITLE
Renovate: Do not attempt to upgrade pinned versions

### DIFF
--- a/flow/cmd/check_pinned_versions/main.go
+++ b/flow/cmd/check_pinned_versions/main.go
@@ -14,7 +14,8 @@ import (
 // accidentally upgraded. Each entry maps a module path to the exact version
 // that should appear in go.mod.
 //
-// To update a pinned dependency, change both go.mod AND this map.
+// To update a pinned dependency, change both go.mod, this map AND
+// the Renovate package rules in renovate.json that skips automated updates for that dependency.
 var pinnedVersions = map[string]string{
 	"cloud.google.com/go/bigquery":                    "v1.72.0",
 	"cloud.google.com/go/pubsub/v2":                   "v2.3.0",

--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,17 @@
         "github.com/PeerDB-io/peerdb/flow/generated/**"
       ],
       "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "cloud.google.com/go/bigquery",
+        "cloud.google.com/go/pubsub/v2",
+        "github.com/aws/aws-sdk-go-v2/feature/s3/manager",
+        "google.golang.org/api",
+        "github.com/tikv/pd/client"
+      ],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
This PR adds the list of pinned versions at

https://github.com/PeerDB-io/peerdb/blob/7ef375c5e8f88df847bd5f22786d02313f584b16/flow/cmd/check_pinned_versions/main.go#L18-L24 

to a renovate package rule that disables updates on them.

Follow-up work will add mechanisms to keep these in sync once we complete Renovate infra fixes.