### PR TITLE
Load dynamic settings at start

### DIFF
--- a/flow/activities/cancel_table_addition_activity.go
+++ b/flow/activities/cancel_table_addition_activity.go
@@ -365,7 +365,11 @@ func (a *CancelTableAdditionActivity) RemoveCancelledTablesFromPublicationIfAppl
 			slog.String("flowName", flowJobName),
 			slog.String("publicationName", publicationName))
 
-		conn, connClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, a.CatalogPool, sourcePeerName)
+		settings, err := internal.LoadSettings(ctx, nil)
+		if err != nil {
+			return err
+		}
+		conn, connClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, settings, a.CatalogPool, sourcePeerName)
 		if err != nil {
 			return fmt.Errorf("failed to get connector for peer %s: %w", sourcePeerName, err)
 		}

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -67,9 +67,9 @@ func cdcIdleTimeout(value int) time.Duration {
 
 func getInitialNormalizeBatchID(
 	ctx context.Context,
+	settings *internal.Settings,
 	logger log.Logger,
 	catalogPool shared.CatalogPool,
-	env map[string]string,
 	destinationName string,
 	flowName string,
 ) (int64, error) {
@@ -80,7 +80,7 @@ func getInitialNormalizeBatchID(
 
 	// Postgres keeps normalize progress in destination-local metadata.
 	if dstPeer.Type == protos.DBType_POSTGRES {
-		dstPgConn, dstClose, err := connectors.GetPostgresConnectorByName(ctx, env, catalogPool, destinationName)
+		dstPgConn, dstClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, settings, catalogPool, destinationName)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get postgres destination connector for normalize state: %w", err)
 		}
@@ -108,7 +108,7 @@ func (a *FlowableActivity) CheckConnection(
 	config *protos.SetupInput,
 ) error {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowName)
-	conn, connClose, err := connectors.GetByNameAs[connectors.Connector](ctx, config.Env, a.CatalogPool, config.PeerName)
+	conn, connClose, err := connectors.GetByNameWithEnvAs[connectors.Connector](ctx, config.Env, a.CatalogPool, config.PeerName)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
 			return nil
@@ -129,7 +129,7 @@ func (a *FlowableActivity) CheckMetadataTables(
 	config *protos.SetupInput,
 ) (*CheckMetadataTablesResult, error) {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowName)
-	conn, connClose, err := connectors.GetByNameAs[connectors.CDCSyncConnector](ctx, config.Env, a.CatalogPool, config.PeerName)
+	conn, connClose, err := connectors.GetByNameWithEnvAs[connectors.CDCSyncConnector](ctx, config.Env, a.CatalogPool, config.PeerName)
 	if err != nil {
 		return nil, a.Alerter.LogFlowError(ctx, config.FlowName, fmt.Errorf("failed to get connector: %w", err))
 	}
@@ -147,7 +147,7 @@ func (a *FlowableActivity) CheckMetadataTables(
 
 func (a *FlowableActivity) SetupMetadataTables(ctx context.Context, config *protos.SetupInput) error {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowName)
-	dstConn, dstClose, err := connectors.GetByNameAs[connectors.CDCSyncConnector](ctx, config.Env, a.CatalogPool, config.PeerName)
+	dstConn, dstClose, err := connectors.GetByNameWithEnvAs[connectors.CDCSyncConnector](ctx, config.Env, a.CatalogPool, config.PeerName)
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowName, fmt.Errorf("failed to get connector: %w", err))
 	}
@@ -165,7 +165,8 @@ func (a *FlowableActivity) EnsurePullability(
 	config *protos.EnsurePullabilityBatchInput,
 ) (*protos.EnsurePullabilityBatchOutput, error) {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
-	srcConn, srcClose, err := connectors.GetByNameAs[connectors.CDCPullConnectorCore](ctx, nil, a.CatalogPool, config.PeerName)
+	srcConn, srcClose, err := connectors.GetByNameWithEnvAs[connectors.CDCPullConnectorCore](
+		ctx, nil, a.CatalogPool, config.PeerName)
 	if err != nil {
 		return nil, a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to get connector: %w", err))
 	}
@@ -185,7 +186,8 @@ func (a *FlowableActivity) CreateRawTable(
 	config *protos.CreateRawTableInput,
 ) (*protos.CreateRawTableOutput, error) {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
-	dstConn, dstClose, err := connectors.GetByNameAs[connectors.CDCSyncConnector](ctx, nil, a.CatalogPool, config.PeerName)
+	dstConn, dstClose, err := connectors.GetByNameWithEnvAs[connectors.CDCSyncConnector](
+		ctx, nil, a.CatalogPool, config.PeerName)
 	if err != nil {
 		return nil, a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to get connector: %w", err))
 	}
@@ -214,13 +216,17 @@ func (a *FlowableActivity) SetupTableSchema(
 
 	logger := internal.LoggerFromCtx(ctx)
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowName)
-	srcConn, srcClose, err := connectors.GetByNameAs[connectors.GetTableSchemaConnector](ctx, config.Env, a.CatalogPool, config.PeerName)
+	settings, err := internal.LoadSettings(ctx, config.Env)
+	if err != nil {
+		return a.Alerter.LogFlowError(ctx, config.FlowName, err)
+	}
+	srcConn, srcClose, err := connectors.GetByNameAs[connectors.GetTableSchemaConnector](ctx, settings, a.CatalogPool, config.PeerName)
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowName, fmt.Errorf("failed to get GetTableSchemaConnector: %w", err))
 	}
 	defer srcClose(ctx)
 
-	tableNameSchemaMapping, err := srcConn.GetTableSchema(ctx, config.Env, config.Version, config.System, config.TableMappings)
+	tableNameSchemaMapping, err := srcConn.GetTableSchema(ctx, config.Version, config.System, config.TableMappings)
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowName, fmt.Errorf("failed to get GetTableSchemaConnector: %w", err))
 	}
@@ -268,7 +274,11 @@ func (a *FlowableActivity) CreateNormalizedTable(
 	logger := internal.LoggerFromCtx(ctx)
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowName)
 	a.Alerter.LogFlowInfo(ctx, config.FlowName, "Setting up destination tables")
-	conn, connClose, err := connectors.GetByNameAs[connectors.NormalizedTablesConnector](ctx, config.Env, a.CatalogPool, config.PeerName)
+	settings, err := internal.LoadSettings(ctx, config.Env)
+	if err != nil {
+		return nil, a.Alerter.LogFlowError(ctx, config.FlowName, err)
+	}
+	conn, connClose, err := connectors.GetByNameAs[connectors.NormalizedTablesConnector](ctx, settings, a.CatalogPool, config.PeerName)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
 			logger.Info("Connector does not implement normalized tables")
@@ -360,18 +370,18 @@ func (a *FlowableActivity) SyncFlow(
 	ctx = internal.WithOperationContext(ctx, protos.FlowOperation_FLOW_OPERATION_SYNC)
 	logger := internal.LoggerFromCtx(ctx)
 
-	srcConn, srcClose, err := connectors.GetByNameAs[connectors.CDCPullConnectorCore](ctx, config.Env, a.CatalogPool, config.SourceName)
+	settings, err := internal.LoadSettings(ctx, config.Env)
+	if err != nil {
+		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
+	}
+
+	srcConn, srcClose, err := connectors.GetByNameAs[connectors.CDCPullConnectorCore](ctx, settings, a.CatalogPool, config.SourceName)
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 	}
 	defer srcClose(ctx)
 
-	if err := srcConn.SetupReplConn(ctx, config.Env); err != nil {
-		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
-	}
-
-	reconnectAfterBatches, err := internal.PeerDBReconnectAfterBatches(ctx, config.Env)
-	if err != nil {
+	if err := srcConn.SetupReplConn(ctx); err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 	}
 
