### PR TITLE
Renovate: Pinned versions as allowedVersions packages rules

### DIFF
--- a/flow/cmd/check_pinned_versions/main.go
+++ b/flow/cmd/check_pinned_versions/main.go
@@ -14,8 +14,7 @@ import (
 // accidentally upgraded. Each entry maps a module path to the exact version
 // that should appear in go.mod.
 //
-// To update a pinned dependency, change both go.mod, this map AND
-// the Renovate package rules in renovate.json that skips automated updates for that dependency.
+// To update a pinned dependency, change both go.mod AND this map.
 var pinnedVersions = map[string]string{
 	"cloud.google.com/go/bigquery":                    "v1.72.0",
 	"cloud.google.com/go/pubsub/v2":                   "v2.3.0",

--- a/flow/cmd/check_pinned_versions/main.go
+++ b/flow/cmd/check_pinned_versions/main.go
@@ -14,7 +14,8 @@ import (
 // accidentally upgraded. Each entry maps a module path to the exact version
 // that should appear in go.mod.
 //
-// To update a pinned dependency, change both go.mod AND this map.
+// To update a pinned dependency, change both go.mod, this map AND
+// the Renovate package rules in renovate.json that skips automated updates for that dependency.
 var pinnedVersions = map[string]string{
 	"cloud.google.com/go/bigquery":                    "v1.72.0",
 	"cloud.google.com/go/pubsub/v2":                   "v2.3.0",

--- a/renovate.json
+++ b/renovate.json
@@ -34,18 +34,34 @@
     {
       "matchManagers": ["gomod"],
       "matchPackageNames": [
-        "github.com/pingcap/tidb",
-        "github.com/pingcap/tidb/pkg/parser",
-        "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+        "github.com/PeerDB-io/peerdb/flow/generated/**"
       ],
       "enabled": false
     },
     {
       "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "github.com/PeerDB-io/peerdb/flow/generated/**"
-      ],
-      "enabled": false
+      "matchPackageNames": ["cloud.google.com/go/bigquery"],
+      "allowedVersions": "v1.72.0"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["cloud.google.com/go/pubsub/v2"],
+      "allowedVersions": "v2.3.0"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/aws/aws-sdk-go-v2/feature/s3/manager"],
+      "allowedVersions": "v1.21.0"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["google.golang.org/api"],
+      "allowedVersions": "v0.257.0"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/tikv/pd/client"],
+      "allowedVersions": "v0.0.0-20251229071808-6173d50c004c"
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -46,17 +46,6 @@
         "github.com/PeerDB-io/peerdb/flow/generated/**"
       ],
       "enabled": false
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "cloud.google.com/go/bigquery",
-        "cloud.google.com/go/pubsub/v2",
-        "github.com/aws/aws-sdk-go-v2/feature/s3/manager",
-        "google.golang.org/api",
-        "github.com/tikv/pd/client"
-      ],
-      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
Using Renovate/reconfigure branch to propose Renovate changes:

- Pin versions at Renovate level using `allowedVersions` package rules: https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions

This PR branch name is `renovate/reconfigure` to make use of configuration changes preview feature: https://docs.renovatebot.com/getting-started/installing-onboarding/#reconfigure-via-pr thus letting us testing the changes before merging.

:warning: DO NOT MERGE UNTIL RENOVATE POSTS RESULTS :warning: 