### PR TITLE
tilt: check for required dependencies before starting

### DIFF
--- a/tilt.sh
+++ b/tilt.sh
@@ -5,6 +5,20 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+missing=()
+for cmd in tilt yq docker; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        missing+=("$cmd")
+    fi
+done
+if ! docker compose version >/dev/null 2>&1; then
+    missing+=("docker compose")
+fi
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "Missing required dependencies: ${missing[*]}" >&2
+    exit 1
+fi
+
 cleanup() {
     echo "Shutting down PeerDB..."
     tilt down


### PR DESCRIPTION
Verify tilt, yq, docker, and docker compose are available and exit with a clear message if any are missing. yq is needed at startup via generate-test-environment.sh, not just for the cleanup button.