@@ -383,7 +393,7 @@ func (a *FlowableActivity) SyncFlow(
 	normResponses := concurrency.NewLastChan()
 
 	lastNormBatchID, err := getInitialNormalizeBatchID(
-		ctx, logger, a.CatalogPool, config.Env, config.DestinationName, config.FlowJobName,
+		ctx, settings, logger, a.CatalogPool, config.DestinationName, config.FlowJobName,
 	)
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
@@ -392,17 +402,13 @@ func (a *FlowableActivity) SyncFlow(
 		normalizingBatchID.Store(lastNormBatchID)
 		normResponses.Update(lastNormBatchID)
 	}
-	normBufferHours, err := internal.PeerDBNormalizeBufferHours(ctx, config.Env)
-	if err != nil {
-		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
-	}
 	idleTimeout := cdcIdleTimeout(int(options.IdleTimeoutSeconds))
-	// normBufferSize allows _approximately_ normBufferHours delay between pull/sync and normalize
+	// normBufferSize allows _approximately_ NormalizeBufferHours delay between pull/sync and normalize
 	// under normal steady operation where the batch hits idle timeout every time it will match the hours very closely
 	// effective hours will be longer if pull is idling, or there are waits on big transactions,
 	// or the sync interval is so small that start/stop overhead starts being visible
 	// will be shorter if the batches hit the size limit rather rather than idle timeout
-	normBufferSize := normBufferHours * 3600 / int64(idleTimeout.Seconds())
+	normBufferSize := settings.NormalizeBufferHours * 3600 / int64(idleTimeout.Seconds())
 	// Normalize is always 1 batch behind, allow 2 to still run in parallel with pull-sync
 	normBufferSize = max(normBufferSize, 2)
 
@@ -410,7 +416,7 @@ func (a *FlowableActivity) SyncFlow(
 	group.Go(func() error {
 		normalizeCtx := internal.WithOperationContext(groupCtx, protos.FlowOperation_FLOW_OPERATION_NORMALIZE)
 		// returning error signals sync to stop, normalize can recover connections without interrupting sync, so never return error
-		a.normalizeLoop(normalizeCtx, logger, config, syncDone, normRequests, normResponses, &normalizingBatchID, &normalizeWaiting)
+		a.normalizeLoop(normalizeCtx, logger, settings, config, syncDone, normRequests, normResponses, &normalizingBatchID, &normalizeWaiting)
 		return nil
 	})
 
@@ -421,10 +427,10 @@ func (a *FlowableActivity) SyncFlow(
 		var syncResponse *model.SyncResponse
 		var syncErr error
 		if config.System == protos.TypeSystem_Q {
-			syncResponse, syncErr = a.syncRecords(groupCtx, config, options, srcConn.(connectors.CDCPullConnector),
+			syncResponse, syncErr = a.syncRecords(groupCtx, settings, config, options, srcConn.(connectors.CDCPullConnector),
 				normRequests, normResponses, normBufferSize, idleTimeout, &syncingBatchID, &syncState)
 		} else {
-			syncResponse, syncErr = a.syncPg(groupCtx, config, options, srcConn.(connectors.CDCPullPgConnector),
+			syncResponse, syncErr = a.syncPg(groupCtx, settings, config, options, srcConn.(connectors.CDCPullPgConnector),
 				normRequests, normResponses, normBufferSize, idleTimeout, &syncingBatchID, &syncState)
 		}
 
@@ -446,7 +452,7 @@ func (a *FlowableActivity) SyncFlow(
 			a.OtelManager.Metrics.RecordsSyncedGauge.Record(ctx, syncResponse.NumRecordsSynced)
 			a.OtelManager.Metrics.RecordsSyncedCounter.Add(ctx, syncResponse.NumRecordsSynced)
 		}
-		if reconnectAfterBatches > 0 && syncNum >= reconnectAfterBatches {
+		if settings.ReconnectAfterBatches > 0 && syncNum >= settings.ReconnectAfterBatches {
 			break
 		}
 	}
@@ -469,6 +475,7 @@ func (a *FlowableActivity) SyncFlow(
 
 func (a *FlowableActivity) syncRecords(
 	ctx context.Context,
+	settings *internal.Settings,
 	config *protos.FlowConnectionConfigsCore,
 	options *protos.SyncFlowOptions,
 	srcConn connectors.CDCPullConnector,
@@ -508,7 +515,7 @@ func (a *FlowableActivity) syncRecords(
 			return stream, nil
 		}
 	}
-	return syncCore(ctx, a, config, options, srcConn,
+	return syncCore(ctx, a, settings, config, options, srcConn,
 		normRequests, normResponses, normBufferSize, idleTimeout,
 		syncingBatchID, syncWaiting, adaptStream,
 		connectors.CDCPullConnector.PullRecords,
@@ -517,6 +524,7 @@ func (a *FlowableActivity) syncRecords(
 
 func (a *FlowableActivity) syncPg(
 	ctx context.Context,
+	settings *internal.Settings,
 	config *protos.FlowConnectionConfigsCore,
 	options *protos.SyncFlowOptions,
 	srcConn connectors.CDCPullPgConnector,
@@ -527,7 +535,7 @@ func (a *FlowableActivity) syncPg(
 	syncingBatchID *atomic.Int64,
 	syncWaiting *atomic.Pointer[string],
 ) (*model.SyncResponse, error) {
-	return syncCore(ctx, a, config, options, srcConn,
+	return syncCore(ctx, a, settings, config, options, srcConn,
 		normRequests, normResponses, normBufferSize, idleTimeout,
 		syncingBatchID, syncWaiting, nil,
 		connectors.CDCPullPgConnector.PullPg,
@@ -536,7 +544,11 @@ func (a *FlowableActivity) syncPg(
 
 // SetupQRepMetadataTables sets up the metadata tables for QReplication.
 func (a *FlowableActivity) SetupQRepMetadataTables(ctx context.Context, config *protos.QRepConfig) error {
-	conn, connClose, err := connectors.GetByNameAs[connectors.QRepSyncConnector](ctx, config.Env, a.CatalogPool, config.DestinationName)
+	settings, err := internal.LoadSettings(ctx, config.Env)
+	if err != nil {
+		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
+	}
+	conn, connClose, err := connectors.GetByNameAs[connectors.QRepSyncConnector](ctx, settings, a.CatalogPool, config.DestinationName)
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to get connector: %w", err))
 	}
@@ -565,7 +577,11 @@ func (a *FlowableActivity) GetQRepPartitions(ctx context.Context,
 	if err := monitoring.InitializeQRepRun(ctx, logger, a.CatalogPool, config, runUUID, nil, config.ParentMirrorName); err != nil {
 		return nil, err
 	}
-	srcConn, srcClose, err := connectors.GetByNameAs[connectors.QRepPullConnectorCore](ctx, config.Env, a.CatalogPool, config.SourceName)
+	settings, err := internal.LoadSettings(ctx, config.Env)
+	if err != nil {
+		return nil, a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
+	}
+	srcConn, srcClose, err := connectors.GetByNameAs[connectors.QRepPullConnectorCore](ctx, settings, a.CatalogPool, config.SourceName)
 	if err != nil {
 		return nil, a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to get qrep pull connector: %w", err))
 	}
@@ -636,8 +652,12 @@ func (a *FlowableActivity) ReplicateQRepPartitions(ctx context.Context,
 		slog.Int64("batchID", int64(partitions.BatchId)),
 		slog.Int("totalPartitions", numPartitions))
 
+	settings, err := internal.LoadSettings(ctx, config.Env)
+	if err != nil {
+		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
+	}
 	qRepPullCoreConn, qRepPullCoreClose, err := connectors.GetByNameAs[connectors.QRepPullConnectorCore](
-		ctx, config.Env, a.CatalogPool, config.SourceName)
+		ctx, settings, a.CatalogPool, config.SourceName)
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to get qrep source connector: %w", err))
 	}
@@ -645,7 +665,7 @@ func (a *FlowableActivity) ReplicateQRepPartitions(ctx context.Context,
 
 	dstPeer, qRepSyncCoreConn, qRepSyncCoreClose, err := connectors.LoadPeerAndGetByNameAs[connectors.QRepSyncConnectorCore](
 		ctx,
-		config.Env,
+		settings,
 		a.CatalogPool,
 		config.DestinationName,
 	)
@@ -785,7 +805,7 @@ func (a *FlowableActivity) ConsolidateQRepPartitions(ctx context.Context, config
 	defer shutdown()
 
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
-	dstConn, dstClose, err := connectors.GetByNameAs[connectors.QRepConsolidateConnector](
+	dstConn, dstClose, err := connectors.GetByNameWithEnvAs[connectors.QRepConsolidateConnector](
 		ctx, config.Env, a.CatalogPool, config.DestinationName)
 	if errors.Is(err, errors.ErrUnsupported) {
 		return monitoring.UpdateEndTimeForQRepRun(ctx, a.CatalogPool, runUUID)
@@ -803,7 +823,7 @@ func (a *FlowableActivity) ConsolidateQRepPartitions(ctx context.Context, config
 
 func (a *FlowableActivity) CleanupQRepFlow(ctx context.Context, config *protos.QRepConfig) error {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
-	dstConn, dstClose, err := connectors.GetByNameAs[connectors.QRepConsolidateConnector](
+	dstConn, dstClose, err := connectors.GetByNameWithEnvAs[connectors.QRepConsolidateConnector](
 		ctx, config.Env, a.CatalogPool, config.DestinationName)
 	if errors.Is(err, errors.ErrUnsupported) {
 		return nil
@@ -817,7 +837,8 @@ func (a *FlowableActivity) CleanupQRepFlow(ctx context.Context, config *protos.Q
 
 func (a *FlowableActivity) DropFlowSource(ctx context.Context, req *protos.DropFlowActivityInput) error {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, req.FlowJobName)
-	srcConn, srcClose, err := connectors.GetByNameAs[connectors.CDCPullConnectorCore](ctx, nil, a.CatalogPool, req.PeerName)
+	srcConn, srcClose, err := connectors.GetByNameWithEnvAs[connectors.CDCPullConnectorCore](
+		ctx, nil, a.CatalogPool, req.PeerName)
 	if err != nil {
 		if _, ok := errors.AsType[*exceptions.NotFoundError](err); ok {
 			logger := internal.LoggerFromCtx(ctx)
@@ -856,7 +877,7 @@ func (a *FlowableActivity) DropFlowSource(ctx context.Context, req *protos.DropF
 
 func (a *FlowableActivity) DropFlowDestination(ctx context.Context, req *protos.DropFlowActivityInput) error {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, req.FlowJobName)
-	dstConn, dstClose, err := connectors.GetByNameAs[connectors.CDCSyncConnector](ctx, nil, a.CatalogPool, req.PeerName)
+	dstConn, dstClose, err := connectors.GetByNameWithEnvAs[connectors.CDCSyncConnector](ctx, nil, a.CatalogPool, req.PeerName)
 	if err != nil {
 		if dnsErr, ok := errors.AsType[*net.DNSError](err); ok && dnsErr.IsNotFound {
 			a.Alerter.LogFlowWarning(ctx, req.FlowJobName, fmt.Errorf("[DropFlowDestination] hostname not found, skipping: %w", err))
@@ -909,6 +930,11 @@ func (a *FlowableActivity) SendWALHeartbeat(ctx context.Context) error {
 		return err
 	}
 
+	settings, err := internal.LoadSettings(ctx, nil)
+	if err != nil {
+		return err
+	}
+
 	// run above command for each Postgres peer
 	for _, pgPeer := range pgPeers {
 		if err := ctx.Err(); err != nil {
@@ -917,7 +943,7 @@ func (a *FlowableActivity) SendWALHeartbeat(ctx context.Context) error {
 
 		func() {
 			pgConfig := pgPeer.GetPostgresConfig()
-			pgConn, peerErr := connpostgres.NewPostgresConnector(ctx, nil, pgConfig)
+			pgConn, peerErr := connpostgres.NewPostgresConnector(ctx, settings, pgConfig)
 			if peerErr != nil {
 				logger.Error("error creating connector for postgres peer",
 					slog.String("peer", pgPeer.Name), slog.String("host", pgConfig.Host), slog.Any("error", err))
@@ -1014,7 +1040,7 @@ func (a *FlowableActivity) getRuntimeInfo(
 	variant := "N/A"
 	replicationMechanismInUseByFlow := make(map[string]string, len(flowNames))
 
-	conn, err := connectors.GetConnector(ctx, nil, peer)
+	conn, err := connectors.GetConnectorWithEnv(ctx, nil, peer)
 	if err != nil {
 		logger.Error("failed to create connector for source peer info", slog.String("peer", peer.Name), slog.Any("error", err))
 		return version, variant, replicationMechanismInUseByFlow
@@ -1455,7 +1481,8 @@ func (a *FlowableActivity) recordSlotInformation(
 	}
 
 	ctx = context.WithValue(ctx, internal.FlowMetadataKey, flowMetadata)
-	srcConn, srcClose, err := connectors.GetPostgresConnectorByName(ctx, nil, a.CatalogPool, info.config.SourceName)
+	_, srcConn, srcClose, err := connectors.LoadPeerAndGetByNameWithEnvAs[*connpostgres.PostgresConnector](
+		ctx, info.config.Env, a.CatalogPool, info.config.SourceName)
 	if err != nil {
 		if !errors.Is(err, errors.ErrUnsupported) {
 			logger.Error("Failed to create connector to handle slot info", slog.Any("error", err))
@@ -1498,7 +1525,8 @@ func (a *FlowableActivity) emitLogRetentionHours(
 		return err
 	}
 	ctx = context.WithValue(ctx, internal.FlowMetadataKey, flowMetadata)
-	srcConn, srcClose, err := connectors.GetByNameAs[connectors.GetLogRetentionConnector](ctx, nil, a.CatalogPool, info.config.SourceName)
+	srcConn, srcClose, err := connectors.GetByNameWithEnvAs[connectors.GetLogRetentionConnector](
+		ctx, info.config.Env, a.CatalogPool, info.config.SourceName)
 	if errors.Is(err, errors.ErrUnsupported) {
 		return nil
 	} else if err != nil {
@@ -1541,8 +1569,8 @@ func (a *FlowableActivity) recordServerSideCommitLag(
 		return err
 	}
 	ctx = context.WithValue(ctx, internal.FlowMetadataKey, flowMetadata)
-	srcConn, srcClose, err := connectors.GetByNameAs[connectors.GetServerSideCommitLagConnector](
-		ctx, nil, a.CatalogPool, info.config.SourceName)
+	srcConn, srcClose, err := connectors.GetByNameWithEnvAs[connectors.GetServerSideCommitLagConnector](
+		ctx, info.config.Env, a.CatalogPool, info.config.SourceName)
 	if errors.Is(err, errors.ErrUnsupported) {
 		return nil
 	} else if err != nil {
@@ -1583,7 +1611,8 @@ func (a *FlowableActivity) QRepHasNewRows(ctx context.Context,
 	logger := log.With(internal.LoggerFromCtx(ctx), slog.String(string(shared.FlowNameKey), config.FlowJobName))
 
 	// TODO implement for other QRepPullConnector sources
-	srcConn, srcClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, config.Env, a.CatalogPool, config.SourceName)
+	_, srcConn, srcClose, err := connectors.LoadPeerAndGetByNameWithEnvAs[*connpostgres.PostgresConnector](
+		ctx, config.Env, a.CatalogPool, config.SourceName)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
 			return true, nil
@@ -1631,12 +1660,12 @@ func (a *FlowableActivity) RenameTables(ctx context.Context, config *protos.Rena
 
 	var renameOutput *protos.RenameTablesOutput
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
-	renameWithSoftDeleteConn, renameWithSoftDeleteClose, err := connectors.GetByNameAs[connectors.RenameTablesWithSoftDeleteConnector](
+	renameWithSoftDeleteConn, renameWithSoftDeleteClose, err := connectors.GetByNameWithEnvAs[connectors.RenameTablesWithSoftDeleteConnector](
 		ctx, nil, a.CatalogPool, config.PeerName)
 	if err != nil {
 		if err == errors.ErrUnsupported {
 			// Rename without soft-delete
-			renameConn, renameClose, renameErr := connectors.GetByNameAs[connectors.RenameTablesConnector](
+			renameConn, renameClose, renameErr := connectors.GetByNameWithEnvAs[connectors.RenameTablesConnector](
 				ctx, nil, a.CatalogPool, config.PeerName)
 			if renameErr != nil {
 				return nil, a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to get rename connector: %w", renameErr))
@@ -1754,7 +1783,8 @@ func (a *FlowableActivity) CreateTablesFromExisting(ctx context.Context, req *pr
 	*protos.CreateTablesFromExistingOutput, error,
 ) {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, req.FlowJobName)
-	dstConn, dstClose, err := connectors.GetByNameAs[connectors.CreateTablesFromExistingConnector](ctx, nil, a.CatalogPool, req.PeerName)
+	dstConn, dstClose, err := connectors.GetByNameWithEnvAs[connectors.CreateTablesFromExistingConnector](
+		ctx, nil, a.CatalogPool, req.PeerName)
 	if err != nil {
 		return nil, a.Alerter.LogFlowError(ctx, req.FlowJobName, fmt.Errorf("failed to get connector: %w", err))
 	}
@@ -1800,7 +1830,8 @@ func (a *FlowableActivity) AddTablesToPublication(ctx context.Context, cfg *prot
 	defer shutdown()
 
 	ctx = context.WithValue(ctx, shared.FlowNameKey, cfg.FlowJobName)
-	srcConn, srcClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, cfg.Env, a.CatalogPool, cfg.SourceName)
+	_, srcConn, srcClose, err := connectors.LoadPeerAndGetByNameWithEnvAs[*connpostgres.PostgresConnector](
+		ctx, cfg.Env, a.CatalogPool, cfg.SourceName)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
 			return nil
@@ -1832,7 +1863,8 @@ func (a *FlowableActivity) RemoveTablesFromPublication(
 	})
 	defer shutdown()
 	ctx = context.WithValue(ctx, shared.FlowNameKey, cfg.FlowJobName)
-	srcConn, srcClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, cfg.Env, a.CatalogPool, cfg.SourceName)
+	_, srcConn, srcClose, err := connectors.LoadPeerAndGetByNameWithEnvAs[*connpostgres.PostgresConnector](
+		ctx, cfg.Env, a.CatalogPool, cfg.SourceName)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
 			return nil
@@ -1878,7 +1910,7 @@ func (a *FlowableActivity) RemoveTablesFromRawTable(
 		return a.Alerter.LogFlowError(ctx, cfg.FlowJobName, err)
 	}
 
-	dstConn, dstClose, err := connectors.GetByNameAs[connectors.RawTableConnector](ctx, cfg.Env, a.CatalogPool, cfg.DestinationName)
+	dstConn, dstClose, err := connectors.GetByNameWithEnvAs[connectors.RawTableConnector](ctx, cfg.Env, a.CatalogPool, cfg.DestinationName)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
 			// For connectors where raw table is not a concept,
@@ -2027,7 +2059,7 @@ func (a *FlowableActivity) GetFlowMetadata(
 		// Use a short timeout for optional variant detection to avoid consuming entire activity timeout
 		variantCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		if srcConn, srcClose, err := connectors.GetByNameAs[connectors.DatabaseVariantConnector](
+		if srcConn, srcClose, err := connectors.GetByNameWithEnvAs[connectors.DatabaseVariantConnector](
 			variantCtx, nil, a.CatalogPool, input.SourceName,
 		); err == nil {
 			if variant, variantErr := srcConn.GetDatabaseVariant(variantCtx); variantErr == nil {
@@ -2064,13 +2096,21 @@ func (a *FlowableActivity) UpdateCDCConfigInCatalogActivity(ctx context.Context,
 }
 
 func (a *FlowableActivity) PeerDBFullRefreshOverwriteMode(ctx context.Context, env map[string]string) (bool, error) {
-	return internal.PeerDBFullRefreshOverwriteMode(ctx, env)
+	settings, err := internal.LoadSettings(ctx, env)
+	if err != nil {
+		return false, err
+	}
+	return settings.FullRefreshOverwriteMode, nil
 }
 
 func (a *FlowableActivity) PeerDBClickHouseInitialLoadAllowNonEmptyTables(
 	ctx context.Context, env map[string]string,
 ) (bool, error) {
-	return internal.PeerDBClickHouseInitialLoadAllowNonEmptyTables(ctx, env)
+	settings, err := internal.LoadSettings(ctx, env)
+	if err != nil {
+		return false, err
+	}
+	return settings.ClickHouseInitialLoadAllowNonEmptyTables, nil
 }
 
 func (a *FlowableActivity) ReportStatusMetric(ctx context.Context, status protos.FlowStatus) error {

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -121,6 +121,7 @@ func (a *FlowableActivity) applySchemaDeltas(
 func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncConnectorCore, Items model.Items](
 	ctx context.Context,
 	a *FlowableActivity,
+	settings *internal.Settings,
 	config *protos.FlowConnectionConfigsCore,
 	options *protos.SyncFlowOptions,
 	srcConn TPull,
@@ -160,7 +161,8 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	lastOffset, err := func() (model.CdcCheckpoint, error) {
 		// special case pg-pg replication, where offsets are stored on destination instead of catalog
 		if _, isSourcePg := any(srcConn).(*connpostgres.PostgresConnector); isSourcePg {
-			dstPgConn, dstPgClose, err := connectors.GetPostgresConnectorByName(ctx, config.Env, a.CatalogPool, config.DestinationName)
+			dstPgConn, dstPgClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](
+				ctx, settings, a.CatalogPool, config.DestinationName)
 			if err != nil {
 				if !errors.Is(err, errors.ErrUnsupported) {
 					return model.CdcCheckpoint{}, fmt.Errorf("failed to get destination connector to get last offset: %w", err)
@@ -203,7 +205,8 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 	syncBatchID, err := func() (int64, error) {
 		// special case pg-pg replication, where batch ID is stored on destination instead of catalog
 		if _, isSourcePg := any(srcConn).(*connpostgres.PostgresConnector); isSourcePg {
-			dstPgConn, dstPgClose, err := connectors.GetPostgresConnectorByName(ctx, config.Env, a.CatalogPool, config.DestinationName)
+			dstPgConn, dstPgClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](
+				ctx, settings, a.CatalogPool, config.DestinationName)
 			if err != nil {
 				if !errors.Is(err, errors.ErrUnsupported) {
 					return 0, fmt.Errorf("failed to get destination connector to get last sync batch ID: %w", err)
@@ -247,7 +250,6 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 			OverridePublicationName:     config.PublicationName,
 			OverrideReplicationSlotName: config.ReplicationSlotName,
 			RecordStream:                recordBatchPull,
-			Env:                         config.Env,
 			InternalVersion:             config.Version,
 		})
 		if err != nil {
@@ -272,7 +274,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 		}
 		logger.Info("no records to push")
 
-		dstConn, dstClose, err := connectors.GetByNameAs[TSync](ctx, config.Env, a.CatalogPool, config.DestinationName)
+		dstConn, dstClose, err := connectors.GetByNameAs[TSync](ctx, settings, a.CatalogPool, config.DestinationName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to recreate destination connector: %w", err)
 		}
@@ -280,7 +282,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 
 		syncState.Store(new("updating schema"))
 		if err := dstConn.ReplayTableSchemaDeltas(
-			ctx, config.Env, flowName, options.TableMappings, recordBatchSync.SchemaDeltas, config.Flags,
+			ctx, flowName, options.TableMappings, recordBatchSync.SchemaDeltas, config.Flags,
 		); err != nil {
 			return nil, fmt.Errorf("failed to sync schema: %w", err)
 		}
@@ -310,7 +312,7 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 			return a.Alerter.LogFlowError(ctx, flowName, err)
 		}
 
-		dstConn, dstClose, err := connectors.GetByNameAs[TSync](syncCtx, config.Env, a.CatalogPool, config.DestinationName)
+		dstConn, dstClose, err := connectors.GetByNameAs[TSync](syncCtx, settings, a.CatalogPool, config.DestinationName)
 		if err != nil {
 			syncSpan.RecordError(err)
 			syncSpan.SetStatus(codes.Error, err.Error())
@@ -327,7 +329,6 @@ func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncCon
 			StagingPath:            config.CdcStagingPath,
 			Script:                 config.Script,
 			TableNameSchemaMapping: tableNameSchemaMapping,
-			Env:                    config.Env,
 			Version:                config.Version,
 			Flags:                  config.Flags,
 		})
@@ -580,7 +581,11 @@ func replicateXminPartition[TRead any, TWrite QRepStreamCloser, TSync connectors
 	errGroup, errCtx := errgroup.WithContext(ctx)
 	startTime := time.Now()
 
-	dstPeer, dstConn, dstClose, err := connectors.LoadPeerAndGetByNameAs[TSync](ctx, config.Env, a.CatalogPool, config.DestinationName)
+	settings, err := internal.LoadSettings(ctx, config.Env)
+	if err != nil {
+		return 0, err
+	}
+	dstPeer, dstConn, dstClose, err := connectors.LoadPeerAndGetByNameAs[TSync](ctx, settings, a.CatalogPool, config.DestinationName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get qrep destination connector: %w", err)
 	}
@@ -589,7 +594,7 @@ func replicateXminPartition[TRead any, TWrite QRepStreamCloser, TSync connectors
 	var currentSnapshotXmin int64
 	var rowsSynced int64
 	errGroup.Go(func() error {
-		srcConn, srcClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, config.Env, a.CatalogPool, config.SourceName)
+		srcConn, srcClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, settings, a.CatalogPool, config.SourceName)
 		if err != nil {
 			return fmt.Errorf("failed to get qrep source connector: %w", err)
 		}
@@ -680,6 +685,7 @@ func replicateXminPartition[TRead any, TWrite QRepStreamCloser, TSync connectors
 
 func (a *FlowableActivity) startNormalize(
 	ctx context.Context,
+	settings *internal.Settings,
 	config *protos.FlowConnectionConfigsCore,
 	batchID int64,
 	normalizeResponses *concurrency.LastChan,
@@ -688,7 +694,7 @@ func (a *FlowableActivity) startNormalize(
 
 	dstConn, dstClose, err := connectors.GetByNameAs[connectors.CDCNormalizeConnector](
 		ctx,
-		config.Env,
+		settings,
 		a.CatalogPool,
 		config.DestinationName,
 	)
@@ -715,7 +721,6 @@ func (a *FlowableActivity) startNormalize(
 			defer normSpan.End()
 			res, err := dstConn.NormalizeRecords(normCtx, &model.NormalizeRecordsRequest{
 				FlowJobName:            config.FlowJobName,
-				Env:                    config.Env,
 				TableNameSchemaMapping: tableNameSchemaMapping,
 				TableMappings:          config.TableMappings,
 				SoftDeleteColName:      config.SoftDeleteColName,
@@ -757,6 +762,7 @@ func (a *FlowableActivity) startNormalize(
 func (a *FlowableActivity) normalizeLoop(
 	ctx context.Context,
 	logger log.Logger,
+	settings *internal.Settings,
 	config *protos.FlowConnectionConfigsCore,
 	syncDone <-chan struct{},
 	normalizeRequests *concurrency.LastChan,
@@ -797,7 +803,7 @@ func (a *FlowableActivity) normalizeLoop(
 	retryLoop:
 		for {
 			normalizingBatchID.Store(reqBatchID)
-			if err := a.startNormalize(ctx, config, reqBatchID, normalizeResponses); err != nil {
+			if err := a.startNormalize(ctx, settings, config, reqBatchID, normalizeResponses); err != nil {
 				_ = a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 				for {
 					// update req to latest normalize request & retry

--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -67,7 +67,8 @@ func (a *SnapshotActivity) SetupReplication(
 	a.Alerter.LogFlowInfo(ctx, config.FlowJobName, "Setting up replication slot and publication")
 	a.Alerter.EmitFlowInfoTelemetryEvent(ctx, config.FlowJobName, "Started Snapshot Flow Job")
 
-	conn, connClose, err := connectors.GetByNameAs[connectors.CDCPullConnectorCore](ctx, nil, a.CatalogPool, config.PeerName)
+	conn, connClose, err := connectors.GetByNameWithEnvAs[connectors.CDCPullConnectorCore](
+		ctx, config.Env, a.CatalogPool, config.PeerName)
 	if err != nil {
 		return nil, a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to get connector: %w", err))
 	}
@@ -109,13 +110,17 @@ func (a *SnapshotActivity) MaintainTx(ctx context.Context, sessionID string, flo
 		return "maintaining transaction snapshot"
 	})
 	defer shutdown()
-	conn, connClose, err := connectors.GetByNameAs[connectors.CDCPullConnectorCore](ctx, nil, a.CatalogPool, peer)
+	settings, err := internal.LoadSettings(ctx, env)
+	if err != nil {
+		return a.Alerter.LogFlowError(ctx, sessionID, err)
+	}
+	conn, connClose, err := connectors.GetByNameAs[connectors.CDCPullConnectorCore](ctx, settings, a.CatalogPool, peer)
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, sessionID, err)
 	}
 	defer connClose(ctx)
 
-	exportSnapshotOutput, tx, err := conn.ExportTxSnapshot(ctx, flowName, env)
+	exportSnapshotOutput, tx, err := conn.ExportTxSnapshot(ctx, flowName)
 	if err != nil {
 		return err
 	}
@@ -186,7 +191,8 @@ func (a *SnapshotActivity) GetDefaultPartitionKeyForTables(
 	ctx context.Context,
 	input *protos.FlowConnectionConfigsCore,
 ) (*protos.GetDefaultPartitionKeyForTablesOutput, error) {
-	conn, connClose, err := connectors.GetByNameAs[connectors.QRepPullConnectorCore](ctx, nil, a.CatalogPool, input.SourceName)
+	conn, connClose, err := connectors.GetByNameWithEnvAs[connectors.QRepPullConnectorCore](
+		ctx, input.Env, a.CatalogPool, input.SourceName)
 	if err != nil {
 		return nil, a.Alerter.LogFlowError(ctx, input.FlowJobName, fmt.Errorf("failed to get connector: %w", err))
 	}

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -63,10 +63,10 @@ func (h *FlowRequestHandler) getPeerID(ctx context.Context, peerName string) (in
 
 func (h *FlowRequestHandler) determineFlags(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	destPeerName string,
 ) ([]string, error) {
-	conn, connClose, err := connectors.GetByNameAs[connectors.GetFlagsConnector](ctx, env, h.pool, destPeerName)
+	conn, connClose, err := connectors.GetByNameAs[connectors.GetFlagsConnector](ctx, settings, h.pool, destPeerName)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
 			return nil, nil
@@ -162,12 +162,12 @@ func (h *FlowRequestHandler) CreateCDCFlow(
 	if cfg == nil {
 		return nil, NewInvalidArgumentApiError(fmt.Errorf("connection configs cannot be nil"))
 	}
-	if internalVersion, err := internal.PeerDBForceInternalVersion(ctx, cfg.Env); err != nil {
+	settings, err := internal.LoadSettings(ctx, cfg.Env)
+	if err != nil {
 		return nil, NewInternalApiError(err)
-	} else {
-		cfg.Version = internalVersion
 	}
-	if flags, err := h.determineFlags(ctx, cfg.Env, cfg.DestinationName); err != nil {
+	cfg.Version = settings.ForceInternalVersion
+	if flags, err := h.determineFlags(ctx, settings, cfg.DestinationName); err != nil {
 		return nil, NewInternalApiError(err)
 	} else {
 		cfg.Flags = flags
@@ -205,7 +205,7 @@ func (h *FlowRequestHandler) CreateCDCFlow(
 
 	// Use idempotent validation that skips mirror existence check
 	connectionConfigsCore := pconv.FlowConnectionConfigsToCore(req.ConnectionConfigs, 0)
-	if _, err := h.validateCDCMirrorImpl(ctx, connectionConfigsCore, true); err != nil {
+	if _, err := h.validateCDCMirrorImpl(ctx, settings, connectionConfigsCore, true); err != nil {
 		slog.ErrorContext(ctx, "validate mirror error", slog.Any("error", err))
 		return nil, NewInternalApiError(fmt.Errorf("invalid mirror: %w", err))
 	}
@@ -248,12 +248,12 @@ func (h *FlowRequestHandler) CreateQRepFlow(
 	ctx context.Context, req *protos.CreateQRepFlowRequest,
 ) (*protos.CreateQRepFlowResponse, APIError) {
 	cfg := req.QrepConfig
-	if internalVersion, err := internal.PeerDBForceInternalVersion(ctx, cfg.Env); err != nil {
+	settings, err := internal.LoadSettings(ctx, cfg.Env)
+	if err != nil {
 		return nil, NewInternalApiError(err)
-	} else {
-		cfg.Version = internalVersion
 	}
-	if flags, err := h.determineFlags(ctx, cfg.Env, cfg.DestinationName); err != nil {
+	cfg.Version = settings.ForceInternalVersion
+	if flags, err := h.determineFlags(ctx, settings, cfg.DestinationName); err != nil {
 		return nil, NewInternalApiError(err)
 	} else {
 		cfg.Flags = flags

--- a/flow/cmd/peer_data.go
+++ b/flow/cmd/peer_data.go
@@ -57,7 +57,7 @@ func (h *FlowRequestHandler) GetPeerInfo(
 	}
 
 	var version string
-	versionConn, versionClose, err := connectors.GetAs[connectors.GetVersionConnector](ctx, nil, peer)
+	versionConn, versionClose, err := connectors.GetWithEnvAs[connectors.GetVersionConnector](ctx, nil, peer)
 	if err != nil {
 		if !errors.Is(err, errors.ErrUnsupported) {
 			slog.ErrorContext(ctx, "failed to get version connector", slog.Any("error", err))
@@ -152,7 +152,7 @@ func (h *FlowRequestHandler) GetSchemas(
 	ctx context.Context,
 	req *protos.PostgresPeerActivityInfoRequest,
 ) (*protos.PeerSchemasResponse, APIError) {
-	conn, connClose, err := connectors.GetByNameAs[connectors.GetSchemaConnector](ctx, nil, h.pool, req.PeerName)
+	conn, connClose, err := connectors.GetByNameWithEnvAs[connectors.GetSchemaConnector](ctx, nil, h.pool, req.PeerName)
 	if err != nil {
 		return nil, NewInvalidArgumentApiError(fmt.Errorf("failed to get schema connector: %w", err))
 	}
@@ -164,7 +164,7 @@ func (h *FlowRequestHandler) GetTablesInSchema(
 	ctx context.Context,
 	req *protos.SchemaTablesRequest,
 ) (*protos.SchemaTablesResponse, APIError) {
-	conn, connClose, err := connectors.GetByNameAs[connectors.GetSchemaConnector](ctx, nil, h.pool, req.PeerName)
+	conn, connClose, err := connectors.GetByNameWithEnvAs[connectors.GetSchemaConnector](ctx, nil, h.pool, req.PeerName)
 	if err != nil {
 		return nil, NewFailedPreconditionApiError(fmt.Errorf("failed to get schema connector: %w", err))
 	}
@@ -177,7 +177,7 @@ func (h *FlowRequestHandler) GetAllTables(
 	ctx context.Context,
 	req *protos.PostgresPeerActivityInfoRequest,
 ) (*protos.AllTablesResponse, APIError) {
-	conn, connClose, err := connectors.GetByNameAs[connectors.GetSchemaConnector](ctx, nil, h.pool, req.PeerName)
+	conn, connClose, err := connectors.GetByNameWithEnvAs[connectors.GetSchemaConnector](ctx, nil, h.pool, req.PeerName)
 	if err != nil {
 		return nil, NewFailedPreconditionApiError(fmt.Errorf("failed to get schema connector: %w", err))
 	}
@@ -189,16 +189,16 @@ func (h *FlowRequestHandler) GetColumns(
 	ctx context.Context,
 	req *protos.TableColumnsRequest,
 ) (*protos.TableColumnsResponse, APIError) {
-	conn, connClose, err := connectors.GetByNameAs[connectors.GetSchemaConnector](ctx, nil, h.pool, req.PeerName)
+	settings, err := internal.LoadSettings(ctx, nil)
+	if err != nil {
+		return nil, NewInternalApiError(err)
+	}
+	conn, connClose, err := connectors.GetByNameAs[connectors.GetSchemaConnector](ctx, settings, h.pool, req.PeerName)
 	if err != nil {
 		return nil, NewFailedPreconditionApiError(fmt.Errorf("failed to get schema connector: %w", err))
 	}
 	defer connClose(ctx)
-	internalVersion, err := internal.PeerDBForceInternalVersion(ctx, nil)
-	if err != nil {
-		return nil, NewInternalApiError(fmt.Errorf("failed to get internal version: %w", err))
-	}
-	return wrapErrorAsFailedPrecondition(conn.GetColumns(ctx, internalVersion, req.SchemaName, req.TableName))
+	return wrapErrorAsFailedPrecondition(conn.GetColumns(ctx, settings.ForceInternalVersion, req.SchemaName, req.TableName))
 }
 
 func (h *FlowRequestHandler) GetColumnsTypeConversion(
@@ -212,7 +212,11 @@ func (h *FlowRequestHandler) GetSlotInfo(
 	ctx context.Context,
 	req *protos.PostgresPeerActivityInfoRequest,
 ) (*protos.PeerSlotResponse, APIError) {
-	pgConn, pgClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, h.pool, req.PeerName)
+	settings, err := internal.LoadSettings(ctx, nil)
+	if err != nil {
+		return nil, NewInternalApiError(err)
+	}
+	pgConn, pgClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, settings, h.pool, req.PeerName)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create postgres connector", slog.Any("error", err))
 		return nil, NewFailedPreconditionApiError(fmt.Errorf("failed to get postgres connector: %w", err))
@@ -311,7 +315,7 @@ func (h *FlowRequestHandler) GetStatInfo(
 	ctx context.Context,
 	req *protos.PostgresPeerActivityInfoRequest,
 ) (*protos.PeerStatResponse, APIError) {
-	peerConn, peerClose, err := connectors.GetByNameAs[connectors.StatActivityConnector](ctx, nil, h.pool, req.PeerName)
+	peerConn, peerClose, err := connectors.GetByNameWithEnvAs[connectors.StatActivityConnector](ctx, nil, h.pool, req.PeerName)
 	if err != nil {
 		return nil, NewFailedPreconditionApiError(fmt.Errorf("failed to get stat activity connector: %w", err))
 	}
@@ -324,7 +328,11 @@ func (h *FlowRequestHandler) GetPublications(
 	ctx context.Context,
 	req *protos.PostgresPeerActivityInfoRequest,
 ) (*protos.PeerPublicationsResponse, APIError) {
-	peerConn, peerClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, h.pool, req.PeerName)
+	settings, err := internal.LoadSettings(ctx, nil)
+	if err != nil {
+		return nil, NewInternalApiError(err)
+	}
+	peerConn, peerClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, settings, h.pool, req.PeerName)
 	if err != nil {
 		return nil, NewFailedPreconditionApiError(fmt.Errorf("failed to get postgres connector: %w", err))
 	}

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -35,19 +35,17 @@ var FlagConstraints = map[string]flagConstraint{
 func (h *FlowRequestHandler) ValidateCDCMirror(
 	ctx context.Context, req *protos.CreateCDCFlowRequest,
 ) (*protos.ValidateCDCMirrorResponse, APIError) {
-	if req.ConnectionConfigs != nil {
-		if internalVersion, err := internal.PeerDBForceInternalVersion(ctx, req.ConnectionConfigs.Env); err != nil {
-			return nil, NewInternalApiError(err)
-		} else {
-			req.ConnectionConfigs.Version = internalVersion
-		}
+	settings, err := internal.LoadSettings(ctx, req.ConnectionConfigs.Env)
+	if err != nil {
+		return nil, NewInternalApiError(err)
 	}
+	req.ConnectionConfigs.Version = settings.ForceInternalVersion
 	flowConnectionConfigsCore := proto_conversions.FlowConnectionConfigsToCore(req.ConnectionConfigs, 0)
-	return h.validateCDCMirrorImpl(ctx, flowConnectionConfigsCore, false)
+	return h.validateCDCMirrorImpl(ctx, settings, flowConnectionConfigsCore, false)
 }
 
 func (h *FlowRequestHandler) validateCDCMirrorImpl(
-	ctx context.Context, connectionConfigs *protos.FlowConnectionConfigsCore, idempotent bool,
+	ctx context.Context, settings *internal.Settings, connectionConfigs *protos.FlowConnectionConfigsCore, idempotent bool,
 ) (*protos.ValidateCDCMirrorResponse, APIError) {
 	ctx = context.WithValue(ctx, shared.FlowNameKey, connectionConfigs.FlowJobName)
 	underMaintenance, err := internal.PeerDBMaintenanceModeEnabled(ctx, nil)
@@ -79,7 +77,7 @@ func (h *FlowRequestHandler) validateCDCMirrorImpl(
 	}
 
 	if connectionConfigs.Resync {
-		if apiErr := h.checkFlagsCompatibility(ctx, connectionConfigs); apiErr != nil {
+		if apiErr := h.checkFlagsCompatibility(ctx, settings, connectionConfigs); apiErr != nil {
 			return nil, apiErr
 		}
 	}
@@ -103,7 +101,7 @@ func (h *FlowRequestHandler) validateCDCMirrorImpl(
 	}
 
 	srcConn, srcClose, err := connectors.GetByNameAs[connectors.MirrorSourceValidationConnector](
-		ctx, connectionConfigs.Env, h.pool, connectionConfigs.SourceName,
+		ctx, settings, h.pool, connectionConfigs.SourceName,
 	)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
@@ -131,7 +129,7 @@ func (h *FlowRequestHandler) validateCDCMirrorImpl(
 	}
 
 	dstConn, dstClose, err := connectors.GetByNameAs[connectors.MirrorDestinationValidationConnector](
-		ctx, connectionConfigs.Env, h.pool, connectionConfigs.DestinationName,
+		ctx, settings, h.pool, connectionConfigs.DestinationName,
 	)
 	if err != nil {
 		if errors.Is(err, errors.ErrUnsupported) {
@@ -144,7 +142,7 @@ func (h *FlowRequestHandler) validateCDCMirrorImpl(
 	var tableSchemaMap map[string]*protos.TableSchema
 	if !connectionConfigs.Resync {
 		var getTableSchemaError error
-		tableSchemaMap, getTableSchemaError = srcConn.GetTableSchema(ctx, connectionConfigs.Env, connectionConfigs.Version,
+		tableSchemaMap, getTableSchemaError = srcConn.GetTableSchema(ctx, connectionConfigs.Version,
 			connectionConfigs.System, connectionConfigs.TableMappings)
 		if getTableSchemaError != nil {
 			return nil, NewFailedPreconditionApiError(fmt.Errorf("failed to get source table schema: %w", getTableSchemaError))
@@ -172,9 +170,10 @@ func (h *FlowRequestHandler) checkIfMirrorNameExists(ctx context.Context, mirror
 // column types whose type mapping depends on that flag.
 func (h *FlowRequestHandler) checkFlagsCompatibility(
 	ctx context.Context,
+	settings *internal.Settings,
 	cfg *protos.FlowConnectionConfigsCore,
 ) APIError {
-	newFlags, err := h.determineFlags(ctx, cfg.Env, cfg.DestinationName)
+	newFlags, err := h.determineFlags(ctx, settings, cfg.DestinationName)
 	if err != nil {
 		return NewInternalApiError(fmt.Errorf("failed to determine destination flags: %w", err))
 	}

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -37,7 +37,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 	ctx, cancelCtx := context.WithTimeout(ctx, validatePeerDeadline)
 	defer cancelCtx()
 
-	conn, err := connectors.GetConnector(ctx, nil, req.Peer)
+	conn, err := connectors.GetConnectorWithEnv(ctx, nil, req.Peer)
 	if err != nil {
 		displayErr := fmt.Errorf("%s peer %s was invalidated: %w", req.Peer.Type, req.Peer.Name, err)
 		return &protos.ValidatePeerResponse{

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -54,6 +54,7 @@ func NewBigQueryServiceAccount(bqConfig *protos.BigqueryConfig) (*utils.GcpServi
 
 type BigQueryConnector struct {
 	*metadataStore.PostgresMetadata
+	Settings      *internal.Settings
 	logger        log.Logger
 	bqConfig      *protos.BigqueryConfig
 	credentials   *auth.Credentials
@@ -64,7 +65,7 @@ type BigQueryConnector struct {
 	projectID     string
 }
 
-func NewBigQueryConnector(ctx context.Context, config *protos.BigqueryConfig) (*BigQueryConnector, error) {
+func NewBigQueryConnector(ctx context.Context, settings *internal.Settings, config *protos.BigqueryConfig) (*BigQueryConnector, error) {
 	logger := internal.LoggerFromCtx(ctx)
 
 	datasetID := config.GetDatasetId()
@@ -126,6 +127,7 @@ func NewBigQueryConnector(ctx context.Context, config *protos.BigqueryConfig) (*
 
 	return &BigQueryConnector{
 		credentials:      creds,
+		Settings:         settings,
 		bqConfig:         config,
 		client:           client,
 		datasetID:        datasetID,
@@ -236,7 +238,6 @@ func (c *BigQueryConnector) waitForTableReady(ctx context.Context, datasetTable 
 // This could involve adding or dropping multiple columns.
 func (c *BigQueryConnector) ReplayTableSchemaDeltas(
 	ctx context.Context,
-	env map[string]string,
 	flowJobName string,
 	_ []*protos.TableMapping,
 	schemaDeltas []*protos.TableSchemaDelta,
@@ -427,11 +428,8 @@ func (c *BigQueryConnector) syncRecordsViaAvro(
 // NormalizeRecords normalizes raw table to destination table,
 // one batch at a time from the previous normalized batch to the currently synced batch.
 func (c *BigQueryConnector) NormalizeRecords(ctx context.Context, req *model.NormalizeRecordsRequest) (model.NormalizeResponse, error) {
-	unchangedToastMergeChunking, err := internal.PeerDBBigQueryToastMergeChunking(ctx, req.Env)
-	if err != nil {
-		c.logger.Warn("failed to load PEERDB_BIGQUERY_TOAST_MERGE_CHUNKING, continuing with 8", slog.Any("error", err))
-		unchangedToastMergeChunking = 8
-	} else if unchangedToastMergeChunking == 0 {
+	unchangedToastMergeChunking := c.Settings.BigQueryToastMergeChunking
+	if unchangedToastMergeChunking == 0 {
 		unchangedToastMergeChunking = 8
 	}
 
@@ -739,12 +737,8 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 		}
 	}
 
-	timePartitionEnabled, err := internal.PeerDBBigQueryEnableSyncedAtPartitioning(ctx, config.Env)
-	if err != nil {
-		return false, fmt.Errorf("failed to get dynamic setting for BigQuery time partitioning: %w", err)
-	}
 	var timePartitioning *bigquery.TimePartitioning
-	if timePartitionEnabled && config.SyncedAtColName != "" {
+	if c.Settings.BigQueryEnableSyncedAtPartitioning && config.SyncedAtColName != "" {
 		timePartitioning = &bigquery.TimePartitioning{
 			Type:  bigquery.DayPartitioningType,
 			Field: config.SyncedAtColName,

--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -38,7 +38,7 @@ func (c *BigQueryConnector) SyncQRepRecords(
 		partition.PartitionId, destTable))
 
 	avroSync := NewQRepAvroSyncMethod(c, config.StagingPath, config.FlowJobName)
-	result, err := avroSync.SyncQRepRecords(ctx, config.Env, config.FlowJobName, destTable, partition,
+	result, err := avroSync.SyncQRepRecords(ctx, c.Settings, config.FlowJobName, destTable, partition,
 		tblMetadata, stream, config.SyncedAtColName, config.SoftDeleteColName)
 	if err != nil {
 		return result, nil, err
@@ -87,7 +87,7 @@ func (c *BigQueryConnector) replayTableSchemaDeltasQRep(
 	}
 
 	if err := c.ReplayTableSchemaDeltas(
-		ctx, config.Env, config.FlowJobName, nil, []*protos.TableSchemaDelta{tableSchemaDelta}, nil,
+		ctx, config.FlowJobName, nil, []*protos.TableSchemaDelta{tableSchemaDelta}, nil,
 	); err != nil {
 		return nil, fmt.Errorf("failed to add columns to destination table: %w", err)
 	}

--- a/flow/connectors/bigquery/qrep_avro_sync.go
+++ b/flow/connectors/bigquery/qrep_avro_sync.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -57,7 +58,7 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 	}
 
 	stagingTable := fmt.Sprintf("%s_%s_staging", rawTableName, strconv.FormatInt(syncBatchID, 10))
-	numRecords, err := s.writeToStage(ctx, req.Env, strconv.FormatInt(syncBatchID, 10), rawTableName, avroSchema,
+	numRecords, err := s.writeToStage(ctx, s.connector.Settings, strconv.FormatInt(syncBatchID, 10), rawTableName, avroSchema,
 		&datasetTable{
 			project: s.connector.projectID,
 			dataset: s.connector.datasetID,
@@ -99,7 +100,7 @@ func (s *QRepAvroSyncMethod) SyncRecords(
 		slog.String("dstTableName", rawTableName))
 
 	if err := s.connector.ReplayTableSchemaDeltas(
-		ctx, req.Env, req.FlowJobName, req.TableMappings, req.Records.SchemaDeltas, nil,
+		ctx, req.FlowJobName, req.TableMappings, req.Records.SchemaDeltas, nil,
 	); err != nil {
 		return nil, fmt.Errorf("failed to sync schema changes: %w", err)
 	}
@@ -141,7 +142,7 @@ func getTransformedColumns(dstSchema *bigquery.Schema, syncedAtCol string, softD
 
 func (s *QRepAvroSyncMethod) SyncQRepRecords(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	flowJobName string,
 	dstTableName string,
 	partition *protos.QRepPartition,
@@ -170,7 +171,7 @@ func (s *QRepAvroSyncMethod) SyncQRepRecords(
 		table: fmt.Sprintf("%s_%s_staging", dstDatasetTable.table,
 			strings.ReplaceAll(partition.PartitionId, "-", "_")),
 	}
-	numRecords, err := s.writeToStage(ctx, env, partition.PartitionId, flowJobName, avroSchema,
+	numRecords, err := s.writeToStage(ctx, settings, partition.PartitionId, flowJobName, avroSchema,
 		stagingDatasetTable, stream, flowJobName)
 	if err != nil {
 		return -1, fmt.Errorf("failed to push to avro stage: %w", err)
@@ -352,7 +353,7 @@ func GetAvroField(bqField *bigquery.FieldSchema) (*avro.Field, error) {
 
 func (s *QRepAvroSyncMethod) writeToStage(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	syncID string,
 	objectFolder string,
 	avroSchema *model.QRecordAvroSchemaDefinition,
@@ -372,7 +373,7 @@ func (s *QRepAvroSyncMethod) writeToStage(
 		obj := bucket.Object(avroFilePath)
 		w := obj.NewWriter(ctx)
 
-		numRecords, err := ocfWriter.WriteOCF(ctx, env, w, nil, nil)
+		numRecords, err := ocfWriter.WriteOCF(ctx, settings, w, nil, nil)
 		if err != nil {
 			return 0, fmt.Errorf("failed to write records to Avro file on GCS: %w", err)
 		}
@@ -394,7 +395,7 @@ func (s *QRepAvroSyncMethod) writeToStage(
 
 		avroFilePath := fmt.Sprintf("%s/%s.avro", tmpDir, syncID)
 		s.connector.logger.Info("writing records to local file", idLog)
-		avroFile, err = ocfWriter.WriteRecordsToAvroFile(ctx, env, avroFilePath)
+		avroFile, err = ocfWriter.WriteRecordsToAvroFile(ctx, settings, avroFilePath)
 		if err != nil {
 			return 0, fmt.Errorf("failed to write records to local Avro file: %w", err)
 		}

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -322,7 +322,6 @@ func (c *BigQueryConnector) EnsurePullability(
 func (c *BigQueryConnector) ExportTxSnapshot(
 	ctx context.Context,
 	flowName string,
-	_ map[string]string,
 ) (*protos.ExportTxSnapshotOutput, any, error) {
 	cfg, err := internal.FetchConfigFromDB(ctx, c.catalogPool, flowName)
 	if err != nil {
@@ -485,7 +484,7 @@ func (c *BigQueryConnector) FinishExport(v any) error {
 	return nil
 }
 
-func (c *BigQueryConnector) SetupReplConn(context.Context, map[string]string) error {
+func (c *BigQueryConnector) SetupReplConn(context.Context) error {
 	return nil
 }
 

--- a/flow/connectors/bigquery/source_schema.go
+++ b/flow/connectors/bigquery/source_schema.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
-	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 func (c *BigQueryConnector) GetAllTables(ctx context.Context) (*protos.AllTablesResponse, error) {
@@ -148,20 +147,14 @@ func (c *BigQueryConnector) GetTablesInSchema(ctx context.Context, schema string
 
 func (c *BigQueryConnector) GetTableSchema(
 	ctx context.Context,
-	env map[string]string,
 	version uint32,
 	system protos.TypeSystem,
 	tableMappings []*protos.TableMapping,
 ) (map[string]*protos.TableSchema, error) {
 	res := make(map[string]*protos.TableSchema, len(tableMappings))
 
-	nullableEnabled, err := internal.PeerDBNullable(ctx, env)
-	if err != nil {
-		return nil, err
-	}
-
 	for _, tm := range tableMappings {
-		tableSchema, err := c.getTableSchemaForTable(ctx, tm, system, nullableEnabled)
+		tableSchema, err := c.getTableSchemaForTable(ctx, tm, system, c.Settings.Nullable)
 		if err != nil {
 			c.logger.Error("error fetching schema", slog.String("table", tm.SourceTableIdentifier), slog.Any("error", err))
 			return nil, err

--- a/flow/connectors/clickhouse/avro_sync.go
+++ b/flow/connectors/clickhouse/avro_sync.go
@@ -56,7 +56,6 @@ func (s *ClickHouseAvroSyncMethod) CopyStageToDestination(ctx context.Context, a
 
 func (s *ClickHouseAvroSyncMethod) SyncRecords(
 	ctx context.Context,
-	env map[string]string,
 	stream *model.QRecordStream,
 	flowJobName string,
 	syncBatchID int64,
@@ -70,13 +69,13 @@ func (s *ClickHouseAvroSyncMethod) SyncRecords(
 	s.logger.Info("sync function called and schema acquired",
 		slog.String("dstTable", dstTableName))
 
-	avroSchema, err := s.getAvroSchema(ctx, env, dstTableName, schema, nil)
+	avroSchema, err := s.getAvroSchema(ctx, dstTableName, schema, nil)
 	if err != nil {
 		return 0, err
 	}
 
 	batchIdentifierForFile := fmt.Sprintf("%s_%d", common.RandomString(16), syncBatchID)
-	avroFile, err := s.writeToAvroFile(ctx, env, stream, nil, avroSchema, batchIdentifierForFile, flowJobName, nil, nil)
+	avroFile, err := s.writeToAvroFile(ctx, stream, nil, avroSchema, batchIdentifierForFile, flowJobName, nil, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -151,7 +150,7 @@ func (s *ClickHouseAvroSyncMethod) pushDataToStagingForSnapshot(
 	destTypeConversions map[string]types.TypeConversion,
 	numericTruncator model.SnapshotTableNumericTruncator,
 ) ([]utils.AvroFile, int64, error) {
-	avroSchema, err := s.getAvroSchema(ctx, config.Env, dstTableName, schema, columnNameAvroFieldMap)
+	avroSchema, err := s.getAvroSchema(ctx, dstTableName, schema, columnNameAvroFieldMap)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -200,7 +199,7 @@ func (s *ClickHouseAvroSyncMethod) pushDataToStagingForSnapshot(
 			}
 
 			substream, sizeTracker := createChunkedSubstream(&done)
-			subFile, err := s.writeToAvroFile(ctx, config.Env, substream, sizeTracker, avroSchema,
+			subFile, err := s.writeToAvroFile(ctx, substream, sizeTracker, avroSchema,
 				fmt.Sprintf("%s.%06d", partition.PartitionId, chunkNum),
 				config.FlowJobName, destTypeConversions, numericTruncator,
 			)
@@ -217,7 +216,7 @@ func (s *ClickHouseAvroSyncMethod) pushDataToStagingForSnapshot(
 		}
 	} else {
 		avroFile, err := s.writeToAvroFile(
-			ctx, config.Env, stream, nil, avroSchema, partition.PartitionId, config.FlowJobName,
+			ctx, stream, nil, avroSchema, partition.PartitionId, config.FlowJobName,
 			destTypeConversions, numericTruncator,
 		)
 		if err != nil {
@@ -248,16 +247,12 @@ func (s *ClickHouseAvroSyncMethod) pushStagingDataToClickHouseForSnapshot(
 		columnNameMap:    columnNameAvroFieldMap,
 		excludedColumns:  config.Exclude,
 		config:           config,
+		settings:         s.Settings,
 		connector:        s.ClickHouseConnector,
 		logger:           s.logger,
 	}
 
-	numParts, err := internal.PeerDBClickHouseInitialLoadPartsPerPartition(ctx, s.config.Env)
-	if err != nil {
-		s.logger.Warn("failed to get chunking parts, proceeding without chunking", slog.Any("error", err))
-		numParts = 1
-	}
-	numParts = max(numParts, 1)
+	numParts := max(s.Settings.ClickHouseInitialLoadPartsPerPartition, 1)
 
 	chSettings := clickhouse.NewCHSettings(s.chVersion)
 	chSettings.Add(clickhouse.SettingThrowOnMaxPartitionsPerInsertBlock, "0")
@@ -338,12 +333,11 @@ func (s *ClickHouseAvroSyncMethod) pushStagingDataToClickHouseForSnapshot(
 
 func (s *ClickHouseAvroSyncMethod) getAvroSchema(
 	ctx context.Context,
-	env map[string]string,
 	dstTableName string,
 	schema types.QRecordSchema,
 	avroNameMap map[string]string,
 ) (*model.QRecordAvroSchemaDefinition, error) {
-	avroSchema, err := model.GetAvroSchemaDefinition(ctx, env, dstTableName, schema, protos.DBType_CLICKHOUSE, avroNameMap)
+	avroSchema, err := model.GetAvroSchemaDefinition(ctx, s.Settings, dstTableName, schema, protos.DBType_CLICKHOUSE, avroNameMap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to define Avro schema: %w", err)
 	}
@@ -352,7 +346,6 @@ func (s *ClickHouseAvroSyncMethod) getAvroSchema(
 
 func (s *ClickHouseAvroSyncMethod) writeToAvroFile(
 	ctx context.Context,
-	env map[string]string,
 	stream *model.QRecordStream,
 	sizeTracker *model.QRecordAvroChunkSizeTracker,
 	avroSchema *model.QRecordAvroSchemaDefinition,
@@ -364,13 +357,8 @@ func (s *ClickHouseAvroSyncMethod) writeToAvroFile(
 	ocfWriter := utils.NewPeerDBOCFWriter(stream, avroSchema, ocf.ZStandard, protos.DBType_CLICKHOUSE, sizeTracker)
 	prefix := s.staging.KeyPrefix()
 
-	s3UuidPrefix, err := internal.PeerDBS3UuidPrefix(ctx, s.config.Env)
-	if err != nil {
-		return utils.AvroFile{}, err
-	}
-
 	var stagingAvroFileKey string
-	if s3UuidPrefix {
+	if s.Settings.S3UuidPrefix {
 		stagingAvroFileKey = fmt.Sprintf("%s/%s/%s/%s.avro", prefix, uuid.NewString(), flowJobName, identifierForFile)
 	} else {
 		stagingAvroFileKey = fmt.Sprintf("%s/%s/%s.avro", prefix, flowJobName, identifierForFile)
@@ -389,10 +377,10 @@ func (s *ClickHouseAvroSyncMethod) writeToAvroFile(
 			}
 			w.Close()
 		}()
-		numRows, writeOcfError = ocfWriter.WriteOCF(ctx, env, w, typeConversions, numericTruncator)
+		numRows, writeOcfError = ocfWriter.WriteOCF(ctx, s.Settings, w, typeConversions, numericTruncator)
 	}()
 
-	if err := s.staging.Upload(ctx, env, stagingAvroFileKey, r); err != nil {
+	if err := s.staging.Upload(ctx, s.Settings.Env, stagingAvroFileKey, r); err != nil {
 		return utils.AvroFile{}, fmt.Errorf("failed to upload to staging: %w", err)
 	}
 	if writeOcfError != nil {

--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -101,12 +101,12 @@ func (c *ClickHouseConnector) CreateRawTable(ctx context.Context, req *protos.Cr
 	}, nil
 }
 
-func (c *ClickHouseConnector) avroSyncMethod(flowJobName string, env map[string]string, version uint32) *ClickHouseAvroSyncMethod {
+func (c *ClickHouseConnector) avroSyncMethod(flowJobName string, settings *internal.Settings, version uint32) *ClickHouseAvroSyncMethod {
 	qrepConfig := &protos.QRepConfig{
 		StagingPath:                c.staging.BucketPath(),
 		FlowJobName:                flowJobName,
 		DestinationTableIdentifier: c.GetRawTableName(flowJobName),
-		Env:                        env,
+		Env:                        settings.Env,
 		Version:                    version,
 	}
 	return NewClickHouseAvroSyncMethod(qrepConfig, c)
@@ -118,12 +118,8 @@ func (c *ClickHouseConnector) syncRecordsViaAvro(
 	syncBatchID int64,
 ) (*model.SyncResponse, error) {
 	tableNameRowsMapping := utils.InitialiseTableRowsMap(req.TableMappings)
-	unboundedNumericAsString, err := internal.PeerDBEnableClickHouseNumericAsString(ctx, req.Env)
-	if err != nil {
-		return nil, err
-	}
 	streamReq := model.NewRecordsToStreamRequest(
-		req.Records.GetRecords(), tableNameRowsMapping, syncBatchID, unboundedNumericAsString,
+		req.Records.GetRecords(), tableNameRowsMapping, syncBatchID, c.Settings.ClickHouseUnboundedNumericAsString,
 		protos.DBType_CLICKHOUSE,
 	)
 	numericTruncator := model.NewStreamNumericTruncator(req.TableMappings, NumericDestinationTypes)
@@ -132,14 +128,16 @@ func (c *ClickHouseConnector) syncRecordsViaAvro(
 		return nil, fmt.Errorf("failed to convert records to raw table stream: %w", err)
 	}
 
-	avroSyncer := c.avroSyncMethod(req.FlowJobName, req.Env, req.Version)
-	numRecords, err := avroSyncer.SyncRecords(ctx, req.Env, stream, req.FlowJobName, syncBatchID)
+	avroSyncer := c.avroSyncMethod(req.FlowJobName, c.Settings, req.Version)
+	numRecords, err := avroSyncer.SyncRecords(ctx, stream, req.FlowJobName, syncBatchID)
 	if err != nil {
 		return nil, err
 	}
 	warnings := numericTruncator.Warnings()
 
-	if err := c.ReplayTableSchemaDeltas(ctx, req.Env, req.FlowJobName, req.TableMappings, req.Records.SchemaDeltas, req.Flags); err != nil {
+	if err := c.ReplayTableSchemaDeltas(
+		ctx, req.FlowJobName, req.TableMappings, req.Records.SchemaDeltas, req.Flags,
+	); err != nil {
 		return nil, fmt.Errorf("failed to sync schema changes: %w", err)
 	}
 
@@ -225,7 +223,6 @@ func extractSingleQuotedStrings(s string) []string {
 
 func (c *ClickHouseConnector) ReplayTableSchemaDeltas(
 	ctx context.Context,
-	env map[string]string,
 	flowJobName string,
 	tableMappings []*protos.TableMapping,
 	schemaDeltas []*protos.TableSchemaDelta,
@@ -266,7 +263,7 @@ func (c *ClickHouseConnector) ReplayTableSchemaDeltas(
 		for _, addedColumn := range schemaDelta.AddedColumns {
 			qvKind := types.QValueKind(addedColumn.Type)
 			clickHouseColType, err := qvalue.ToDWHColumnType(
-				ctx, qvKind, env, protos.DBType_CLICKHOUSE, c.chVersion, addedColumn, schemaDelta.NullableEnabled, flags,
+				ctx, qvKind, c.Settings, protos.DBType_CLICKHOUSE, c.chVersion, addedColumn, schemaDelta.NullableEnabled, flags,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to convert column type %s to ClickHouse type: %w", addedColumn.Type, err)

--- a/flow/connectors/clickhouse/cdc_test.go
+++ b/flow/connectors/clickhouse/cdc_test.go
@@ -107,7 +107,7 @@ func TestCreateRawTableHasTTL(t *testing.T) {
 			t.Setenv("PEERDB_CLICKHOUSE_AWS_S3_BUCKET_NAME", "dummy-bucket-for-ttl-test")
 
 			ctx := t.Context()
-			conn, err := NewClickHouseConnector(ctx, nil, &protos.ClickhouseConfig{
+			conn, err := NewClickHouseConnector(ctx, internal.NewSettings(nil), &protos.ClickhouseConfig{
 				Host:       internal.ClickHouseTestHost(),
 				Port:       internal.ClickHouseTestPort(),
 				Database:   "default",

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -29,6 +29,7 @@ import (
 
 type ClickHouseConnector struct {
 	*metadataStore.PostgresMetadata
+	Settings  *internal.Settings
 	database  clickhouse.Conn
 	logger    log.Logger
 	Config    *protos.ClickhouseConfig
@@ -38,11 +39,11 @@ type ClickHouseConnector struct {
 
 func NewClickHouseConnector(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	config *protos.ClickhouseConfig,
 ) (*ClickHouseConnector, error) {
 	logger := internal.LoggerFromCtx(ctx)
-	database, err := Connect(ctx, env, config)
+	database, err := Connect(ctx, settings, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open connection to ClickHouse peer: %w", err)
 	}
@@ -58,7 +59,7 @@ func NewClickHouseConnector(
 		return nil, fmt.Errorf("failed to get ClickHouse version: %w", err)
 	}
 
-	staging, err := createStagingStore(ctx, env, config, clickHouseVersion.Version)
+	staging, err := createStagingStore(ctx, settings.Env, config, clickHouseVersion.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -66,6 +67,7 @@ func NewClickHouseConnector(
 	return &ClickHouseConnector{
 		database:         database,
 		PostgresMetadata: pgMetadata,
+		Settings:         settings,
 		Config:           config,
 		logger:           logger,
 		staging:          staging,
@@ -189,13 +191,13 @@ func buildTLSConfig(config *protos.ClickhouseConfig) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func Connect(ctx context.Context, env map[string]string, config *protos.ClickhouseConfig) (clickhouse.Conn, error) {
+func Connect(ctx context.Context, settings *internal.Settings, config *protos.ClickhouseConfig) (clickhouse.Conn, error) {
 	tlsSetting, err := buildTLSConfig(config)
 	if err != nil {
 		return nil, err
 	}
 
-	settings := clickhouse.Settings{
+	chSettings := clickhouse.Settings{
 		// See: https://clickhouse.com/docs/en/cloud/reference/shared-merge-tree#consistency
 		"select_sequential_consistency": uint64(1),
 		// broken downstream views should not interrupt ingestion
@@ -205,19 +207,14 @@ func Connect(ctx context.Context, env map[string]string, config *protos.Clickhou
 		// to handle JSON like "{"key": []}"
 		"input_format_json_infer_incomplete_types_as_strings": uint64(1),
 	}
-	if maxInsertThreads, err := internal.PeerDBClickHouseMaxInsertThreads(ctx, env); err != nil {
+	if maxInsertThreads, err := internal.PeerDBClickHouseMaxInsertThreads(ctx, settings.Env); err != nil {
 		return nil, fmt.Errorf("failed to load max_insert_threads config: %w", err)
 	} else if maxInsertThreads != 0 {
-		settings["max_insert_threads"] = maxInsertThreads
+		chSettings["max_insert_threads"] = maxInsertThreads
 	}
 	if config.Cluster != "" {
-		settings["insert_distributed_sync"] = uint64(1)
+		chSettings["insert_distributed_sync"] = uint64(1)
 	}
-	clientName, err := internal.PeerDBClickHouseClientName(ctx, env)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load ClickHouse client name: %w", err)
-	}
-
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Addr: []string{shared.JoinHostPort(config.Host, config.Port)},
 		Auth: clickhouse.Auth{
@@ -232,10 +229,10 @@ func Connect(ctx context.Context, env map[string]string, config *protos.Clickhou
 				Name    string
 				Version string
 			}{
-				{Name: clientName},
+				{Name: settings.ClickHouseClientName},
 			},
 		},
-		Settings:    settings,
+		Settings:    chSettings,
 		DialTimeout: 3600 * time.Second,
 		ReadTimeout: 3600 * time.Second,
 	})
@@ -457,7 +454,6 @@ func GetTableSchemaForTable(tm *protos.TableMapping, columns []driver.ColumnType
 
 func (c *ClickHouseConnector) GetTableSchema(
 	ctx context.Context,
-	_env map[string]string,
 	_version uint32,
 	_system protos.TypeSystem,
 	tableMappings []*protos.TableMapping,

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -60,7 +60,6 @@ func (c *ClickHouseConnector) SetupNormalizedTable(
 		c.logger.Info("[clickhouse] destination ClickHouse table already exists, skipping", "table", destinationTableIdentifier)
 		return true, nil
 	}
-
 	normalizedTableCreateSQL, err := c.generateCreateTableSQLForNormalizedTable(
 		ctx,
 		config,
@@ -145,10 +144,7 @@ func (c *ClickHouseConnector) generateCreateTableSQLForNormalizedTable(
 		engine = "Null"
 	}
 
-	sourceSchemaAsDestinationColumn, err := internal.PeerDBSourceSchemaAsDestinationColumn(ctx, config.Env)
-	if err != nil {
-		return nil, err
-	}
+	sourceSchemaAsDestinationColumn := c.Settings.SourceSchemaAsDestinationColumn
 
 	var stmtBuilder strings.Builder
 	var stmtBuilderDistributed strings.Builder
@@ -206,7 +202,7 @@ func (c *ClickHouseConnector) generateCreateTableSQLForNormalizedTable(
 			if clickHouseType == "" {
 				var err error
 				clickHouseType, err = qvalue.ToDWHColumnType(
-					ctx, colType, config.Env, protos.DBType_CLICKHOUSE, chVersion, column,
+					ctx, colType, c.Settings, protos.DBType_CLICKHOUSE, chVersion, column,
 					tableSchema.NullableEnabled || columnNullableEnabled, flags,
 				)
 				if err != nil {
@@ -436,15 +432,15 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		}, nil
 	}
 
-	groupBatches, err := internal.PeerDBGroupNormalize(ctx, req.Env)
-	if err != nil || groupBatches <= 0 {
-		c.logger.Error("failed to lookup PEERDB_GROUP_NORMALIZE, only normalizing 4 batches")
+	groupBatches := c.Settings.GroupNormalize
+	if groupBatches <= 0 {
+		c.logger.Error("PEERDB_GROUP_NORMALIZE is invalid, only normalizing 4 batches")
 		groupBatches = 4
 	}
 
 	endBatchID := min(req.SyncBatchID, lastNormBatchID+groupBatches)
 
-	if err := c.copyAvroStagesToDestination(ctx, req.FlowJobName, lastNormBatchID, endBatchID, req.Env, req.Version); err != nil {
+	if err := c.copyAvroStagesToDestination(ctx, req.FlowJobName, lastNormBatchID, endBatchID, req.Version); err != nil {
 		return model.NormalizeResponse{}, fmt.Errorf("failed to copy avro stages to destination: %w", err)
 	}
 
@@ -460,17 +456,14 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		return model.NormalizeResponse{}, err
 	}
 
-	enablePrimaryUpdate, err := internal.PeerDBEnableClickHousePrimaryUpdate(ctx, req.Env)
+	enablePrimaryUpdate, err := internal.PeerDBEnableClickHousePrimaryUpdate(ctx, c.Settings.Env)
 	if err != nil {
 		return model.NormalizeResponse{}, err
 	}
 
-	sourceSchemaAsDestinationColumn, err := internal.PeerDBSourceSchemaAsDestinationColumn(ctx, req.Env)
-	if err != nil {
-		return model.NormalizeResponse{}, err
-	}
+	sourceSchemaAsDestinationColumn := c.Settings.SourceSchemaAsDestinationColumn
 
-	parallelNormalize, err := internal.PeerDBClickHouseParallelNormalize(ctx, req.Env)
+	parallelNormalize, err := internal.PeerDBClickHouseParallelNormalize(ctx, c.Settings.Env)
 	if err != nil {
 		return model.NormalizeResponse{}, err
 	}
@@ -508,7 +501,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				chConn = c.database
 			} else {
 				var err error
-				chConn, err = Connect(errCtx, req.Env, c.Config)
+				chConn, err = Connect(errCtx, c.Settings, c.Config)
 				if err != nil {
 					return err
 				}
@@ -581,7 +574,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				lastNormBatchIDForTable,
 				enablePrimaryUpdate,
 				sourceSchemaAsDestinationColumn,
-				req.Env,
+				c.Settings,
 				rawTbl,
 				c.chVersion,
 				c.Config.Cluster != "",
@@ -674,10 +667,9 @@ func (c *ClickHouseConnector) copyAvroStageToDestination(
 	ctx context.Context,
 	flowJobName string,
 	syncBatchID int64,
-	env map[string]string,
 	version uint32,
 ) error {
-	avroSyncMethod := c.avroSyncMethod(flowJobName, env, version)
+	avroSyncMethod := c.avroSyncMethod(flowJobName, c.Settings, version)
 	avroFile, err := GetAvroStage(ctx, flowJobName, syncBatchID)
 	if err != nil {
 		return fmt.Errorf("failed to get avro stage: %w", err)
@@ -691,7 +683,7 @@ func (c *ClickHouseConnector) copyAvroStageToDestination(
 }
 
 func (c *ClickHouseConnector) copyAvroStagesToDestination(
-	ctx context.Context, flowJobName string, lastNormBatchID int64, endBatchID int64, env map[string]string, version uint32,
+	ctx context.Context, flowJobName string, lastNormBatchID int64, endBatchID int64, version uint32,
 ) error {
 	// Skip batches already copied to raw table. This can happen if a previous normalization
 	// run failed after copying to raw table but before completing normalization.
@@ -704,7 +696,7 @@ func (c *ClickHouseConnector) copyAvroStagesToDestination(
 		slog.Int64("batchID", lastCopiedBatchID), slog.Int64("endBatchID", endBatchID))
 
 	for batchID := lastCopiedBatchID + 1; batchID <= endBatchID; batchID++ {
-		if err := c.copyAvroStageToDestination(ctx, flowJobName, batchID, env, version); err != nil {
+		if err := c.copyAvroStageToDestination(ctx, flowJobName, batchID, version); err != nil {
 			return fmt.Errorf("failed to copy avro stage to destination: %w", err)
 		}
 		c.logger.Info("[clickhouse] setting last batch id in raw table",

--- a/flow/connectors/clickhouse/normalize_query.go
+++ b/flow/connectors/clickhouse/normalize_query.go
@@ -18,7 +18,7 @@ import (
 )
 
 type NormalizeQueryGenerator struct {
-	env                             map[string]string
+	settings                        *internal.Settings
 	flags                           []string
 	tableNameSchemaMapping          map[string]*protos.TableSchema
 	chVersion                       *chproto.Version
@@ -44,7 +44,7 @@ func NewNormalizeQueryGenerator(
 	lastNormBatchID int64,
 	enablePrimaryUpdate bool,
 	sourceSchemaAsDestinationColumn bool,
-	env map[string]string,
+	settings *internal.Settings,
 	rawTableName string,
 	chVersion *chproto.Version,
 	cluster bool,
@@ -64,7 +64,7 @@ func NewNormalizeQueryGenerator(
 		lastNormBatchID:                 lastNormBatchID,
 		enablePrimaryUpdate:             enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn: sourceSchemaAsDestinationColumn,
-		env:                             env,
+		settings:                        settings,
 		rawTableName:                    rawTableName,
 		chVersion:                       chVersion,
 		cluster:                         cluster,
@@ -128,7 +128,8 @@ func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error
 		if clickHouseType == "" {
 			var err error
 			clickHouseType, err = qvalue.ToDWHColumnType(
-				ctx, colType, t.env, protos.DBType_CLICKHOUSE, t.chVersion, column, schema.NullableEnabled || columnNullableEnabled, t.flags,
+				ctx, colType, t.settings, protos.DBType_CLICKHOUSE, t.chVersion, column,
+				schema.NullableEnabled || columnNullableEnabled, t.flags,
 			)
 			if err != nil {
 				return "", fmt.Errorf("error while converting column type to clickhouse type: %w", err)
@@ -222,11 +223,7 @@ func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error
 		default:
 			projLen := projection.Len()
 			if colType == types.QValueKindBytes {
-				format, err := internal.PeerDBBinaryFormat(ctx, t.env)
-				if err != nil {
-					return "", err
-				}
-				switch format {
+				switch t.settings.ClickHouseBinaryFormat {
 				case internal.BinaryFormatRaw:
 					fmt.Fprintf(&projection,
 						"base64Decode(JSONExtractString(_peerdb_data, %s)) AS %s,",

--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
@@ -253,7 +254,7 @@ func TestBuildQuery_Basic(t *testing.T) {
 		lastNormBatchID,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,
-		env,
+		internal.NewSettings(env),
 		rawTableName,
 		nil,
 		false,
@@ -308,7 +309,7 @@ func TestBuildQuery_WithPrimaryUpdate(t *testing.T) {
 		lastNormBatchID,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,
-		env,
+		internal.NewSettings(env),
 		rawTableName,
 		nil,
 		false,
@@ -360,7 +361,7 @@ func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {
 		lastNormBatchID,
 		enablePrimaryUpdate,
 		sourceSchemaAsDestinationColumn,
-		env,
+		internal.NewSettings(env),
 		rawTableName,
 		nil,
 		true,
@@ -489,10 +490,6 @@ func TestGenerateCreateTableSQLForNormalizedTable(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := t.Context()
-			c := &ClickHouseConnector{
-				Config:    &protos.ClickhouseConfig{Database: "db"},
-				chVersion: tc.chVersion,
-			}
 			config := &protos.SetupNormalizedTableBatchInput{
 				Env: map[string]string{"PEERDB_SOURCE_SCHEMA_AS_DESTINATION_COLUMN": "false"},
 				TableMappings: []*protos.TableMapping{
@@ -502,6 +499,11 @@ func TestGenerateCreateTableSQLForNormalizedTable(t *testing.T) {
 					},
 				},
 				IsResync: tc.isResync,
+			}
+			c := &ClickHouseConnector{
+				Config:    &protos.ClickhouseConfig{Database: "db"},
+				chVersion: tc.chVersion,
+				Settings:  internal.NewSettings(config.Env),
 			}
 
 			result, err := c.generateCreateTableSQLForNormalizedTable(ctx, config, tableIdentifier, tableSchema, tc.chVersion, nil)

--- a/flow/connectors/clickhouse/object_sync.go
+++ b/flow/connectors/clickhouse/object_sync.go
@@ -238,6 +238,7 @@ func (c *ClickHouseConnector) insertFromURLBatch(
 		columnNameMap:             columnNameFieldMap,
 		excludedColumns:           config.Exclude,
 		config:                    config,
+		settings:                  c.Settings,
 		connector:                 c,
 		logger:                    c.logger,
 		fieldExpressionConverters: fieldExpressionConverters,

--- a/flow/connectors/clickhouse/s3_iam_role_test.go
+++ b/flow/connectors/clickhouse/s3_iam_role_test.go
@@ -39,7 +39,7 @@ func TestIAMRoleCanIssueSelectFromS3(t *testing.T) {
 	t.Setenv("PEERDB_CLICKHOUSE_RAW_TABLE_TTL_DAYS", "36500")
 	ctx := t.Context()
 
-	conn, err := NewClickHouseConnector(ctx, nil,
+	conn, err := NewClickHouseConnector(ctx, internal.NewSettings(nil),
 		&protos.ClickhouseConfig{
 			Host:       internal.ClickHouseTestHost(),
 			Port:       internal.ClickHouseTestPort(),

--- a/flow/connectors/clickhouse/table_function.go
+++ b/flow/connectors/clickhouse/table_function.go
@@ -22,6 +22,7 @@ import (
 type insertFromTableFunctionConfig struct {
 	columnNameMap             map[string]string
 	config                    *protos.QRepConfig
+	settings                  *internal.Settings
 	connector                 *ClickHouseConnector
 	logger                    log.Logger
 	destinationTable          string
@@ -47,7 +48,7 @@ func jsonFieldExpressionConverter(
 		return sourceFieldIdentifier, nil
 	}
 
-	if !qvalue.ShouldUseNativeJSONType(ctx, config.config.Env, config.connector.chVersion) {
+	if !qvalue.ShouldUseNativeJSONType(config.settings, config.connector.chVersion) {
 		return sourceFieldIdentifier, nil
 	}
 
@@ -96,10 +97,7 @@ func buildInsertFromTableFunctionQuery(
 	fieldExpressionConverters := defaultFieldExpressionConverters
 	fieldExpressionConverters = append(fieldExpressionConverters, config.fieldExpressionConverters...)
 
-	sourceSchemaAsDestinationColumn, err := internal.PeerDBSourceSchemaAsDestinationColumn(ctx, config.config.Env)
-	if err != nil {
-		return "", err
-	}
+	sourceSchemaAsDestinationColumn := config.settings.SourceSchemaAsDestinationColumn
 
 	selectedColumnNames := make([]string, 0, len(config.schema.Fields))
 	insertedColumnNames := make([]string, 0, len(config.schema.Fields))

--- a/flow/connectors/clickhouse/table_function_test.go
+++ b/flow/connectors/clickhouse/table_function_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	chinternal "github.com/PeerDB-io/peerdb/flow/internal/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
@@ -23,13 +24,15 @@ func TestBuildInsertFromTableFunctionQuery(t *testing.T) {
 		},
 	}
 
+	env := map[string]string{
+		"PEERDB_SOURCE_SCHEMA_AS_DESTINATION_COLUMN": "false",
+	}
 	config := &insertFromTableFunctionConfig{
 		destinationTable: "t1",
 		schema:           schema,
+		settings:         internal.NewSettings(env),
 		config: &protos.QRepConfig{
-			Env: map[string]string{
-				"PEERDB_SOURCE_SCHEMA_AS_DESTINATION_COLUMN": "false",
-			},
+			Env: env,
 		},
 	}
 

--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -64,19 +64,10 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 	// they'll always get swapped out with the _resync tables which we CREATE OR REPLACE
 	// also in case of this setting; multiple source tables can be mapped to the same destination table
 	// so ignore the check in this case as well
-	sourceSchemaAsDestinationColumn, err := internal.PeerDBSourceSchemaAsDestinationColumn(ctx, cfg.Env)
-	if err != nil {
-		return err
-	}
 
-	initialLoadAllowNonEmptyTables, err := internal.PeerDBClickHouseInitialLoadAllowNonEmptyTables(ctx, cfg.Env)
-	if err != nil {
-		return err
-	}
-
-	if !sourceSchemaAsDestinationColumn {
+	if !c.Settings.SourceSchemaAsDestinationColumn {
 		if err := chvalidate.CheckIfTablesEmptyAndEngine(ctx, c.logger, c.database,
-			dstTableNames, cfg.DoInitialSnapshot, internal.PeerDBOnlyClickHouseAllowed(), initialLoadAllowNonEmptyTables,
+			dstTableNames, cfg.DoInitialSnapshot, internal.PeerDBOnlyClickHouseAllowed(), c.Settings.ClickHouseInitialLoadAllowNonEmptyTables,
 		); err != nil {
 			return err
 		}

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -52,7 +52,9 @@ type MirrorSourceValidationConnector interface {
 type MirrorDestinationValidationConnector interface {
 	Connector
 
-	ValidateMirrorDestination(context.Context, *protos.FlowConnectionConfigsCore, map[string]*protos.TableSchema) error
+	ValidateMirrorDestination(
+		context.Context, *protos.FlowConnectionConfigsCore, map[string]*protos.TableSchema,
+	) error
 }
 
 type StatActivityConnector interface {
@@ -67,7 +69,6 @@ type GetTableSchemaConnector interface {
 	// GetTableSchema returns the schema of a table in terms of type system.
 	GetTableSchema(
 		ctx context.Context,
-		env map[string]string,
 		version uint32,
 		system protos.TypeSystem,
 		tableMappings []*protos.TableMapping,
@@ -103,7 +104,6 @@ type CDCPullConnectorCore interface {
 	ExportTxSnapshot(
 		ctx context.Context,
 		flowName string,
-		env map[string]string,
 	) (*protos.ExportTxSnapshotOutput, any, error)
 
 	// `any` from ExportSnapshot passed here when done, allowing transaction to commit
@@ -113,7 +113,7 @@ type CDCPullConnectorCore interface {
 	SetupReplication(context.Context, *protos.SetupReplicationInput) (model.SetupReplicationResult, error)
 
 	// Methods related to retrieving and pushing records for this connector as a source and destination.
-	SetupReplConn(context.Context, map[string]string) error
+	SetupReplConn(context.Context) error
 
 	// Ping source to keep connection alive. Can be called concurrently with pulling records; skips ping in that case.
 	ReplPing(context.Context) error
@@ -194,7 +194,7 @@ type CDCSyncConnectorCore interface {
 	// ReplayTableSchemaDelta changes a destination table to match the schema at source
 	// This could involve adding multiple columns.
 	// Connectors which are non-normalizing should implement this as a nop.
-	ReplayTableSchemaDeltas(ctx context.Context, env map[string]string, flowJobName string,
+	ReplayTableSchemaDeltas(ctx context.Context, flowJobName string,
 		tableMappings []*protos.TableMapping, schemaDeltas []*protos.TableSchemaDelta, flags []string,
 	) error
 }
@@ -234,7 +234,9 @@ type QRepPullConnectorCore interface {
 	Connector
 
 	// GetQRepPartitions returns the partitions for a given table that haven't been synced yet.
-	GetQRepPartitions(ctx context.Context, config *protos.QRepConfig, last *protos.QRepPartition) ([]*protos.QRepPartition, error)
+	GetQRepPartitions(
+		ctx context.Context, config *protos.QRepConfig, last *protos.QRepPartition,
+	) ([]*protos.QRepPartition, error)
 
 	GetDefaultPartitionKeyForTables(ctx context.Context,
 		input *protos.GetDefaultPartitionKeyForTablesInput) (*protos.GetDefaultPartitionKeyForTablesOutput, error)
@@ -548,41 +550,51 @@ func LoadPeer(ctx context.Context, catalogPool shared.CatalogPool, peerName stri
 	return peers[peerName], nil
 }
 
-func GetConnector(ctx context.Context, env map[string]string, config *protos.Peer) (Connector, error) {
+func GetConnector(ctx context.Context, settings *internal.Settings, config *protos.Peer) (Connector, error) {
 	switch inner := config.Config.(type) {
 	case *protos.Peer_PostgresConfig:
-		return connpostgres.NewPostgresConnector(ctx, env, inner.PostgresConfig)
+		return connpostgres.NewPostgresConnector(ctx, settings, inner.PostgresConfig)
 	case *protos.Peer_BigqueryConfig:
-		return connbigquery.NewBigQueryConnector(ctx, inner.BigqueryConfig)
+		return connbigquery.NewBigQueryConnector(ctx, settings, inner.BigqueryConfig)
 	case *protos.Peer_SnowflakeConfig:
-		return connsnowflake.NewSnowflakeConnector(ctx, inner.SnowflakeConfig)
+		return connsnowflake.NewSnowflakeConnector(ctx, settings, inner.SnowflakeConfig)
 	case *protos.Peer_EventhubGroupConfig:
-		return conneventhub.NewEventHubConnector(ctx, inner.EventhubGroupConfig)
+		return conneventhub.NewEventHubConnector(ctx, settings, inner.EventhubGroupConfig)
 	case *protos.Peer_S3Config:
-		return conns3.NewS3Connector(ctx, inner.S3Config)
+		return conns3.NewS3Connector(ctx, settings, inner.S3Config)
 	case *protos.Peer_MongoConfig:
-		return connmongo.NewMongoConnector(ctx, inner.MongoConfig)
+		return connmongo.NewMongoConnector(ctx, settings, inner.MongoConfig)
 	case *protos.Peer_MysqlConfig:
-		return connmysql.NewMySqlConnector(ctx, inner.MysqlConfig)
+		return connmysql.NewMySqlConnector(ctx, settings, inner.MysqlConfig)
 	case *protos.Peer_ClickhouseConfig:
-		return connclickhouse.NewClickHouseConnector(ctx, env, inner.ClickhouseConfig)
+		return connclickhouse.NewClickHouseConnector(ctx, settings, inner.ClickhouseConfig)
 	case *protos.Peer_KafkaConfig:
-		return connkafka.NewKafkaConnector(ctx, env, inner.KafkaConfig)
+		return connkafka.NewKafkaConnector(ctx, settings, inner.KafkaConfig)
 	case *protos.Peer_PubsubConfig:
-		return connpubsub.NewPubSubConnector(ctx, env, inner.PubsubConfig)
+		return connpubsub.NewPubSubConnector(ctx, settings, inner.PubsubConfig)
 	case *protos.Peer_ElasticsearchConfig:
-		return connelasticsearch.NewElasticsearchConnector(ctx, inner.ElasticsearchConfig)
+		return connelasticsearch.NewElasticsearchConnector(ctx, settings, inner.ElasticsearchConfig)
 	default:
 		return nil, errors.ErrUnsupported
 	}
 }
 
+// GetConnectorWithEnv loads settings from env then calls GetConnector. Used when the
+// caller has env but no preloaded *Settings.
+func GetConnectorWithEnv(ctx context.Context, env map[string]string, config *protos.Peer) (Connector, error) {
+	settings, err := internal.LoadSettings(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	return GetConnector(ctx, settings, config)
+}
+
 var noopClose = func(context.Context) {}
 
 // Gets typed connector by config. Returns a close function to recruit the compiler into helping us avoid connection leaks.
-func GetAs[T Connector](ctx context.Context, env map[string]string, config *protos.Peer) (T, func(context.Context), error) {
+func GetAs[T Connector](ctx context.Context, settings *internal.Settings, config *protos.Peer) (T, func(context.Context), error) {
 	var none T
-	conn, err := GetConnector(ctx, env, config)
+	conn, err := GetConnector(ctx, settings, config)
 	if err != nil {
 		return none, noopClose, exceptions.NewPeerCreateError(err)
 	}
@@ -603,6 +615,51 @@ func GetAs[T Connector](ctx context.Context, env map[string]string, config *prot
 // Gets peer and connector by name. Returns a close function to recruit the compiler into helping us avoid connection leaks.
 func LoadPeerAndGetByNameAs[T Connector](
 	ctx context.Context,
+	settings *internal.Settings,
+	catalogPool shared.CatalogPool,
+	name string,
+) (*protos.Peer, T, func(context.Context), error) {
+	peer, err := LoadPeer(ctx, catalogPool, name)
+	if err != nil {
+		var none T
+		return nil, none, noopClose, err
+	}
+	conn, connClose, err := GetAs[T](ctx, settings, peer)
+	return peer, conn, connClose, err
+}
+
+// Gets connector by name. Returns a close function to recruit the compiler into helping us avoid connection leaks.
+func GetByNameAs[T Connector](
+	ctx context.Context, settings *internal.Settings, catalogPool shared.CatalogPool, name string,
+) (T, func(context.Context), error) {
+	_, conn, connClose, err := LoadPeerAndGetByNameAs[T](ctx, settings, catalogPool, name)
+	return conn, connClose, err
+}
+
+// GetWithEnvAs is like GetAs but defers settings loading to GetConnectorWithEnv (lazy by peer type).
+func GetWithEnvAs[T Connector](ctx context.Context, env map[string]string, config *protos.Peer) (T, func(context.Context), error) {
+	var none T
+	conn, err := GetConnectorWithEnv(ctx, env, config)
+	if err != nil {
+		return none, noopClose, exceptions.NewPeerCreateError(err)
+	}
+
+	if tconn, ok := conn.(T); ok {
+		connClose := func(closeCtx context.Context) {
+			if err := conn.Close(); err != nil {
+				internal.LoggerFromCtx(closeCtx).Error("error closing connector", slog.Any("error", err))
+			}
+		}
+		return tconn, connClose, nil
+	} else {
+		conn.Close()
+		return none, noopClose, errors.ErrUnsupported
+	}
+}
+
+// LoadPeerAndGetByNameWithEnvAs is like LoadPeerAndGetByNameAs but defers settings loading.
+func LoadPeerAndGetByNameWithEnvAs[T Connector](
+	ctx context.Context,
 	env map[string]string,
 	catalogPool shared.CatalogPool,
 	name string,
@@ -612,37 +669,23 @@ func LoadPeerAndGetByNameAs[T Connector](
 		var none T
 		return nil, none, noopClose, err
 	}
-	conn, connClose, err := GetAs[T](ctx, env, peer)
+	conn, connClose, err := GetWithEnvAs[T](ctx, env, peer)
 	return peer, conn, connClose, err
 }
 
-// Gets connector by name. Returns a close function to recruit the compiler into helping us avoid connection leaks.
-func GetByNameAs[T Connector](
+// GetByNameWithEnvAs is like GetByNameAs but defers settings loading; settings are read from
+// the catalog only when the resolved peer type requires them.
+func GetByNameWithEnvAs[T Connector](
 	ctx context.Context, env map[string]string, catalogPool shared.CatalogPool, name string,
 ) (T, func(context.Context), error) {
-	_, conn, connClose, err := LoadPeerAndGetByNameAs[T](ctx, env, catalogPool, name)
+	_, conn, connClose, err := LoadPeerAndGetByNameWithEnvAs[T](ctx, env, catalogPool, name)
 	return conn, connClose, err
-}
-
-// Gets Postgres connector by name. Returns a close function to recruit the compiler into helping us avoid connection leaks.
-func GetPostgresConnectorByName(
-	ctx context.Context,
-	env map[string]string,
-	catalogPool shared.CatalogPool,
-	name string,
-) (*connpostgres.PostgresConnector, func(context.Context), error) {
-	peer, err := LoadPeer(ctx, catalogPool, name)
-	if err != nil {
-		return nil, noopClose, err
-	}
-	if peer.Type != protos.DBType_POSTGRES {
-		return nil, noopClose, errors.ErrUnsupported
-	}
-	return GetAs[*connpostgres.PostgresConnector](ctx, env, peer)
 }
 
 // create type assertions to cause compile time error if connector interface not implemented
 var (
+	_ CDCPullConnectorCore = &connbigquery.BigQueryConnector{}
+
 	_ CDCPullConnector = &connpostgres.PostgresConnector{}
 	_ CDCPullConnector = &connmysql.MySqlConnector{}
 	_ CDCPullConnector = &connmongo.MongoConnector{}

--- a/flow/connectors/elasticsearch/elasticsearch.go
+++ b/flow/connectors/elasticsearch/elasticsearch.go
@@ -39,12 +39,14 @@ type tableUpsertCol struct {
 
 type ElasticsearchConnector struct {
 	*metadataStore.PostgresMetadata
+	Settings                 *internal.Settings
 	client                   *elasticsearch.Client
 	logger                   log.Logger
 	hushWarnUpsertColMissing map[tableUpsertCol]struct{}
 }
 
 func NewElasticsearchConnector(ctx context.Context,
+	settings *internal.Settings,
 	config *protos.ElasticsearchConfig,
 ) (*ElasticsearchConnector, error) {
 	esCfg := &elasticsearch.Config{
@@ -72,6 +74,7 @@ func NewElasticsearchConnector(ctx context.Context,
 
 	return &ElasticsearchConnector{
 		PostgresMetadata:         pgMetadata,
+		Settings:                 settings,
 		client:                   esClient,
 		logger:                   internal.LoggerFromCtx(ctx),
 		hushWarnUpsertColMissing: make(map[tableUpsertCol]struct{}),
@@ -99,7 +102,7 @@ func (esc *ElasticsearchConnector) CreateRawTable(ctx context.Context,
 }
 
 // we handle schema changes by not handling them since no mapping is being enforced right now
-func (esc *ElasticsearchConnector) ReplayTableSchemaDeltas(ctx context.Context, env map[string]string,
+func (esc *ElasticsearchConnector) ReplayTableSchemaDeltas(ctx context.Context,
 	flowJobName string, _ []*protos.TableMapping, schemaDeltas []*protos.TableSchemaDelta, _ []string,
 ) error {
 	return nil
@@ -150,7 +153,7 @@ func (esc *ElasticsearchConnector) SyncRecords(ctx context.Context,
 
 	flushLoopDone := make(chan struct{})
 	go func() {
-		flushTimeout, err := internal.PeerDBQueueFlushTimeoutSeconds(ctx, req.Env)
+		flushTimeout, err := internal.PeerDBQueueFlushTimeoutSeconds(ctx, esc.Settings.Env)
 		if err != nil {
 			esc.logger.Warn("[elasticsearch] failed to get flush timeout, no periodic flushing", slog.Any("error", err))
 			return

--- a/flow/connectors/eventhub/eventhub.go
+++ b/flow/connectors/eventhub/eventhub.go
@@ -23,6 +23,7 @@ import (
 
 type EventHubConnector struct {
 	*metadataStore.PostgresMetadata
+	Settings   *internal.Settings
 	config     *protos.EventHubGroupConfig
 	creds      *azidentity.DefaultAzureCredential
 	hubManager *EventHubManager
@@ -32,6 +33,7 @@ type EventHubConnector struct {
 // NewEventHubConnector creates a new EventHubConnector.
 func NewEventHubConnector(
 	ctx context.Context,
+	settings *internal.Settings,
 	config *protos.EventHubGroupConfig,
 ) (*EventHubConnector, error) {
 	logger := internal.LoggerFromCtx(ctx)
@@ -50,6 +52,7 @@ func NewEventHubConnector(
 
 	return &EventHubConnector{
 		PostgresMetadata: pgMetadata,
+		Settings:         settings,
 		config:           config,
 		creds:            defaultAzureCreds,
 		hubManager:       hubManager,
@@ -175,7 +178,7 @@ func (c *EventHubConnector) processBatch(
 	batchPerTopic := NewHubBatches(c.hubManager)
 	toJSONOpts := model.NewToJSONOptions(c.config.UnnestColumns, false)
 
-	flushTimeout, err := internal.PeerDBQueueFlushTimeoutSeconds(ctx, req.Env)
+	flushTimeout, err := internal.PeerDBQueueFlushTimeoutSeconds(ctx, c.Settings.Env)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get flush timeout: %w", err)
 	}
@@ -370,7 +373,7 @@ func (c *EventHubConnector) CreateRawTable(ctx context.Context, req *protos.Crea
 	}, nil
 }
 
-func (c *EventHubConnector) ReplayTableSchemaDeltas(_ context.Context, _ map[string]string,
+func (c *EventHubConnector) ReplayTableSchemaDeltas(_ context.Context,
 	flowJobName string, _ []*protos.TableMapping, schemaDeltas []*protos.TableSchemaDelta, _ []string,
 ) error {
 	return nil

--- a/flow/connectors/kafka/kafka.go
+++ b/flow/connectors/kafka/kafka.go
@@ -30,8 +30,9 @@ import (
 
 type KafkaConnector struct {
 	*metadataStore.PostgresMetadata
-	client *kgo.Client
-	logger log.Logger
+	Settings *internal.Settings
+	client   *kgo.Client
+	logger   log.Logger
 }
 
 type kgoTemporalLogger struct {
@@ -65,7 +66,7 @@ func (logger kgoTemporalLogger) Log(level kgo.LogLevel, msg string, keyvals ...a
 
 func NewKafkaConnector(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	config *protos.KafkaConfig,
 ) (*KafkaConnector, error) {
 	logger := internal.LoggerFromCtx(ctx)
@@ -127,8 +128,7 @@ func NewKafkaConnector(
 			return nil, fmt.Errorf("unsupported SASL mechanism: %s", config.Sasl)
 		}
 	}
-	force, err := internal.PeerDBQueueForceTopicCreation(ctx, env)
-	if err == nil && force {
+	if settings.QueueForceTopicCreation {
 		optionalOpts = append(optionalOpts, kgo.UnknownTopicRetries(0))
 	}
 
@@ -144,6 +144,7 @@ func NewKafkaConnector(
 
 	return &KafkaConnector{
 		PostgresMetadata: pgMetadata,
+		Settings:         settings,
 		client:           client,
 		logger:           logger,
 	}, nil
@@ -164,7 +165,7 @@ func (c *KafkaConnector) CreateRawTable(ctx context.Context, req *protos.CreateR
 	return &protos.CreateRawTableOutput{TableIdentifier: "n/a"}, nil
 }
 
-func (c *KafkaConnector) ReplayTableSchemaDeltas(_ context.Context, _ map[string]string,
+func (c *KafkaConnector) ReplayTableSchemaDeltas(_ context.Context,
 	flowJobName string, _ []*protos.TableMapping, schemaDeltas []*protos.TableSchemaDelta, _ []string,
 ) error {
 	return nil
@@ -225,13 +226,12 @@ type poolResult struct {
 
 func (c *KafkaConnector) createPool(
 	ctx context.Context,
-	env map[string]string,
 	script string,
 	flowJobName string,
 	lastSeenLSN *atomic.Int64,
 	queueErr func(error),
 ) (*utils.LPool[poolResult], error) {
-	maxSize, err := internal.PeerDBQueueParallelism(ctx, env)
+	maxSize, err := internal.PeerDBQueueParallelism(ctx, c.Settings.Env)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get parallelism: %w", err)
 	}
@@ -261,8 +261,7 @@ func (c *KafkaConnector) createPool(
 				if err != nil {
 					var success bool
 					if errors.Is(err, kerr.UnknownTopicOrPartition) {
-						force, envErr := internal.PeerDBQueueForceTopicCreation(ctx, env)
-						if envErr == nil && force {
+						if c.Settings.QueueForceTopicCreation {
 							c.logger.Info("[kafka] force topic creation", slog.String("topic", kr.Topic))
 							_, err := kadm.NewClient(c.client).CreateTopic(ctx, 1, 3, nil, kr.Topic)
 							if err != nil && !errors.Is(err, kerr.TopicAlreadyExists) {
@@ -298,7 +297,7 @@ func (c *KafkaConnector) SyncRecords(ctx context.Context, req *model.SyncRecords
 
 	queueCtx, queueErr := context.WithCancelCause(ctx)
 
-	pool, err := c.createPool(queueCtx, req.Env, req.Script, req.FlowJobName, &lastSeenLSN, queueErr)
+	pool, err := c.createPool(queueCtx, req.Script, req.FlowJobName, &lastSeenLSN, queueErr)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +306,7 @@ func (c *KafkaConnector) SyncRecords(ctx context.Context, req *model.SyncRecords
 	tableNameRowsMapping := utils.InitialiseTableRowsMap(req.TableMappings)
 	flushLoopDone := make(chan struct{})
 	go func() {
-		flushTimeout, err := internal.PeerDBQueueFlushTimeoutSeconds(ctx, req.Env)
+		flushTimeout, err := internal.PeerDBQueueFlushTimeoutSeconds(ctx, c.Settings.Env)
 		if err != nil {
 			c.logger.Warn("[kafka] failed to get flush timeout, no periodic flushing", slog.Any("error", err))
 			return

--- a/flow/connectors/kafka/qrep.go
+++ b/flow/connectors/kafka/qrep.go
@@ -34,7 +34,7 @@ func (c *KafkaConnector) SyncQRepRecords(
 	}
 
 	queueCtx, queueErr := context.WithCancelCause(ctx)
-	pool, err := c.createPool(queueCtx, config.Env, config.Script, config.FlowJobName, nil, queueErr)
+	pool, err := c.createPool(queueCtx, config.Script, config.FlowJobName, nil, queueErr)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -57,7 +57,6 @@ func (w *changeStreamWrapper) Current() bson.Raw {
 
 func (c *MongoConnector) GetTableSchema(
 	ctx context.Context,
-	_ map[string]string,
 	internalVersion uint32,
 	_ protos.TypeSystem,
 	tableMappings []*protos.TableMapping,
@@ -539,7 +538,7 @@ func (c *MongoConnector) EnsurePullability(ctx context.Context, req *protos.Ensu
 	return nil, nil
 }
 
-func (c *MongoConnector) ExportTxSnapshot(context.Context, string, map[string]string) (*protos.ExportTxSnapshotOutput, any, error) {
+func (c *MongoConnector) ExportTxSnapshot(context.Context, string) (*protos.ExportTxSnapshotOutput, any, error) {
 	return nil, nil, nil
 }
 
@@ -547,7 +546,7 @@ func (c *MongoConnector) FinishExport(any) error {
 	return nil
 }
 
-func (c *MongoConnector) SetupReplConn(context.Context, map[string]string) error {
+func (c *MongoConnector) SetupReplConn(context.Context) error {
 	return nil
 }
 

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -60,6 +60,7 @@ type createChangeStreamFunc func(
 ) (ChangeStream, error)
 
 type MongoConnector struct {
+	Settings           *internal.Settings
 	logger             log.Logger
 	metadataStore      metadataStore
 	config             *protos.MongoConfig
@@ -70,7 +71,7 @@ type MongoConnector struct {
 	deltaBytesRead     atomic.Int64
 }
 
-func NewMongoConnector(ctx context.Context, config *protos.MongoConfig) (*MongoConnector, error) {
+func NewMongoConnector(ctx context.Context, settings *internal.Settings, config *protos.MongoConfig) (*MongoConnector, error) {
 	logger := internal.LoggerFromCtx(ctx)
 	pgMetadata, err := metadata.NewPostgresMetadata(ctx)
 	if err != nil {
@@ -78,6 +79,7 @@ func NewMongoConnector(ctx context.Context, config *protos.MongoConfig) (*MongoC
 	}
 
 	mc := &MongoConnector{
+		Settings:      settings,
 		metadataStore: pgMetadata,
 		config:        config,
 		logger:        logger,

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -45,14 +45,13 @@ func (c *MySqlConnector) binlogStalenessThreshold() time.Duration {
 
 func (c *MySqlConnector) GetTableSchema(
 	ctx context.Context,
-	env map[string]string,
 	version uint32,
 	system protos.TypeSystem,
 	tableMappings []*protos.TableMapping,
 ) (map[string]*protos.TableSchema, error) {
 	res := make(map[string]*protos.TableSchema, len(tableMappings))
 	for _, tm := range tableMappings {
-		tableSchema, err := c.getTableSchemaForTable(ctx, env, tm, system, version)
+		tableSchema, err := c.getTableSchemaForTable(ctx, tm, system, version)
 		if err != nil {
 			c.logger.Info("error fetching schema", slog.String("table", tm.SourceTableIdentifier), slog.Any("error", err))
 			return nil, err
@@ -66,17 +65,11 @@ func (c *MySqlConnector) GetTableSchema(
 
 func (c *MySqlConnector) getTableSchemaForTable(
 	ctx context.Context,
-	env map[string]string,
 	tm *protos.TableMapping,
 	system protos.TypeSystem,
 	mirrorVersion uint32,
 ) (*protos.TableSchema, error) {
 	qualifiedTable, err := common.ParseTableIdentifier(tm.SourceTableIdentifier)
-	if err != nil {
-		return nil, err
-	}
-
-	nullableEnabled, err := internal.PeerDBNullable(ctx, env)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +172,7 @@ func (c *MySqlConnector) getTableSchemaForTable(
 		PrimaryKeyColumns:     primary,
 		IsReplicaIdentityFull: false,
 		System:                system,
-		NullableEnabled:       nullableEnabled,
+		NullableEnabled:       c.Settings.Nullable,
 		Columns:               columns,
 	}, nil
 }
@@ -190,7 +183,7 @@ func (c *MySqlConnector) EnsurePullability(
 	return nil, nil
 }
 
-func (c *MySqlConnector) ExportTxSnapshot(context.Context, string, map[string]string) (*protos.ExportTxSnapshotOutput, any, error) {
+func (c *MySqlConnector) ExportTxSnapshot(context.Context, string) (*protos.ExportTxSnapshotOutput, any, error) {
 	// https://dev.mysql.com/doc/refman/8.4/en/replication-howto-masterstatus.html
 	return nil, nil, nil
 }
@@ -236,7 +229,7 @@ func (c *MySqlConnector) SetupReplication(
 	return model.SetupReplicationResult{}, nil
 }
 
-func (c *MySqlConnector) SetupReplConn(context.Context, map[string]string) error {
+func (c *MySqlConnector) SetupReplConn(context.Context) error {
 	// mysql code will spin up new connection for each normalize for now
 	return nil
 }
@@ -378,11 +371,6 @@ func (c *MySqlConnector) PullRecords(
 	req *model.PullRecordsRequest[model.RecordItems],
 ) error {
 	defer req.RecordStream.Close()
-
-	sourceSchemaAsDestinationColumn, err := internal.PeerDBSourceSchemaAsDestinationColumn(ctx, req.Env)
-	if err != nil {
-		return err
-	}
 
 	binlogRowMetadataSupported, err := c.IsBinlogRowMetadataSupported(ctx)
 	if err != nil {
@@ -643,7 +631,7 @@ func (c *MySqlConnector) PullRecords(
 							}
 							items.AddColumn(fd.Name, val)
 						}
-						if sourceSchemaAsDestinationColumn {
+						if c.Settings.SourceSchemaAsDestinationColumn {
 							items.AddColumn("_peerdb_source_schema", types.QValueString{Val: string(ev.Table.Schema)})
 						}
 
@@ -694,7 +682,7 @@ func (c *MySqlConnector) PullRecords(
 							}
 							newItems.AddColumn(fd.Name, val)
 						}
-						if sourceSchemaAsDestinationColumn {
+						if c.Settings.SourceSchemaAsDestinationColumn {
 							newItems.AddColumn("_peerdb_source_schema", types.QValueString{Val: string(ev.Table.Schema)})
 						}
 
@@ -732,7 +720,7 @@ func (c *MySqlConnector) PullRecords(
 							}
 							items.AddColumn(fd.Name, val)
 						}
-						if sourceSchemaAsDestinationColumn {
+						if c.Settings.SourceSchemaAsDestinationColumn {
 							items.AddColumn("_peerdb_source_schema", types.QValueString{Val: string(ev.Table.Schema)})
 						}
 

--- a/flow/connectors/mysql/cdc_test.go
+++ b/flow/connectors/mysql/cdc_test.go
@@ -18,7 +18,7 @@ func newTestConnector(t *testing.T, ctx context.Context) *MySqlConnector {
 	if internal.MySQLTestVersionIsMaria() {
 		flavor = protos.MySqlFlavor_MYSQL_MARIA
 	}
-	connector, err := NewMySqlConnector(ctx, &protos.MySqlConfig{
+	connector, err := NewMySqlConnector(ctx, internal.NewSettings(nil), &protos.MySqlConfig{
 		Host:       internal.MySQLTestHost(),
 		Port:       internal.MySQLTestPort(),
 		User:       "root",
@@ -93,7 +93,7 @@ func TestGetTableSchemaCaseSensitiveIdentifiers(t *testing.T) {
 	exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, ul TEXT)", ulTable))
 	exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, uu TEXT)", uuTable))
 
-	schemas, err := connector.GetTableSchema(ctx, nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	schemas, err := connector.GetTableSchema(ctx, shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{
 			{SourceTableIdentifier: llTable},
 			{SourceTableIdentifier: luTable},

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -29,6 +29,7 @@ import (
 
 type MySqlConnector struct {
 	*metadataStore.PostgresMetadata
+	Settings              *internal.Settings
 	config                *protos.MySqlConfig
 	ssh                   *utils.SSHTunnel
 	conn                  atomic.Pointer[client.Conn] // atomic used for internal concurrency, connector interface is not threadsafe
@@ -41,7 +42,7 @@ type MySqlConnector struct {
 	deltaBytesRead        atomic.Int64
 }
 
-func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlConnector, error) {
+func NewMySqlConnector(ctx context.Context, settings *internal.Settings, config *protos.MySqlConfig) (*MySqlConnector, error) {
 	pgMetadata, err := metadataStore.NewPostgresMetadata(ctx)
 	if err != nil {
 		return nil, err
@@ -64,6 +65,7 @@ func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlC
 	contexts := make(chan context.Context)
 	c := &MySqlConnector{
 		PostgresMetadata:      pgMetadata,
+		Settings:              settings,
 		config:                config,
 		ssh:                   ssh,
 		conn:                  atomic.Pointer[client.Conn]{},

--- a/flow/connectors/mysql/qrep.go
+++ b/flow/connectors/mysql/qrep.go
@@ -212,7 +212,7 @@ func (c *MySqlConnector) PullQRepRecords(
 	partition *protos.QRepPartition,
 	stream *model.QRecordStream,
 ) (int64, int64, error) {
-	tableSchema, err := c.getTableSchemaForTable(ctx, config.Env,
+	tableSchema, err := c.getTableSchemaForTable(ctx,
 		&protos.TableMapping{SourceTableIdentifier: config.WatermarkTable}, protos.TypeSystem_Q,
 		config.Version)
 	if err != nil {

--- a/flow/connectors/mysql/rds_test.go
+++ b/flow/connectors/mysql/rds_test.go
@@ -12,7 +12,7 @@ import (
 func TestAwsRDSIAMAuthConnectForMYSQL(t *testing.T) {
 	internal.SetupRDSIAMAuthAWSCredentials(t)
 	conn := internal.RDSIAMAuthMySQLTestConnectionInfo(t)
-	mysqlConnector, err := NewMySqlConnector(t.Context(),
+	mysqlConnector, err := NewMySqlConnector(t.Context(), internal.NewSettings(nil),
 		&protos.MySqlConfig{
 			Host:       conn.Host,
 			Database:   "postgres",
@@ -29,7 +29,7 @@ func TestAwsRDSIAMAuthConnectForMYSQL(t *testing.T) {
 func TestAwsRDSIAMAuthConnectForMYSQLViaProxy(t *testing.T) {
 	internal.SetupRDSIAMAuthAWSCredentials(t)
 	conn := internal.RDSIAMAuthMySQLTestConnectionInfo(t)
-	mysqlConnector, err := NewMySqlConnector(t.Context(),
+	mysqlConnector, err := NewMySqlConnector(t.Context(), internal.NewSettings(nil),
 		&protos.MySqlConfig{
 			Host:       conn.ProxyHost,
 			Database:   "postgres",

--- a/flow/connectors/mysql/ssh_keepalive_test.go
+++ b/flow/connectors/mysql/ssh_keepalive_test.go
@@ -47,7 +47,7 @@ func setupMySQLConnectorWithSSHProxy(ctx context.Context, t *testing.T, proxyNam
 
 	mysqlHost, mysqlPort, mysqlRootPass := resolveMySQL(t)
 
-	connector, err := NewMySqlConnector(ctx, &protos.MySqlConfig{
+	connector, err := NewMySqlConnector(ctx, internal.NewSettings(nil), &protos.MySqlConfig{
 		Host:     mysqlHost,
 		Port:     mysqlPort,
 		User:     "root",
@@ -85,7 +85,7 @@ func setupMySQLConnectorWithMySQLProxy(
 	sshPort, err := strconv.ParseUint(sshPortStr, 10, 32)
 	require.NoError(t, err)
 
-	connector, err := NewMySqlConnector(ctx, &protos.MySqlConfig{
+	connector, err := NewMySqlConnector(ctx, internal.NewSettings(nil), &protos.MySqlConfig{
 		Host:     utils.MySQLProxyHost,
 		Port:     uint32(proxyPort),
 		User:     "root",

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -503,13 +503,12 @@ func PullCdcRecords[Items model.Items](
 
 	// determine message wait period in function of idle and wal_sender timeouts
 	var walSenderTimeout time.Duration
-	if walSenderTimeoutStr, err := internal.PeerDBPostgresWalSenderTimeout(ctx, req.Env); err != nil {
-		return fmt.Errorf("could't get wal_sender_timeout parameter: %w", err)
-	} else if walSenderTimeoutStr != NoWALSenderTimeoutSetting {
+	if walSenderTimeoutStr := p.Settings.PostgresWalSenderTimeout; walSenderTimeoutStr != NoWALSenderTimeoutSetting {
 		// If no units are provided, milliseconds are assumed
 		if regexp.MustCompile(`^\d+$`).MatchString(walSenderTimeoutStr) {
 			walSenderTimeoutStr += "ms"
 		}
+		var err error
 		if walSenderTimeout, err = time.ParseDuration(walSenderTimeoutStr); err != nil {
 			return fmt.Errorf("failed to parse wal_sender_timeout value: %w", err)
 		}
@@ -547,13 +546,13 @@ func PullCdcRecords[Items model.Items](
 	}
 
 	// Remove exceptions.PrimaryKeyModifiedError and its classification when cdc store is removed
-	cdcStoreEnabled, err := internal.PeerDBCDCStoreEnabled(ctx, req.Env)
+	cdcStoreEnabled, err := internal.PeerDBCDCStoreEnabled(ctx, p.Settings.Env)
 	if err != nil {
 		return err
 	}
 	var cdcRecordsStorage *utils.CDCStore[Items]
 	if cdcStoreEnabled {
-		cdcRecordsStorage, err = utils.NewCDCStore[Items](ctx, req.Env, p.flowJobName)
+		cdcRecordsStorage, err = utils.NewCDCStore[Items](ctx, p.Settings, p.flowJobName)
 		if err != nil {
 			return err
 		}
@@ -639,10 +638,6 @@ func PullCdcRecords[Items model.Items](
 		return nil
 	}
 
-	pkmEmptyBatchThrottleThresholdSeconds, err := internal.PeerDBPKMEmptyBatchThrottleThresholdSeconds(ctx, req.Env)
-	if err != nil {
-		logger.Error("failed to get PeerDBPKMEmptyBatchThrottleThresholdSeconds", slog.Any("error", err))
-	}
 	lastEmptyBatchPkmSentTime := time.Now()
 	for {
 		if pkmRequiresResponse {
@@ -773,8 +768,8 @@ func PullCdcRecords[Items model.Items](
 					clientXLogPos = pkm.ServerWALEnd
 				}
 
-				if pkm.ReplyRequested || (pkmEmptyBatchThrottleThresholdSeconds != -1 &&
-					time.Since(lastEmptyBatchPkmSentTime) >= time.Duration(pkmEmptyBatchThrottleThresholdSeconds)*time.Second) {
+				if pkm.ReplyRequested || (p.Settings.PKMEmptyBatchThrottleThresholdSeconds != -1 &&
+					time.Since(lastEmptyBatchPkmSentTime) >= time.Duration(p.Settings.PKMEmptyBatchThrottleThresholdSeconds)*time.Second) {
 					pkmRequiresResponse = true
 				}
 

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -526,7 +526,6 @@ func (c *PostgresConnector) createSlotAndPublication(
 	tableNameMapping map[string]model.NameAndExclude,
 	doInitialCopy bool,
 	skipSnapshotExport bool,
-	env map[string]string,
 ) (model.SetupReplicationResult, error) {
 	// iterate through source tables and create publication,
 	// expecting tablenames to be schema qualified
@@ -546,7 +545,7 @@ func (c *PostgresConnector) createSlotAndPublication(
 
 	// create slot only after we succeeded in creating publication.
 	if !s.SlotExists {
-		conn, err := c.CreateReplConn(ctx, env)
+		conn, err := c.CreateReplConn(ctx)
 		if err != nil {
 			return model.SetupReplicationResult{}, fmt.Errorf("[slot] error acquiring connection: %w", err)
 		}
@@ -569,7 +568,7 @@ func (c *PostgresConnector) createSlotAndPublication(
 		}
 
 		var optionsString string
-		if failoverEnabled, err := internal.PeerDBPostgresEnableFailoverSlots(ctx, env); err != nil {
+		if failoverEnabled, err := internal.PeerDBPostgresEnableFailoverSlots(ctx, c.Settings.Env); err != nil {
 			conn.Close(ctx)
 			return model.SetupReplicationResult{}, fmt.Errorf("[slot] error checking dynamic config for failover slots: %w", err)
 		} else if failoverEnabled {

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -41,6 +41,7 @@ type PostgresConnector struct {
 	replConn               *pgx.Conn
 	replState              *ReplState
 	Config                 *protos.PostgresConfig
+	Settings               *internal.Settings
 	hushWarnOID            map[uint32]struct{}
 	relationMessageMapping model.RelationMessageMapping
 	typeMap                *pgtype.Map
@@ -51,14 +52,10 @@ type PostgresConnector struct {
 	pgVersion              shared.PGVersion
 }
 
-func NewPostgresConnector(ctx context.Context, env map[string]string, pgConfig *protos.PostgresConfig) (*PostgresConnector, error) {
+func NewPostgresConnector(ctx context.Context, settings *internal.Settings, pgConfig *protos.PostgresConfig) (*PostgresConnector, error) {
 	logger := internal.LoggerFromCtx(ctx)
-	flowNameInApplicationName, err := internal.PeerDBApplicationNamePerMirrorName(ctx, nil)
-	if err != nil {
-		logger.Error("Failed to get flow name from application name", slog.Any("error", err))
-	}
 	var flowName string
-	if flowNameInApplicationName {
+	if settings.ApplicationNamePerMirrorName {
 		flowName, _ = ctx.Value(shared.FlowNameKey).(string)
 	}
 	connectionString := internal.GetPGConnectionString(pgConfig, flowName)
@@ -115,6 +112,7 @@ func NewPostgresConnector(ctx context.Context, env map[string]string, pgConfig *
 	connector := &PostgresConnector{
 		logger:                 logger,
 		Config:                 pgConfig,
+		Settings:               settings,
 		ssh:                    tunnel,
 		conn:                   conn,
 		replConn:               nil,

--- a/flow/connectors/postgres/postgres_destination.go
+++ b/flow/connectors/postgres/postgres_destination.go
@@ -212,7 +212,7 @@ func syncRecordsCore[Items model.Items](
 		return nil, err
 	}
 
-	if err := c.ReplayTableSchemaDeltas(ctx, req.Env, req.FlowJobName, req.TableMappings, req.Records.SchemaDeltas, nil); err != nil {
+	if err := c.ReplayTableSchemaDeltas(ctx, req.FlowJobName, req.TableMappings, req.Records.SchemaDeltas, nil); err != nil {
 		return nil, fmt.Errorf("failed to sync schema changes: %w", err)
 	}
 
@@ -475,7 +475,6 @@ func (c *PostgresConnector) SetupNormalizedTable(
 // This could involve adding or dropping multiple columns.
 func (c *PostgresConnector) ReplayTableSchemaDeltas(
 	ctx context.Context,
-	_ map[string]string,
 	flowJobName string,
 	_ []*protos.TableMapping,
 	schemaDeltas []*protos.TableSchemaDelta,

--- a/flow/connectors/postgres/postgres_publication_test.go
+++ b/flow/connectors/postgres/postgres_publication_test.go
@@ -44,7 +44,7 @@ func createTableInPublication(t *testing.T, conn *pgx.Conn, schema, table, pubNa
 
 func TestRemoveTablesFromPublication(t *testing.T) {
 	t.Parallel()
-	connector, err := NewPostgresConnector(t.Context(), nil, internal.GetCatalogPostgresConfigFromEnv(t.Context()))
+	connector, err := NewPostgresConnector(t.Context(), internal.NewSettings(nil), internal.GetCatalogPostgresConfigFromEnv(t.Context()))
 	require.NoError(t, err)
 	t.Cleanup(func() { connector.Close() })
 

--- a/flow/connectors/postgres/postgres_schema_delta_test.go
+++ b/flow/connectors/postgres/postgres_schema_delta_test.go
@@ -26,7 +26,7 @@ type PostgresSchemaDeltaTestSuite struct {
 func SetupSuite(t *testing.T) PostgresSchemaDeltaTestSuite {
 	t.Helper()
 
-	connector, err := NewPostgresConnector(t.Context(), nil, internal.GetCatalogPostgresConfigFromEnv(t.Context()))
+	connector, err := NewPostgresConnector(t.Context(), internal.NewSettings(nil), internal.GetCatalogPostgresConfigFromEnv(t.Context()))
 	require.NoError(t, err)
 
 	setupTx, err := connector.conn.Begin(t.Context())
@@ -78,14 +78,15 @@ func (s PostgresSchemaDeltaTestSuite) testSimpleAddColumn(t *testing.T, system p
 		},
 	}, system)
 
-	require.NoError(t, s.connector.ReplayTableSchemaDeltas(t.Context(), nil, "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
-		SrcTableName: tableName,
-		DstTableName: tableName,
-		AddedColumns: addedColumns,
-		System:       system,
-	}}, nil))
+	require.NoError(t, s.connector.ReplayTableSchemaDeltas(
+		t.Context(), "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
+			SrcTableName: tableName,
+			DstTableName: tableName,
+			AddedColumns: addedColumns,
+			System:       system,
+		}}, nil))
 
-	output, err := s.connector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, system,
+	output, err := s.connector.GetTableSchema(t.Context(), shared.InternalVersion_Latest, system,
 		[]*protos.TableMapping{{SourceTableIdentifier: tableName}})
 	require.NoError(t, err)
 	require.NotEqual(t, 0, output[tableName].TableOid)
@@ -144,14 +145,15 @@ func (s PostgresSchemaDeltaTestSuite) testAddAllColumnTypes(t *testing.T, system
 		}
 	}
 
-	require.NoError(t, s.connector.ReplayTableSchemaDeltas(t.Context(), nil, "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
-		SrcTableName: tableName,
-		DstTableName: tableName,
-		AddedColumns: addedColumns,
-		System:       system,
-	}}, nil))
+	require.NoError(t, s.connector.ReplayTableSchemaDeltas(
+		t.Context(), "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
+			SrcTableName: tableName,
+			DstTableName: tableName,
+			AddedColumns: addedColumns,
+			System:       system,
+		}}, nil))
 
-	output, err := s.connector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, system,
+	output, err := s.connector.GetTableSchema(t.Context(), shared.InternalVersion_Latest, system,
 		[]*protos.TableMapping{{SourceTableIdentifier: tableName}})
 	require.NoError(t, err)
 	require.NotEqual(t, 0, output[tableName].TableOid)
@@ -188,14 +190,15 @@ func (s PostgresSchemaDeltaTestSuite) testAddTrickyColumnNames(t *testing.T, sys
 		}
 	}
 
-	require.NoError(t, s.connector.ReplayTableSchemaDeltas(t.Context(), nil, "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
-		SrcTableName: tableName,
-		DstTableName: tableName,
-		AddedColumns: addedColumns,
-		System:       system,
-	}}, nil))
+	require.NoError(t, s.connector.ReplayTableSchemaDeltas(
+		t.Context(), "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
+			SrcTableName: tableName,
+			DstTableName: tableName,
+			AddedColumns: addedColumns,
+			System:       system,
+		}}, nil))
 
-	output, err := s.connector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, system,
+	output, err := s.connector.GetTableSchema(t.Context(), shared.InternalVersion_Latest, system,
 		[]*protos.TableMapping{{SourceTableIdentifier: tableName}})
 	require.NoError(t, err)
 	require.NotEqual(t, 0, output[tableName].TableOid)
@@ -232,14 +235,15 @@ func (s PostgresSchemaDeltaTestSuite) testAddDropWhitespaceColumnNames(t *testin
 		}
 	}
 
-	require.NoError(t, s.connector.ReplayTableSchemaDeltas(t.Context(), nil, "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
-		SrcTableName: tableName,
-		DstTableName: tableName,
-		AddedColumns: addedColumns,
-		System:       system,
-	}}, nil))
+	require.NoError(t, s.connector.ReplayTableSchemaDeltas(
+		t.Context(), "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
+			SrcTableName: tableName,
+			DstTableName: tableName,
+			AddedColumns: addedColumns,
+			System:       system,
+		}}, nil))
 
-	output, err := s.connector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, system,
+	output, err := s.connector.GetTableSchema(t.Context(), shared.InternalVersion_Latest, system,
 		[]*protos.TableMapping{{SourceTableIdentifier: tableName}})
 	require.NoError(t, err)
 	require.NotEqual(t, 0, output[tableName].TableOid)

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -35,7 +35,7 @@ type SlotCheckResult struct {
 	PublicationExists bool
 }
 
-func (c *PostgresConnector) CreateReplConn(ctx context.Context, env map[string]string) (*pgx.Conn, error) {
+func (c *PostgresConnector) CreateReplConn(ctx context.Context) (*pgx.Conn, error) {
 	// create a separate connection for non-replication queries as replication connections cannot
 	// be used for extended query protocol, i.e. prepared statements
 	replConfig, err := ParseConfig(c.connStr, c.Config)
@@ -55,13 +55,9 @@ func (c *PostgresConnector) CreateReplConn(ctx context.Context, env map[string]s
 	replConfig.Config.RuntimeParams["standard_conforming_strings"] = "on"
 	replConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 
-	walSenderTimeout, err := internal.PeerDBPostgresWalSenderTimeout(ctx, env)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get wal_sender_timeout value: %w", err)
-	}
-	if !strings.EqualFold(walSenderTimeout, "NONE") {
-		c.logger.Info("set wal_sender_timeout", slog.String("wal_sender_timeout", walSenderTimeout))
-		replConfig.Config.RuntimeParams["wal_sender_timeout"] = walSenderTimeout
+	if !strings.EqualFold(c.Settings.PostgresWalSenderTimeout, "NONE") {
+		c.logger.Info("set wal_sender_timeout", slog.String("wal_sender_timeout", c.Settings.PostgresWalSenderTimeout))
+		replConfig.Config.RuntimeParams["wal_sender_timeout"] = c.Settings.PostgresWalSenderTimeout
 	} else {
 		c.logger.Info("not setting wal_sender_timeout")
 	}
@@ -74,8 +70,8 @@ func (c *PostgresConnector) CreateReplConn(ctx context.Context, env map[string]s
 	return conn, nil
 }
 
-func (c *PostgresConnector) SetupReplConn(ctx context.Context, env map[string]string) error {
-	conn, err := c.CreateReplConn(ctx, env)
+func (c *PostgresConnector) SetupReplConn(ctx context.Context) error {
+	conn, err := c.CreateReplConn(ctx)
 	if err != nil {
 		return err
 	}
@@ -237,17 +233,9 @@ func pullCore[Items model.Items](
 		c.logger.Error("error starting replication", slog.Any("error", err))
 		return err
 	}
-	handleInheritanceForNonPartitionedTables, err := internal.PeerDBPostgresCDCHandleInheritanceForNonPartitionedTables(ctx, req.Env)
+	handleInheritanceForNonPartitionedTables, err := internal.PeerDBPostgresCDCHandleInheritanceForNonPartitionedTables(ctx, c.Settings.Env)
 	if err != nil {
 		return fmt.Errorf("failed to get get setting for handleInheritanceForNonPartitionedTables: %w", err)
-	}
-	sourceSchemaAsDestinationColumn, err := internal.PeerDBSourceSchemaAsDestinationColumn(ctx, req.Env)
-	if err != nil {
-		return fmt.Errorf("failed to get get setting for sourceSchemaAsDestinationColumn: %w", err)
-	}
-	originMetaAsDestinationColumn, err := internal.PeerDBOriginMetaAsDestinationColumn(ctx, req.Env)
-	if err != nil {
-		return fmt.Errorf("failed to get get setting for originMetaAsDestinationColumn: %w", err)
 	}
 
 	cdc, err := c.NewPostgresCDCSource(ctx, &PostgresCDCConfig{
@@ -261,8 +249,8 @@ func pullCore[Items model.Items](
 		Slot:                                     slotName,
 		Publication:                              publicationName,
 		HandleInheritanceForNonPartitionedTables: handleInheritanceForNonPartitionedTables,
-		SourceSchemaAsDestinationColumn:          sourceSchemaAsDestinationColumn,
-		OriginMetaAsDestinationColumn:            originMetaAsDestinationColumn,
+		SourceSchemaAsDestinationColumn:          c.Settings.SourceSchemaAsDestinationColumn,
+		OriginMetaAsDestinationColumn:            c.Settings.OriginMetadataAsDestinationColumn,
 		InternalVersion:                          req.InternalVersion,
 	})
 	if err != nil {
@@ -296,7 +284,6 @@ func (c *PostgresConnector) UpdateReplStateLastOffset(_ context.Context, lastOff
 
 func (c *PostgresConnector) GetTableSchema(
 	ctx context.Context,
-	env map[string]string,
 	version uint32,
 	system protos.TypeSystem,
 	tableMapping []*protos.TableMapping,
@@ -304,7 +291,7 @@ func (c *PostgresConnector) GetTableSchema(
 	res := make(map[string]*protos.TableSchema, len(tableMapping))
 	typeSchemaNameMapping := make(map[uint32]string, len(tableMapping))
 	for _, tm := range tableMapping {
-		tableSchema, err := c.getTableSchemaForTable(ctx, env, tm, system, version, typeSchemaNameMapping)
+		tableSchema, err := c.getTableSchemaForTable(ctx, tm, system, version, typeSchemaNameMapping)
 		if err != nil {
 			c.logger.Info("error fetching schema", slog.String("table", tm.SourceTableIdentifier), slog.Any("error", err))
 			return nil, err
@@ -451,7 +438,6 @@ func (c *PostgresConnector) GetSchemaNameOfColumnTypeByOID(ctx context.Context, 
 
 func (c *PostgresConnector) getTableSchemaForTable(
 	ctx context.Context,
-	env map[string]string,
 	tm *protos.TableMapping,
 	system protos.TypeSystem,
 	version uint32,
@@ -481,10 +467,7 @@ func (c *PostgresConnector) getTableSchemaForTable(
 		return nil, fmt.Errorf("[getTableSchema] error getting primary key column for table %s: %w", schemaTable, err)
 	}
 
-	nullableEnabled, err := internal.PeerDBNullable(ctx, env)
-	if err != nil {
-		return nil, err
-	}
+	nullableEnabled := c.Settings.Nullable
 
 	var nullableCols map[string]struct{}
 	nullableCols, err = c.getNullableColumns(ctx, relID)
@@ -636,15 +619,11 @@ func (c *PostgresConnector) EnsurePullability(
 func (c *PostgresConnector) ExportTxSnapshot(
 	ctx context.Context,
 	_ string,
-	env map[string]string,
 ) (*protos.ExportTxSnapshotOutput, any, error) {
-	skipSnapshotExport, err := internal.PeerDBSkipSnapshotExport(ctx, env)
-	if err != nil {
-		c.logger.Error("failed to check PEERDB_SKIP_SNAPSHOT_EXPORT, proceeding with export snapshot", slog.Any("error", err))
-	} else if skipSnapshotExport {
+	if c.Settings.SkipSnapshotExport {
 		return &protos.ExportTxSnapshotOutput{
 			SnapshotName: "",
-		}, nil, err
+		}, nil, nil
 	}
 
 	var snapshotName string
@@ -713,12 +692,6 @@ func (c *PostgresConnector) SetupReplication(
 		return model.SetupReplicationResult{}, err
 	}
 
-	skipSnapshotExport, err := internal.PeerDBSkipSnapshotExport(ctx, req.Env)
-	if err != nil {
-		c.logger.Error("failed to check PEERDB_SKIP_SNAPSHOT_EXPORT, proceeding with export snapshot", slog.Any("error", err))
-		skipSnapshotExport = false
-	}
-
 	tableNameMapping := make(map[string]model.NameAndExclude, len(req.TableNameMapping))
 	for k, v := range req.TableNameMapping {
 		tableNameMapping[k] = model.NameAndExclude{
@@ -728,7 +701,7 @@ func (c *PostgresConnector) SetupReplication(
 	}
 	// Create the replication slot and publication
 	return c.createSlotAndPublication(ctx, exists, slotName, publicationName, tableNameMapping,
-		req.DoInitialSnapshot, skipSnapshotExport, req.Env)
+		req.DoInitialSnapshot, c.Settings.SkipSnapshotExport)
 }
 
 func (c *PostgresConnector) PullFlowCleanup(ctx context.Context, jobName string) error {

--- a/flow/connectors/postgres/postgres_test.go
+++ b/flow/connectors/postgres/postgres_test.go
@@ -13,7 +13,7 @@ func TestNewPostgresConnectorAuthError(t *testing.T) {
 	t.Parallel()
 	config := internal.GetCatalogPostgresConfigFromEnv(t.Context())
 	config.Password = "wrong_password"
-	_, err := NewPostgresConnector(t.Context(), nil, config)
+	_, err := NewPostgresConnector(t.Context(), internal.NewSettings(nil), config)
 	require.Error(t, err)
 
 	var authErr *exceptions.AuthError

--- a/flow/connectors/postgres/qrep_bench_test.go
+++ b/flow/connectors/postgres/qrep_bench_test.go
@@ -13,12 +13,12 @@ func BenchmarkQRepQueryExecutor(b *testing.B) {
 	query := "SELECT * FROM bench.large_table"
 
 	ctx := b.Context()
-	connector, err := NewPostgresConnector(ctx, nil, internal.GetCatalogPostgresConfigFromEnv(ctx))
+	connector, err := NewPostgresConnector(ctx, internal.NewSettings(nil), internal.GetCatalogPostgresConfigFromEnv(ctx))
 	require.NoError(b, err, "error while creating connector")
 	defer connector.Close()
 
 	// Create a new QRepQueryExecutor instance
-	qe, err := connector.NewQRepQueryExecutor(ctx, nil, shared.InternalVersion_Latest, "test flow", "test part")
+	qe, err := connector.NewQRepQueryExecutor(ctx, internal.NewSettings(nil), shared.InternalVersion_Latest, "test flow", "test part")
 	require.NoError(b, err, "error while creating QRepQueryExecutor")
 
 	// Run the benchmark

--- a/flow/connectors/postgres/qrep_partition_test.go
+++ b/flow/connectors/postgres/qrep_partition_test.go
@@ -191,11 +191,13 @@ func TestGetQRepPartitions(t *testing.T) {
 	}
 
 	c := &PostgresConnector{
-		conn:   conn,
-		logger: log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testGetQRepPartitions"))),
+		conn:     conn,
+		Settings: internal.NewSettings(nil),
+		logger:   log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testGetQRepPartitions"))),
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			c.Settings = internal.NewSettings(tc.config.Env)
 			got, err := c.GetQRepPartitions(t.Context(), tc.config, tc.last)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("GetQRepPartitions() error = %v, wantErr %v", err, tc.wantErr)
@@ -248,11 +250,13 @@ func TestGetQRepPartitionsWithNulls(t *testing.T) {
 	}
 
 	c := &PostgresConnector{
-		conn:   conn,
-		logger: log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testGetQRepPartitionsWithNulls"))),
+		conn:     conn,
+		Settings: internal.NewSettings(nil),
+		logger:   log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testGetQRepPartitionsWithNulls"))),
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			c.Settings = internal.NewSettings(tc.config.Env)
 			got, err := c.GetQRepPartitions(t.Context(), tc.config, tc.last)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("GetQRepPartitions() error = %v, wantErr %v", err, tc.wantErr)
@@ -312,10 +316,11 @@ func TestCTIDPartitioningOnPartitionedTable(t *testing.T) {
 	}
 
 	c := &PostgresConnector{
-		connStr: connStr,
-		Config:  &protos.PostgresConfig{},
-		conn:    conn,
-		logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testCTIDPartitioned"))),
+		connStr:  connStr,
+		Config:   &protos.PostgresConfig{},
+		conn:     conn,
+		Settings: internal.NewSettings(nil),
+		logger:   log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testCTIDPartitioned"))),
 	}
 	query := fmt.Sprintf(`SELECT * FROM %s WHERE ctid BETWEEN {{.start}} AND {{.end}}`, parentTable)
 	partitions, err := c.GetQRepPartitions(t.Context(), &protos.QRepConfig{
@@ -415,10 +420,11 @@ func TestCTIDPartitioningOnMultiLevelPartitionedTable(t *testing.T) {
 	}
 
 	c := &PostgresConnector{
-		connStr: connStr,
-		Config:  &protos.PostgresConfig{},
-		conn:    conn,
-		logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testMultiLevel"))),
+		connStr:  connStr,
+		Config:   &protos.PostgresConfig{},
+		conn:     conn,
+		Settings: internal.NewSettings(nil),
+		logger:   log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testMultiLevel"))),
 	}
 	query := fmt.Sprintf(`SELECT * FROM %s WHERE ctid BETWEEN {{.start}} AND {{.end}}`, rootTableDDL)
 	partitions, err := c.GetQRepPartitions(t.Context(), &protos.QRepConfig{
@@ -476,10 +482,11 @@ func TestCTIDPartitioningOnEmptyPartitionedTable(t *testing.T) {
 	}
 
 	c := &PostgresConnector{
-		connStr: connStr,
-		Config:  &protos.PostgresConfig{},
-		conn:    conn,
-		logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testEmptyPartitioned"))),
+		connStr:  connStr,
+		Config:   &protos.PostgresConfig{},
+		conn:     conn,
+		Settings: internal.NewSettings(nil),
+		logger:   log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testEmptyPartitioned"))),
 	}
 	query := fmt.Sprintf(`SELECT * FROM %s WHERE ctid BETWEEN {{.start}} AND {{.end}}`, parentTable)
 	partitions, err := c.GetQRepPartitions(t.Context(), &protos.QRepConfig{
@@ -533,10 +540,11 @@ func TestCTIDPartitioningGroupingWhenChildrenExceedBudget(t *testing.T) {
 	}
 
 	c := &PostgresConnector{
-		connStr: connStr,
-		Config:  &protos.PostgresConfig{},
-		conn:    conn,
-		logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testGrouping"))),
+		connStr:  connStr,
+		Config:   &protos.PostgresConfig{},
+		conn:     conn,
+		Settings: internal.NewSettings(nil),
+		logger:   log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testGrouping"))),
 	}
 	query := fmt.Sprintf(`SELECT * FROM %s WHERE ctid BETWEEN {{.start}} AND {{.end}}`, parentTable)
 	partitions, err := c.GetQRepPartitions(t.Context(), &protos.QRepConfig{
@@ -657,10 +665,11 @@ func TestCTIDPartitioningOnInheritedTable(t *testing.T) {
 	}
 
 	c := &PostgresConnector{
-		connStr: connStr,
-		Config:  &protos.PostgresConfig{},
-		conn:    conn,
-		logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testInherited"))),
+		connStr:  connStr,
+		Config:   &protos.PostgresConfig{},
+		conn:     conn,
+		Settings: internal.NewSettings(nil),
+		logger:   log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testInherited"))),
 	}
 	partitions, err := c.GetQRepPartitions(t.Context(), &protos.QRepConfig{
 		FlowJobName:           "test_ctid_inherited",
@@ -720,10 +729,11 @@ func TestCTIDPartitioningOnMultiLevelInheritedTable(t *testing.T) {
 	}
 
 	c := &PostgresConnector{
-		connStr: connStr,
-		Config:  &protos.PostgresConfig{},
-		conn:    conn,
-		logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testMultiLevelInherited"))),
+		connStr:  connStr,
+		Config:   &protos.PostgresConfig{},
+		conn:     conn,
+		Settings: internal.NewSettings(nil),
+		logger:   log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testMultiLevelInherited"))),
 	}
 	partitions, err := c.GetQRepPartitions(t.Context(), &protos.QRepConfig{
 		FlowJobName:           "test_ctid_multi_inherited",
@@ -764,10 +774,11 @@ func TestCTIDPartitioningOnEmptyInheritedTable(t *testing.T) {
 	}
 
 	c := &PostgresConnector{
-		connStr: connStr,
-		Config:  &protos.PostgresConfig{},
-		conn:    conn,
-		logger:  log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testAllEmptyInherited"))),
+		connStr:  connStr,
+		Config:   &protos.PostgresConfig{},
+		conn:     conn,
+		Settings: internal.NewSettings(nil),
+		logger:   log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testAllEmptyInherited"))),
 	}
 	partitions, err := c.GetQRepPartitions(t.Context(), &protos.QRepConfig{
 		FlowJobName:           "test_ctid_all_empty_inherited",

--- a/flow/connectors/postgres/qrep_query_executor.go
+++ b/flow/connectors/postgres/qrep_query_executor.go
@@ -25,20 +25,20 @@ import (
 type QRepQueryExecutor struct {
 	*PostgresConnector
 	logger      log.Logger
-	env         map[string]string
+	settings    *internal.Settings
 	snapshot    string
 	flowJobName string
 	partitionID string
 	version     uint32
 }
 
-func (c *PostgresConnector) NewQRepQueryExecutor(ctx context.Context, env map[string]string, version uint32,
+func (c *PostgresConnector) NewQRepQueryExecutor(ctx context.Context, settings *internal.Settings, version uint32,
 	flowJobName string, partitionID string,
 ) (*QRepQueryExecutor, error) {
-	return c.NewQRepQueryExecutorSnapshot(ctx, env, version, "", flowJobName, partitionID)
+	return c.NewQRepQueryExecutorSnapshot(ctx, settings, version, "", flowJobName, partitionID)
 }
 
-func (c *PostgresConnector) NewQRepQueryExecutorSnapshot(ctx context.Context, env map[string]string, version uint32,
+func (c *PostgresConnector) NewQRepQueryExecutorSnapshot(ctx context.Context, settings *internal.Settings, version uint32,
 	snapshot string, flowJobName string, partitionID string,
 ) (*QRepQueryExecutor, error) {
 	if _, err := c.fetchCustomTypeMapping(ctx); err != nil {
@@ -47,7 +47,7 @@ func (c *PostgresConnector) NewQRepQueryExecutorSnapshot(ctx context.Context, en
 	}
 	return &QRepQueryExecutor{
 		PostgresConnector: c,
-		env:               env,
+		settings:          settings,
 		snapshot:          snapshot,
 		flowJobName:       flowJobName,
 		partitionID:       partitionID,
@@ -71,10 +71,7 @@ func (qe *QRepQueryExecutor) cursorToSchema(
 	tx pgx.Tx,
 	cursorName string,
 ) (types.QRecordSchema, *types.NullableSchemaDebug, error) {
-	laxMode, err := internal.PeerDBAvroNullableLax(ctx, qe.env)
-	if err != nil {
-		return types.QRecordSchema{}, nil, err
-	}
+	laxMode := qe.settings.AvroNullableLax
 
 	rows, err := tx.Query(ctx, "FETCH 0 FROM "+cursorName)
 	if err != nil {

--- a/flow/connectors/postgres/qrep_query_executor_test.go
+++ b/flow/connectors/postgres/qrep_query_executor_test.go
@@ -19,8 +19,8 @@ import (
 func setupDB(t *testing.T, testName string) (*PostgresConnector, string) {
 	t.Helper()
 
-	connector, err := NewPostgresConnector(t.Context(),
-		nil, internal.GetCatalogPostgresConfigFromEnv(t.Context()))
+	connector, err := NewPostgresConnector(t.Context(), internal.NewSettings(nil),
+		internal.GetCatalogPostgresConfigFromEnv(t.Context()))
 	require.NoError(t, err, "error while creating connector")
 
 	// Create unique schema name using current time
@@ -58,7 +58,7 @@ func TestExecuteAndProcessQuery(t *testing.T) {
 		fmt.Sprintf("INSERT INTO %s.test(data) VALUES ('testdata')", common.QuoteIdentifier(schemaName)))
 	require.NoError(t, err, "error while inserting data")
 
-	qe, err := connector.NewQRepQueryExecutor(ctx, nil, shared.InternalVersion_Latest, "test flow", "test part")
+	qe, err := connector.NewQRepQueryExecutor(ctx, internal.NewSettings(nil), shared.InternalVersion_Latest, "test flow", "test part")
 	require.NoError(t, err, "error while creating QRepQueryExecutor")
 
 	batch, err := qe.ExecuteAndProcessQuery(t.Context(), fmt.Sprintf("SELECT * FROM %s.test", common.QuoteIdentifier(schemaName)))
@@ -175,7 +175,7 @@ func TestSupportedDataTypes(t *testing.T) {
 	)
 	require.NoError(t, err, "error while inserting into test table")
 
-	qe, err := connector.NewQRepQueryExecutor(ctx, nil, shared.InternalVersion_Latest, "test flow", "test part")
+	qe, err := connector.NewQRepQueryExecutor(ctx, internal.NewSettings(nil), shared.InternalVersion_Latest, "test flow", "test part")
 	require.NoError(t, err, "error while creating QRepQueryExecutor")
 	// Select the row back out of the table
 	batch, err := qe.ExecuteAndProcessQuery(t.Context(),
@@ -674,7 +674,7 @@ func TestStringDataTypes(t *testing.T) {
 			_, err = conn.Exec(ctx, query)
 			require.NoError(t, err)
 
-			qe, err := connector.NewQRepQueryExecutor(ctx, nil, shared.InternalVersion_Latest, "test flow", "test part")
+			qe, err := connector.NewQRepQueryExecutor(ctx, internal.NewSettings(nil), shared.InternalVersion_Latest, "test flow", "test part")
 			require.NoError(t, err)
 			// Select the row back out of the table
 			batch, err := qe.ExecuteAndProcessQuery(t.Context(),

--- a/flow/connectors/postgres/qrep_source.go
+++ b/flow/connectors/postgres/qrep_source.go
@@ -116,8 +116,8 @@ func (c *PostgresConnector) GetDefaultPartitionKeyForTables(
 	// compressed hypertables cannot do ctid scans, so disable for them
 	// NOTE: it appears that the hypercore "TAM" may give us access to ctid scans, but that's to be removed in Timescale 2.22
 	rows, err := c.conn.Query(ctx, `SELECT DISTINCT hypertable_schema, hypertable_name
-		FROM timescaledb_information.chunks
-		WHERE is_compressed='t';`)
+	FROM timescaledb_information.chunks
+	WHERE is_compressed='t';`)
 	if err != nil {
 		return nil, fmt.Errorf("query compressed hypertables: %w", err)
 	}
@@ -214,15 +214,11 @@ func (c *PostgresConnector) getPartitions(
 
 	isCTIDWatermarkCol := config.WatermarkColumn == ctidColumnName
 	hasPartitionOverride := config.NumPartitionsOverride > 0 // backwards-compatibility with old behavior
-	hasCTIDOverride, err := internal.PeerDBPostgresApplyCtidBlockPartitioning(ctx, config.Env)
-	if err != nil {
-		c.logger.Warn("failed to get CTID partitioning config", slog.Any("error", err))
-	}
 
 	var partitionFunc PartitioningFunc
 	var partitionFuncName string
 	switch {
-	case isCTIDWatermarkCol && (hasCTIDOverride || hasPartitionOverride):
+	case isCTIDWatermarkCol && (c.Settings.PostgresApplyCtidBlockPartitioning || hasPartitionOverride):
 		partitionFunc = CTIDBlockPartitioningFunc
 		partitionFuncName = "CTIDBlockPartitioningFunc"
 	case hasPartitionOverride:
@@ -361,6 +357,7 @@ func corePullQRepRecords(
 	partitionIdLog := slog.String(string(shared.PartitionIDKey), partition.PartitionId)
 
 	selectedColumns := "*"
+	var err error
 	if len(config.Exclude) != 0 || len(partition.ChildTableRanges) > 0 {
 		tableSchema, err := internal.LoadTableSchemaFromCatalog(ctx, catalogPool, config.ParentMirrorName, config.DestinationTableIdentifier)
 		if err != nil {
@@ -383,7 +380,7 @@ func corePullQRepRecords(
 
 	if partition.FullTablePartition {
 		c.logger.Info("pulling full table partition", partitionIdLog)
-		executor, err := c.NewQRepQueryExecutorSnapshot(ctx, config.Env, config.Version, config.SnapshotName,
+		executor, err := c.NewQRepQueryExecutorSnapshot(ctx, c.Settings, config.Version, config.SnapshotName,
 			config.FlowJobName, partition.PartitionId)
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to create query executor: %w", err)
@@ -456,7 +453,7 @@ func corePullQRepRecords(
 	}
 
 	executor, err := c.NewQRepQueryExecutorSnapshot(
-		ctx, config.Env, config.Version, config.SnapshotName, config.FlowJobName, partition.PartitionId)
+		ctx, c.Settings, config.Version, config.SnapshotName, config.FlowJobName, partition.PartitionId)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to create query executor: %w", err)
 	}
@@ -486,7 +483,7 @@ func pullChildTableRanges(
 	partitionIdLog := slog.String(string(shared.PartitionIDKey), partition.PartitionId)
 
 	executor, err := c.NewQRepQueryExecutorSnapshot(
-		ctx, config.Env, config.Version, config.SnapshotName, config.FlowJobName, partition.PartitionId)
+		ctx, c.Settings, config.Version, config.SnapshotName, config.FlowJobName, partition.PartitionId)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to create query executor: %w", err)
 	}
@@ -574,7 +571,7 @@ func pullXminRecordStream(
 		queryArgs = []any{strconv.FormatInt(partition.Range.Range.(*protos.PartitionRange_IntRange).IntRange.Start&0xffffffff, 10)}
 	}
 
-	executor, err := c.NewQRepQueryExecutorSnapshot(ctx, config.Env, config.Version, config.SnapshotName,
+	executor, err := c.NewQRepQueryExecutorSnapshot(ctx, c.Settings, config.Version, config.SnapshotName,
 		config.FlowJobName, partition.PartitionId)
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("failed to create query executor: %w", err)

--- a/flow/connectors/postgres/rds_test.go
+++ b/flow/connectors/postgres/rds_test.go
@@ -13,8 +13,7 @@ func TestAwsRDSIAMAuthConnectForPostgres(t *testing.T) {
 	t.Skip("flaky")
 	internal.SetupRDSIAMAuthAWSCredentials(t)
 	conn := internal.RDSIAMAuthPostgresTestConnectionInfo(t)
-	postgresConnector, err := NewPostgresConnector(t.Context(),
-		nil,
+	postgresConnector, err := NewPostgresConnector(t.Context(), internal.NewSettings(nil),
 		&protos.PostgresConfig{
 			Host:       conn.Host,
 			Database:   "postgres",
@@ -42,8 +41,7 @@ func TestAwsRDSIAMAuthConnectForPostgresViaProxy(t *testing.T) {
 	t.Skip("flaky")
 	internal.SetupRDSIAMAuthAWSCredentials(t)
 	conn := internal.RDSIAMAuthPostgresTestConnectionInfo(t)
-	postgresConnector, err := NewPostgresConnector(t.Context(),
-		nil,
+	postgresConnector, err := NewPostgresConnector(t.Context(), internal.NewSettings(nil),
 		&protos.PostgresConfig{
 			Host:       conn.ProxyHost,
 			Port:       5432,

--- a/flow/connectors/postgres/ssh_keepalive_test.go
+++ b/flow/connectors/postgres/ssh_keepalive_test.go
@@ -37,7 +37,7 @@ func setupPostgresConnectorWithSSH(ctx context.Context, t *testing.T, proxyName 
 		Password: "testpass",
 	}
 
-	connector, err := NewPostgresConnector(ctx, nil, pgConfig)
+	connector, err := NewPostgresConnector(ctx, internal.NewSettings(nil), pgConfig)
 	require.NoError(t, err)
 
 	// Test initial connection works

--- a/flow/connectors/postgres/validate.go
+++ b/flow/connectors/postgres/validate.go
@@ -198,9 +198,9 @@ func (c *PostgresConnector) CheckReplicationPermissions(ctx context.Context, use
 	return nil
 }
 
-func (c *PostgresConnector) CheckReplicationConnectivity(ctx context.Context, env map[string]string) error {
+func (c *PostgresConnector) CheckReplicationConnectivity(ctx context.Context) error {
 	// Check if we can create a replication connection
-	conn, err := c.CreateReplConn(ctx, env)
+	conn, err := c.CreateReplConn(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create replication connection: %v", err)
 	}
@@ -229,7 +229,7 @@ func (c *PostgresConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 	noCDC := cfg.DoInitialSnapshot && cfg.InitialSnapshotOnly
 	if !noCDC {
 		// Check replication connectivity
-		if err := c.CheckReplicationConnectivity(ctx, cfg.Env); err != nil {
+		if err := c.CheckReplicationConnectivity(ctx); err != nil {
 			return fmt.Errorf("unable to establish replication connectivity: %w", err)
 		}
 

--- a/flow/connectors/pubsub/pubsub.go
+++ b/flow/connectors/pubsub/pubsub.go
@@ -26,13 +26,14 @@ import (
 
 type PubSubConnector struct {
 	*metadataStore.PostgresMetadata
-	client *pubsub.Client
-	logger log.Logger
+	Settings *internal.Settings
+	client   *pubsub.Client
+	logger   log.Logger
 }
 
 func NewPubSubConnector(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	config *protos.PubSubConfig,
 ) (*PubSubConnector, error) {
 	sa := utils.GcpServiceAccountFromProto(config.ServiceAccount)
@@ -48,6 +49,7 @@ func NewPubSubConnector(
 
 	return &PubSubConnector{
 		client:           client,
+		Settings:         settings,
 		PostgresMetadata: pgMetadata,
 		logger:           internal.LoggerFromCtx(ctx),
 	}, nil
@@ -74,7 +76,7 @@ func (c *PubSubConnector) CreateRawTable(ctx context.Context, req *protos.Create
 	return &protos.CreateRawTableOutput{TableIdentifier: "n/a"}, nil
 }
 
-func (c *PubSubConnector) ReplayTableSchemaDeltas(_ context.Context, _ map[string]string,
+func (c *PubSubConnector) ReplayTableSchemaDeltas(_ context.Context,
 	flowJobName string, _ []*protos.TableMapping, schemaDeltas []*protos.TableSchemaDelta, _ []string,
 ) error {
 	return nil
@@ -141,14 +143,13 @@ func lvalueToPubSubMessage(ls *lua.LState, value lua.LValue) (PubSubMessage, err
 
 func (c *PubSubConnector) createPool(
 	ctx context.Context,
-	env map[string]string,
 	script string,
 	flowJobName string,
 	topiccache *topicCache,
 	publish chan<- publishResult,
 	queueErr func(error),
 ) (*utils.LPool[poolResult], error) {
-	maxSize, err := internal.PeerDBQueueParallelism(ctx, env)
+	maxSize, err := internal.PeerDBQueueParallelism(ctx, c.Settings.Env)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get parallelism: %w", err)
 	}
@@ -173,11 +174,7 @@ func (c *PubSubConnector) createPool(
 				})
 
 				if err != nil && status.Code(err) == codes.NotFound {
-					force, envErr := internal.PeerDBQueueForceTopicCreation(ctx, env)
-					if envErr != nil {
-						return nil, envErr
-					}
-					if force {
+					if c.Settings.QueueForceTopicCreation {
 						if newTopic, err := c.client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{
 							Name: topicName,
 						}); err != nil {
@@ -217,7 +214,7 @@ func (c *PubSubConnector) SyncRecords(ctx context.Context, req *model.SyncRecord
 
 	queueCtx, queueErr := context.WithCancelCause(ctx)
 
-	pool, err := c.createPool(queueCtx, req.Env, req.Script, req.FlowJobName, &topiccache, publish, queueErr)
+	pool, err := c.createPool(queueCtx, req.Script, req.FlowJobName, &topiccache, publish, queueErr)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +234,7 @@ func (c *PubSubConnector) SyncRecords(ctx context.Context, req *model.SyncRecord
 
 	flushLoopDone := make(chan struct{})
 	go func() {
-		flushTimeout, err := internal.PeerDBQueueFlushTimeoutSeconds(ctx, req.Env)
+		flushTimeout, err := internal.PeerDBQueueFlushTimeoutSeconds(ctx, c.Settings.Env)
 		if err != nil {
 			c.logger.Warn("[pubsub] failed to get flush timeout, no periodic flushing", slog.Any("error", err))
 			return

--- a/flow/connectors/pubsub/qrep.go
+++ b/flow/connectors/pubsub/qrep.go
@@ -37,7 +37,7 @@ func (c *PubSubConnector) SyncQRepRecords(
 	numRecords := atomic.Int64{}
 
 	queueCtx, queueErr := context.WithCancelCause(ctx)
-	pool, err := c.createPool(queueCtx, config.Env, config.Script, config.FlowJobName, &topiccache, publish, queueErr)
+	pool, err := c.createPool(queueCtx, config.Script, config.FlowJobName, &topiccache, publish, queueErr)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/flow/connectors/s3/qrep.go
+++ b/flow/connectors/s3/qrep.go
@@ -27,12 +27,12 @@ func (c *S3Connector) SyncQRepRecords(
 	}
 
 	dstTableName := config.DestinationTableIdentifier
-	avroSchema, err := getAvroSchema(ctx, config.Env, dstTableName, schema)
+	avroSchema, err := getAvroSchema(ctx, c.Settings, dstTableName, schema)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	numRecords, err := c.writeToAvroFile(ctx, config.Env, stream, avroSchema, partition.PartitionId, config.FlowJobName)
+	numRecords, err := c.writeToAvroFile(ctx, stream, avroSchema, partition.PartitionId, config.FlowJobName)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -42,12 +42,12 @@ func (c *S3Connector) SyncQRepRecords(
 
 func getAvroSchema(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	dstTableName string,
 	schema types.QRecordSchema,
 ) (*model.QRecordAvroSchemaDefinition, error) {
 	// TODO: Support avro-incompatible column names
-	avroSchema, err := model.GetAvroSchemaDefinition(ctx, env, dstTableName, schema, protos.DBType_S3, nil)
+	avroSchema, err := model.GetAvroSchemaDefinition(ctx, settings, dstTableName, schema, protos.DBType_S3, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to define Avro schema: %w", err)
 	}
@@ -57,7 +57,6 @@ func getAvroSchema(
 
 func (c *S3Connector) writeToAvroFile(
 	ctx context.Context,
-	env map[string]string,
 	stream *model.QRecordStream,
 	avroSchema *model.QRecordAvroSchemaDefinition,
 	partitionID string,
@@ -68,12 +67,8 @@ func (c *S3Connector) writeToAvroFile(
 		return 0, fmt.Errorf("failed to parse bucket path: %w", err)
 	}
 
-	s3UuidPrefix, err := internal.PeerDBS3UuidPrefix(ctx, env)
-	if err != nil {
-		return 0, err
-	}
 	var s3AvroFileKey string
-	if s3UuidPrefix {
+	if c.Settings.S3UuidPrefix {
 		s3AvroFileKey = fmt.Sprintf("%s/%s/%s/%s.avro", s3o.Prefix, uuid.NewString(), jobName, partitionID)
 	} else {
 		s3AvroFileKey = fmt.Sprintf("%s/%s/%s.avro", s3o.Prefix, jobName, partitionID)
@@ -94,7 +89,7 @@ func (c *S3Connector) writeToAvroFile(
 	}
 
 	writer := utils.NewPeerDBOCFWriter(stream, avroSchema, codec, protos.DBType_S3, nil)
-	avroFile, err := writer.WriteRecordsToS3(ctx, env, s3o.Bucket, s3AvroFileKey, c.credentialsProvider, nil, nil)
+	avroFile, err := writer.WriteRecordsToS3(ctx, c.Settings, s3o.Bucket, s3AvroFileKey, c.credentialsProvider, nil, nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write records to S3: %w", err)
 	}

--- a/flow/connectors/s3/s3.go
+++ b/flow/connectors/s3/s3.go
@@ -18,6 +18,7 @@ import (
 
 type S3Connector struct {
 	*metadataStore.PostgresMetadata
+	Settings            *internal.Settings
 	logger              log.Logger
 	credentialsProvider utils.AWSCredentialsProvider
 	client              s3.Client
@@ -27,6 +28,7 @@ type S3Connector struct {
 
 func NewS3Connector(
 	ctx context.Context,
+	settings *internal.Settings,
 	config *protos.S3Config,
 ) (*S3Connector, error) {
 	logger := internal.LoggerFromCtx(ctx)
@@ -47,6 +49,7 @@ func NewS3Connector(
 	}
 	return &S3Connector{
 		PostgresMetadata:    pgMetadata,
+		Settings:            settings,
 		client:              *s3Client,
 		credentialsProvider: provider,
 		logger:              logger,
@@ -89,7 +92,7 @@ func (c *S3Connector) SyncRecords(ctx context.Context, req *model.SyncRecordsReq
 	qrepConfig := &protos.QRepConfig{
 		FlowJobName:                req.FlowJobName,
 		DestinationTableIdentifier: "raw_table_" + req.FlowJobName,
-		Env:                        req.Env,
+		Env:                        c.Settings.Env,
 		Version:                    req.Version,
 	}
 	partition := &protos.QRepPartition{
@@ -116,7 +119,7 @@ func (c *S3Connector) SyncRecords(ctx context.Context, req *model.SyncRecordsReq
 	}, nil
 }
 
-func (c *S3Connector) ReplayTableSchemaDeltas(_ context.Context, _ map[string]string,
+func (c *S3Connector) ReplayTableSchemaDeltas(_ context.Context,
 	flowJobName string, _ []*protos.TableMapping, schemaDeltas []*protos.TableSchemaDelta, _ []string,
 ) error {
 	return nil

--- a/flow/connectors/snowflake/avro_file_writer_test.go
+++ b/flow/connectors/snowflake/avro_file_writer_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
@@ -146,14 +147,15 @@ func TestWriteRecordsToAvroFileHappyPath(t *testing.T) {
 	// Define sample data
 	records, schema := generateRecords(t, true, 10, false)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
+	avroSchema, err := model.GetAvroSchemaDefinition(
+		t.Context(), internal.NewSettings(nil), "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
 	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.Null, protos.DBType_SNOWFLAKE, nil)
-	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
+	_, err = writer.WriteRecordsToAvroFile(t.Context(), internal.NewSettings(nil), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty
@@ -173,14 +175,15 @@ func TestWriteRecordsToZstdAvroFileHappyPath(t *testing.T) {
 	// Define sample data
 	records, schema := generateRecords(t, true, 10, false)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
+	avroSchema, err := model.GetAvroSchemaDefinition(
+		t.Context(), internal.NewSettings(nil), "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
 	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.ZStandard, protos.DBType_SNOWFLAKE, nil)
-	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
+	_, err = writer.WriteRecordsToAvroFile(t.Context(), internal.NewSettings(nil), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty
@@ -200,14 +203,15 @@ func TestWriteRecordsToDeflateAvroFileHappyPath(t *testing.T) {
 	// Define sample data
 	records, schema := generateRecords(t, true, 10, false)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
+	avroSchema, err := model.GetAvroSchemaDefinition(
+		t.Context(), internal.NewSettings(nil), "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
 	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.Deflate, protos.DBType_SNOWFLAKE, nil)
-	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
+	_, err = writer.WriteRecordsToAvroFile(t.Context(), internal.NewSettings(nil), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty
@@ -226,14 +230,15 @@ func TestWriteRecordsToAvroFileNonNull(t *testing.T) {
 
 	records, schema := generateRecords(t, false, 10, false)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
+	avroSchema, err := model.GetAvroSchemaDefinition(
+		t.Context(), internal.NewSettings(nil), "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
 	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.Null, protos.DBType_SNOWFLAKE, nil)
-	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
+	_, err = writer.WriteRecordsToAvroFile(t.Context(), internal.NewSettings(nil), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty
@@ -253,14 +258,15 @@ func TestWriteRecordsToAvroFileAllNulls(t *testing.T) {
 	// Define sample data
 	records, schema := generateRecords(t, true, 10, true)
 
-	avroSchema, err := model.GetAvroSchemaDefinition(t.Context(), nil, "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
+	avroSchema, err := model.GetAvroSchemaDefinition(
+		t.Context(), internal.NewSettings(nil), "not_applicable", schema, protos.DBType_SNOWFLAKE, nil)
 	require.NoError(t, err)
 
 	t.Logf("[test] avroSchema: %v", avroSchema)
 
 	// Call function
 	writer := utils.NewPeerDBOCFWriter(records, avroSchema, ocf.Null, protos.DBType_SNOWFLAKE, nil)
-	_, err = writer.WriteRecordsToAvroFile(t.Context(), nil, tmpfile.Name())
+	_, err = writer.WriteRecordsToAvroFile(t.Context(), internal.NewSettings(nil), tmpfile.Name())
 	require.NoError(t, err, "expected WriteRecordsToAvroFile to complete without errors")
 
 	// Check file is not empty

--- a/flow/connectors/snowflake/get_schema_for_tests.go
+++ b/flow/connectors/snowflake/get_schema_for_tests.go
@@ -44,7 +44,6 @@ func (c *SnowflakeConnector) getTableSchemaForTable(ctx context.Context, tm *pro
 // only used for testing atm. doesn't return info about pkey or ReplicaIdentity [which is PG specific anyway].
 func (c *SnowflakeConnector) GetTableSchema(
 	ctx context.Context,
-	_env map[string]string,
 	_version uint32,
 	_system protos.TypeSystem,
 	tableMappings []*protos.TableMapping,

--- a/flow/connectors/snowflake/merge_stmt_generator.go
+++ b/flow/connectors/snowflake/merge_stmt_generator.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -26,7 +27,7 @@ type mergeStmtGenerator struct {
 	mergeBatchId int64
 }
 
-func (m *mergeStmtGenerator) generateMergeStmt(ctx context.Context, env map[string]string, dstTable string) (string, error) {
+func (m *mergeStmtGenerator) generateMergeStmt(ctx context.Context, settings *internal.Settings, dstTable string) (string, error) {
 	parsedDstTable, _ := common.ParseTableIdentifier(dstTable)
 	normalizedTableSchema := m.tableSchemaMapping[dstTable]
 	unchangedToastColumns := m.unchangedToastColumnsMap[dstTable]
@@ -37,7 +38,7 @@ func (m *mergeStmtGenerator) generateMergeStmt(ctx context.Context, env map[stri
 		genericColumnType := column.Type
 		qvKind := types.QValueKind(genericColumnType)
 		sfType, err := qvalue.ToDWHColumnType(
-			ctx, qvKind, env, protos.DBType_SNOWFLAKE, nil, column, normalizedTableSchema.NullableEnabled, nil)
+			ctx, qvKind, settings, protos.DBType_SNOWFLAKE, nil, column, normalizedTableSchema.NullableEnabled, nil)
 		if err != nil {
 			return "", fmt.Errorf("failed to convert column type %s to snowflake type: %w", genericColumnType, err)
 		}

--- a/flow/connectors/snowflake/qrep_avro_sync.go
+++ b/flow/connectors/snowflake/qrep_avro_sync.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
-	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -38,7 +37,6 @@ func NewSnowflakeAvroSyncHandler(
 
 func (s *SnowflakeAvroSyncHandler) SyncRecords(
 	ctx context.Context,
-	env map[string]string,
 	dstTableSchema []*sql.ColumnType,
 	stream *model.QRecordStream,
 	flowJobName string,
@@ -53,13 +51,13 @@ func (s *SnowflakeAvroSyncHandler) SyncRecords(
 
 	s.logger.Info("sync function called and schema acquired", tableLog)
 
-	avroSchema, err := s.getAvroSchema(ctx, env, dstTableName, schema)
+	avroSchema, err := s.getAvroSchema(ctx, dstTableName, schema)
 	if err != nil {
 		return 0, err
 	}
 
 	partitionID := common.RandomString(16)
-	avroFile, err := s.writeToAvroFile(ctx, env, stream, avroSchema, partitionID, flowJobName)
+	avroFile, err := s.writeToAvroFile(ctx, stream, avroSchema, partitionID, flowJobName)
 	if err != nil {
 		return 0, err
 	}
@@ -104,12 +102,12 @@ func (s *SnowflakeAvroSyncHandler) SyncQRepRecords(
 	}
 	s.logger.Info("sync function called and schema acquired", partitionLog)
 
-	avroSchema, err := s.getAvroSchema(ctx, config.Env, dstTableName, schema)
+	avroSchema, err := s.getAvroSchema(ctx, dstTableName, schema)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	avroFile, err := s.writeToAvroFile(ctx, config.Env, stream, avroSchema, partition.PartitionId, config.FlowJobName)
+	avroFile, err := s.writeToAvroFile(ctx, stream, avroSchema, partition.PartitionId, config.FlowJobName)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -131,12 +129,11 @@ func (s *SnowflakeAvroSyncHandler) SyncQRepRecords(
 
 func (s *SnowflakeAvroSyncHandler) getAvroSchema(
 	ctx context.Context,
-	env map[string]string,
 	dstTableName string,
 	schema types.QRecordSchema,
 ) (*model.QRecordAvroSchemaDefinition, error) {
 	// TODO: Support avroNameMap for avro-incompatible column name support
-	avroSchema, err := model.GetAvroSchemaDefinition(ctx, env, dstTableName, schema, protos.DBType_SNOWFLAKE, nil)
+	avroSchema, err := model.GetAvroSchemaDefinition(ctx, s.Settings, dstTableName, schema, protos.DBType_SNOWFLAKE, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to define Avro schema: %w", err)
 	}
@@ -147,7 +144,6 @@ func (s *SnowflakeAvroSyncHandler) getAvroSchema(
 
 func (s *SnowflakeAvroSyncHandler) writeToAvroFile(
 	ctx context.Context,
-	env map[string]string,
 	stream *model.QRecordStream,
 	avroSchema *model.QRecordAvroSchemaDefinition,
 	partitionID string,
@@ -155,23 +151,19 @@ func (s *SnowflakeAvroSyncHandler) writeToAvroFile(
 ) (utils.AvroFile, error) {
 	if s.config.StagingPath == "" {
 		compression := ocf.ZStandard
-		skipCompression, err := internal.PeerDBSnowflakeSkipCompression(ctx, s.config.Env)
-		if err != nil {
-			s.logger.Warn("Failed to load PEERDB_SNOWFLAKE_SKIP_COMPRESSION, proceeding without", slog.Any("error", err))
-		} else if skipCompression {
+		if s.Settings.SnowflakeSkipCompression {
 			compression = ocf.Null
 		}
 
 		ocfWriter := utils.NewPeerDBOCFWriter(stream, avroSchema, compression, protos.DBType_SNOWFLAKE, nil)
 		tmpDir := fmt.Sprintf("%s/peerdb-avro-%s", os.TempDir(), flowJobName)
-		err = os.MkdirAll(tmpDir, os.ModePerm)
-		if err != nil {
+		if err := os.MkdirAll(tmpDir, os.ModePerm); err != nil {
 			return utils.AvroFile{}, fmt.Errorf("failed to create temp dir: %w", err)
 		}
 
 		localFilePath := fmt.Sprintf("%s/%s.avro", tmpDir, partitionID)
 		s.logger.Info("writing records to local file " + localFilePath)
-		avroFile, err := ocfWriter.WriteRecordsToAvroFile(ctx, env, localFilePath)
+		avroFile, err := ocfWriter.WriteRecordsToAvroFile(ctx, s.Settings, localFilePath)
 		if err != nil {
 			return utils.AvroFile{}, fmt.Errorf("failed to write records to Avro file: %w", err)
 		}
@@ -192,7 +184,7 @@ func (s *SnowflakeAvroSyncHandler) writeToAvroFile(
 		if err != nil {
 			return utils.AvroFile{}, err
 		}
-		avroFile, err := ocfWriter.WriteRecordsToS3(ctx, env, s3o.Bucket, s3AvroFileKey, provider, nil, nil)
+		avroFile, err := ocfWriter.WriteRecordsToS3(ctx, s.Settings, s3o.Bucket, s3AvroFileKey, provider, nil, nil)
 		if err != nil {
 			return utils.AvroFile{}, fmt.Errorf("failed to write records to S3: %w", err)
 		}
@@ -203,17 +195,18 @@ func (s *SnowflakeAvroSyncHandler) writeToAvroFile(
 	return utils.AvroFile{}, fmt.Errorf("unsupported staging path: %s", s.config.StagingPath)
 }
 
-func (s *SnowflakeAvroSyncHandler) putFileToStage(ctx context.Context, avroFile utils.AvroFile, stage string) error {
+func (s *SnowflakeAvroSyncHandler) putFileToStage(
+	ctx context.Context,
+	avroFile utils.AvroFile,
+	stage string,
+) error {
 	if avroFile.StorageLocation != utils.AvroLocalStorage {
 		s.logger.Info("no file to put to stage")
 		return nil
 	}
 
 	autoCompressionStr := ""
-	autoCompression, err := internal.PeerDBSnowflakeAutoCompress(ctx, s.config.Env)
-	if err != nil {
-		s.logger.Warn("Failed to load PEERDB_SNOWFLAKE_AUTO_COMPRESS, proceeding without", slog.Any("error", err))
-	} else if !autoCompression {
+	if !s.Settings.SnowflakeAutoCompress {
 		autoCompressionStr = " AUTO_COMPRESS=FALSE"
 	}
 

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -74,6 +74,7 @@ const (
 type SnowflakeConnector struct {
 	*metadataStore.PostgresMetadata
 	*sql.DB
+	Settings  *internal.Settings
 	logger    log.Logger
 	config    *protos.SnowflakeConfig
 	rawSchema string
@@ -81,6 +82,7 @@ type SnowflakeConnector struct {
 
 func NewSnowflakeConnector(
 	ctx context.Context,
+	settings *internal.Settings,
 	snowflakeProtoConfig *protos.SnowflakeConfig,
 ) (*SnowflakeConnector, error) {
 	logger := internal.LoggerFromCtx(ctx)
@@ -133,6 +135,7 @@ func NewSnowflakeConnector(
 	return &SnowflakeConnector{
 		PostgresMetadata: pgMetadata,
 		DB:               database,
+		Settings:         settings,
 		rawSchema:        rawSchema,
 		logger:           logger,
 		config:           snowflakeProtoConfig,
@@ -324,7 +327,7 @@ func (c *SnowflakeConnector) SetupNormalizedTable(
 		return true, nil
 	}
 
-	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(ctx, config, normalizedSchemaTable, tableSchema)
+	normalizedTableCreateSQL := generateCreateTableSQLForNormalizedTable(ctx, c.Settings, config, normalizedSchemaTable, tableSchema)
 	if _, err := c.execWithLogging(ctx, normalizedTableCreateSQL); err != nil {
 		return false, fmt.Errorf("[sf] error while creating normalized table: %w", err)
 	}
@@ -335,7 +338,6 @@ func (c *SnowflakeConnector) SetupNormalizedTable(
 // This could involve adding or dropping multiple columns.
 func (c *SnowflakeConnector) ReplayTableSchemaDeltas(
 	ctx context.Context,
-	env map[string]string,
 	flowJobName string,
 	_ []*protos.TableMapping,
 	schemaDeltas []*protos.TableSchemaDelta,
@@ -365,7 +367,7 @@ func (c *SnowflakeConnector) ReplayTableSchemaDeltas(
 		for _, addedColumn := range schemaDelta.AddedColumns {
 			qvKind := types.QValueKind(addedColumn.Type)
 			sfColtype, err := qvalue.ToDWHColumnType(
-				ctx, qvKind, env, protos.DBType_SNOWFLAKE, nil, addedColumn, schemaDelta.NullableEnabled, nil,
+				ctx, qvKind, c.Settings, protos.DBType_SNOWFLAKE, nil, addedColumn, schemaDelta.NullableEnabled, nil,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to convert column type %s to snowflake type: %w",
@@ -436,7 +438,7 @@ func (c *SnowflakeConnector) syncRecordsViaAvro(
 		FlowJobName: req.FlowJobName,
 		DestinationTableIdentifier: strings.ToLower(fmt.Sprintf("%s.%s", c.rawSchema,
 			rawTableIdentifier)),
-		Env:     req.Env,
+		Env:     c.Settings.Env,
 		Version: req.Version,
 	}
 	avroSyncer := NewSnowflakeAvroSyncHandler(qrepConfig, c)
@@ -445,12 +447,12 @@ func (c *SnowflakeConnector) syncRecordsViaAvro(
 		return nil, err
 	}
 
-	numRecords, err := avroSyncer.SyncRecords(ctx, req.Env, destinationTableSchema, stream, req.FlowJobName)
+	numRecords, err := avroSyncer.SyncRecords(ctx, destinationTableSchema, stream, req.FlowJobName)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := c.ReplayTableSchemaDeltas(ctx, req.Env, req.FlowJobName, req.TableMappings, req.Records.SchemaDeltas, nil); err != nil {
+	if err := c.ReplayTableSchemaDeltas(ctx, req.FlowJobName, req.TableMappings, req.Records.SchemaDeltas, nil); err != nil {
 		return nil, fmt.Errorf("failed to sync schema changes: %w", err)
 	}
 
@@ -482,7 +484,7 @@ func (c *SnowflakeConnector) NormalizeRecords(ctx context.Context, req *model.No
 	for batchId := normBatchID + 1; batchId <= req.SyncBatchID; batchId++ {
 		c.logger.Info(fmt.Sprintf("normalizing records for batch %d [of %d]", batchId, req.SyncBatchID))
 		mergeErr := c.mergeTablesForBatch(ctx, batchId,
-			req.FlowJobName, req.Env, req.TableNameSchemaMapping,
+			req.FlowJobName, req.TableNameSchemaMapping,
 			&protos.PeerDBColumns{
 				SoftDeleteColName: req.SoftDeleteColName,
 				SyncedAtColName:   req.SyncedAtColName,
@@ -507,7 +509,6 @@ func (c *SnowflakeConnector) mergeTablesForBatch(
 	ctx context.Context,
 	batchId int64,
 	flowName string,
-	env map[string]string,
 	tableToSchema map[string]*protos.TableSchema,
 	peerdbCols *protos.PeerDBColumns,
 ) error {
@@ -523,7 +524,7 @@ func (c *SnowflakeConnector) mergeTablesForBatch(
 
 	var totalRowsAffected int64 = 0
 	g, gCtx := errgroup.WithContext(ctx)
-	mergeParallelism, err := internal.PeerDBSnowflakeMergeParallelism(ctx, env)
+	mergeParallelism, err := internal.PeerDBSnowflakeMergeParallelism(ctx, c.Settings.Env)
 	if err != nil {
 		return fmt.Errorf("failed to get merge parallelism: %w", err)
 	}
@@ -543,7 +544,7 @@ func (c *SnowflakeConnector) mergeTablesForBatch(
 		}
 
 		g.Go(func() error {
-			mergeStatement, err := mergeGen.generateMergeStmt(gCtx, env, tableName)
+			mergeStatement, err := mergeGen.generateMergeStmt(gCtx, c.Settings, tableName)
 			if err != nil {
 				return err
 			}
@@ -653,6 +654,7 @@ func (c *SnowflakeConnector) checkIfTableExists(
 
 func generateCreateTableSQLForNormalizedTable(
 	ctx context.Context,
+	settings *internal.Settings,
 	config *protos.SetupNormalizedTableBatchInput,
 	dstSchemaTable *common.QualifiedTable,
 	tableSchema *protos.TableSchema,
@@ -663,7 +665,7 @@ func generateCreateTableSQLForNormalizedTable(
 		normalizedColName := SnowflakeIdentifierNormalize(column.Name)
 		qvKind := types.QValueKind(genericColumnType)
 		sfColType, err := qvalue.ToDWHColumnType(
-			ctx, qvKind, config.Env, protos.DBType_SNOWFLAKE, nil, column, tableSchema.NullableEnabled, nil,
+			ctx, qvKind, settings, protos.DBType_SNOWFLAKE, nil, column, tableSchema.NullableEnabled, nil,
 		)
 		if err != nil {
 			slog.WarnContext(ctx, fmt.Sprintf("failed to convert column type %s to snowflake type", genericColumnType),

--- a/flow/connectors/utils/avro_writer.go
+++ b/flow/connectors/utils/avro_writer.go
@@ -72,7 +72,7 @@ func NewPeerDBOCFWriter(
 
 func (p *peerDBOCFWriter) WriteOCF(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	w io.Writer,
 	typeConversions map[string]types.TypeConversion,
 	numericTruncator model.SnapshotTableNumericTruncator,
@@ -86,7 +86,7 @@ func (p *peerDBOCFWriter) WriteOCF(
 	}
 	defer ocfWriter.Close()
 
-	numRows, err := p.writeRecordsToOCFWriter(ctx, env, ocfWriter, typeConversions, numericTruncator)
+	numRows, err := p.writeRecordsToOCFWriter(ctx, settings, ocfWriter, typeConversions, numericTruncator)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write records to OCF writer: %w", err)
 	}
@@ -95,7 +95,7 @@ func (p *peerDBOCFWriter) WriteOCF(
 
 func (p *peerDBOCFWriter) WriteRecordsToS3(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	bucketName string,
 	key string,
 	s3Creds AWSCredentialsProvider,
@@ -124,10 +124,10 @@ func (p *peerDBOCFWriter) WriteRecordsToS3(
 			}
 			w.Close()
 		}()
-		numRows, writeOcfError = p.WriteOCF(ctx, env, w, typeConversions, numericTruncator)
+		numRows, writeOcfError = p.WriteOCF(ctx, settings, w, typeConversions, numericTruncator)
 	}()
 
-	partSize, err := internal.PeerDBS3PartSize(ctx, env)
+	partSize, err := internal.PeerDBS3PartSize(ctx, settings.Env)
 	if err != nil {
 		return AvroFile{}, fmt.Errorf("could not get s3 part size config: %w", err)
 	}
@@ -166,7 +166,7 @@ func (p *peerDBOCFWriter) WriteRecordsToS3(
 	}, nil
 }
 
-func (p *peerDBOCFWriter) WriteRecordsToAvroFile(ctx context.Context, env map[string]string, filePath string) (AvroFile, error) {
+func (p *peerDBOCFWriter) WriteRecordsToAvroFile(ctx context.Context, settings *internal.Settings, filePath string) (AvroFile, error) {
 	file, err := os.Create(filePath)
 	if err != nil {
 		return AvroFile{}, fmt.Errorf("failed to create temporary Avro file: %w", err)
@@ -183,7 +183,7 @@ func (p *peerDBOCFWriter) WriteRecordsToAvroFile(ctx context.Context, env map[st
 	shutdown := common.Interval(ctx, time.Minute, func() { printFileStats("writing to temporary Avro file") })
 	defer shutdown()
 
-	numRecords, err := p.WriteOCF(ctx, env, file, nil, nil)
+	numRecords, err := p.WriteOCF(ctx, settings, file, nil, nil)
 	if err != nil {
 		return AvroFile{}, fmt.Errorf("failed to write records to temporary Avro file: %w", err)
 	}
@@ -207,7 +207,7 @@ func (p *peerDBOCFWriter) getAvroFieldNamesFromSchema() ([]string, error) {
 
 func (p *peerDBOCFWriter) writeRecordsToOCFWriter(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	ocfWriter *ocf.Encoder,
 	typeConversions map[string]types.TypeConversion,
 	numericTruncator model.SnapshotTableNumericTruncator,
@@ -218,12 +218,9 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(
 	if err != nil {
 		return 0, fmt.Errorf("failed to get Avro field names from schema: %w", err)
 	}
-	avroConverter, err := model.NewQRecordAvroConverter(
-		ctx, env, p.avroSchema, p.targetDWH, avroFieldNames, logger,
+	avroConverter := model.NewQRecordAvroConverter(
+		settings, p.avroSchema, p.targetDWH, avroFieldNames, logger,
 	)
-	if err != nil {
-		return 0, err
-	}
 
 	// Create null mismatch tracker if in nullable lax mode
 	avroConverter.NullMismatchTracker = model.NewNullMismatchTracker(p.stream.SchemaDebug())
@@ -243,17 +240,14 @@ func (p *peerDBOCFWriter) writeRecordsToOCFWriter(
 	})
 	defer shutdown()
 
-	format, err := internal.PeerDBBinaryFormat(ctx, env)
-	if err != nil {
-		return 0, err
-	}
+	format := settings.ClickHouseBinaryFormat
 
 	calcSize := p.sizeTracker != nil
 	for qrecord := range p.stream.Records {
 		if err := ctx.Err(); err != nil {
 			return numRows.Load(), err
 		} else {
-			avroMap, size, err := avroConverter.Convert(ctx, env, qrecord, typeConversions, numericTruncator, format, calcSize)
+			avroMap, size, err := avroConverter.Convert(ctx, settings, qrecord, typeConversions, numericTruncator, format, calcSize)
 			if err != nil {
 				logger.Error("Failed to convert QRecord to Avro compatible map", slog.Any("error", err))
 				return numRows.Load(), fmt.Errorf("failed to convert QRecord to Avro compatible map: %w", err)

--- a/flow/connectors/utils/cdc_store.go
+++ b/flow/connectors/utils/cdc_store.go
@@ -46,12 +46,12 @@ type CDCStore[Items model.Items] struct {
 	numRecords                atomic.Int32
 }
 
-func NewCDCStore[Items model.Items](ctx context.Context, env map[string]string, flowJobName string) (*CDCStore[Items], error) {
-	numRecordsSwitchThreshold, err := internal.PeerDBCDCDiskSpillRecordsThreshold(ctx, env)
+func NewCDCStore[Items model.Items](ctx context.Context, settings *internal.Settings, flowJobName string) (*CDCStore[Items], error) {
+	numRecordsSwitchThreshold, err := internal.PeerDBCDCDiskSpillRecordsThreshold(ctx, settings.Env)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CDC disk spill records threshold: %w", err)
 	}
-	memPercent, err := internal.PeerDBCDCDiskSpillMemPercentThreshold(ctx, env)
+	memPercent, err := internal.PeerDBCDCDiskSpillMemPercentThreshold(ctx, settings.Env)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CDC disk spill memory percent threshold: %w", err)
 	}

--- a/flow/connectors/utils/cdc_store_test.go
+++ b/flow/connectors/utils/cdc_store_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
@@ -52,7 +53,7 @@ func genKeyAndRec(t *testing.T) (model.TableWithPkey, model.Record[model.RecordI
 
 func TestSingleRecord(t *testing.T) {
 	t.Parallel()
-	cdcRecordsStore, err := NewCDCStore[model.RecordItems](t.Context(), nil, "test_single_record")
+	cdcRecordsStore, err := NewCDCStore[model.RecordItems](t.Context(), internal.NewSettings(nil), "test_single_record")
 	require.NoError(t, err)
 	cdcRecordsStore.numRecordsSwitchThreshold = 10
 
@@ -72,7 +73,7 @@ func TestSingleRecord(t *testing.T) {
 
 func TestRecordsTillSpill(t *testing.T) {
 	t.Parallel()
-	cdcRecordsStore, err := NewCDCStore[model.RecordItems](t.Context(), nil, "test_records_till_spill")
+	cdcRecordsStore, err := NewCDCStore[model.RecordItems](t.Context(), internal.NewSettings(nil), "test_records_till_spill")
 	require.NoError(t, err)
 	cdcRecordsStore.numRecordsSwitchThreshold = 10
 
@@ -103,7 +104,7 @@ func TestRecordsTillSpill(t *testing.T) {
 func TestTimeAndDecimalEncoding(t *testing.T) {
 	t.Parallel()
 
-	cdcRecordsStore, err := NewCDCStore[model.RecordItems](t.Context(), nil, "test_time_encoding")
+	cdcRecordsStore, err := NewCDCStore[model.RecordItems](t.Context(), internal.NewSettings(nil), "test_time_encoding")
 	require.NoError(t, err)
 	cdcRecordsStore.numRecordsSwitchThreshold = 0
 
@@ -124,7 +125,7 @@ func TestTimeAndDecimalEncoding(t *testing.T) {
 func TestNullKeyDoesntStore(t *testing.T) {
 	t.Parallel()
 
-	cdcRecordsStore, err := NewCDCStore[model.RecordItems](t.Context(), nil, "test_time_encoding")
+	cdcRecordsStore, err := NewCDCStore[model.RecordItems](t.Context(), internal.NewSettings(nil), "test_time_encoding")
 	require.NoError(t, err)
 	cdcRecordsStore.numRecordsSwitchThreshold = 0
 

--- a/flow/e2e/bigquery_source_test.go
+++ b/flow/e2e/bigquery_source_test.go
@@ -18,6 +18,7 @@ import (
 	connbigquery "github.com/PeerDB-io/peerdb/flow/connectors/bigquery"
 	"github.com/PeerDB-io/peerdb/flow/e2eshared"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
@@ -114,7 +115,7 @@ func setupBigQuerySource(t *testing.T) (*bigQuerySource, error) {
 		return nil, fmt.Errorf("failed to create BigQuery helper: %w", err)
 	}
 
-	conn, err := connbigquery.NewBigQueryConnector(t.Context(), helper.Config)
+	conn, err := connbigquery.NewBigQueryConnector(t.Context(), internal.NewSettings(nil), helper.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BigQuery connector: %w", err)
 	}
@@ -381,7 +382,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_Source_Get_Table_Schema() {
 		},
 	}
 
-	schemas, err := bqConn.GetTableSchema(ctx, map[string]string{}, 0, protos.TypeSystem_Q, tableMappings)
+	schemas, err := bqConn.GetTableSchema(ctx, 0, protos.TypeSystem_Q, tableMappings)
 	require.NoError(t, err, "should successfully get table schema")
 	require.NotNil(t, schemas, "schemas should not be nil")
 	require.Len(t, schemas, 1, "should have one table schema")

--- a/flow/e2e/clickhouse.go
+++ b/flow/e2e/clickhouse.go
@@ -115,7 +115,7 @@ type TestClickHouseColumn struct {
 
 // CreateRMTTable creates a ReplacingMergeTree table with the given name and columns.
 func (s ClickHouseSuite) CreateRMTTable(tableName string, columns []TestClickHouseColumn, orderingKey string) error {
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (s ClickHouseSuite) CreateRMTTable(tableName string, columns []TestClickHou
 }
 
 func (s ClickHouseSuite) DropTable(tableName string) error {
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (s ClickHouseSuite) DropTable(tableName string) error {
 
 func (s ClickHouseSuite) GetRows(table string, cols string) (*model.QRecordBatch, error) {
 	peer := s.Peer()
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, peer.GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), peer.GetClickhouseConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +402,7 @@ func SetupClickHouseSuite[TSource SuiteSource](
 			cluster:  cluster,
 		}
 
-		ch, err := connclickhouse.Connect(t.Context(), nil, s.PeerForDatabase("default").GetClickhouseConfig())
+		ch, err := connclickhouse.Connect(t.Context(), internal.NewSettings(nil), s.PeerForDatabase("default").GetClickhouseConfig())
 		require.NoError(t, err, "failed to connect to clickhouse")
 		if cluster {
 			err = ch.Exec(t.Context(), "CREATE DATABASE e2e_test_"+suffix+" ON CLUSTER cicluster")
@@ -411,7 +411,7 @@ func SetupClickHouseSuite[TSource SuiteSource](
 		}
 		require.NoError(t, err, "failed to create clickhouse database")
 
-		connector, err := connclickhouse.NewClickHouseConnector(t.Context(), nil, s.Peer().GetClickhouseConfig())
+		connector, err := connclickhouse.NewClickHouseConnector(t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 		require.NoError(t, err)
 		s.connector = connector
 

--- a/flow/e2e/clickhouse_mv.go
+++ b/flow/e2e/clickhouse_mv.go
@@ -6,6 +6,7 @@ import (
 
 	connclickhouse "github.com/PeerDB-io/peerdb/flow/connectors/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 // ClickHouseMVManager manages materialized views for ClickHouse testing
@@ -34,7 +35,7 @@ func newClickHouseMVManager(
 // that will fail when data is inserted.
 // Source schema is assumed to correspond to (id UInt64, val String).
 func (m *ClickHouseMVManager) CreateBadMV(ctx context.Context) error {
-	ch, err := connclickhouse.Connect(ctx, nil, m.config)
+	ch, err := connclickhouse.Connect(ctx, internal.NewSettings(nil), m.config)
 	if err != nil {
 		return err
 	}
@@ -73,7 +74,7 @@ func (m *ClickHouseMVManager) CreateBadMV(ctx context.Context) error {
 
 // DropBadMV removes the materialized view and its target table
 func (m *ClickHouseMVManager) DropBadMV(ctx context.Context) error {
-	ch, err := connclickhouse.Connect(ctx, nil, m.config)
+	ch, err := connclickhouse.Connect(ctx, internal.NewSettings(nil), m.config)
 	if err != nil {
 		return err
 	}

--- a/flow/e2e/clickhouse_mysql_test.go
+++ b/flow/e2e/clickhouse_mysql_test.go
@@ -804,7 +804,8 @@ func (s ClickHouseSuite) Test_MySQL_Schema_Changes() {
 			},
 		},
 	}
-	output, err := destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err := destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema, output[dstTableName]))
@@ -839,7 +840,8 @@ func (s ClickHouseSuite) Test_MySQL_Schema_Changes() {
 			},
 		},
 	}
-	output, err = destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err = destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema, output[dstTableName]))
@@ -925,7 +927,8 @@ func (s ClickHouseSuite) Test_MySQL_GhOst_Schema_Changes() {
 			},
 		},
 	}
-	output, err := destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err := destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema, output[dstTableName]))
@@ -1043,7 +1046,8 @@ func (s ClickHouseSuite) Test_MySQL_GhOst_Schema_Changes() {
 			},
 		},
 	}
-	output, err = destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err = destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema, output[dstTableName]))
@@ -1093,7 +1097,7 @@ func (s ClickHouseSuite) Test_MySQL_NumToVarcharCoercion() {
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id")
 
 	var numCount, f32Count, f64Count uint64
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	require.NoError(s.t, ch.QueryRow(s.t.Context(),
 		"SELECT count(distinct num), count(distinct f32), count(distinct f64) FROM "+clickhouse.QuoteIdentifier(dstTableName),

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -24,6 +24,7 @@ import (
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/e2eshared"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
 	"github.com/PeerDB-io/peerdb/flow/pkg/clickhouse"
@@ -516,7 +517,7 @@ func (s ClickHouseSuite) WeirdTable(tableName string) {
 	EnvWaitForFinished(s.t, env, 3*time.Minute)
 
 	// now test weird names with rename based resync
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	onCluster := ""
 	if s.cluster {
@@ -534,7 +535,7 @@ func (s ClickHouseSuite) WeirdTable(tableName string) {
 	env = ExecuteDropFlow(s.t.Context(), tc, flowConnConfig, 0)
 	EnvWaitForFinished(s.t, env, 3*time.Minute)
 	// now test weird names with exchange based resync
-	ch, err = connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err = connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	require.NoError(s.t, ch.Exec(s.t.Context(), "TRUNCATE TABLE "+clickhouse.QuoteIdentifier(dstTableName)+onCluster))
 	require.NoError(s.t, ch.Close())
@@ -1378,7 +1379,7 @@ func (s ClickHouseSuite) Test_Time64() {
 
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,t,t_nullable,t_nullable_2")
 
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	defer ch.Close()
 	var dstTableSuffix string
@@ -1456,7 +1457,7 @@ func (s ClickHouseSuite) Test_InfiniteTimestamp() {
 
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id")
 
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	rows, err := ch.Query(s.t.Context(),
 		fmt.Sprintf("select id,t_null,t_notnull,d_null,d_notnull,n_null,n_notnull from %s order by id", dstTableName))
@@ -1540,7 +1541,7 @@ func (s ClickHouseSuite) Test_JSON_Null() {
 
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id")
 
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	rows, err := ch.Query(s.t.Context(),
 		fmt.Sprintf("select id,j_null,j_notnull,j_sqlnull,jb_null,jb_notnull,jb_sqlnull from %s order by id", dstTableName))
@@ -2209,7 +2210,7 @@ func (s ClickHouseSuite) Test_Normalize_Metadata_With_Retry() {
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName1, dstTableName1, "id,\"key\"")
 
 	// Rename the table to simulate a push failure to ClickHouse
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	fakeDestination2 := "test_normalize_metadata_with_retry_dst_2_fake"
 	onCluster := ""
@@ -2604,7 +2605,7 @@ func (s ClickHouseSuite) Test_NullEngine() {
 	env := ExecutePeerflow(s.t, tc, flowConnConfig)
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, chPeer)
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), chPeer)
 	require.NoError(s.t, err)
 	require.NoError(s.t, ch.Exec(s.t.Context(),
 		`create table nulltarget (id Int32, "key" String, _peerdb_is_deleted Int8) engine = ReplacingMergeTree() order by id`))
@@ -2623,7 +2624,7 @@ func (s ClickHouseSuite) Test_NullEngine() {
 	EnvWaitForEqualTablesWithNames(env, s, "null insert after column added", srcTableName, "nulltarget", "id,\"key\"")
 
 	var count uint64
-	ch, err = connclickhouse.Connect(s.t.Context(), nil, chPeer)
+	ch, err = connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), chPeer)
 	require.NoError(s.t, err)
 	row := ch.QueryRow(s.t.Context(),
 		fmt.Sprintf("select count(*) from system.columns where database = '%s' and table = 'test_nullengine'", chPeer.Database))
@@ -2639,7 +2640,7 @@ func (s ClickHouseSuite) Test_NullEngine() {
 
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf("ALTER TABLE %s DROP COLUMN val", srcFullName)))
 
-	ch, err = connclickhouse.Connect(s.t.Context(), nil, chPeer)
+	ch, err = connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), chPeer)
 	require.NoError(s.t, err)
 	require.NoError(s.t, ch.Exec(s.t.Context(), "TRUNCATE TABLE nulltarget"))
 	require.NoError(s.t, ch.Close())
@@ -2653,7 +2654,7 @@ func (s ClickHouseSuite) Test_NullEngine() {
 		fmt.Sprintf(`insert into %s values (3,'cdcresync',1)`, srcFullName)))
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on insert after resync", srcTableName, "nulltarget", "id,\"key\"")
 
-	ch, err = connclickhouse.Connect(s.t.Context(), nil, chPeer)
+	ch, err = connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), chPeer)
 	require.NoError(s.t, err)
 	row = ch.QueryRow(s.t.Context(),
 		fmt.Sprintf("select count(*) from system.columns where database = '%s' and table = 'test_nullengine'", chPeer.Database))
@@ -3012,7 +3013,7 @@ func (s ClickHouseSuite) Test_PartitionBy() {
 	EnvWaitForEqualTablesWithNames(env, s, "table setup", srcTableName, dstTableName, "id")
 
 	var partitionKey, sortingKey string
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	var dstTableSuffix string
 	if s.cluster {
@@ -3065,7 +3066,7 @@ func (s ClickHouseSuite) Test_PartitionByExpr() {
 	EnvWaitForEqualTablesWithNames(env, s, "table setup", srcTableName, dstTableName, "id")
 
 	var partitionKey string
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	var dstTableSuffix string
 	if s.cluster {
@@ -3540,7 +3541,7 @@ func (s ClickHouseSuite) Test_Composite_PKey() {
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, orderedPk)
 
 	var sortingKey string
-	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(s.t.Context(), internal.NewSettings(nil), s.Peer().GetClickhouseConfig())
 	require.NoError(s.t, err)
 	var dstTableSuffix string
 	if s.cluster {

--- a/flow/e2e/clickhouse_tls_test.go
+++ b/flow/e2e/clickhouse_tls_test.go
@@ -10,6 +10,7 @@ import (
 
 	connclickhouse "github.com/PeerDB-io/peerdb/flow/connectors/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 // TestClickHouseTLSDirectory verifies that connclickhouse.Connect works
@@ -36,7 +37,7 @@ func TestClickHouseTLSDirectory(t *testing.T) {
 		TlsCertificateDirectory: proto.String(certDir),
 	}
 
-	conn, err := connclickhouse.Connect(t.Context(), nil, config)
+	conn, err := connclickhouse.Connect(t.Context(), internal.NewSettings(nil), config)
 	require.NoError(t, err, "failed to connect to ClickHouse")
 	defer conn.Close()
 

--- a/flow/e2e/generic_test.go
+++ b/flow/e2e/generic_test.go
@@ -264,7 +264,8 @@ func (s Generic) Test_Simple_Schema_Changes() {
 			},
 		},
 	}
-	output, err := destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err := destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema, output[dstTableName]))
@@ -300,7 +301,8 @@ func (s Generic) Test_Simple_Schema_Changes() {
 			},
 		},
 	}
-	output, err = destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err = destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema, output[dstTableName]))
@@ -342,7 +344,8 @@ func (s Generic) Test_Simple_Schema_Changes() {
 			},
 		},
 	}
-	output, err = destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err = destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema, output[dstTableName]))
@@ -384,7 +387,8 @@ func (s Generic) Test_Simple_Schema_Changes() {
 			},
 		},
 	}
-	output, err = destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err = destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema, output[dstTableName]))
@@ -668,7 +672,8 @@ func (s Generic) Test_Schema_Changes_Cutoff_Bug() {
 			},
 		},
 	}
-	output, err := destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err := destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName1}, {SourceTableIdentifier: dstTableName2}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema1, output[dstTableName1]))
@@ -680,7 +685,8 @@ func (s Generic) Test_Schema_Changes_Cutoff_Bug() {
 	// verify we got our two rows, if schema did not match up it will error.
 	EnvWaitForEqualTablesWithNames(env, s, "table1 added column", srcTable1, dstTable1, "id,c1,coalesce(c2,0) c2")
 	EnvWaitForEqualTablesWithNames(env, s, "table2 added column", srcTable2, dstTable2, "id,c1,coalesce(c2,0) c2")
-	output, err = destinationSchemaConnector.GetTableSchema(t.Context(), nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	output, err = destinationSchemaConnector.GetTableSchema(
+		t.Context(), shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: dstTableName1}, {SourceTableIdentifier: dstTableName2}})
 	EnvNoError(t, env, err)
 	EnvTrue(t, env, CompareTableSchemas(expectedTableSchema1, output[dstTableName1]))

--- a/flow/e2e/mongo.go
+++ b/flow/e2e/mongo.go
@@ -117,7 +117,7 @@ func SetupMongo(t *testing.T, suffix string) (*MongoSource, error) {
 		DisableTls: true,
 	}
 
-	mongoConn, err := connmongo.NewMongoConnector(t.Context(), mongoConfig)
+	mongoConn, err := connmongo.NewMongoConnector(t.Context(), internal.NewSettings(nil), mongoConfig)
 	require.NoError(t, err, "failed to setup mongo connector")
 
 	testDb := GetTestDatabase(suffix)

--- a/flow/e2e/mongo_test.go
+++ b/flow/e2e/mongo_test.go
@@ -836,7 +836,7 @@ func (s MongoClickhouseSuite) Test_Json_Disabled() {
 	EnvWaitForCount(env, s, "cdc", dstTable, "_id,doc", 2)
 
 	peer := s.Peer()
-	ch, err := connclickhouse.Connect(t.Context(), nil, peer.GetClickhouseConfig())
+	ch, err := connclickhouse.Connect(t.Context(), internal.NewSettings(nil), peer.GetClickhouseConfig())
 	require.NoError(t, err)
 	defer ch.Close()
 

--- a/flow/e2e/mysql.go
+++ b/flow/e2e/mysql.go
@@ -61,7 +61,7 @@ func SetupMyCore(t *testing.T, suffix string, replication protos.MySqlReplicatio
 		ReplicationMechanism: replication,
 	}
 
-	connector, err := connmysql.NewMySqlConnector(t.Context(), config)
+	connector, err := connmysql.NewMySqlConnector(t.Context(), internal.NewSettings(nil), config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mysql connection: %w", err)
 	}
@@ -187,7 +187,7 @@ func (s *MySqlSource) GetRows(ctx context.Context, suffix string, table string, 
 	}
 
 	tableName := fmt.Sprintf("e2e_test_%s.%s", suffix, table)
-	tableSchemas, err := s.GetTableSchema(ctx, nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+	tableSchemas, err := s.GetTableSchema(ctx, shared.InternalVersion_Latest, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: tableName}})
 	if err != nil {
 		return nil, err

--- a/flow/e2e/pg.go
+++ b/flow/e2e/pg.go
@@ -109,7 +109,7 @@ func SetupPostgres(t *testing.T, suffix string) (*PostgresSource, error) {
 	t.Helper()
 
 	connector, err := connpostgres.NewPostgresConnector(t.Context(),
-		nil, internal.GetAncillaryPostgresConfigFromEnv())
+		internal.NewSettings(nil), internal.GetAncillaryPostgresConfigFromEnv())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create postgres connection: %w", err)
 	}
@@ -196,7 +196,8 @@ func (s *PostgresSource) Exec(ctx context.Context, sql string, args ...any) erro
 }
 
 func (s *PostgresSource) GetRows(ctx context.Context, suffix string, table string, cols string) (*model.QRecordBatch, error) {
-	pgQueryExecutor, err := s.PostgresConnector.NewQRepQueryExecutor(ctx, nil, shared.InternalVersion_Latest, "testflow", "testpart")
+	pgQueryExecutor, err := s.PostgresConnector.NewQRepQueryExecutor(
+		ctx, internal.NewSettings(nil), shared.InternalVersion_Latest, "testflow", "testpart")
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +210,8 @@ func (s *PostgresSource) GetRows(ctx context.Context, suffix string, table strin
 
 // to avoid fetching rows from "child" tables ala Postgres table inheritance
 func (s *PostgresSource) GetRowsOnly(ctx context.Context, suffix string, table string, cols string) (*model.QRecordBatch, error) {
-	pgQueryExecutor, err := s.PostgresConnector.NewQRepQueryExecutor(ctx, nil, shared.InternalVersion_Latest, "testflow", "testpart")
+	pgQueryExecutor, err := s.PostgresConnector.NewQRepQueryExecutor(
+		ctx, internal.NewSettings(nil), shared.InternalVersion_Latest, "testflow", "testpart")
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +248,8 @@ func RevokePermissionForTableColumns(ctx context.Context, conn *pgx.Conn, tableI
 }
 
 func (s *PostgresSource) Query(ctx context.Context, query string) (*model.QRecordBatch, error) {
-	pgQueryExecutor, err := s.PostgresConnector.NewQRepQueryExecutor(ctx, nil, shared.InternalVersion_Latest, "testflow", "testpart")
+	pgQueryExecutor, err := s.PostgresConnector.NewQRepQueryExecutor(
+		ctx, internal.NewSettings(nil), shared.InternalVersion_Latest, "testflow", "testpart")
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +311,7 @@ func SetupPostgresWithToxiproxy(t *testing.T, suffix string, port uint32) (*Post
 	// Don't set RequireTls - let it use the default from env
 
 	// Rest is same as SetupPostgres
-	connector, err := connpostgres.NewPostgresConnector(t.Context(), nil, config)
+	connector, err := connpostgres.NewPostgresConnector(t.Context(), internal.NewSettings(nil), config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create postgres connection: %w", err)
 	}

--- a/flow/e2e/postgres.go
+++ b/flow/e2e/postgres.go
@@ -12,6 +12,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/connectors"
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -63,7 +64,8 @@ func (s PeerFlowE2ETestSuitePG) Exec(ctx context.Context, sql string) error {
 
 func (s PeerFlowE2ETestSuitePG) GetRows(table string, cols string) (*model.QRecordBatch, error) {
 	s.t.Helper()
-	pgQueryExecutor, err := s.conn.NewQRepQueryExecutor(s.t.Context(), nil, shared.InternalVersion_Latest, "testflow", "testpart")
+	pgQueryExecutor, err := s.conn.NewQRepQueryExecutor(
+		s.t.Context(), internal.NewSettings(nil), shared.InternalVersion_Latest, "testflow", "testpart")
 	if err != nil {
 		return nil, err
 	}

--- a/flow/e2e/snowflake.go
+++ b/flow/e2e/snowflake.go
@@ -14,6 +14,7 @@ import (
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	connsnowflake "github.com/PeerDB-io/peerdb/flow/connectors/snowflake"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 )
@@ -95,6 +96,7 @@ func SetupSnowflakeSuite(t *testing.T) PeerFlowE2ETestSuiteSF {
 
 	connector, err := connsnowflake.NewSnowflakeConnector(
 		t.Context(),
+		internal.NewSettings(nil),
 		sfHelper.Config,
 	)
 	require.NoError(t, err)

--- a/flow/e2e/snowflake_helper.go
+++ b/flow/e2e/snowflake_helper.go
@@ -11,6 +11,7 @@ import (
 	connsnowflake "github.com/PeerDB-io/peerdb/flow/connectors/snowflake"
 	"github.com/PeerDB-io/peerdb/flow/e2eshared"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
@@ -50,7 +51,7 @@ func NewSnowflakeTestHelper(t *testing.T) (*SnowflakeTestHelper, error) {
 	runID := rand.Uint64()
 	testDatabaseName := fmt.Sprintf("e2e_test_%d", runID)
 
-	adminClient, err := connsnowflake.NewSnowflakeConnector(t.Context(), config)
+	adminClient, err := connsnowflake.NewSnowflakeConnector(t.Context(), internal.NewSettings(nil), config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Snowflake client: %w", err)
 	}
@@ -63,7 +64,7 @@ func NewSnowflakeTestHelper(t *testing.T) (*SnowflakeTestHelper, error) {
 	}
 
 	config.Database = testDatabaseName
-	testClient, err := connsnowflake.NewSnowflakeConnector(t.Context(), config)
+	testClient, err := connsnowflake.NewSnowflakeConnector(t.Context(), internal.NewSettings(nil), config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Snowflake client: %w", err)
 	}

--- a/flow/e2e/snowflake_schema_delta_test.go
+++ b/flow/e2e/snowflake_schema_delta_test.go
@@ -10,6 +10,7 @@ import (
 	connsnowflake "github.com/PeerDB-io/peerdb/flow/connectors/snowflake"
 	"github.com/PeerDB-io/peerdb/flow/e2eshared"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
@@ -35,6 +36,7 @@ func setupSchemaDeltaSuite(t *testing.T) SnowflakeSchemaDeltaTestSuite {
 
 	connector, err := connsnowflake.NewSnowflakeConnector(
 		t.Context(),
+		internal.NewSettings(nil),
 		sfTestHelper.Config,
 	)
 	if err != nil {
@@ -53,19 +55,20 @@ func (s SnowflakeSchemaDeltaTestSuite) TestSimpleAddColumn() {
 	err := s.sfTestHelper.RunCommand(s.t.Context(), fmt.Sprintf("CREATE TABLE %s(ID TEXT PRIMARY KEY)", tableName))
 	require.NoError(s.t, err)
 
-	require.NoError(s.t, s.connector.ReplayTableSchemaDeltas(s.t.Context(), nil, "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
-		SrcTableName: tableName,
-		DstTableName: tableName,
-		AddedColumns: []*protos.FieldDescription{
-			{
-				Name:         "HI",
-				Type:         string(types.QValueKindJSON),
-				TypeModifier: -1,
+	require.NoError(s.t, s.connector.ReplayTableSchemaDeltas(
+		s.t.Context(), "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
+			SrcTableName: tableName,
+			DstTableName: tableName,
+			AddedColumns: []*protos.FieldDescription{
+				{
+					Name:         "HI",
+					Type:         string(types.QValueKindJSON),
+					TypeModifier: -1,
+				},
 			},
-		},
-	}}, nil))
+		}}, nil))
 
-	output, err := s.connector.GetTableSchema(s.t.Context(), nil, 0, protos.TypeSystem_Q,
+	output, err := s.connector.GetTableSchema(s.t.Context(), 0, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: tableName}})
 	require.NoError(s.t, err)
 	require.Equal(s.t, &protos.TableSchema{
@@ -167,13 +170,14 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddAllColumnTypes() {
 		}
 	}
 
-	require.NoError(s.t, s.connector.ReplayTableSchemaDeltas(s.t.Context(), nil, "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
-		SrcTableName: tableName,
-		DstTableName: tableName,
-		AddedColumns: addedColumns,
-	}}, nil))
+	require.NoError(s.t, s.connector.ReplayTableSchemaDeltas(
+		s.t.Context(), "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
+			SrcTableName: tableName,
+			DstTableName: tableName,
+			AddedColumns: addedColumns,
+		}}, nil))
 
-	output, err := s.connector.GetTableSchema(s.t.Context(), nil, 0, protos.TypeSystem_Q,
+	output, err := s.connector.GetTableSchema(s.t.Context(), 0, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: tableName}})
 	require.NoError(s.t, err)
 	require.Equal(s.t, expectedTableSchema, output[tableName])
@@ -246,13 +250,14 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddTrickyColumnNames() {
 		}
 	}
 
-	require.NoError(s.t, s.connector.ReplayTableSchemaDeltas(s.t.Context(), nil, "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
-		SrcTableName: tableName,
-		DstTableName: tableName,
-		AddedColumns: addedColumns,
-	}}, nil))
+	require.NoError(s.t, s.connector.ReplayTableSchemaDeltas(
+		s.t.Context(), "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
+			SrcTableName: tableName,
+			DstTableName: tableName,
+			AddedColumns: addedColumns,
+		}}, nil))
 
-	output, err := s.connector.GetTableSchema(s.t.Context(), nil, 0, protos.TypeSystem_Q,
+	output, err := s.connector.GetTableSchema(s.t.Context(), 0, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: tableName}})
 	require.NoError(s.t, err)
 	require.Equal(s.t, expectedTableSchema, output[tableName])
@@ -301,13 +306,14 @@ func (s SnowflakeSchemaDeltaTestSuite) TestAddWhitespaceColumnNames() {
 		}
 	}
 
-	require.NoError(s.t, s.connector.ReplayTableSchemaDeltas(s.t.Context(), nil, "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
-		SrcTableName: tableName,
-		DstTableName: tableName,
-		AddedColumns: addedColumns,
-	}}, nil))
+	require.NoError(s.t, s.connector.ReplayTableSchemaDeltas(
+		s.t.Context(), "schema_delta_flow", nil, []*protos.TableSchemaDelta{{
+			SrcTableName: tableName,
+			DstTableName: tableName,
+			AddedColumns: addedColumns,
+		}}, nil))
 
-	output, err := s.connector.GetTableSchema(s.t.Context(), nil, 0, protos.TypeSystem_Q,
+	output, err := s.connector.GetTableSchema(s.t.Context(), 0, protos.TypeSystem_Q,
 		[]*protos.TableMapping{{SourceTableIdentifier: tableName}})
 	require.NoError(s.t, err)
 	require.Equal(s.t, expectedTableSchema, output[tableName])

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -333,7 +334,7 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		Description:      "Set Postgres application_name to have mirror name as suffix for each mirror",
 		DefaultValue:     "false",
 		ValueType:        protos.DynconfValueType_BOOL,
-		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
@@ -479,6 +480,24 @@ const (
 	BinaryFormatHex
 )
 
+func (b *BinaryFormat) SetDynConf(s string) error {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "raw":
+		*b = BinaryFormatRaw
+	case "hex":
+		*b = BinaryFormatHex
+	case "base64":
+		*b = BinaryFormatBase64
+	default:
+		return fmt.Errorf("unknown binary format %s", s)
+	}
+	return nil
+}
+
+type DynSetter interface {
+	SetDynConf(string) error
+}
+
 func dynLookup(ctx context.Context, env map[string]string, key string) (string, error) {
 	if val, ok := env[key]; ok {
 		return val, nil
@@ -503,20 +522,11 @@ func dynLookup(ctx context.Context, env map[string]string, key string) (string, 
 	}
 	if !value.Valid {
 		if val, ok := os.LookupEnv(key); ok {
-			if env != nil && setting != nil && setting.ApplyMode != protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE {
-				env[key] = val
-			}
 			return val, nil
 		}
 		if setting != nil {
-			if env != nil && setting.ApplyMode != protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE {
-				env[key] = setting.DefaultValue
-			}
 			return setting.DefaultValue, nil
 		}
-	}
-	if env != nil && setting != nil && setting.ApplyMode != protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE {
-		env[key] = value.String
 	}
 	return value.String, nil
 }
@@ -597,28 +607,8 @@ func PeerDBOpenConnectionsAlertThreshold(ctx context.Context, env map[string]str
 	return dynamicConfUnsigned[uint32](ctx, env, "PEERDB_PGPEER_OPEN_CONNECTIONS_ALERT_THRESHOLD")
 }
 
-// PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS, for creating target tables with
-// partitioning by _PEERDB_SYNCED_AT column
-// If true, the target tables will be partitioned by _PEERDB_SYNCED_AT column
-// If false, the target tables will not be partitioned
-func PeerDBBigQueryEnableSyncedAtPartitioning(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS")
-}
-
-func PeerDBBigQueryToastMergeChunking(ctx context.Context, env map[string]string) (uint32, error) {
-	return dynamicConfUnsigned[uint32](ctx, env, "PEERDB_BIGQUERY_TOAST_MERGE_CHUNKING")
-}
-
 func PeerDBCDCChannelBufferSize(ctx context.Context, env map[string]string) (int, error) {
 	return dynamicConfSigned[int](ctx, env, "PEERDB_CDC_CHANNEL_BUFFER_SIZE")
-}
-
-func PeerDBNormalizeBufferHours(ctx context.Context, env map[string]string) (int64, error) {
-	return dynamicConfSigned[int64](ctx, env, "PEERDB_NORMALIZE_BUFFER_HOURS")
-}
-
-func PeerDBGroupNormalize(ctx context.Context, env map[string]string) (int64, error) {
-	return dynamicConfSigned[int64](ctx, env, "PEERDB_GROUP_NORMALIZE")
 }
 
 func PeerDBQueueFlushTimeoutSeconds(ctx context.Context, env map[string]string) (time.Duration, error) {
@@ -653,39 +643,6 @@ func PeerDBWALHeartbeatQuery(ctx context.Context, env map[string]string) (string
 	return dynLookup(ctx, env, "PEERDB_WAL_HEARTBEAT_QUERY")
 }
 
-func PeerDBReconnectAfterBatches(ctx context.Context, env map[string]string) (int32, error) {
-	return dynamicConfSigned[int32](ctx, env, "PEERDB_RECONNECT_AFTER_BATCHES")
-}
-
-func PeerDBFullRefreshOverwriteMode(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_FULL_REFRESH_OVERWRITE_MODE")
-}
-
-func PeerDBNullable(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_NULLABLE")
-}
-
-func PeerDBAvroNullableLax(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_AVRO_NULLABLE_LAX")
-}
-
-func PeerDBBinaryFormat(ctx context.Context, env map[string]string) (BinaryFormat, error) {
-	format, err := dynLookup(ctx, env, "PEERDB_CLICKHOUSE_BINARY_FORMAT")
-	if err != nil {
-		return 0, err
-	}
-	switch strings.ToLower(strings.TrimSpace(format)) {
-	case "raw":
-		return BinaryFormatRaw, nil
-	case "hex":
-		return BinaryFormatHex, nil
-	case "base64":
-		return BinaryFormatBase64, nil
-	default:
-		return 0, fmt.Errorf("unknown binary format %s", format)
-	}
-}
-
 func PeerDBEnableClickHousePrimaryUpdate(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_ENABLE_PRIMARY_UPDATE")
 }
@@ -698,32 +655,12 @@ func PeerDBClickHouseParallelNormalize(ctx context.Context, env map[string]strin
 	return dynamicConfSigned[int](ctx, env, "PEERDB_CLICKHOUSE_PARALLEL_NORMALIZE")
 }
 
-func PeerDBEnableClickHouseNumericAsString(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_UNBOUNDED_NUMERIC_AS_STRING")
-}
-
-func PeerDBEnableClickHouseJSON(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_ENABLE_JSON")
-}
-
-func PeerDBClickHouseClientName(ctx context.Context, env map[string]string) (string, error) {
-	return dynLookup(ctx, env, "PEERDB_CLICKHOUSE_CLIENT_NAME")
-}
-
 func PeerDBClickHouseRawTableTTLDays(ctx context.Context, env map[string]string) (uint32, error) {
 	return dynamicConfUnsigned[uint32](ctx, env, "PEERDB_CLICKHOUSE_RAW_TABLE_TTL_DAYS")
 }
 
 func PeerDBSnowflakeMergeParallelism(ctx context.Context, env map[string]string) (int64, error) {
 	return dynamicConfSigned[int64](ctx, env, "PEERDB_SNOWFLAKE_MERGE_PARALLELISM")
-}
-
-func PeerDBSnowflakeSkipCompression(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_SNOWFLAKE_SKIP_COMPRESSION")
-}
-
-func PeerDBSnowflakeAutoCompress(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_SNOWFLAKE_AUTO_COMPRESS")
 }
 
 func PeerDBClickHouseStagingProvider(ctx context.Context, env map[string]string) (string, error) {
@@ -738,22 +675,12 @@ func PeerDBClickHouseAWSS3BucketName(ctx context.Context, env map[string]string)
 	return dynLookup(ctx, env, "PEERDB_CLICKHOUSE_AWS_S3_BUCKET_NAME")
 }
 
-func PeerDBS3UuidPrefix(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_S3_UUID_PREFIX")
-}
-
 func PeerDBS3PartSize(ctx context.Context, env map[string]string) (int64, error) {
 	return dynamicConfSigned[int64](ctx, env, "PEERDB_S3_PART_SIZE")
 }
 
 func PeerDBS3BytesPerAvroFile(ctx context.Context, env map[string]string) (int64, error) {
 	return dynamicConfSigned[int64](ctx, env, "PEERDB_S3_BYTES_PER_AVRO_FILE")
-}
-
-// Kafka has topic auto create as an option, auto.create.topics.enable
-// But non-dedicated cluster maybe can't set config, may want peerdb to create topic. Similar for PubSub
-func PeerDBQueueForceTopicCreation(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_QUEUE_FORCE_TOPIC_CREATION")
 }
 
 // PEERDB_INTERVAL_SINCE_LAST_NORMALIZE_THRESHOLD_MINUTES, 0 disables normalize gap alerting entirely
@@ -773,54 +700,139 @@ func UpdatePeerDBMaintenanceModeEnabled(ctx context.Context, pool shared.Catalog
 	return UpdateDynamicSetting(ctx, pool, "PEERDB_MAINTENANCE_MODE_ENABLED", new(strconv.FormatBool(enabled)))
 }
 
-func PeerDBPKMEmptyBatchThrottleThresholdSeconds(ctx context.Context, env map[string]string) (int64, error) {
-	return dynamicConfSigned[int64](ctx, env, "PEERDB_PKM_EMPTY_BATCH_THROTTLE_THRESHOLD_SECONDS")
-}
-
-func PeerDBClickHouseInitialLoadPartsPerPartition(ctx context.Context, env map[string]string) (uint64, error) {
-	return dynamicConfUnsigned[uint64](ctx, env, "PEERDB_CLICKHOUSE_INITIAL_LOAD_PARTS_PER_PARTITION")
-}
-
-func PeerDBClickHouseInitialLoadAllowNonEmptyTables(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_INITIAL_LOAD_ALLOW_NON_EMPTY_TABLES")
-}
-
-func PeerDBSkipSnapshotExport(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_SKIP_SNAPSHOT_EXPORT")
-}
-
-func PeerDBSourceSchemaAsDestinationColumn(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_SOURCE_SCHEMA_AS_DESTINATION_COLUMN")
-}
-
-func PeerDBOriginMetaAsDestinationColumn(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_ORIGIN_METADATA_AS_DESTINATION_COLUMN")
-}
-
 func PeerDBPostgresCDCHandleInheritanceForNonPartitionedTables(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_POSTGRES_CDC_HANDLE_INHERITANCE_FOR_NON_PARTITIONED_TABLES")
-}
-
-func PeerDBForceInternalVersion(ctx context.Context, env map[string]string) (uint32, error) {
-	return dynamicConfUnsigned[uint32](ctx, env, "PEERDB_FORCE_INTERNAL_VERSION")
 }
 
 func PeerDBPostgresEnableFailoverSlots(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_POSTGRES_ENABLE_FAILOVER_SLOTS")
 }
 
-func PeerDBPostgresWalSenderTimeout(ctx context.Context, env map[string]string) (string, error) {
-	return dynLookup(ctx, env, "PEERDB_POSTGRES_WAL_SENDER_TIMEOUT")
-}
-
 func PeerDBMetricsRecordAggregatesEnabled(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_METRICS_RECORD_AGGREGATES_ENABLED")
 }
 
-func PeerDBPostgresApplyCtidBlockPartitioning(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_POSTGRES_APPLY_CTID_BLOCK_PARTITIONING_OVERRIDE")
-}
-
 func PeerDBPGAutomatedSchemaDump(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_PG_AUTOMATED_SCHEMA_DUMP")
+}
+
+type Settings struct {
+	Env                                      map[string]string
+	PostgresWalSenderTimeout                 string       `dyn:"PEERDB_POSTGRES_WAL_SENDER_TIMEOUT"`
+	ClickHouseClientName                     string       `dyn:"PEERDB_CLICKHOUSE_CLIENT_NAME"`
+	NormalizeBufferHours                     int64        `dyn:"PEERDB_NORMALIZE_BUFFER_HOURS"`
+	GroupNormalize                           int64        `dyn:"PEERDB_GROUP_NORMALIZE"`
+	ClickHouseInitialLoadPartsPerPartition   uint64       `dyn:"PEERDB_CLICKHOUSE_INITIAL_LOAD_PARTS_PER_PARTITION"`
+	PKMEmptyBatchThrottleThresholdSeconds    int64        `dyn:"PEERDB_PKM_EMPTY_BATCH_THROTTLE_THRESHOLD_SECONDS"`
+	ClickHouseBinaryFormat                   BinaryFormat `dyn:"PEERDB_CLICKHOUSE_BINARY_FORMAT"`
+	BigQueryToastMergeChunking               uint32       `dyn:"PEERDB_BIGQUERY_TOAST_MERGE_CHUNKING"`
+	ReconnectAfterBatches                    int32        `dyn:"PEERDB_RECONNECT_AFTER_BATCHES"`
+	ForceInternalVersion                     uint32       `dyn:"PEERDB_FORCE_INTERNAL_VERSION"`
+	AvroNullableLax                          bool         `dyn:"PEERDB_AVRO_NULLABLE_LAX"`
+	SnowflakeAutoCompress                    bool         `dyn:"PEERDB_SNOWFLAKE_AUTO_COMPRESS"`
+	QueueForceTopicCreation                  bool         `dyn:"PEERDB_QUEUE_FORCE_TOPIC_CREATION"`
+	ClickHouseUnboundedNumericAsString       bool         `dyn:"PEERDB_CLICKHOUSE_UNBOUNDED_NUMERIC_AS_STRING"`
+	ClickHouseEnableJSON                     bool         `dyn:"PEERDB_CLICKHOUSE_ENABLE_JSON"`
+	S3UuidPrefix                             bool         `dyn:"PEERDB_S3_UUID_PREFIX"`
+	SnowflakeSkipCompression                 bool         `dyn:"PEERDB_SNOWFLAKE_SKIP_COMPRESSION"`
+	BigQueryEnableSyncedAtPartitioning       bool         `dyn:"PEERDB_BIGQUERY_ENABLE_SYNCED_AT_PARTITIONING_BY_DAYS"`
+	ClickHouseInitialLoadAllowNonEmptyTables bool         `dyn:"PEERDB_CLICKHOUSE_INITIAL_LOAD_ALLOW_NON_EMPTY_TABLES"`
+	SkipSnapshotExport                       bool         `dyn:"PEERDB_SKIP_SNAPSHOT_EXPORT"`
+	SourceSchemaAsDestinationColumn          bool         `dyn:"PEERDB_SOURCE_SCHEMA_AS_DESTINATION_COLUMN"`
+	OriginMetadataAsDestinationColumn        bool         `dyn:"PEERDB_ORIGIN_METADATA_AS_DESTINATION_COLUMN"`
+	Nullable                                 bool         `dyn:"PEERDB_NULLABLE"`
+	FullRefreshOverwriteMode                 bool         `dyn:"PEERDB_FULL_REFRESH_OVERWRITE_MODE"`
+	PostgresApplyCtidBlockPartitioning       bool         `dyn:"PEERDB_POSTGRES_APPLY_CTID_BLOCK_PARTITIONING_OVERRIDE"`
+	ApplicationNamePerMirrorName             bool         `dyn:"PEERDB_APPLICATION_NAME_PER_MIRROR_NAME"`
+}
+
+var SettingsType = reflect.TypeFor[Settings]()
+
+// NewSettings builds Settings without consulting catalog, intended for tests
+func NewSettings(env map[string]string) *Settings {
+	s := &Settings{Env: env}
+	if err := s.fillSettings(nil); err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func LoadSettings(ctx context.Context, env map[string]string) (*Settings, error) {
+	conn, err := GetCatalogConnectionPoolFromEnv(ctx)
+	if err != nil {
+		LoggerFromCtx(ctx).Error("Failed to get catalog connection pool", slog.Any("error", err))
+		return nil, fmt.Errorf("failed to get catalog connection pool: %w", err)
+	}
+	rows, err := conn.Query(ctx, "SELECT config_name, config_value FROM dynamic_settings")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query dynamic settings: %w", err)
+	}
+	catalog := make(map[string]string, SettingsType.NumField())
+	var name, value string
+	if _, err := pgx.ForEachRow(rows, []any{&name, &value}, func() error {
+		catalog[name] = value
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to load dynamic settings: %w", err)
+	}
+
+	s := &Settings{Env: env}
+	err = s.fillSettings(catalog)
+	return s, err
+}
+
+func (s *Settings) fillSettings(catalog map[string]string) error {
+	rv := reflect.ValueOf(s).Elem()
+	var errs []error
+	for field := range SettingsType.Fields() {
+		name := field.Tag.Get("dyn")
+		if name == "" {
+			continue
+		}
+		var raw string
+		if v, ok := s.Env[name]; ok {
+			raw = v
+		} else if v, ok := catalog[name]; ok {
+			raw = v
+		} else if v, ok := os.LookupEnv(name); ok {
+			raw = v
+		} else {
+			raw = DynamicSettings[DynamicIndex[name]].DefaultValue
+		}
+		if err := assignField(rv.FieldByIndex(field.Index), raw); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func assignField(field reflect.Value, raw string) error {
+	if setter, ok := field.Addr().Interface().(DynSetter); ok {
+		return setter.SetDynConf(raw)
+	}
+	switch field.Kind() {
+	case reflect.String:
+		field.SetString(raw)
+	case reflect.Bool:
+		v, err := strconv.ParseBool(raw)
+		if err != nil {
+			return err
+		}
+		field.SetBool(v)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v, err := strconv.ParseInt(raw, 10, field.Type().Bits())
+		if err != nil {
+			return err
+		}
+		field.SetInt(v)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v, err := strconv.ParseUint(raw, 10, field.Type().Bits())
+		if err != nil {
+			return err
+		}
+		field.SetUint(v)
+	default:
+		return fmt.Errorf("unsupported kind %v", field.Kind())
+	}
+	return nil
 }

--- a/flow/model/conversion_avro.go
+++ b/flow/model/conversion_avro.go
@@ -27,20 +27,15 @@ type QRecordAvroConverter struct {
 }
 
 func NewQRecordAvroConverter(
-	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	schema *QRecordAvroSchemaDefinition,
 	targetDWH protos.DBType,
 	colNames []string,
 	logger log.Logger,
-) (*QRecordAvroConverter, error) {
+) *QRecordAvroConverter {
 	var unboundedNumericAsString bool
-	if targetDWH == protos.DBType_CLICKHOUSE {
-		var err error
-		unboundedNumericAsString, err = internal.PeerDBEnableClickHouseNumericAsString(ctx, env)
-		if err != nil {
-			return nil, err
-		}
+	if targetDWH == protos.DBType_CLICKHOUSE && settings != nil {
+		unboundedNumericAsString = settings.ClickHouseUnboundedNumericAsString
 	}
 
 	return &QRecordAvroConverter{
@@ -49,12 +44,12 @@ func NewQRecordAvroConverter(
 		ColNames:                 colNames,
 		logger:                   logger,
 		UnboundedNumericAsString: unboundedNumericAsString,
-	}, nil
+	}
 }
 
 func (qac *QRecordAvroConverter) Convert(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	qrecord []types.QValue,
 	typeConversions map[string]types.TypeConversion,
 	numericTruncator SnapshotTableNumericTruncator,
@@ -115,7 +110,7 @@ type QRecordAvroChunkSizeTracker struct {
 
 func GetAvroSchemaDefinition(
 	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	dstTableName string,
 	qRecordSchema types.QRecordSchema,
 	targetDWH protos.DBType,
@@ -125,7 +120,7 @@ func GetAvroSchemaDefinition(
 	namedSchemaSeen := make(map[string]avro.NamedSchema)
 
 	for _, qField := range qRecordSchema.Fields {
-		avroType, err := qvalue.GetAvroSchemaFromQValueKind(ctx, env, qField.Type, targetDWH, qField.Precision, qField.Scale)
+		avroType, err := qvalue.GetAvroSchemaFromQValueKind(settings, qField.Type, targetDWH, qField.Precision, qField.Scale)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/model/conversion_avro_test.go
+++ b/flow/model/conversion_avro_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
@@ -28,7 +29,7 @@ func TestAvroSchemaMultipleNamedTypeColumns(t *testing.T) {
 			}
 			schema := types.QRecordSchema{Fields: fields}
 			_, err := GetAvroSchemaDefinition(
-				context.Background(), nil, "test_table", schema, protos.DBType_CLICKHOUSE, nil,
+				context.Background(), internal.NewSettings(nil), "test_table", schema, protos.DBType_CLICKHOUSE, nil,
 			)
 			require.NoError(t, err)
 		})

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -76,8 +76,6 @@ type PullRecordsRequest[T Items] struct {
 	TableNameMapping map[string]NameAndExclude
 	// tablename to schema mapping
 	TableNameSchemaMapping map[string]*protos.TableSchema
-	// overrides dynamic configuration
-	Env map[string]string
 	// override publication name
 	OverridePublicationName string
 	// override replication slot name
@@ -148,7 +146,6 @@ type SyncRecordsRequest[T Items] struct {
 	FlowJobName string
 	// destination table name -> schema mapping
 	TableNameSchemaMapping map[string]*protos.TableSchema
-	Env                    map[string]string
 	// Staging path for AVRO files in CDC
 	StagingPath string
 	// Lua script
@@ -160,7 +157,6 @@ type SyncRecordsRequest[T Items] struct {
 	Flags         []string
 }
 type NormalizeRecordsRequest struct {
-	Env                    map[string]string
 	TableNameSchemaMapping map[string]*protos.TableSchema
 	Flags                  []string
 	FlowJobName            string

--- a/flow/model/qrecord_avro_size_test.go
+++ b/flow/model/qrecord_avro_size_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/log"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
@@ -93,7 +94,7 @@ func TestMongoDBAvroSizeComputation(t *testing.T) {
 			defer os.Remove(tmpfile.Name())
 			defer tmpfile.Close()
 
-			avroSchema, computedSize := writeAvroFileCompressed(t, schema, tc.numRecords, tmpfile.Name(), nil, genRecord)
+			avroSchema, computedSize := writeAvroFileCompressed(t, schema, tc.numRecords, tmpfile.Name(), internal.NewSettings(nil), genRecord)
 
 			t.Logf("Total computed size for %d records: %d bytes (%.2f MiB)",
 				tc.numRecords, computedSize, float64(computedSize)/(1024*1024))
@@ -126,7 +127,7 @@ func TestAvroSizeComputation(t *testing.T) {
 		precision  int16
 		scale      int16
 		numRecords int
-		env        map[string]string
+		settings   *internal.Settings
 		genValue   func() types.QValue
 	}
 
@@ -378,7 +379,7 @@ func TestAvroSizeComputation(t *testing.T) {
 			name:       "bytes_base64",
 			kind:       types.QValueKindBytes,
 			numRecords: 10_000,
-			env:        map[string]string{"PEERDB_CLICKHOUSE_BINARY_FORMAT": "base64"},
+			settings:   internal.NewSettings(map[string]string{"PEERDB_CLICKHOUSE_BINARY_FORMAT": "base64"}),
 			genValue: func() types.QValue {
 				return types.QValueBytes{Val: randomBytes(50 + rand.IntN(200))}
 			},
@@ -600,7 +601,11 @@ func TestAvroSizeComputation(t *testing.T) {
 				}
 				return vals
 			}
-			runSizeSubtest(t, tc.env, schema, tc.numRecords, tc.name, genRecord)
+			settings := tc.settings
+			if settings == nil {
+				settings = internal.NewSettings(nil)
+			}
+			runSizeSubtest(t, settings, schema, tc.numRecords, tc.name, genRecord)
 		})
 	}
 }
@@ -675,7 +680,7 @@ func TestAvroSizeComputationSpecial(t *testing.T) {
 			}
 			return vals
 		}
-		runSizeSubtest(t, nil, schema, 10_000, "nullable_mixed", genRecord)
+		runSizeSubtest(t, internal.NewSettings(nil), schema, 10_000, "nullable_mixed", genRecord)
 	})
 
 	t.Run("mixed_all_scalar", func(t *testing.T) {
@@ -717,7 +722,7 @@ func TestAvroSizeComputationSpecial(t *testing.T) {
 				types.QValueJSON{Val: smallJSON()},
 			}
 		}
-		runSizeSubtest(t, nil, schema, 10_000, "mixed_all_scalar", genRecord)
+		runSizeSubtest(t, internal.NewSettings(nil), schema, 10_000, "mixed_all_scalar", genRecord)
 	})
 }
 
@@ -812,7 +817,7 @@ func TestAllQValueKindsSizeCovered(t *testing.T) {
 
 func runSizeSubtest(
 	t *testing.T,
-	env map[string]string,
+	settings *internal.Settings,
 	schema types.QRecordSchema,
 	numRecords int,
 	name string,
@@ -825,7 +830,7 @@ func runSizeSubtest(
 	defer os.Remove(tmpfile.Name())
 	defer tmpfile.Close()
 
-	avroSchema, computedSize := writeAvroFileCompressed(t, schema, numRecords, tmpfile.Name(), env, genRecord)
+	avroSchema, computedSize := writeAvroFileCompressed(t, schema, numRecords, tmpfile.Name(), settings, genRecord)
 
 	t.Logf("Computed size for %d records: %d bytes (%.2f MiB)",
 		numRecords, computedSize, float64(computedSize)/(1024*1024))
@@ -846,14 +851,14 @@ func writeAvroFileCompressed(
 	schema types.QRecordSchema,
 	numRecords int,
 	filePath string,
-	env map[string]string,
+	settings *internal.Settings,
 	genRecord func() []types.QValue,
 ) (*QRecordAvroSchemaDefinition, int64) {
 	t.Helper()
 
 	avroSchema, err := GetAvroSchemaDefinition(
 		context.Background(),
-		env,
+		settings,
 		"avro_size_dst_table",
 		schema,
 		protos.DBType_CLICKHOUSE,
@@ -879,18 +884,15 @@ func writeAvroFileCompressed(
 		avroFieldNames[i] = field.Name()
 	}
 
-	avroConverter, err := NewQRecordAvroConverter(
-		context.Background(),
-		env,
+	avroConverter := NewQRecordAvroConverter(
+		settings,
 		avroSchema,
 		protos.DBType_CLICKHOUSE,
 		avroFieldNames,
-		nil,
+		log.NewStructuredLogger(nil),
 	)
-	require.NoError(t, err)
 
-	binaryFormat, err := internal.PeerDBBinaryFormat(context.Background(), env)
-	require.NoError(t, err)
+	binaryFormat := settings.ClickHouseBinaryFormat
 
 	bytes := int64(0)
 	for range numRecords {
@@ -898,7 +900,7 @@ func writeAvroFileCompressed(
 
 		avroMap, size, err := avroConverter.Convert(
 			context.Background(),
-			env,
+			settings,
 			record,
 			nil,
 			nil,

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -53,8 +53,7 @@ func ConvertToAvroCompatibleName(columnName string) string {
 // For example, QValueKindInt64 would return an AvroLogicalSchema of "long". Unsupported QValueKinds
 // will return an error.
 func GetAvroSchemaFromQValueKind(
-	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	kind types.QValueKind,
 	targetDWH protos.DBType,
 	precision int16,
@@ -88,16 +87,12 @@ func GetAvroSchemaFromQValueKind(
 	case types.QValueKindBoolean:
 		return avro.NewPrimitiveSchema(avro.Boolean, nil), nil
 	case types.QValueKindBytes:
-		format, err := internal.PeerDBBinaryFormat(ctx, env)
-		if err != nil {
-			return nil, err
-		}
-		if targetDWH == protos.DBType_CLICKHOUSE && format != internal.BinaryFormatRaw {
+		if targetDWH == protos.DBType_CLICKHOUSE && settings.ClickHouseBinaryFormat != internal.BinaryFormatRaw {
 			return avro.NewPrimitiveSchema(avro.String, nil), nil
 		}
 		return avro.NewPrimitiveSchema(avro.Bytes, nil), nil
 	case types.QValueKindNumeric:
-		return getAvroNumericSchema(ctx, env, targetDWH, precision, scale)
+		return getAvroNumericSchema(settings, targetDWH, precision, scale), nil
 	case types.QValueKindInt256:
 		return avro.NewFixedSchema("int256", "", 32, nil)
 	case types.QValueKindUInt256:
@@ -144,11 +139,7 @@ func GetAvroSchemaFromQValueKind(
 	case types.QValueKindArrayString, types.QValueKindArrayEnum:
 		return avro.NewArraySchema(avro.NewPrimitiveSchema(avro.String, nil)), nil
 	case types.QValueKindArrayNumeric:
-		numericSchema, err := getAvroNumericSchema(ctx, env, targetDWH, precision, scale)
-		if err != nil {
-			return nil, err
-		}
-		return avro.NewArraySchema(numericSchema), nil
+		return avro.NewArraySchema(getAvroNumericSchema(settings, targetDWH, precision, scale)), nil
 	case types.QValueKindInvalid:
 		// lets attempt to do invalid as a string
 		return avro.NewPrimitiveSchema(avro.String, nil), nil
@@ -162,22 +153,17 @@ func NullableAvroSchema(schema avro.Schema) (avro.Schema, error) {
 }
 
 func getAvroNumericSchema(
-	ctx context.Context,
-	env map[string]string,
+	settings *internal.Settings,
 	targetDWH protos.DBType,
 	precision int16,
 	scale int16,
-) (avro.Schema, error) {
-	asString, err := internal.PeerDBEnableClickHouseNumericAsString(ctx, env)
-	if err != nil {
-		return nil, err
-	}
-	destinationType := GetNumericDestinationType(precision, scale, targetDWH, asString)
+) avro.Schema {
+	destinationType := GetNumericDestinationType(precision, scale, targetDWH, settings.ClickHouseUnboundedNumericAsString)
 	if destinationType.IsString {
-		return avro.NewPrimitiveSchema(avro.String, nil), nil
+		return avro.NewPrimitiveSchema(avro.String, nil)
 	}
 	return avro.NewPrimitiveSchema(avro.Bytes,
-		avro.NewDecimalLogicalSchema(int(destinationType.Precision), int(destinationType.Scale))), nil
+		avro.NewDecimalLogicalSchema(int(destinationType.Precision), int(destinationType.Scale)))
 }
 
 type QValueAvroConverter struct {

--- a/flow/model/qvalue/avro_converter_test.go
+++ b/flow/model/qvalue/avro_converter_test.go
@@ -165,7 +165,7 @@ func TestAvroQValueSize(t *testing.T) {
 		}
 
 		t.Run(string(qv.Kind()), func(t *testing.T) {
-			schema := getAvroSchema(t, ctx, env, qv, &field)
+			schema := getAvroSchema(t, internal.NewSettings(env), qv, &field)
 			avroVal, computedSize := qvalueToAvro(t, ctx, qv, &field, false)
 			actualSize := avroEncodedSize(t, schema, avroVal)
 			assert.Equal(t, actualSize, computedSize)
@@ -173,7 +173,7 @@ func TestAvroQValueSize(t *testing.T) {
 
 		t.Run(string(qv.Kind())+"_nullable", func(t *testing.T) {
 			nullableField := types.QField{Type: qv.Kind(), Nullable: true, Precision: field.Precision, Scale: field.Scale}
-			schema := getAvroSchema(t, ctx, env, qv, &nullableField)
+			schema := getAvroSchema(t, internal.NewSettings(env), qv, &nullableField)
 			avroVal, computedSize := qvalueToAvro(t, ctx, qv, &nullableField, false)
 			actualSize := avroEncodedSize(t, schema, avroVal)
 			assert.Equal(t, actualSize, computedSize)
@@ -215,7 +215,7 @@ func TestVarIntSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qv := types.QValueInt64{Val: tt.value}
 			field := types.QField{Type: types.QValueKindInt64, Nullable: false}
-			schema := getAvroSchema(t, ctx, env, qv, &field)
+			schema := getAvroSchema(t, internal.NewSettings(env), qv, &field)
 			avroVal, computedSize := qvalueToAvro(t, ctx, qv, &field, false)
 			actualSize := avroEncodedSize(t, schema, avroVal)
 			assert.Equal(t, actualSize, computedSize)
@@ -243,7 +243,7 @@ func TestStringSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qv := types.QValueString{Val: tt.str}
 			field := types.QField{Type: types.QValueKindString, Nullable: tt.nullable}
-			schema := getAvroSchema(t, ctx, env, qv, &field)
+			schema := getAvroSchema(t, internal.NewSettings(env), qv, &field)
 			avroVal, computedSize := qvalueToAvro(t, ctx, qv, &field, false)
 			actualSize := avroEncodedSize(t, schema, avroVal)
 			assert.Equal(t, actualSize, computedSize)
@@ -271,7 +271,7 @@ func TestFixedArraySize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			field := types.QField{Type: tt.qv.Kind(), Nullable: tt.nullable}
-			schema := getAvroSchema(t, ctx, env, tt.qv, &field)
+			schema := getAvroSchema(t, internal.NewSettings(env), tt.qv, &field)
 			avroVal, computedSize := qvalueToAvro(t, ctx, tt.qv, &field, false)
 			actualSize := avroEncodedSize(t, schema, avroVal)
 			assert.Equal(t, actualSize, computedSize)
@@ -298,7 +298,7 @@ func TestStringArraySize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qv := types.QValueArrayString{Val: tt.vals}
 			field := types.QField{Type: types.QValueKindArrayString, Nullable: tt.nullable}
-			schema := getAvroSchema(t, ctx, env, qv, &field)
+			schema := getAvroSchema(t, internal.NewSettings(env), qv, &field)
 			avroVal, computedSize := qvalueToAvro(t, ctx, qv, &field, false)
 			actualSize := avroEncodedSize(t, schema, avroVal)
 			assert.Equal(t, actualSize, computedSize)
@@ -364,7 +364,7 @@ func TestDecimalSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qv := types.QValueNumeric{Val: tt.num, Precision: tt.precision, Scale: tt.scale}
 			field := types.QField{Type: types.QValueKindNumeric, Nullable: tt.nullable, Precision: tt.precision, Scale: tt.scale}
-			schema := getAvroSchema(t, ctx, env, qv, &field)
+			schema := getAvroSchema(t, internal.NewSettings(env), qv, &field)
 			avroVal, computedSize := qvalueToAvro(t, ctx, qv, &field, false)
 			actualSize := avroEncodedSize(t, schema, avroVal)
 			// computedSize may overestimate by up to 1 byte due to log2(10) estimation rounding
@@ -387,7 +387,7 @@ func TestDecimalSize(t *testing.T) {
 		t.Run("string/"+num.String(), func(t *testing.T) {
 			qv := types.QValueNumeric{Val: num}
 			field := types.QField{Type: types.QValueKindNumeric, Nullable: false}
-			schema := getAvroSchema(t, ctx, stringEnv, qv, &field)
+			schema := getAvroSchema(t, internal.NewSettings(stringEnv), qv, &field)
 			avroVal, computedSize := qvalueToAvro(t, ctx, qv, &field, true)
 			actualSize := avroEncodedSize(t, schema, avroVal)
 			assert.Equal(t, actualSize, computedSize)
@@ -396,10 +396,10 @@ func TestDecimalSize(t *testing.T) {
 }
 
 func getAvroSchema(
-	t *testing.T, ctx context.Context, env map[string]string, qv types.QValue, field *types.QField,
+	t *testing.T, settings *internal.Settings, qv types.QValue, field *types.QField,
 ) avro.Schema {
 	t.Helper()
-	schema, err := GetAvroSchemaFromQValueKind(ctx, env, qv.Kind(), protos.DBType_CLICKHOUSE, field.Precision, field.Scale)
+	schema, err := GetAvroSchemaFromQValueKind(settings, qv.Kind(), protos.DBType_CLICKHOUSE, field.Precision, field.Scale)
 	require.NoError(t, err)
 	if field.Nullable {
 		schema, err = NullableAvroSchema(schema)

--- a/flow/model/qvalue/kind.go
+++ b/flow/model/qvalue/kind.go
@@ -39,23 +39,19 @@ func GetNumericDestinationType(
 	}
 }
 
-func getClickHouseTypeForNumericColumn(ctx context.Context, env map[string]string, typeModifier int32) (string, error) {
+func getClickHouseTypeForNumericColumn(settings *internal.Settings, typeModifier int32) string {
 	precision, scale := common.ParseNumericTypmod(typeModifier)
-	asString, err := internal.PeerDBEnableClickHouseNumericAsString(ctx, env)
-	if err != nil {
-		return "", err
-	}
-	destinationType := GetNumericDestinationType(precision, scale, protos.DBType_CLICKHOUSE, asString)
+	destinationType := GetNumericDestinationType(precision, scale, protos.DBType_CLICKHOUSE, settings.ClickHouseUnboundedNumericAsString)
 	if destinationType.IsString {
-		return "String", nil
+		return "String"
 	}
-	return fmt.Sprintf("Decimal(%d, %d)", destinationType.Precision, destinationType.Scale), nil
+	return fmt.Sprintf("Decimal(%d, %d)", destinationType.Precision, destinationType.Scale)
 }
 
 func ToDWHColumnType(
 	ctx context.Context,
 	kind types.QValueKind,
-	env map[string]string,
+	settings *internal.Settings,
 	dwhType protos.DBType,
 	dwhVersion *chproto.Version,
 	column *protos.FieldDescription,
@@ -78,19 +74,10 @@ func ToDWHColumnType(
 		}
 	case protos.DBType_CLICKHOUSE:
 		if kind == types.QValueKindNumeric {
-			var err error
-			colType, err = getClickHouseTypeForNumericColumn(ctx, env, column.TypeModifier)
-			if err != nil {
-				return "", err
-			}
+			colType = getClickHouseTypeForNumericColumn(settings, column.TypeModifier)
 		} else if kind == types.QValueKindArrayNumeric {
-			var err error
-			colType, err = getClickHouseTypeForNumericColumn(ctx, env, column.TypeModifier)
-			if err != nil {
-				return "", err
-			}
-			colType = fmt.Sprintf("Array(%s)", colType)
-		} else if (kind == types.QValueKindJSON || kind == types.QValueKindJSONB) && ShouldUseNativeJSONType(ctx, env, dwhVersion) {
+			colType = fmt.Sprintf("Array(%s)", getClickHouseTypeForNumericColumn(settings, column.TypeModifier))
+		} else if (kind == types.QValueKindJSON || kind == types.QValueKindJSONB) && ShouldUseNativeJSONType(settings, dwhVersion) {
 			colType = "JSON"
 		} else if (kind == types.QValueKindTime || kind == types.QValueKindTimeTZ) &&
 			slices.Contains(flags, shared.Flag_ClickHouseTime64Enabled) {
@@ -113,13 +100,11 @@ func ToDWHColumnType(
 	return colType, nil
 }
 
-func ShouldUseNativeJSONType(ctx context.Context, env map[string]string, chVersion *chproto.Version) bool {
+func ShouldUseNativeJSONType(settings *internal.Settings, chVersion *chproto.Version) bool {
 	if chVersion == nil {
 		return false
 	}
 	// JSON data type is marked as production ready in version ClickHouse 25.3
 	isJsonSupported := chproto.CheckMinVersion(chproto.Version{Major: 25, Minor: 3, Patch: 0}, *chVersion)
-	// Treat error the same as not enabled
-	isJsonEnabled, _ := internal.PeerDBEnableClickHouseJSON(ctx, env)
-	return isJsonSupported && isJsonEnabled
+	return isJsonSupported && settings.ClickHouseEnableJSON
 }

--- a/flow/switchboard/upstream_mongodb.go
+++ b/flow/switchboard/upstream_mongodb.go
@@ -14,6 +14,7 @@ import (
 
 	connmongo "github.com/PeerDB-io/peerdb/flow/connectors/mongo"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/switchboard/mongodb"
 )
 
@@ -39,7 +40,11 @@ type MongoUpstream struct {
 
 // NewMongoUpstream creates a new MongoDB upstream connection
 func NewMongoUpstream(ctx context.Context, config *protos.MongoConfig, database string) (*MongoUpstream, error) {
-	conn, err := connmongo.NewMongoConnector(ctx, config)
+	settings, err := internal.LoadSettings(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := connmongo.NewMongoConnector(ctx, settings, config)
 	if err != nil {
 		return nil, err
 	}

--- a/flow/switchboard/upstream_mysql.go
+++ b/flow/switchboard/upstream_mysql.go
@@ -17,6 +17,7 @@ import (
 
 	connmysql "github.com/PeerDB-io/peerdb/flow/connectors/mysql"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 // wrapMySQLError converts a MySQL error to an UpstreamError
@@ -59,7 +60,11 @@ var mysqlDeniedFunctions = map[string]struct{}{
 
 // NewMySQLUpstream creates a new MySQL upstream connection
 func NewMySQLUpstream(ctx context.Context, config *protos.MySqlConfig, queryTimeout time.Duration) (*MySQLUpstream, error) {
-	conn, err := connmysql.NewMySqlConnector(ctx, config)
+	settings, err := internal.LoadSettings(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := connmysql.NewMySqlConnector(ctx, settings, config)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +157,7 @@ func (u *MySQLUpstream) BackendKeyData() (uint32, []byte) {
 // Cancel cancels the currently running query via KILL QUERY
 func (u *MySQLUpstream) Cancel(ctx context.Context) error {
 	// Open ephemeral connection with same credentials
-	ephemeral, err := connmysql.NewMySqlConnector(ctx, u.config)
+	ephemeral, err := connmysql.NewMySqlConnector(ctx, u.conn.Settings, u.config)
 	if err != nil {
 		return fmt.Errorf("failed to create ephemeral connection for cancel: %w", err)
 	}

--- a/flow/switchboard/upstream_postgres.go
+++ b/flow/switchboard/upstream_postgres.go
@@ -14,6 +14,7 @@ import (
 
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 // wrapPgError converts a PostgreSQL error to an UpstreamError
@@ -62,7 +63,11 @@ type PostgresUpstream struct {
 func NewPostgresUpstream(
 	ctx context.Context, config *protos.PostgresConfig, queryTimeout time.Duration, readOnly bool,
 ) (*PostgresUpstream, error) {
-	conn, err := connpostgres.NewPostgresConnector(ctx, nil, config)
+	settings, err := internal.LoadSettings(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := connpostgres.NewPostgresConnector(ctx, settings, config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Have query at top of activity load most settings up front, rather than querying for each setting individually

This is designed to be refactor/optimization, there is incompatibility when invalid setting now makes LoadSettings fail on code paths that wouldn't've loaded that setting before. This could be fixed by making value parsing lazy. But means making all accessor methods for every field