### PR TITLE
Fix Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
             --model claude-opus-4-6
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
The `code-review`  command  in the code-review  Anthropic plugin will not comment in the PR unless `--comment` is passed as an argument.

See: 

https://github.com/anthropics/claude-code/blob/e512ec99188d191b07662fc9f69c5764f750a302/plugins/code-review/commands/code-review.md?plain=1#L63-L67