### PR TITLE
Add Snowpipe Streaming ingestion

### DIFF
--- a/.claude/skills/skills/peerdb-snowpipe-test/SKILL.md
+++ b/.claude/skills/skills/peerdb-snowpipe-test/SKILL.md
@@ -1,0 +1,408 @@
+---
+name: peerdb-snowpipe-test
+description: |
+  Run a quick end-to-end Postgres → Snowflake CDC smoke test for PeerDB's Snowpipe
+  Streaming v2 path on the local `dev-peerdb.sh` stack. Covers preflight (Docker,
+  credentials), bootstrap, source seeding, mirror creation, the standard CDC
+  workload (insert / update / delete / TOAST update / ALTER TABLE ADD COLUMN),
+  Snowflake-side verification, log assertions on flow-worker, and cleanup.
+  Use when: user says "test peerdb snowpipe streaming", "postgres to snowflake
+  quickstart", "verify snowpipe streaming locally", "smoke test snowflake
+  streaming mirror", "dev-peerdb snowflake streaming", or asks to validate
+  changes to `flow/connectors/snowflake/streaming_*.go` against a real Snowflake
+  account.
+license: MIT
+metadata:
+  author: Gustavo
+  version: "1.1.0"
+allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion, TodoWrite
+---
+
+# PeerDB Snowpipe Streaming — Postgres → Snowflake Quickstart
+
+You are a focused operator helping the user validate the PeerDB Snowpipe
+Streaming v2 CDC path against a **real Snowflake account** using the local
+`dev-peerdb.sh` Docker stack. Your job is to drive the test deterministically,
+verify each stage, and surface failures with a known root-cause matrix.
+
+## When to Apply
+
+Invoke this skill when the user wants to:
+- Smoke-test Snowpipe Streaming v2 end-to-end against their own Snowflake account.
+- Validate a change in `flow/connectors/snowflake/streaming_*.go` without writing Go tests.
+- Reproduce one of the LEARNINGS.md gotchas (TOAST carry-forward, schema evolution, idempotency on worker restart, soft-delete-as-first-event).
+
+Do **not** invoke for unit tests (`go test ./connectors/snowflake/...`) or for
+the Avro/COPY path — both have their own existing flows.
+
+## Preflight (run all checks before any mutation)
+
+1. **Workspace** — confirm CWD is the PeerDB repo root (file `dev-peerdb.sh` exists). If not, ask the user for the path.
+2. **Docker** — `docker info > /dev/null 2>&1`. If it fails, abort with "Start Docker Desktop and re-run."
+3. **jq** — `command -v jq`. If missing, ask the user to install it (`brew install jq`) before continuing — it is required for the Snowflake peer creation step.
+4. **Credentials file** — check `~/sf_streaming_creds.json` exists. If missing, print the template below and ask the user to populate it before continuing. Never fabricate credentials and never commit this file.
+
+   ```json
+   {
+     "account_id": "<ORG>-<ACCOUNT>",
+     "username": "<SNOWFLAKE_USER>",
+     "private_key": "-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n",
+     "database": "PEERDB_STREAMING_TEST",
+     "warehouse": "<WAREHOUSE>",
+     "role": "ACCOUNTADMIN",
+     "query_timeout": 300,
+     "enable_streaming": true
+   }
+   ```
+
+   Helper to convert a PEM file to a single-line `private_key` value:
+   ```bash
+   awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' ~/path/to/snowflake_rsa_key.p8
+   ```
+
+5. **Snowflake grants reminder** — show the user once (do not execute):
+   ```sql
+   GRANT CREATE PIPE         ON SCHEMA <DB>.<SCHEMA> TO ROLE <ROLE>;
+   GRANT EVOLVE SCHEMA       ON SCHEMA <DB>.<SCHEMA> TO ROLE <ROLE>;
+   GRANT USAGE               ON DATABASE <DB>          TO ROLE <ROLE>;
+   ```
+6. **Port collisions** — `lsof -nP -iTCP:3000 -iTCP:9900 -iTCP:9901 -iTCP:8085 -sTCP:LISTEN`. If anything is bound, ask whether to stop it before continuing.
+
+If any preflight fails, **stop and report**; do not move to bootstrap.
+
+## Process
+
+### Step 1 — Bootstrap PeerDB
+
+```bash
+./dev-peerdb.sh
+```
+
+Wait for healthy. Poll, do not `sleep` blindly:
+```bash
+for i in {1..60}; do
+  curl -fsS http://localhost:3000 >/dev/null 2>&1 && \
+  nc -z localhost 9900 && \
+  nc -z localhost 9901 && \
+  nc -z localhost 8085 && echo "ALL_UP" && break
+  echo "Attempt $i/60 — waiting 5s..."
+  sleep 5
+done
+```
+
+If after 5 minutes a port is still down, run:
+```bash
+docker compose -f docker-compose-dev.yml ps
+docker compose -f docker-compose-dev.yml logs --tail 100 flow-api flow-worker temporal catalog
+```
+and surface the first error to the user.
+
+### Step 2 — Seed the source Postgres
+
+The catalog Postgres on `localhost:9901` doubles as the local source DB for testing.
+Create the `source` database, the test table, configure it for logical replication,
+create the publication, and insert initial rows — **all before the mirror is created**
+so the initial snapshot captures them.
+
+```bash
+psql "postgres://postgres:postgres@localhost:9901/postgres" \
+  -c "CREATE DATABASE source;" 2>/dev/null || true
+
+psql "postgres://postgres:postgres@localhost:9901/source" <<'SQL'
+CREATE TABLE IF NOT EXISTS test_streaming (
+  id          SERIAL PRIMARY KEY,
+  name        TEXT NOT NULL,
+  amount      NUMERIC(10,2),
+  is_active   BOOLEAN DEFAULT true,
+  metadata    JSONB,
+  created_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Required for CDC: emit full old row in WAL on UPDATE/DELETE
+ALTER TABLE test_streaming REPLICA IDENTITY FULL;
+
+-- Required for logical replication: must exist before mirror is created
+CREATE PUBLICATION streaming_smoke_pub FOR TABLE test_streaming;
+
+-- Seed rows for the initial snapshot
+INSERT INTO test_streaming (name, amount, is_active, metadata) VALUES
+  ('alice',   100.50, true,  '{"tier":"gold"}'),
+  ('bob',     200.75, true,  '{"tier":"silver"}'),
+  ('charlie', 300.00, false, '{"tier":"bronze"}'),
+  ('diana',   450.00, true,  '{"tier":"platinum"}'),
+  ('eve',     75.25,  true,  NULL);
+SQL
+```
+
+After this step, Snowflake should eventually receive all 5 rows via the initial
+snapshot once the mirror is created.
+
+For richer test data, the repo provides `scripts/test-snowpipe-streaming.sh --reset`
+which seeds a `streaming_test.orders` schema with TOAST-eligible columns. Use that
+script when the user wants the full multi-stage workload.
+
+### Step 3 — Create the Postgres peer
+
+```bash
+psql "postgres://peerdb:peerdb@localhost:9900/peerdb" <<'SQL'
+CREATE PEER pg_source FROM POSTGRES WITH (
+  host     = 'catalog',
+  port     = 5432,
+  user     = 'postgres',
+  password = 'postgres',
+  database = 'source'
+);
+SQL
+```
+
+> **Note:** `host = 'catalog'` is the Docker-internal hostname for the catalog
+> Postgres container. PeerDB's flow-worker runs inside the same Docker network,
+> so it resolves `catalog` correctly. Do not use `localhost` here — that would
+> resolve to the flow-worker container itself.
+
+### Step 4 — Create the Snowflake peer
+
+Ask the user to create the Snowflake peer. Two options:
+
+**Option A — UI (recommended, avoids shell escaping issues):**
+Direct the user to <http://localhost:3000> → **Peers → Create → Snowflake**.
+Toggle **Enable Streaming = ON** before saving.
+
+**Option B — SQL proxy (reproducible, requires jq):**
+```bash
+# jq expands BEFORE psql sees the heredoc (note: <<SQL not <<'SQL')
+psql "postgres://peerdb:peerdb@localhost:9900/peerdb" <<SQL
+CREATE PEER sf_streaming FROM SNOWFLAKE WITH (
+  $(jq -r 'to_entries | map("\(.key) = \(.value | @json)") | join(",\n  ")' ~/sf_streaming_creds.json)
+);
+SQL
+```
+
+Ask the user what they named the peer — you need it for the mirror creation command.
+
+### Step 5 — Create the mirror and wait for snapshot
+
+Replace `<SF_PEER_NAME>` with the name the user chose in Step 4:
+
+```bash
+psql "postgres://peerdb:peerdb@localhost:9900/peerdb" <<SQL
+CREATE MIRROR streaming_smoke
+FROM pg_source TO <SF_PEER_NAME>
+FOR TABLES (test_streaming)
+WITH (
+  do_initial_snapshot    = true,
+  publication_name       = 'streaming_smoke_pub',
+  replication_slot_name  = 'streaming_smoke_slot'
+);
+SQL
+```
+
+**Verify the mirror started:** open <http://localhost:3000> → **Mirrors** and confirm
+`streaming_smoke` is listed as **Running** (not Failed or Paused).
+
+**Watch the snapshot in Temporal:** open
+<http://localhost:8085/namespaces/default/workflows> and find the workflow named
+after your mirror. A successful snapshot shows the snapshot child workflow completing
+before the CDC workflow takes over. If it stays stuck or fails, check:
+
+```bash
+docker compose -f docker-compose-dev.yml logs --tail 100 flow-worker
+```
+
+**Do not proceed to Step 6 until the initial snapshot is complete.** The Temporal
+workflow will transition from snapshot to CDC mode when done. You can also confirm
+by querying Snowflake — the 5 seeded rows should be present:
+
+```sql
+-- Snowflake
+SELECT id, name, amount, is_active FROM <SF_DB>.<SF_SCHEMA>.test_streaming ORDER BY id;
+```
+
+Expected:
+
+| id | name    | amount | is_active |
+|----|---------|--------|-----------|
+| 1  | alice   | 100.50 | true      |
+| 2  | bob     | 200.75 | true      |
+| 3  | charlie | 300.00 | false     |
+| 4  | diana   | 450.00 | true      |
+| 5  | eve     | 75.25  | true      |
+
+### Step 6 — Drive the CDC workload (one stage at a time, verify between each)
+
+After each stage, **wait 10–15 s** then run the verification SQL on Snowflake
+(have the user run it; check `command -v snowsql` if they want CLI access).
+
+#### 6a. Update / Delete (happy path CDC)
+
+```sql
+-- Postgres (run via psql)
+UPDATE test_streaming SET amount = 150.00, metadata = '{"tier":"platinum"}' WHERE name = 'alice';
+DELETE FROM test_streaming WHERE name = 'charlie';
+```
+
+Expected Snowflake state:
+
+| id | name  | amount | metadata             |
+|----|-------|--------|----------------------|
+| 1  | alice | 150.00 | {"tier":"platinum"}  |
+| 2  | bob   | 200.75 | {"tier":"silver"}    |
+| 4  | diana | 450.00 | {"tier":"platinum"}  |
+| 5  | eve   | 75.25  | null                 |
+
+(Row 3 / charlie deleted. If `_PEERDB_IS_DELETED` is configured on the mirror, it will be `true` for that row instead of disappearing.)
+
+#### 6b. TOAST carry-forward
+
+The TOAST scenario only kicks in when the omitted column actually lives in
+TOAST storage (>~2KB after compression). The default `metadata = '{"tier":"gold"}'`
+seed values are too small. Use the bundled script — it inflates `alice.metadata`
+to a TOAST-eligible size, waits for that to sync, then triggers the omission update:
+
+```bash
+psql "postgres://postgres:postgres@localhost:9901/source" \
+     -f ~/.claude/skills/peerdb-snowpipe-test/scripts/toast_carry_forward.sql
+```
+
+Stages (the script runs all three; you can also split them manually):
+1. Inflate `alice.metadata` with a ~6KB JSONB containing `marker = 'toast-test-stage-1'`.
+2. Wait 180s for the setup batch to MERGE into Snowflake.
+3. `UPDATE test_streaming SET amount = 999.99 WHERE name = 'alice'` — Postgres
+   marks `metadata` as unchanged-TOAST in the WAL.
+
+Verify in Snowflake:
+
+```sql
+SELECT name,
+       amount,
+       LENGTH(TO_VARCHAR(metadata)) AS metadata_chars,
+       metadata:marker::STRING      AS marker
+FROM <SF_DB>.<SF_SCHEMA>.test_streaming
+WHERE name = 'alice';
+-- expected: amount=999.99, metadata_chars > 6000, marker='toast-test-stage-1'
+```
+
+If `marker` is NULL or `metadata_chars` is small, see the troubleshooting matrix
+row for `metadata column NULL after TOAST update` (LEARNINGS §2.1).
+
+#### 6c. Schema evolution
+
+```sql
+-- Postgres
+ALTER TABLE test_streaming ADD COLUMN score INT DEFAULT 0;
+INSERT INTO test_streaming (name, amount, score) VALUES ('dan', 50.00, 99);
+```
+
+The streaming pipe is **not** recreated for source-schema changes. New columns are
+absorbed by the JSON `_PEERDB_DATA` blob on the raw table, then projected into the
+destination table by MERGE after `ALTER TABLE … ADD COLUMN IF NOT EXISTS` runs on
+the destination side.
+
+Expected log evidence (no `CREATE … PIPE` line should appear; instead, look for
+the destination ALTER and a successful MERGE):
+
+```bash
+docker compose -f docker-compose-dev.yml logs flow-worker 2>&1 \
+  | grep -E "ADD COLUMN|merged records into|schema delta" | tail -20
+```
+
+Verify in Snowflake that the new column exists and was populated:
+
+```sql
+SELECT id, name, amount, score FROM <SF_DB>.<SF_SCHEMA>.test_streaming WHERE name = 'dan';
+-- expected: score = 99
+```
+
+Also confirm in Temporal (<http://localhost:8085/namespaces/default/workflows>)
+that the mirror workflow did not error out — schema evolution should be handled
+transparently.
+
+#### 6d. Idempotency on worker restart (LEARNINGS §Temporal heartbeat timeouts)
+
+```bash
+# Insert a large batch in Postgres, then immediately restart flow-worker
+docker compose -f docker-compose-dev.yml restart flow-worker
+```
+
+After recovery, query Snowflake row count: it must equal the Postgres row count.
+Duplicates indicate the `GetLastSyncBatchID` guard regressed.
+
+### Step 7 — Verify the streaming path was used
+
+```bash
+docker compose -f docker-compose-dev.yml logs flow-worker 2>&1 \
+  | grep "\[streaming\]" | tail -40
+```
+
+If nothing matches, first check the raw tail to confirm the log prefix format:
+```bash
+docker compose -f docker-compose-dev.yml logs flow-worker 2>&1 | tail -50
+```
+
+The expected sequence per batch:
+```
+[streaming] flushing buffer       — table=…, pipe=…, channel=…, rows=N
+[streaming] executing CREATE PIPE — only on first flush or after schema change
+[streaming] pipe created
+[streaming] channel ready
+[streaming] rows sent to Snowpipe Streaming API
+[streaming] channel status        — rowsInserted:0, rowsErrors:0
+[streaming] channel status        — rowsInserted:N, rowsErrors:0, latencyMs:NNN
+[streaming] ingestion confirmed   — rowsInserted:N, baseline:M
+```
+
+Confirm the raw table name is `_PEERDB_INTERNAL._PEERDB_STREAMING_<JOB>` (not
+`_PEERDB_RAW_<JOB>`) — the job name is uppercased from the mirror name:
+```sql
+-- Snowflake
+SELECT COUNT(*) FROM _PEERDB_INTERNAL._PEERDB_STREAMING_STREAMING_SMOKE;
+```
+
+### Step 8 — Cleanup
+
+Always confirm with the user before running destructive cleanup. Default to
+**preserve-by-default** so the user can re-inspect failures.
+
+```bash
+# Stop PeerDB (preserves volumes)
+docker compose -f docker-compose-dev.yml down
+
+# Hard reset (drops volumes — ASK BEFORE RUNNING)
+docker compose -f docker-compose-dev.yml down -v
+```
+
+Snowflake side (run via the user's `snowsql` or UI; do not assume credentials):
+```sql
+DROP DATABASE IF EXISTS PEERDB_STREAMING_TEST;
+```
+
+## Troubleshooting matrix
+
+Map symptoms to the LEARNINGS.md root cause **before** the user starts guessing.
+Also check the Temporal workflow at <http://localhost:8085/namespaces/default/workflows>
+for structured error messages — it often shows the failure reason more clearly than raw Docker logs.
+
+| Symptom in `flow-worker` logs / Snowflake | Likely root cause | Fix / next step |
+|------------------------------------------|-------------------|-----------------|
+| `401 Unauthorized` from `/oauth/token` | Clock skew or stale JWT | Check NTP (`chronyc tracking`); restart flow-worker to force token refresh |
+| `STALE_CONTINUATION_TOKEN_SEQUENCER` | Channel reopen race | Expected on first retry — should self-heal in `sendChunkWithRetry` |
+| `pendingFileCount` stuck at 1, no `[streaming] ingestion confirmed` | Channel state lost mid-batch | Inspect Temporal workflow for retries; check `sendChunkWithRetry` self-heal logic and `STALE_CONTINUATION_TOKEN_SEQUENCER` handling |
+| Rows missing in Snowflake but no error | Positional pipe DDL fallback (LEARNINGS §1.2) | Confirm `CREATE PIPE IF NOT EXISTS` SQL in `createStreamingPipe` contains explicit column list `("COL1","COL2",…)` |
+| `CREATE OR REPLACE PIPE` line in flow-worker logs | Regression — streaming path should use `CREATE PIPE IF NOT EXISTS` | Inspect `createStreamingPipe` in `streaming_sync.go`; OR-REPLACE invalidates channels and breaks offsetToken idempotency |
+| `metadata` column NULL after TOAST update | `processStreamingDelete` did not populate `columnNames` (LEARNINGS §2.1) | Confirm `buildColumnNames` is called in both `processStreamingRecord` and `processStreamingDelete` |
+| Duplicate rows after `restart flow-worker` | `GetLastSyncBatchID` idempotency guard regressed (LEARNINGS §2.3) | Check `syncRecordsViaStreaming` early-exit when `syncBatchID <= lastBatchID` |
+| `NumRecordsSynced` reports 3 when batch had 1000 rows across 3 tables | Counting tables, not rows (LEARNINGS §2.2) | Sum `Insert+Update+Delete` across `tableNameRowsMapping` |
+| `RelationRecord` log spam in record loop | Reading deltas from records channel instead of `req.Records.SchemaDeltas` (LEARNINGS §2.5) | Use `req.Records.SchemaDeltas` like every other connector |
+| `EVOLVE SCHEMA` permission error | Missing grant | Run grants from preflight step 5 |
+| Hostname `myaccount_us_east_1...` in error messages | Underscore→hyphen conversion missed (LEARNINGS §1.4) | Confirm `streaming_auth.go` strips quotes and replaces `_` with `-` in `GetIngestHost` |
+| Mirror shows Failed in UI immediately after creation | Publication missing or replication slot conflict | Confirm `streaming_smoke_pub` publication exists; check for duplicate slot names |
+| Snapshot workflow stuck in Temporal | flow-worker OOM or Temporal heartbeat timeout | Check `docker stats`; reduce snapshot parallelism via PeerDB config |
+
+## Operating constraints
+
+- **Never** modify `~/sf_streaming_creds.json`; only read it.
+- **Never** run `docker compose down -v` without explicit user confirmation — it drops the catalog Postgres volume and loses replication slot state.
+- **Never** run destructive Snowflake DDL (`DROP DATABASE`, `DROP PIPE`) yourself; print the SQL for the user to execute.
+- Always poll service readiness; do **not** sleep blindly.
+- If preflight fails, stop. Do not attempt to recover by guessing.
+- Reference assessment files at `~/Desktop/new_feature_peerdb/{TESTING.md,LEARNINGS.md}` if the user asks for deeper context.

--- a/.claude/skills/skills/peerdb-snowpipe-test/scripts/toast_carry_forward.sql
+++ b/.claude/skills/skills/peerdb-snowpipe-test/scripts/toast_carry_forward.sql
@@ -1,0 +1,82 @@
+-- TOAST carry-forward test for PeerDB Snowpipe Streaming
+--
+-- Verifies that when an UPDATE doesn't touch a TOAST'd column, PeerDB preserves
+-- the prior value on the destination side rather than overwriting it with NULL.
+--
+-- Background
+-- ----------
+-- PostgreSQL stores oversized variable-length values (>~2KB) out-of-line in a
+-- TOAST table. With REPLICA IDENTITY FULL, an UPDATE that does not change the
+-- TOAST'd column omits its value from the logical-replication stream — the
+-- WAL marks it as "unchanged TOAST" instead of carrying the bytes.
+--
+-- A naïve CDC consumer would interpret the absence as NULL and overwrite the
+-- destination column. PeerDB carries the prior value forward via the
+-- _PEERDB_UNCHANGED_TOAST_COLUMNS metadata column on the raw table. The MERGE
+-- step preserves the existing destination value for any column listed there.
+--
+-- Test stages
+-- -----------
+--   1. Seed alice's metadata with a JSONB blob large enough to be TOAST'd (>~6KB).
+--   2. Wait for that batch to sync to Snowflake (so destination has the large value).
+--   3. Trigger TOAST omission by updating only `amount` on alice's row.
+--   4. Verify (in Snowflake): alice.metadata is unchanged — still the large blob.
+--
+-- Usage
+-- -----
+--   psql "postgres://postgres:postgres@localhost:9901/source" \
+--        -f scripts/toast_carry_forward.sql
+--
+-- Or split into two runs if you want to inspect logs between stages:
+--   - run lines through Stage 1 manually
+--   - watch flow-worker for `[streaming] ingestion confirmed` + `merged records into`
+--   - then run Stage 2 manually
+
+-- ============================================================
+-- Stage 1 — seed alice with a TOAST-eligible metadata blob
+-- ============================================================
+
+UPDATE test_streaming
+SET metadata = (
+  SELECT jsonb_object_agg('key_' || g, repeat('x', 200))
+  FROM generate_series(1, 40) g
+) || '{"tier":"platinum","marker":"toast-test-stage-1"}'::jsonb
+WHERE name = 'alice';
+
+SELECT
+  name,
+  pg_column_size(metadata) AS metadata_bytes,
+  metadata->>'marker'      AS marker
+FROM test_streaming
+WHERE name = 'alice';
+
+-- ------------------------------------------------------------
+-- Wait 180s for the setup batch to sync to Snowflake
+-- (PeerDB idle-flush is roughly 2-3 minutes by default)
+-- ------------------------------------------------------------
+SELECT pg_sleep(180);
+
+-- ============================================================
+-- Stage 2 — trigger TOAST omission (UPDATE only amount)
+-- PostgreSQL marks metadata as unchanged-TOAST in the WAL;
+-- PeerDB must carry the prior value forward in the destination MERGE.
+-- ============================================================
+
+UPDATE test_streaming
+SET amount = 999.99
+WHERE name = 'alice';
+
+-- ============================================================
+-- Stage 3 — verification (run separately in Snowflake)
+-- ============================================================
+-- SELECT name,
+--        amount,
+--        LENGTH(TO_VARCHAR(metadata)) AS metadata_chars,
+--        metadata:marker::STRING      AS marker
+-- FROM <SF_DB>.<SF_SCHEMA>.test_streaming
+-- WHERE name = 'alice';
+--
+-- Expected:
+--   amount         = 999.99
+--   metadata_chars > 6000
+--   marker         = 'toast-test-stage-1'  (NOT NULL — carry-forward worked)

--- a/docs/peerdb-architecture.md
+++ b/docs/peerdb-architecture.md
@@ -184,7 +184,7 @@ S3-compatible object storage used for staging AVRO files during snapshot operati
 | Connector | CDC Sync | Normalize/Merge | QRep Sync | Key Features |
 |-----------|----------|----------------|-----------|--------------|
 | **PostgreSQL** | Raw table insert | MERGE (PG15+) or UPSERT fallback | Direct insert | Soft delete, schema evolution, synced_at column |
-| **Snowflake** | Raw table + AVRO staging | SQL MERGE | AVRO file load | Merge-based upsert, AVRO consolidation, warehouse staging |
+| **Snowflake** | Raw table + AVRO staging _or_ Snowpipe Streaming | SQL MERGE | AVRO file load | Merge-based upsert, AVRO consolidation, warehouse staging, opt-in Snowpipe Streaming v2 (see §12) |
 | **BigQuery** | AVRO bulk load | INSERT with dedup | GCS object load | Clustering, partitioning, GCP service account auth |
 | **ClickHouse** | Raw table insert | ReplacingMergeTree / MergeTree | AVRO via S3/table functions | Partition keys, sharding keys, engine selection, S3 IAM, AVRO staging |
 | **S3** | — | — | AVRO file write | Deflate/snappy/zstd codecs |
@@ -661,3 +661,73 @@ PeerDB supports Lua-based record transformation via the `script` field on flow c
 - Route records to different tables
 
 Libraries: `glua64`, `gluajson`, `gluamsgpack` for Lua runtime support.
+
+---
+
+## 12. Snowflake — Snowpipe Streaming v2 (Opt-In)
+
+The Snowflake connector supports two CDC sync paths. The legacy AVRO/S3 path remains the default; **Snowpipe Streaming v2** is opt-in via `enable_streaming = true` on the Snowflake peer config.
+
+### 12.1 Architecture
+
+```
+DEFAULT (AVRO):
+  CDCStream → SyncRecords → Avro write → S3/internal stage → COPY INTO _PEERDB_RAW_<job> → MERGE → destination
+
+STREAMING (opt-in):
+  CDCStream → SyncRecords → NDJSON build → Snowpipe Streaming REST API → _PEERDB_STREAMING_<job> → MERGE → destination
+```
+
+Both paths land in a per-flow raw table inside `_PEERDB_INTERNAL` and reuse the same `mergeTablesForBatch` MERGE logic. The streaming path uses a distinct table prefix (`_PEERDB_STREAMING_*` vs `_PEERDB_RAW_*`) so the two paths never share rows.
+
+### 12.2 Components
+
+| File | Responsibility |
+|------|----------------|
+| `flow/connectors/snowflake/streaming_auth.go` | JWT mint, ingest-host discovery, scoped-token exchange (RS256, KEYPAIR_JWT) |
+| `flow/connectors/snowflake/streaming_channel.go` | `StreamingChannelManager`, `StreamingChannel`, channel reopen, retry classifier, bulk channel-status |
+| `flow/connectors/snowflake/streaming_sync.go` | `syncRecordsViaStreaming`, NDJSON row build, channel-pool routing, flush + ingestion confirmation |
+| `flow/connectors/snowflake/streaming_metrics.go` | OTel instruments: bytes sent, rows confirmed, rows errored, chunk retries, ingestion latency, commit lag |
+
+### 12.3 Channel pool
+
+A single Snowpipe Streaming pipe (`<JOB>_STREAMING_PIPE`) backs the raw table. The number of channels is controlled by the dynamic setting `PEERDB_SNOWFLAKE_STREAMING_CHANNELS_PER_FLOW` (default 1, max 64). Rows are routed by `fnv32(destination_table_name) % N`, preserving per-table ordering required by the downstream MERGE.
+
+Channel naming: `peerdb-{flowJobName}-raw-{idx}`. With `N=1` the legacy name `peerdb-{job}-raw-0` is preserved so existing mirrors retain their durable Snowpipe `offsetToken`s.
+
+### 12.4 Idempotency
+
+Each flush sends one or more NDJSON chunks with `offsetToken = "{syncBatchID}-{flushIndex}"`. Snowflake persists the offset token durably on the channel and treats a second `AppendRows` with the same token as a no-op. In addition, `syncRecordsViaStreaming` reads `GetLastSyncBatchID` at entry and skips re-sending rows when the activity is retried after a Temporal heartbeat timeout.
+
+### 12.5 Observability
+
+OTel instruments (prefixed `peerdb.snowpipe_*`):
+
+| Name | Type | Description |
+|------|------|-------------|
+| `snowpipe_bytes_sent` | counter | Bytes successfully delivered per chunk |
+| `snowpipe_rows_confirmed` | counter | Rows confirmed ingested by Snowflake |
+| `snowpipe_rows_errored` | counter | Rows rejected (`RowsErrorCount > 0`) |
+| `snowpipe_chunk_retries` | counter | Retry attempts, attribute `retry_reason ∈ {transport, channel_reopen, auth, transient}` |
+| `snowpipe_ingestion_latency_ms` | gauge | Snowflake-reported average processing latency |
+| `snowpipe_commit_lag_ms` | gauge | Client-perceived end-to-end commit lag (flush start → confirmation) |
+
+All instruments are context-aware via `otel_metrics.NewContextAwareInt64Counter`/`ContextAwareInt64Gauge` and inherit flow attributes automatically.
+
+### 12.6 Dynamic configuration
+
+| Setting | Default | Effect |
+|---------|---------|--------|
+| `PEERDB_SNOWFLAKE_STREAMING_CHANNELS_PER_FLOW` | `1` | Channel pool size per flow |
+| `PEERDB_SNOWFLAKE_STREAMING_ERROR_LOG_TABLE` | `""` | Fully-qualified Snowflake table to surface as the DLQ via `peerdb_stats.snowflake_streaming_errors` (when populated) |
+
+Peer-level proto fields (`SnowflakeConfig`, fields 12–16): `enable_streaming`, `streaming_rate_limit_per_second`, `streaming_max_chunk_bytes`, `streaming_ingest_timeout_seconds`.
+
+### 12.7 Limits and caveats
+
+- **Snowflake hard limits**: 4 MB compressed per `AppendRows` request, 10 RPS per channel, 2000 channels per pipe, 10 GB/s per table.
+- **Schema evolution**: source-table schema changes do not affect the streaming pipe. Schema deltas (`RelationRecord` → `ReplayTableSchemaDeltas`) are absorbed by the JSON `_PEERDB_DATA` column on the raw table and projected into destination tables by the MERGE step (which adds new columns via `ALTER TABLE … ADD COLUMN IF NOT EXISTS`). The pipe itself is created once per mirror via `CREATE PIPE IF NOT EXISTS` against the fixed `rawTableColumns` list — atomic on Snowflake, idempotent across sync batches, and crucially does not invalidate existing channels (preserving their durable `offsetToken`s for Temporal-retry idempotency).
+- **`SYSTEM$PIPE_STATUS` is not used** — it is unreliable for error detection (rejects stay invisible). Delivery confirmation uses the bulk channel status REST endpoint, which exposes `last_error_message` for fast failure detection.
+- **Inactive channels**: Snowflake auto-deletes channels after 30 days of inactivity, dropping their durable offset tokens. Long-paused mirrors must keep at least one batch flushing within that window.
+- **QRep snapshot path is unchanged**: streaming is CDC-only. Bulk snapshot loads continue to use the AVRO/COPY path.
+

--- a/flow/connectors/snowflake/snowflake.go
+++ b/flow/connectors/snowflake/snowflake.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	rawTablePrefix    = "_PEERDB_RAW"
+	rawTablePrefix          = "_PEERDB_RAW"
+	streamingRawTablePrefix = "_PEERDB_STREAMING"
 	createSchemaSQL   = "CREATE TRANSIENT SCHEMA IF NOT EXISTS %s"
 	createRawTableSQL = `CREATE TABLE IF NOT EXISTS %s.%s(_PEERDB_UID STRING NOT NULL,
 		_PEERDB_TIMESTAMP INT NOT NULL,_PEERDB_DESTINATION_TABLE_NAME STRING NOT NULL,_PEERDB_DATA STRING NOT NULL,
@@ -74,9 +75,10 @@ const (
 type SnowflakeConnector struct {
 	*metadataStore.PostgresMetadata
 	*sql.DB
-	logger    log.Logger
-	config    *protos.SnowflakeConfig
-	rawSchema string
+	logger           log.Logger
+	config           *protos.SnowflakeConfig
+	rawSchema        string
+	streamingManager *StreamingChannelManager
 }
 
 func NewSnowflakeConnector(
@@ -131,13 +133,31 @@ func NewSnowflakeConnector(
 		return nil, fmt.Errorf("could not connect to metadata store: %w", err)
 	}
 
-	return &SnowflakeConnector{
+	connector := &SnowflakeConnector{
 		PostgresMetadata: pgMetadata,
 		DB:               database,
 		rawSchema:        rawSchema,
 		logger:           logger,
 		config:           snowflakeProtoConfig,
-	}, nil
+	}
+
+	if snowflakeProtoConfig.EnableStreaming {
+		rateLimitPerSec := DefaultRateLimitPerSecond
+		if snowflakeProtoConfig.StreamingRateLimitPerSecond != nil {
+			rateLimitPerSec = int(*snowflakeProtoConfig.StreamingRateLimitPerSecond)
+		}
+		maxChunkBytes := DefaultMaxChunkBytes
+		if snowflakeProtoConfig.StreamingMaxChunkBytes != nil {
+			maxChunkBytes = int(*snowflakeProtoConfig.StreamingMaxChunkBytes)
+		}
+		ingestTimeoutSec := DefaultIngestTimeoutSeconds
+		if snowflakeProtoConfig.StreamingIngestTimeoutSeconds != nil {
+			ingestTimeoutSec = int(*snowflakeProtoConfig.StreamingIngestTimeoutSeconds)
+		}
+		connector.streamingManager = NewStreamingChannelManager(&snowflakeConfig, logger, rateLimitPerSec, maxChunkBytes, ingestTimeoutSec)
+	}
+
+	return connector, nil
 }
 
 // creating this to capture array results from snowflake.
@@ -214,6 +234,9 @@ func (c *SnowflakeConnector) ValidateCheck(ctx context.Context) error {
 
 func (c *SnowflakeConnector) Close() error {
 	if c != nil {
+		if c.streamingManager != nil {
+			c.streamingManager.Close()
+		}
 		return c.DB.Close()
 	}
 	return nil
@@ -230,7 +253,7 @@ func (c *SnowflakeConnector) getDistinctTableNamesInBatch(
 	batchId int64,
 	tableToSchema map[string]*protos.TableSchema,
 ) ([]string, error) {
-	rawTableIdentifier := getRawTableIdentifier(flowJobName)
+	rawTableIdentifier := c.rawTableName(flowJobName)
 
 	rows, err := c.QueryContext(ctx, fmt.Sprintf(getDistinctDestinationTableNames, c.rawSchema,
 		rawTableIdentifier, batchId))
@@ -263,7 +286,7 @@ func (c *SnowflakeConnector) getTableNameToUnchangedCols(
 	flowJobName string,
 	batchId int64,
 ) (map[string][]string, error) {
-	rawTableIdentifier := getRawTableIdentifier(flowJobName)
+	rawTableIdentifier := c.rawTableName(flowJobName)
 
 	rows, err := c.QueryContext(ctx, fmt.Sprintf(getTableNameToUnchangedColsSQL, c.rawSchema,
 		rawTableIdentifier, batchId))
@@ -402,10 +425,17 @@ func (c *SnowflakeConnector) withMirrorNameQueryTag(ctx context.Context, mirrorN
 func (c *SnowflakeConnector) SyncRecords(ctx context.Context, req *model.SyncRecordsRequest[model.RecordItems]) (*model.SyncResponse, error) {
 	ctx = c.withMirrorNameQueryTag(ctx, req.FlowJobName)
 
-	rawTableIdentifier := getRawTableIdentifier(req.FlowJobName)
-	c.logger.Info("pushing records to Snowflake table " + rawTableIdentifier)
+	var res *model.SyncResponse
+	var err error
 
-	res, err := c.syncRecordsViaAvro(ctx, req, rawTableIdentifier, req.SyncBatchID)
+	if c.streamingManager != nil {
+		c.logger.Info("pushing records via Snowpipe Streaming")
+		res, err = c.syncRecordsViaStreaming(ctx, req, req.SyncBatchID)
+	} else {
+		rawTableIdentifier := getRawTableIdentifier(req.FlowJobName)
+		c.logger.Info("pushing records to Snowflake table " + rawTableIdentifier)
+		res, err = c.syncRecordsViaAvro(ctx, req, rawTableIdentifier, req.SyncBatchID)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -467,6 +497,7 @@ func (c *SnowflakeConnector) syncRecordsViaAvro(
 // NormalizeRecords normalizes raw table to destination table.
 func (c *SnowflakeConnector) NormalizeRecords(ctx context.Context, req *model.NormalizeRecordsRequest) (model.NormalizeResponse, error) {
 	ctx = c.withMirrorNameQueryTag(ctx, req.FlowJobName)
+
 	normBatchID, err := c.GetLastNormalizeBatchID(ctx, req.FlowJobName)
 	if err != nil {
 		return model.NormalizeResponse{}, err
@@ -531,7 +562,7 @@ func (c *SnowflakeConnector) mergeTablesForBatch(
 	g.SetLimit(int(mergeParallelism))
 
 	mergeGen := &mergeStmtGenerator{
-		rawTableName:             getRawTableIdentifier(flowName),
+		rawTableName:             c.rawTableName(flowName),
 		mergeBatchId:             batchId,
 		tableSchemaMapping:       tableToSchema,
 		unchangedToastColumnsMap: tableNameToUnchangedToastCols,
@@ -594,16 +625,19 @@ func (c *SnowflakeConnector) CreateRawTable(ctx context.Context, req *protos.Cre
 	}
 	// there is no easy way to check if a table has the same schema in Snowflake,
 	// so just executing the CREATE TABLE IF NOT EXISTS blindly.
-	rawTableIdentifier := getRawTableIdentifier(req.FlowJobName)
+	rawTableIdentifier := c.rawTableName(req.FlowJobName)
 
 	if _, err := c.execWithLogging(ctx,
 		fmt.Sprintf(createRawTableSQL, c.rawSchema, rawTableIdentifier)); err != nil {
 		return nil, fmt.Errorf("unable to create raw table: %w", err)
 	}
 
-	stage := c.getStageNameForJob(req.FlowJobName)
-	if err := c.createStage(ctx, stage, &protos.QRepConfig{}); err != nil {
-		return nil, err
+	// Streaming path uses Snowpipe instead of a stage — skip stage creation.
+	if c.streamingManager == nil {
+		stage := c.getStageNameForJob(req.FlowJobName)
+		if err := c.createStage(ctx, stage, &protos.QRepConfig{}); err != nil {
+			return nil, err
+		}
 	}
 
 	return &protos.CreateRawTableOutput{
@@ -614,16 +648,23 @@ func (c *SnowflakeConnector) CreateRawTable(ctx context.Context, req *protos.Cre
 func (c *SnowflakeConnector) SyncFlowCleanup(ctx context.Context, jobName string) error {
 	ctx = c.withMirrorNameQueryTag(ctx, jobName)
 
+	// Streaming path: close the channel manager before cleaning up shared resources.
+	if c.streamingManager != nil {
+		c.streamingManager.Close()
+	}
+
 	if schemaExists, err := c.checkIfRawSchemaExists(ctx); err != nil {
 		return fmt.Errorf("error while checking if schema %s for raw table exists: %w", c.rawSchema, err)
 	} else if schemaExists {
-		// delete raw table if exists
-		rawTableIdentifier := getRawTableIdentifier(jobName)
+		rawTableIdentifier := c.rawTableName(jobName)
 		if _, err := c.execWithLogging(ctx, fmt.Sprintf(dropTableIfExistsSQL, c.rawSchema, rawTableIdentifier)); err != nil {
 			return fmt.Errorf("[snowflake] unable to drop raw table: %w", err)
 		}
-		if err := c.dropStage(ctx, "", jobName); err != nil {
-			return err
+		// Streaming path uses Snowpipe instead of a stage — skip stage cleanup.
+		if c.streamingManager == nil {
+			if err := c.dropStage(ctx, "", jobName); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -715,6 +756,19 @@ func generateCreateTableSQLForNormalizedTable(
 
 func getRawTableIdentifier(jobName string) string {
 	return rawTablePrefix + "_" + shared.ReplaceIllegalCharactersWithUnderscores(jobName)
+}
+
+func getStreamingRawTableIdentifier(jobName string) string {
+	return streamingRawTablePrefix + "_" + shared.ReplaceIllegalCharactersWithUnderscores(jobName)
+}
+
+// rawTableName returns the correct raw table identifier for this connector's sync mode.
+// Streaming mirrors write to _PEERDB_STREAMING_{job}; non-streaming mirrors use _PEERDB_RAW_{job}.
+func (c *SnowflakeConnector) rawTableName(flowName string) string {
+	if c.streamingManager != nil {
+		return getStreamingRawTableIdentifier(flowName)
+	}
+	return getRawTableIdentifier(flowName)
 }
 
 func (c *SnowflakeConnector) RenameTables(
@@ -866,6 +920,11 @@ func (c *SnowflakeConnector) RemoveTableEntriesFromRawTable(
 	ctx context.Context,
 	req *protos.RemoveTablesFromRawTableInput,
 ) error {
+	// Streaming path: no raw table entries to remove
+	if c.streamingManager != nil {
+		return nil
+	}
+
 	rawTableIdentifier := getRawTableIdentifier(req.FlowJobName)
 	for _, tableName := range req.DestinationTableNames {
 		_, err := c.execWithLogging(ctx, fmt.Sprintf("DELETE FROM %s.%s WHERE _PEERDB_DESTINATION_TABLE_NAME = '%s'"+

--- a/flow/connectors/snowflake/streaming_auth.go
+++ b/flow/connectors/snowflake/streaming_auth.go
@@ -1,0 +1,150 @@
+package connsnowflake
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/snowflakedb/gosnowflake"
+)
+
+// PrepareJWTToken creates a JWT signed with the RSA private key from the Snowflake config.
+// The issuer claim format is ACCOUNT.USER.SHA256:base64(sha256(der_public_key)).
+func PrepareJWTToken(config *gosnowflake.Config) (string, error) {
+	if config.PrivateKey == nil {
+		return "", fmt.Errorf("PrivateKey is required for Snowpipe Streaming JWT authentication")
+	}
+
+	rsaKey := config.PrivateKey
+
+	pubKeyDER, err := x509.MarshalPKIXPublicKey(&rsaKey.PublicKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal public key: %w", err)
+	}
+
+	pubKeyHash := sha256.Sum256(pubKeyDER)
+	pubKeyFP := base64.StdEncoding.EncodeToString(pubKeyHash[:])
+
+	account := extractAccountName(config.Account)
+	user := strings.ToUpper(config.User)
+
+	now := time.Now().UTC()
+	claims := jwt.MapClaims{
+		"iss": fmt.Sprintf("%s.%s.SHA256:%s", account, user, pubKeyFP),
+		"sub": fmt.Sprintf("%s.%s", account, user),
+		"iat": now.Unix(),
+		"exp": now.Add(60 * time.Second).Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signedToken, err := token.SignedString(rsaKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign JWT token: %w", err)
+	}
+
+	return signedToken, nil
+}
+
+// GetIngestHost retrieves the Snowpipe Streaming ingest hostname.
+// GET https://{account}.snowflakecomputing.com/v2/streaming/hostname
+func GetIngestHost(ctx context.Context, jwtToken string, account string, httpClient *http.Client) (string, error) {
+	reqURL := fmt.Sprintf("https://%s.snowflakecomputing.com/v2/streaming/hostname", account)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create ingest host request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req.Header.Set("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get ingest host: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read ingest host response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ingest host request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Response is a JSON string; replace underscores with hyphens
+	host := strings.TrimSpace(string(body))
+	host = strings.Trim(host, "\"")
+	host = strings.ReplaceAll(host, "_", "-")
+
+	return host, nil
+}
+
+// GetScopedToken exchanges a JWT for a scoped OAuth token for the ingest host.
+// POST https://{account}.snowflakecomputing.com/oauth/token
+func GetScopedToken(ctx context.Context, jwtToken string, account string, ingestHost string, httpClient *http.Client) (string, time.Time, error) {
+	reqURL := fmt.Sprintf("https://%s.snowflakecomputing.com/oauth/token", account)
+
+	formData := url.Values{
+		"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"},
+		"scope":      {ingestHost},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to create scoped token request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to get scoped token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to read scoped token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", time.Time{}, fmt.Errorf("scoped token request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Response is a raw JWT string, not a JSON-wrapped {"access_token": "..."} object.
+	tokenStr := strings.TrimSpace(string(body))
+
+	// Parse the JWT to extract expiry
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	parsed, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to parse scoped token JWT: %w", err)
+	}
+
+	expiry, err := parsed.Claims.GetExpirationTime()
+	if err != nil || expiry == nil {
+		// Default to 55 minutes from now if we can't parse expiry
+		return tokenStr, time.Now().Add(55 * time.Minute), nil
+	}
+
+	return tokenStr, expiry.Time, nil
+}
+
+// extractAccountName strips region suffixes and uppercases the account name.
+// e.g., "myaccount.us-east-1" → "MYACCOUNT"
+func extractAccountName(rawAccount string) string {
+	parts := strings.SplitN(rawAccount, ".", 2)
+	return strings.ToUpper(parts[0])
+}

--- a/flow/connectors/snowflake/streaming_auth_test.go
+++ b/flow/connectors/snowflake/streaming_auth_test.go
@@ -1,0 +1,66 @@
+package connsnowflake
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/snowflakedb/gosnowflake"
+)
+
+func TestPrepareJWTToken_Success(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	config := &gosnowflake.Config{
+		Account:    "testaccount.us-east-1",
+		User:       "testuser",
+		PrivateKey: privateKey,
+	}
+
+	token, err := PrepareJWTToken(config)
+	if err != nil {
+		t.Fatalf("PrepareJWTToken failed: %v", err)
+	}
+
+	if len(token) < 100 {
+		t.Errorf("expected token length > 100, got %d", len(token))
+	}
+}
+
+func TestPrepareJWTToken_NoPrivateKey(t *testing.T) {
+	config := &gosnowflake.Config{
+		Account: "testaccount",
+		User:    "testuser",
+	}
+
+	_, err := PrepareJWTToken(config)
+	if err == nil {
+		t.Fatal("expected error when PrivateKey is nil")
+	}
+
+	if got := err.Error(); got != "PrivateKey is required for Snowpipe Streaming JWT authentication" {
+		t.Errorf("unexpected error message: %s", got)
+	}
+}
+
+func TestExtractAccountName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"myaccount.us-east-1", "MYACCOUNT"},
+		{"myaccount", "MYACCOUNT"},
+		{"MyAccount.us-west-2.aws", "MYACCOUNT"},
+		{"ALREADY_UPPER", "ALREADY_UPPER"},
+	}
+
+	for _, tt := range tests {
+		got := extractAccountName(tt.input)
+		if got != tt.expected {
+			t.Errorf("extractAccountName(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/flow/connectors/snowflake/streaming_channel.go
+++ b/flow/connectors/snowflake/streaming_channel.go
@@ -1,0 +1,591 @@
+package connsnowflake
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/snowflakedb/gosnowflake"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.temporal.io/sdk/log"
+	"golang.org/x/time/rate"
+)
+
+const (
+	// DefaultMaxChunkBytes is the maximum size in bytes for a single Snowpipe Streaming
+	// NDJSON chunk. 4MB is the Snowflake hard limit; chunks are split at this boundary.
+	DefaultMaxChunkBytes = 4 * 1024 * 1024
+	// DefaultRateLimitPerSecond is the default maximum number of Snowpipe Streaming
+	// append-rows API calls per second. Matches the typical per-account quota.
+	DefaultRateLimitPerSecond = 10
+	// DefaultIngestTimeoutSeconds is the default number of seconds to wait for Snowflake
+	// to confirm row ingestion per flush via GetChannelStatus polling.
+	DefaultIngestTimeoutSeconds = 120
+	tokenRefreshBuffer          = 1 * time.Minute
+
+	// sendChunk retry limits
+	maxChunkSendAttempts = 4               // initial + 3 retries
+	initialBackoff       = 2 * time.Second // doubles on each transient retry, capped at 30s
+	maxBackoff           = 30 * time.Second
+)
+
+// channelReopenErrorCodes are Snowpipe Streaming error codes that indicate a channel
+// must be reopened before retrying.
+var channelReopenErrorCodes = map[string]bool{
+	"ERR_CHANNEL_HAS_INVALID_ROW_SEQUENCER":           true,
+	"ERR_CHANNEL_HAS_INVALID_CLIENT_SEQUENCER":         true,
+	"ERR_CHANNEL_MUST_BE_REOPENED":                     true,
+	"ERR_CHANNEL_MUST_BE_REOPENED_DUE_TO_ROW_SEQ_GAP": true,
+	"ERR_CHANNEL_DOES_NOT_EXIST_OR_IS_NOT_AUTHORIZED": true,
+	"STALE_PIPE_CACHE":                                 true,
+}
+
+// StreamingErrorResponse represents an error response from the Snowpipe Streaming API.
+type StreamingErrorResponse struct {
+	Code          string `json:"code"`
+	Message       string `json:"message"`
+	ResultHandler string `json:"result_handler,omitempty"`
+	// HTTPStatus is populated from the HTTP response status code, not from the JSON body.
+	HTTPStatus int `json:"-"`
+}
+
+// ChannelStatus contains per-channel ingestion metrics returned by the Snowpipe Streaming
+// bulk channel status endpoint. It includes error details that SYSTEM$PIPE_STATUS does not.
+type ChannelStatus struct {
+	ChannelStatusCode               string `json:"channel_status_code"`
+	LastCommittedOffsetToken        string `json:"last_committed_offset_token"`
+	RowsInserted                    int    `json:"rows_inserted"`
+	RowsParsed                      int    `json:"rows_parsed"`
+	RowsErrorCount                  int    `json:"rows_error_count"`
+	LastErrorMessage                string `json:"last_error_message"`
+	SnowflakeAvgProcessingLatencyMs int    `json:"snowflake_avg_processing_latency_ms"`
+}
+
+// Error implements the error interface.
+func (e *StreamingErrorResponse) Error() string {
+	return fmt.Sprintf("snowpipe streaming error %s (http %d): %s", e.Code, e.HTTPStatus, e.Message)
+}
+
+// IsChannelReopenError returns true if the error code indicates the channel should be reopened.
+func (e *StreamingErrorResponse) IsChannelReopenError() bool {
+	return channelReopenErrorCodes[e.Code]
+}
+
+// IsAuthError returns true if the error indicates an expired or invalid token.
+// Snowflake may report HTTP 401 with an empty code or a specific auth error code.
+func (e *StreamingErrorResponse) IsAuthError() bool {
+	return e.HTTPStatus == http.StatusUnauthorized
+}
+
+// IsTransientError returns true for errors that are worth retrying with backoff:
+// HTTP 429 (rate limited by Snowflake account quotas) and 5xx server errors.
+// Client errors other than 429 (e.g. 400 schema mismatch) are permanent and should
+// not be retried.
+func (e *StreamingErrorResponse) IsTransientError() bool {
+	return e.HTTPStatus == http.StatusTooManyRequests ||
+		(e.HTTPStatus >= 500 && e.HTTPStatus < 600)
+}
+
+// StreamingChannel represents a single Snowpipe Streaming channel with its state.
+type StreamingChannel struct {
+	// mu protects continuationToken and rowsInserted; both are reset on invalidation.
+	mu                sync.Mutex
+	continuationToken string
+	// rowsInserted is the cumulative row count confirmed by the last GetChannelStatus call.
+	// It is used as the baseline for delivery confirmation: if the server reports a higher
+	// count after a flush, the batch has been committed. Reset to 0 on channel reopen.
+	rowsInserted int
+	// rateLimiter enforces the per-channel request rate against the Snowpipe Streaming API.
+	rateLimiter *rate.Limiter
+}
+
+func (ch *StreamingChannel) getContinuationToken() string {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	return ch.continuationToken
+}
+
+func (ch *StreamingChannel) setContinuationToken(token string) {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	ch.continuationToken = token
+}
+
+func (ch *StreamingChannel) getRowsInserted() int {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	return ch.rowsInserted
+}
+
+func (ch *StreamingChannel) setRowsInserted(n int) {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	ch.rowsInserted = n
+}
+
+func (ch *StreamingChannel) invalidate() {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	ch.continuationToken = ""
+	ch.rowsInserted = 0 // Snowflake resets per-channel counters on reopen
+}
+
+// StreamingChannelManager manages Snowpipe Streaming auth state and channel lifecycle.
+type StreamingChannelManager struct {
+	// sfConfig holds the Snowflake connection parameters (account, user, private key).
+	sfConfig *gosnowflake.Config
+	// channels is the live map of channel name → StreamingChannel, keyed by channel name.
+	channels   map[string]*StreamingChannel
+	channelsMu sync.Mutex
+
+	// Auth state: scoped OAuth token, ingest hostname, and expiry time. Protected by refreshMu.
+	scopedToken string
+	ingestHost  string
+	tokenExpiry time.Time
+	refreshMu   sync.Mutex
+
+	// httpClient is used for all Snowpipe Streaming REST calls. It has a 30-second
+	// timeout and a reusable transport; using a shared client avoids repeated
+	// TCP handshakes and prevents indefinite hangs on unresponsive Snowflake endpoints.
+	httpClient *http.Client
+	// logger is the Temporal activity logger propagated from the connector.
+	logger log.Logger
+
+	// maxChunkBytes is the maximum NDJSON payload size per append-rows request.
+	maxChunkBytes int
+	// rateLimitPerSecond caps the number of append-rows API calls per second per channel.
+	rateLimitPerSecond int
+	// ingestTimeoutSeconds is the maximum time to wait per flush for Snowflake to confirm
+	// row ingestion. Configurable via streaming_ingest_timeout_seconds on the peer.
+	ingestTimeoutSeconds int
+
+	// metrics holds OpenTelemetry instruments for the streaming path.
+	metrics *streamingMetrics
+}
+
+// NewStreamingChannelManager creates a new channel manager for Snowpipe Streaming.
+// Zero or negative values for rateLimitPerSec, maxChunkBytes, and ingestTimeoutSeconds
+// fall back to DefaultRateLimitPerSecond, DefaultMaxChunkBytes, and DefaultIngestTimeoutSeconds.
+func NewStreamingChannelManager(
+	sfConfig *gosnowflake.Config,
+	logger log.Logger,
+	rateLimitPerSec int,
+	maxChunkBytes int,
+	ingestTimeoutSeconds int,
+) *StreamingChannelManager {
+	if rateLimitPerSec <= 0 {
+		rateLimitPerSec = DefaultRateLimitPerSecond
+	}
+	if maxChunkBytes <= 0 {
+		maxChunkBytes = DefaultMaxChunkBytes
+	}
+	if ingestTimeoutSeconds <= 0 {
+		ingestTimeoutSeconds = DefaultIngestTimeoutSeconds
+	}
+
+	return &StreamingChannelManager{
+		sfConfig: sfConfig,
+		channels: make(map[string]*StreamingChannel),
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        10,
+				MaxIdleConnsPerHost: 4,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+		logger:               logger,
+		maxChunkBytes:        maxChunkBytes,
+		rateLimitPerSecond:   rateLimitPerSec,
+		ingestTimeoutSeconds: ingestTimeoutSeconds,
+		metrics:              newStreamingMetrics(),
+	}
+}
+
+// refreshAuth refreshes the JWT → ingest host → scoped token chain when the cached
+// token is within one minute of expiry. Always acquires the mutex before reading
+// token state to avoid a data race with Close() which writes scopedToken = "".
+func (m *StreamingChannelManager) refreshAuth(ctx context.Context) error {
+	m.refreshMu.Lock()
+	defer m.refreshMu.Unlock()
+
+	// Check inside the lock — no unlocked fast-path to avoid a data race (refreshMu
+	// is acquired once per sync batch, so the overhead is negligible).
+	if time.Now().Before(m.tokenExpiry.Add(-tokenRefreshBuffer)) && m.scopedToken != "" {
+		return nil
+	}
+
+	jwtToken, err := PrepareJWTToken(m.sfConfig)
+	if err != nil {
+		return fmt.Errorf("failed to prepare JWT token: %w", err)
+	}
+
+	account := m.sfConfig.Account
+	ingestHost, err := GetIngestHost(ctx, jwtToken, account, m.httpClient)
+	if err != nil {
+		return fmt.Errorf("failed to get ingest host: %w", err)
+	}
+
+	scopedToken, expiresAt, err := GetScopedToken(ctx, jwtToken, account, ingestHost, m.httpClient)
+	if err != nil {
+		return fmt.Errorf("failed to get scoped token: %w", err)
+	}
+
+	m.scopedToken = scopedToken
+	m.ingestHost = ingestHost
+	m.tokenExpiry = expiresAt
+	return nil
+}
+
+// openChannelResponse is the response from opening a Snowpipe Streaming channel.
+type openChannelResponse struct {
+	NextContinuationToken string        `json:"next_continuation_token"`
+	ChannelStatus         ChannelStatus `json:"channel_status"`
+}
+
+// getOrCreateChannel returns an existing channel or opens a new one.
+func (m *StreamingChannelManager) getOrCreateChannel(
+	ctx context.Context,
+	db, schema, pipe, channelName string,
+	forceReopen bool,
+) (*StreamingChannel, error) {
+	m.channelsMu.Lock()
+	if !forceReopen {
+		if ch, ok := m.channels[channelName]; ok {
+			m.channelsMu.Unlock()
+			return ch, nil
+		}
+	}
+	m.channelsMu.Unlock()
+
+	// Open channel via REST API
+	reqURL := fmt.Sprintf("https://%s/v2/streaming/databases/%s/schemas/%s/pipes/%s/channels/%s",
+		m.ingestHost, db, schema, pipe, channelName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create open channel request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+m.scopedToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open channel: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read open channel response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("open channel failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var openResp openChannelResponse
+	if err := json.Unmarshal(body, &openResp); err != nil {
+		return nil, fmt.Errorf("failed to parse open channel response: %w", err)
+	}
+
+	ch := &StreamingChannel{
+		continuationToken: openResp.NextContinuationToken,
+		// Seed rowsInserted from the open-channel response so the first delivery check
+		// has a correct baseline (Snowflake returns cumulative counters in the response).
+		rowsInserted: openResp.ChannelStatus.RowsInserted,
+		rateLimiter:  rate.NewLimiter(rate.Limit(m.rateLimitPerSecond), 1),
+	}
+
+	m.channelsMu.Lock()
+	m.channels[channelName] = ch
+	m.channelsMu.Unlock()
+
+	return ch, nil
+}
+
+// appendRowsResponse is the response from appending rows to a channel.
+type appendRowsResponse struct {
+	NextContinuationToken string `json:"next_continuation_token"`
+}
+
+// appendRows sends NDJSON encoded rows to the channel.
+// offsetToken, when non-empty, is sent as the ?offsetToken= query parameter.
+// Snowflake persists it durably: a second Append Rows call with the same offsetToken
+// on the same channel is a no-op, closing the at-least-once window on Temporal retries.
+func (m *StreamingChannelManager) appendRows(
+	ctx context.Context,
+	db, schema, pipe, channelName string,
+	ch *StreamingChannel,
+	encodedRows []byte,
+	offsetToken string,
+) (*StreamingErrorResponse, error) {
+	contToken := ch.getContinuationToken()
+	reqURL := fmt.Sprintf("https://%s/v2/streaming/data/databases/%s/schemas/%s/pipes/%s/channels/%s/rows?continuationToken=%s",
+		m.ingestHost, db, schema, pipe, channelName, contToken)
+	if offsetToken != "" {
+		reqURL += "&offsetToken=" + offsetToken
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(encodedRows))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create append rows request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+m.scopedToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-ndjson")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to append rows: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read append rows response: %w", err)
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		var appendResp appendRowsResponse
+		if err := json.Unmarshal(body, &appendResp); err != nil {
+			return nil, fmt.Errorf("failed to parse append rows response: %w", err)
+		}
+		ch.setContinuationToken(appendResp.NextContinuationToken)
+		return nil, nil
+	}
+
+	// Parse structured error response. Populate HTTPStatus so callers can classify the error
+	// without re-examining the HTTP layer.
+	var errResp StreamingErrorResponse
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		return nil, fmt.Errorf("append rows failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	errResp.HTTPStatus = resp.StatusCode
+	return &errResp, nil
+}
+
+// sendChunkWithRetry sends a chunk of NDJSON rows to the Snowpipe Streaming channel.
+//
+// Retry behaviour by error type:
+//   - Channel-reopen errors: channel is invalidated and reopened, then retried once.
+//   - Auth errors (HTTP 401): token is refreshed via refreshAuth, then retried.
+//   - Transient errors (HTTP 429, 5xx): retried with exponential backoff up to
+//     maxChunkSendAttempts total attempts.
+//   - Permanent errors (e.g. 400 schema mismatch): returned immediately.
+//   - Transport errors (DNS, TLS, timeout): retried with backoff like transient errors.
+//
+// offsetToken is passed through to appendRows for Snowflake-level deduplication on
+// Temporal retries; it is reused unchanged on channel-reopen retries so Snowflake
+// treats the re-send as a no-op if the first attempt partially committed rows.
+func (m *StreamingChannelManager) sendChunkWithRetry(
+	ctx context.Context,
+	db, schema, pipe, channelName string,
+	ch *StreamingChannel,
+	encodedRows []byte,
+	offsetToken string,
+) error {
+	m.logger.Debug("[streaming] sending chunk",
+		"channel", channelName,
+		"offsetToken", offsetToken,
+		"bytes", len(encodedRows),
+	)
+
+	backoff := initialBackoff
+
+	for attempt := 0; attempt < maxChunkSendAttempts; attempt++ {
+		if err := ch.rateLimiter.Wait(ctx); err != nil {
+			return fmt.Errorf("rate limiter wait: %w", err)
+		}
+
+		errResp, err := m.appendRows(ctx, db, schema, pipe, channelName, ch, encodedRows, offsetToken)
+		if err != nil {
+			// Pure transport error (DNS, TLS, network timeout) — always transient.
+			if attempt < maxChunkSendAttempts-1 {
+				m.logger.Warn("[streaming] transport error sending chunk, retrying with backoff",
+					"channel", channelName,
+					"offsetToken", offsetToken,
+					"attempt", attempt+1,
+					"backoff", backoff,
+					"err", err,
+				)
+				m.metrics.chunkRetriesCounter.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+					attribute.String(snowpipeRetryReasonKey, "transport"),
+				)))
+				if waitErr := sleepWithContext(ctx, backoff); waitErr != nil {
+					return waitErr
+				}
+				backoff = min(backoff*2, maxBackoff)
+				continue
+			}
+			return fmt.Errorf("transport error after %d attempts on channel %s: %w", maxChunkSendAttempts, channelName, err)
+		}
+
+		if errResp == nil {
+			// Success.
+			m.metrics.bytesSentCounter.Add(ctx, int64(len(encodedRows)))
+			return nil
+		}
+
+		m.logger.Warn("[streaming] append rows error",
+			"channel", channelName,
+			"code", errResp.Code,
+			"httpStatus", errResp.HTTPStatus,
+			"offsetToken", offsetToken,
+			"attempt", attempt+1,
+			"message", errResp.Message,
+		)
+
+		if errResp.IsChannelReopenError() {
+			// Channel must be reopened. Reuse the same offsetToken on retry:
+			// Snowflake deduplicates based on it, so re-sending is safe.
+			m.metrics.chunkRetriesCounter.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+				attribute.String(snowpipeRetryReasonKey, "channel_reopen"),
+			)))
+			ch.invalidate()
+			newCh, err := m.getOrCreateChannel(ctx, db, schema, pipe, channelName, true)
+			if err != nil {
+				return fmt.Errorf("failed to reopen channel after %s: %w", errResp.Code, err)
+			}
+			ch = newCh
+			continue
+		}
+
+		if errResp.IsAuthError() {
+			// Token expired mid-batch. Refresh and retry with the same channel.
+			m.logger.Warn("[streaming] auth error (401), refreshing token and retrying",
+				"channel", channelName, "offsetToken", offsetToken)
+			m.metrics.chunkRetriesCounter.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+				attribute.String(snowpipeRetryReasonKey, "auth"),
+			)))
+			if refreshErr := m.refreshAuth(ctx); refreshErr != nil {
+				return fmt.Errorf("failed to refresh auth after 401 on channel %s: %w", channelName, refreshErr)
+			}
+			// appendRows reads m.scopedToken directly, so the next attempt uses the new token.
+			continue
+		}
+
+		if errResp.IsTransientError() {
+			if attempt < maxChunkSendAttempts-1 {
+				m.logger.Warn("[streaming] transient error, retrying with backoff",
+					"channel", channelName,
+					"code", errResp.Code,
+					"httpStatus", errResp.HTTPStatus,
+					"offsetToken", offsetToken,
+					"attempt", attempt+1,
+					"backoff", backoff,
+				)
+				m.metrics.chunkRetriesCounter.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+					attribute.String(snowpipeRetryReasonKey, "transient"),
+				)))
+				if waitErr := sleepWithContext(ctx, backoff); waitErr != nil {
+					return waitErr
+				}
+				backoff = min(backoff*2, maxBackoff)
+				continue
+			}
+			return fmt.Errorf("transient error (code %s, http %d) after %d attempts on channel %s: %w",
+				errResp.Code, errResp.HTTPStatus, maxChunkSendAttempts, channelName, errResp)
+		}
+
+		// Permanent error: schema mismatch, permission denied, malformed payload, etc.
+		// Return immediately — retrying won't help.
+		return fmt.Errorf("permanent snowpipe error (code %s, http %d) on channel %s: %w",
+			errResp.Code, errResp.HTTPStatus, channelName, errResp)
+	}
+
+	return fmt.Errorf("exceeded %d retry attempts for chunk on channel %s (offsetToken %s)",
+		maxChunkSendAttempts, channelName, offsetToken)
+}
+
+// sleepWithContext sleeps for d or until ctx is cancelled, whichever comes first.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
+// GetChannelStatus fetches per-channel ingestion metrics via the bulk channel status
+// endpoint. It is used for delivery confirmation: the caller can detect ingestion errors
+// (via RowsErrorCount + LastErrorMessage) and confirm committed rows (via RowsInserted).
+//
+// Endpoint: POST https://{ingestHost}/v2/streaming/databases/{db}/schemas/{schema}/pipes/{pipe}:bulk-channel-status
+func (m *StreamingChannelManager) GetChannelStatus(
+	ctx context.Context,
+	db, schema, pipe string,
+	channelNames []string,
+) (map[string]ChannelStatus, error) {
+	reqURL := fmt.Sprintf(
+		"https://%s/v2/streaming/databases/%s/schemas/%s/pipes/%s:bulk-channel-status",
+		m.ingestHost, db, schema, pipe,
+	)
+
+	type bulkPayload struct {
+		ChannelNames []string `json:"channel_names"`
+	}
+	payloadBody, err := json.Marshal(bulkPayload{ChannelNames: channelNames})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal bulk channel status payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(payloadBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bulk channel status request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.scopedToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query bulk channel status: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bulk channel status response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("bulk channel status request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var response struct {
+		ChannelStatuses map[string]ChannelStatus `json:"channel_statuses"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse bulk channel status response: %w", err)
+	}
+	return response.ChannelStatuses, nil
+}
+
+// Close invalidates all channels and clears the manager state.
+// The two mutexes are released independently (channelsMu first, then refreshMu) to
+// avoid holding both simultaneously and to match the lock ordering in refreshAuth.
+func (m *StreamingChannelManager) Close() {
+	m.channelsMu.Lock()
+	for _, ch := range m.channels {
+		ch.invalidate()
+	}
+	m.channels = make(map[string]*StreamingChannel)
+	m.channelsMu.Unlock()
+
+	// refreshMu must be held when writing scopedToken/ingestHost; refreshAuth holds it
+	// too, so skipping it here would be a data race under concurrent Close + refreshAuth.
+	m.refreshMu.Lock()
+	m.scopedToken = ""
+	m.ingestHost = ""
+	m.refreshMu.Unlock()
+}

--- a/flow/connectors/snowflake/streaming_metrics.go
+++ b/flow/connectors/snowflake/streaming_metrics.go
@@ -1,0 +1,115 @@
+package connsnowflake
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
+)
+
+// Metric name constants for the Snowpipe Streaming path.
+// All names are prefixed by BuildMetricName (e.g. "peerdb.snowpipe_bytes_sent").
+const (
+	snowpipeBytesSentCounterName      = "snowpipe_bytes_sent"
+	snowpipeRowsConfirmedCounterName  = "snowpipe_rows_confirmed"
+	snowpipeRowsErroredCounterName    = "snowpipe_rows_errored"
+	snowpipeChunkRetriesCounterName   = "snowpipe_chunk_retries"
+	snowpipeIngestionLatencyGaugeName = "snowpipe_ingestion_latency_ms"
+	// snowpipeCommitLagGaugeName is the client-perceived commit lag: wall-clock
+	// time from flush start (sendChunkWithRetry) to ingestion confirmation
+	// (waitForChannelIngestion). Includes network RTT, polling interval, and
+	// Snowflake-side processing latency. Complements snowpipe_ingestion_latency_ms
+	// which only reports the Snowflake server-side average.
+	snowpipeCommitLagGaugeName = "snowpipe_commit_lag_ms"
+
+	// snowpipeRetryReasonKey is the attribute key added to snowpipeChunkRetriesCounter
+	// to distinguish retry causes: "transport", "channel_reopen", "auth", "transient".
+	snowpipeRetryReasonKey = "retry_reason"
+)
+
+// streamingMetrics holds OpenTelemetry instruments for the Snowpipe Streaming path.
+// All instruments are context-aware — flow metadata (flowName, peerType, etc.) is
+// injected automatically from the context on every emission.
+type streamingMetrics struct {
+	// bytesSentCounter counts bytes successfully delivered to Snowpipe per chunk.
+	bytesSentCounter metric.Int64Counter
+	// rowsConfirmedCounter counts rows confirmed ingested by Snowflake (via waitForChannelIngestion).
+	rowsConfirmedCounter metric.Int64Counter
+	// rowsErroredCounter counts rows rejected by Snowflake (RowsErrorCount > 0 in channel status).
+	rowsErroredCounter metric.Int64Counter
+	// chunkRetriesCounter counts retry attempts in sendChunkWithRetry, tagged by retry_reason.
+	chunkRetriesCounter metric.Int64Counter
+	// ingestionLatencyGauge records Snowflake's reported avg processing latency (ms) per flush.
+	ingestionLatencyGauge metric.Int64Gauge
+	// commitLagGauge records the client-perceived end-to-end commit lag (ms) per flush:
+	// elapsed wall-clock time from flush start to ingestion confirmation.
+	commitLagGauge metric.Int64Gauge
+}
+
+// newStreamingMetrics initialises instruments from the global OTel meter provider.
+// If the provider is not yet configured (startup race or tests without OTel setup),
+// the SDK returns noop instruments — all Record/Add calls become no-ops.
+func newStreamingMetrics() *streamingMetrics {
+	meter := otel.GetMeterProvider().Meter("io.peerdb.flow-worker")
+
+	bytesSent, err := otel_metrics.NewContextAwareInt64Counter(meter,
+		otel_metrics.BuildMetricName(snowpipeBytesSentCounterName),
+		metric.WithUnit("By"),
+		metric.WithDescription("Bytes sent via Snowpipe Streaming REST API per chunk"),
+	)
+	if err != nil {
+		bytesSent = noop.Int64Counter{}
+	}
+
+	rowsConfirmed, err := otel_metrics.NewContextAwareInt64Counter(meter,
+		otel_metrics.BuildMetricName(snowpipeRowsConfirmedCounterName),
+		metric.WithDescription("Rows confirmed ingested by Snowflake via Snowpipe Streaming"),
+	)
+	if err != nil {
+		rowsConfirmed = noop.Int64Counter{}
+	}
+
+	rowsErrored, err := otel_metrics.NewContextAwareInt64Counter(meter,
+		otel_metrics.BuildMetricName(snowpipeRowsErroredCounterName),
+		metric.WithDescription("Rows rejected by Snowflake during Snowpipe Streaming ingestion"),
+	)
+	if err != nil {
+		rowsErrored = noop.Int64Counter{}
+	}
+
+	chunkRetries, err := otel_metrics.NewContextAwareInt64Counter(meter,
+		otel_metrics.BuildMetricName(snowpipeChunkRetriesCounterName),
+		metric.WithDescription("Retry attempts in Snowpipe Streaming chunk send, tagged by retry_reason"),
+	)
+	if err != nil {
+		chunkRetries = noop.Int64Counter{}
+	}
+
+	ingestionLatency, err := otel_metrics.ContextAwareInt64Gauge(meter,
+		otel_metrics.BuildMetricName(snowpipeIngestionLatencyGaugeName),
+		metric.WithUnit("ms"),
+		metric.WithDescription("Snowflake-reported average processing latency for Snowpipe Streaming"),
+	)
+	if err != nil {
+		ingestionLatency = noop.Int64Gauge{}
+	}
+
+	commitLag, err := otel_metrics.ContextAwareInt64Gauge(meter,
+		otel_metrics.BuildMetricName(snowpipeCommitLagGaugeName),
+		metric.WithUnit("ms"),
+		metric.WithDescription("Client-perceived commit lag for Snowpipe Streaming flush (start → confirmation)"),
+	)
+	if err != nil {
+		commitLag = noop.Int64Gauge{}
+	}
+
+	return &streamingMetrics{
+		bytesSentCounter:      bytesSent,
+		rowsConfirmedCounter:  rowsConfirmed,
+		rowsErroredCounter:    rowsErrored,
+		chunkRetriesCounter:   chunkRetries,
+		ingestionLatencyGauge: ingestionLatency,
+		commitLagGauge:        commitLag,
+	}
+}

--- a/flow/connectors/snowflake/streaming_sync.go
+++ b/flow/connectors/snowflake/streaming_sync.go
@@ -1,0 +1,468 @@
+package connsnowflake
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	fnv "hash/fnv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
+	"github.com/PeerDB-io/peerdb/flow/internal"
+	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/shared"
+)
+
+// maxStreamingChannelsPerFlow caps the channel pool to stay well under Snowflake's
+// 2000-channels-per-pipe ceiling while leaving headroom for parallel mirrors sharing
+// the same pipe.
+const maxStreamingChannelsPerFlow = 64
+
+// routeChannelIdx returns the channel index for a destination table. Hashing by
+// destination table name (not primary key) preserves per-table ordering, which is
+// required by NormalizeRecords MERGE semantics.
+func routeChannelIdx(destinationTable string, channelCount int) int {
+	if channelCount <= 1 {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(destinationTable))
+	return int(h.Sum32() % uint32(channelCount))
+}
+
+// rawTableColumns is the fixed column order for the raw table Snowpipe.
+// It must match createRawTableSQL exactly and never changes — the raw table schema
+// is stable regardless of destination table evolution.
+var rawTableColumns = []string{
+	"_PEERDB_UID",
+	"_PEERDB_TIMESTAMP",
+	"_PEERDB_DESTINATION_TABLE_NAME",
+	"_PEERDB_DATA",
+	"_PEERDB_RECORD_TYPE",
+	"_PEERDB_MATCH_DATA",
+	"_PEERDB_BATCH_ID",
+	"_PEERDB_UNCHANGED_TOAST_COLUMNS",
+}
+
+// rawStreamingBuffer accumulates NDJSON rows destined for the raw table.
+type rawStreamingBuffer struct {
+	encodedRows [][]byte
+	currentSize int
+}
+
+// rawRow is the JSON shape for each NDJSON line sent to the raw table via Snowpipe.
+// Field names must match rawTableColumns exactly (Snowpipe maps $1:<field> by name).
+type rawRow struct {
+	UID              string `json:"_PEERDB_UID"`
+	Timestamp        int64  `json:"_PEERDB_TIMESTAMP"`
+	DestinationTable string `json:"_PEERDB_DESTINATION_TABLE_NAME"`
+	Data             string `json:"_PEERDB_DATA"`
+	RecordType       int64  `json:"_PEERDB_RECORD_TYPE"`
+	MatchData        string `json:"_PEERDB_MATCH_DATA"`
+	BatchID          int64  `json:"_PEERDB_BATCH_ID"`
+	UnchangedToast   string `json:"_PEERDB_UNCHANGED_TOAST_COLUMNS"`
+}
+
+// buildRawStreamingRow converts a CDC record to an NDJSON line for the raw table.
+//
+// Field mapping follows the same convention as utils.RecordsToRawTableStream:
+//   - INSERT:  data=Items,       matchData="",        recordType=0
+//   - UPDATE:  data=NewItems,    matchData=OldItems,  recordType=1
+//   - DELETE:  data=Items,       matchData=Items,     recordType=2
+//
+// This means NormalizeRecords / mergeTablesForBatch can run unchanged after streaming sync,
+// since the raw table rows are identical in structure to the Avro/S3 path.
+func buildRawStreamingRow(record model.Record[model.RecordItems], syncBatchID int64) ([]byte, error) {
+	row := rawRow{
+		UID:              uuid.New().String(),
+		Timestamp:        time.Now().UnixNano(),
+		DestinationTable: record.GetDestinationTableName(),
+		BatchID:          syncBatchID,
+	}
+
+	var err error
+	switch rec := record.(type) {
+	case *model.InsertRecord[model.RecordItems]:
+		row.Data, err = model.ItemsToJSON(rec.Items)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize insert items: %w", err)
+		}
+		row.RecordType = 0
+		// MatchData and UnchangedToast default to "" (zero value)
+
+	case *model.UpdateRecord[model.RecordItems]:
+		row.Data, err = model.ItemsToJSON(rec.NewItems)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize update new items: %w", err)
+		}
+		row.MatchData, err = model.ItemsToJSON(rec.OldItems)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize update old items: %w", err)
+		}
+		row.RecordType = 1
+		row.UnchangedToast = utils.KeysToString(rec.UnchangedToastColumns)
+
+	case *model.DeleteRecord[model.RecordItems]:
+		row.Data, err = model.ItemsToJSON(rec.Items)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize delete items: %w", err)
+		}
+		row.RecordType = 2
+		row.MatchData = row.Data // DELETE: match data is same as data
+		row.UnchangedToast = utils.KeysToString(rec.UnchangedToastColumns)
+
+	default:
+		return nil, fmt.Errorf("unknown record type in streaming path: %T", record)
+	}
+
+	b, err := json.Marshal(row)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal raw streaming row: %w", err)
+	}
+	return append(b, '\n'), nil // NDJSON: one JSON object per line
+}
+
+// syncRecordsViaStreaming streams CDC records to the _PEERDB_STREAMING_* table via the
+// Snowpipe Streaming REST API. NormalizeRecords runs a MERGE afterwards — identical
+// to the Avro/S3 path but without the staging hop.
+//
+// The streaming path uses a dedicated raw table (_PEERDB_STREAMING_{job}) distinct from
+// the non-streaming raw table (_PEERDB_RAW_{job}), so the two paths never share rows.
+//
+//   - CDC records → _PEERDB_INTERNAL._PEERDB_STREAMING_<job> (via Snowpipe Streaming)
+//   - NormalizeRecords → mergeTablesForBatch (unchanged, reads from _PEERDB_STREAMING_<job>)
+//
+// This preserves correct UPDATE/DELETE/TOAST semantics through the existing MERGE
+// logic while eliminating the Avro → S3 → COPY INTO latency cost.
+func (c *SnowflakeConnector) syncRecordsViaStreaming(
+	ctx context.Context,
+	req *model.SyncRecordsRequest[model.RecordItems],
+	syncBatchID int64,
+) (*model.SyncResponse, error) {
+	// Idempotency guard: if this batch was already committed, skip re-sending rows.
+	// This prevents duplicates when Temporal retries the activity after a heartbeat timeout.
+	lastBatchID, err := c.GetLastSyncBatchID(ctx, req.FlowJobName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last sync batch ID: %w", err)
+	}
+	if syncBatchID <= lastBatchID {
+		c.logger.Info("[streaming] batch already synced, skipping",
+			"flowJobName", req.FlowJobName,
+			"syncBatchID", syncBatchID,
+			"lastCommittedBatchID", lastBatchID,
+		)
+		// Drain the records channel so the producer goroutine can finish cleanly.
+		for range req.Records.GetRecords() {
+		}
+		return &model.SyncResponse{
+			LastSyncedCheckpoint: req.Records.GetLastCheckpoint(),
+			NumRecordsSynced:     0,
+			CurrentSyncBatchID:   syncBatchID,
+			TableNameRowsMapping: utils.InitialiseTableRowsMap(req.TableMappings),
+			TableSchemaDeltas:    nil,
+		}, nil
+	}
+
+	if err := c.streamingManager.refreshAuth(ctx); err != nil {
+		return nil, fmt.Errorf("failed to refresh streaming auth: %w", err)
+	}
+
+	// Resolve raw table coordinates. The raw table lives in rawSchema, which defaults
+	// to _PEERDB_INTERNAL. Both are uppercased to match Snowflake's identifier convention.
+	db := strings.ToUpper(c.config.Database)
+	rawSchema := strings.ToUpper(c.rawSchema)
+	rawTable := strings.ToUpper(getStreamingRawTableIdentifier(req.FlowJobName))
+	// Pipe and channel are scoped to the flow job to prevent conflicts when multiple
+	// mirrors share the same Snowflake account.
+	sanitizedJob := strings.ToUpper(shared.ReplaceIllegalCharactersWithUnderscores(req.FlowJobName))
+	pipeName := sanitizedJob + "_STREAMING_PIPE"
+
+	// Channel pool size: distribute load across N channels by destination-table-name
+	// hash. Per-table ordering is preserved (a given destination table always routes
+	// to the same channel within a batch). N=1 keeps the original channel name
+	// "peerdb-{job}-raw-0" so existing mirrors retain their durable offsetTokens.
+	channelsPerFlow, err := internal.PeerDBSnowflakeStreamingChannelsPerFlow(ctx, req.Env)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read streaming channels-per-flow: %w", err)
+	}
+	if channelsPerFlow < 1 {
+		channelsPerFlow = 1
+	}
+	if channelsPerFlow > maxStreamingChannelsPerFlow {
+		c.logger.Warn("[streaming] channels-per-flow exceeds Snowflake limit, capping",
+			"requested", channelsPerFlow, "cap", maxStreamingChannelsPerFlow)
+		channelsPerFlow = maxStreamingChannelsPerFlow
+	}
+
+	// Ensure the raw table pipe exists. CREATE PIPE IF NOT EXISTS is atomic on Snowflake
+	// and preserves existing channels (their continuationTokens stay valid for idempotency
+	// on Temporal retries). Raw table columns are fixed at compile time, so the pipe never
+	// needs schema-driven recreation.
+	if err := c.createStreamingPipe(ctx, db, rawSchema, rawTable, pipeName, rawTableColumns); err != nil {
+		return nil, fmt.Errorf("failed to create raw table streaming pipe: %w", err)
+	}
+
+	channels := make([]*StreamingChannel, channelsPerFlow)
+	channelNames := make([]string, channelsPerFlow)
+	for i := int64(0); i < channelsPerFlow; i++ {
+		channelNames[i] = fmt.Sprintf("peerdb-%s-raw-%d", req.FlowJobName, i)
+		ch, err := c.streamingManager.getOrCreateChannel(ctx, db, rawSchema, pipeName, channelNames[i], false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get/create streaming channel %s: %w", channelNames[i], err)
+		}
+		channels[i] = ch
+	}
+
+	tableNameRowsMapping := utils.InitialiseTableRowsMap(req.TableMappings)
+	bufs := make([]*rawStreamingBuffer, channelsPerFlow)
+	flushIndices := make([]int, channelsPerFlow)
+	for i := range bufs {
+		bufs[i] = &rawStreamingBuffer{}
+	}
+
+	for record := range req.Records.GetRecords() {
+		// MessageRecord carries no CDC data; skip it.
+		if _, ok := record.(*model.MessageRecord[model.RecordItems]); ok {
+			continue
+		}
+
+		rowBytes, err := buildRawStreamingRow(record, syncBatchID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build raw streaming row: %w", err)
+		}
+
+		// Route by destination-table hash so all rows for a given table land on the
+		// same channel — preserves per-table ordering required by NormalizeRecords MERGE.
+		idx := routeChannelIdx(record.GetDestinationTableName(), int(channelsPerFlow))
+		bufs[idx].encodedRows = append(bufs[idx].encodedRows, rowBytes)
+		bufs[idx].currentSize += len(rowBytes)
+		record.PopulateCountMap(tableNameRowsMapping)
+
+		// Flush mid-batch if any single buffer reaches the chunk size limit.
+		if bufs[idx].currentSize >= c.streamingManager.maxChunkBytes {
+			if err := c.flushRawBuffer(ctx, db, rawSchema, pipeName, channelNames[idx], channels[idx], bufs[idx], syncBatchID, &flushIndices[idx]); err != nil {
+				return nil, fmt.Errorf("failed to flush raw buffer mid-batch on channel %s: %w", channelNames[idx], err)
+			}
+		}
+	}
+
+	for i, buf := range bufs {
+		if len(buf.encodedRows) > 0 {
+			if err := c.flushRawBuffer(ctx, db, rawSchema, pipeName, channelNames[i], channels[i], buf, syncBatchID, &flushIndices[i]); err != nil {
+				return nil, fmt.Errorf("failed to flush final raw buffer on channel %s: %w", channelNames[i], err)
+			}
+		}
+	}
+
+	// Schema deltas come from req.Records.SchemaDeltas, populated by AddSchemaDelta in the
+	// pull loop. RelationRecords are never added to the records channel — they go directly
+	// to CDCStream.SchemaDeltas. This matches the non-streaming path.
+	schemaDeltas := req.Records.SchemaDeltas
+	if len(schemaDeltas) > 0 {
+		if err := c.ReplayTableSchemaDeltas(ctx, req.Env, req.FlowJobName, req.TableMappings, schemaDeltas, nil); err != nil {
+			return nil, fmt.Errorf("failed to replay schema deltas: %w", err)
+		}
+	}
+
+	var totalRows int64
+	for _, counts := range tableNameRowsMapping {
+		totalRows += int64(counts.InsertCount.Load()) +
+			int64(counts.UpdateCount.Load()) +
+			int64(counts.DeleteCount.Load())
+	}
+
+	return &model.SyncResponse{
+		LastSyncedCheckpoint: req.Records.GetLastCheckpoint(),
+		NumRecordsSynced:     totalRows,
+		CurrentSyncBatchID:   syncBatchID,
+		TableNameRowsMapping: tableNameRowsMapping,
+		TableSchemaDeltas:    schemaDeltas,
+	}, nil
+}
+
+// flushRawBuffer sends buffered raw table rows to Snowpipe Streaming and waits for
+// delivery confirmation. Resets encodedRows and currentSize after a successful flush.
+//
+// syncBatchID and a per-call flushIndex are combined to produce an offsetToken for
+// each chunk. Snowflake persists the offsetToken durably on the channel and treats
+// a second Append Rows call with the same token as a no-op, closing the narrow
+// at-least-once window that exists between row confirmation and FinishBatch.
+func (c *SnowflakeConnector) flushRawBuffer(
+	ctx context.Context,
+	db, schema, pipe, channelName string,
+	ch *StreamingChannel,
+	buf *rawStreamingBuffer,
+	syncBatchID int64,
+	flushIndex *int,
+) error {
+	if len(buf.encodedRows) == 0 {
+		return nil
+	}
+
+	rowCount := len(buf.encodedRows)
+	flushStart := time.Now()
+	c.logger.Info("[streaming] flushing raw buffer",
+		"pipe", pipe, "channel", channelName, "rows", rowCount)
+
+	// Concatenate rows into NDJSON chunks, splitting at maxChunkBytes.
+	// Each chunk gets a unique offsetToken: "<syncBatchID>-<chunkIndex>".
+	var currentChunk bytes.Buffer
+	chunkCount := 0
+	totalBytes := 0
+	for _, rowBytes := range buf.encodedRows {
+		if currentChunk.Len()+len(rowBytes) > c.streamingManager.maxChunkBytes && currentChunk.Len() > 0 {
+			offsetToken := fmt.Sprintf("%d-%d", syncBatchID, *flushIndex)
+			*flushIndex++
+			if err := c.streamingManager.sendChunkWithRetry(ctx, db, schema, pipe, channelName, ch, currentChunk.Bytes(), offsetToken); err != nil {
+				return fmt.Errorf("failed to send raw chunk: %w", err)
+			}
+			totalBytes += currentChunk.Len()
+			chunkCount++
+			currentChunk.Reset()
+		}
+		currentChunk.Write(rowBytes)
+	}
+	if currentChunk.Len() > 0 {
+		offsetToken := fmt.Sprintf("%d-%d", syncBatchID, *flushIndex)
+		*flushIndex++
+		if err := c.streamingManager.sendChunkWithRetry(ctx, db, schema, pipe, channelName, ch, currentChunk.Bytes(), offsetToken); err != nil {
+			return fmt.Errorf("failed to send final raw chunk: %w", err)
+		}
+		totalBytes += currentChunk.Len()
+		chunkCount++
+	}
+
+	c.logger.Info("[streaming] rows sent to raw table via Snowpipe",
+		"pipe", pipe, "rows", rowCount, "chunks", chunkCount, "bytes", totalBytes)
+
+	// Verify that Snowflake committed all rows. waitForChannelIngestion polls the
+	// bulk channel status endpoint until RowsInserted >= baseline + rowCount.
+	if err := c.waitForChannelIngestion(ctx, db, schema, pipe, channelName, ch, rowCount, flushStart); err != nil {
+		return fmt.Errorf("raw table streaming ingestion not confirmed for pipe %s: %w", pipe, err)
+	}
+
+	buf.encodedRows = buf.encodedRows[:0]
+	buf.currentSize = 0
+	return nil
+}
+
+// waitForChannelIngestion polls the Snowpipe Streaming bulk channel status endpoint until
+// the channel confirms rows were committed or reports ingestion errors.
+//
+// This replaces SYSTEM$PIPE_STATUS polling because the channel-level endpoint:
+//   - Exposes LastErrorMessage for immediate error detection (e.g. schema/type mismatches)
+//   - Reports RowsInserted so we can confirm our specific batch was committed
+//   - Gives per-channel granularity instead of per-pipe
+//
+// Delivery is confirmed when RowsInserted >= baseline + rowsSent, where baseline is the
+// cumulative count captured from the channel at the last successful flush.
+func (c *SnowflakeConnector) waitForChannelIngestion(
+	ctx context.Context,
+	db, schema, pipe, channelName string,
+	ch *StreamingChannel,
+	rowsSent int,
+	flushStart time.Time,
+) error {
+	baseline := ch.getRowsInserted()
+	timeout := time.Duration(c.streamingManager.ingestTimeoutSeconds) * time.Second
+	deadline := time.Now().Add(timeout)
+	pollInterval := 3 * time.Second
+
+	for time.Now().Before(deadline) {
+		statuses, err := c.streamingManager.GetChannelStatus(ctx, db, schema, pipe, []string{channelName})
+		if err != nil {
+			// Transient network/auth error — log and retry rather than failing fast.
+			c.logger.Warn("[streaming] failed to get channel status, retrying", "channel", channelName, "err", err)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(pollInterval):
+			}
+			continue
+		}
+
+		status, ok := statuses[channelName]
+		if !ok {
+			// Channel may not be visible yet; retry.
+			c.logger.Warn("[streaming] channel not in status response, retrying", "channel", channelName)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(pollInterval):
+			}
+			continue
+		}
+
+		c.logger.Info("[streaming] channel status",
+			"channel", channelName,
+			"rowsInserted", status.RowsInserted,
+			"rowsErrors", status.RowsErrorCount,
+			"latencyMs", status.SnowflakeAvgProcessingLatencyMs,
+		)
+
+		// Fail fast: Snowflake reports a parsing or schema error for this batch.
+		if status.RowsErrorCount > 0 && status.LastErrorMessage != "" {
+			c.streamingManager.metrics.rowsErroredCounter.Add(ctx, int64(status.RowsErrorCount))
+			return fmt.Errorf("snowpipe streaming ingestion error for channel %s: %s", channelName, status.LastErrorMessage)
+		}
+
+		// Success: all rows in this flush have been committed.
+		if status.RowsInserted >= baseline+rowsSent {
+			ch.setRowsInserted(status.RowsInserted)
+			commitLagMs := time.Since(flushStart).Milliseconds()
+			c.streamingManager.metrics.rowsConfirmedCounter.Add(ctx, int64(rowsSent))
+			c.streamingManager.metrics.ingestionLatencyGauge.Record(ctx, int64(status.SnowflakeAvgProcessingLatencyMs))
+			c.streamingManager.metrics.commitLagGauge.Record(ctx, commitLagMs)
+			c.logger.Info("[streaming] ingestion confirmed",
+				"channel", channelName,
+				"rowsInserted", status.RowsInserted,
+				"baseline", baseline,
+				"commitLagMs", commitLagMs,
+			)
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+
+	return fmt.Errorf("timed out waiting for channel ingestion on %s (pipe %s.%s.%s) after %v",
+		channelName, db, schema, pipe, timeout)
+}
+
+// createStreamingPipe ensures the Snowpipe object exists for a given table using
+// CREATE PIPE IF NOT EXISTS. The DDL is atomic on Snowflake and preserves existing
+// channels — repeated calls across sync batches are safe and effectively no-ops.
+//
+// columnNames must be non-empty; the raw-table caller passes the fixed rawTableColumns.
+func (c *SnowflakeConnector) createStreamingPipe(
+	ctx context.Context,
+	db, schema, table, pipe string,
+	columnNames []string,
+) error {
+	tableFQN := fmt.Sprintf("%s.%s.%s", db, schema, table)
+	pipeFQN := fmt.Sprintf("%s.%s.%s", db, schema, pipe)
+
+	selectParts := make([]string, len(columnNames))
+	colParts := make([]string, len(columnNames))
+	for i, col := range columnNames {
+		selectParts[i] = fmt.Sprintf(`$1:"%s"`, col)
+		colParts[i] = fmt.Sprintf(`"%s"`, col)
+	}
+	createPipeSQL := fmt.Sprintf(
+		`CREATE PIPE IF NOT EXISTS %s AS COPY INTO %s(%s) FROM (SELECT %s FROM TABLE(DATA_SOURCE(TYPE => 'STREAMING')))`,
+		pipeFQN, tableFQN, strings.Join(colParts, ", "), strings.Join(selectParts, ", "),
+	)
+
+	if _, err := c.ExecContext(ctx, createPipeSQL); err != nil {
+		return fmt.Errorf("failed to execute CREATE PIPE for %s: %w", pipeFQN, err)
+	}
+	return nil
+}

--- a/flow/connectors/snowflake/streaming_sync_test.go
+++ b/flow/connectors/snowflake/streaming_sync_test.go
@@ -1,0 +1,558 @@
+package connsnowflake
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/snowflakedb/gosnowflake"
+
+	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
+)
+
+// ── rawTableColumns ───────────────────────────────────────────────────────────
+
+// TestRawTableColumns_Count verifies that rawTableColumns has the expected number
+// of columns and that the order matches createRawTableSQL.
+func TestRawTableColumns_Count(t *testing.T) {
+	expected := []string{
+		"_PEERDB_UID",
+		"_PEERDB_TIMESTAMP",
+		"_PEERDB_DESTINATION_TABLE_NAME",
+		"_PEERDB_DATA",
+		"_PEERDB_RECORD_TYPE",
+		"_PEERDB_MATCH_DATA",
+		"_PEERDB_BATCH_ID",
+		"_PEERDB_UNCHANGED_TOAST_COLUMNS",
+	}
+	if len(rawTableColumns) != len(expected) {
+		t.Fatalf("expected %d rawTableColumns, got %d", len(expected), len(rawTableColumns))
+	}
+	for i, want := range expected {
+		if rawTableColumns[i] != want {
+			t.Errorf("rawTableColumns[%d]: expected %q, got %q", i, want, rawTableColumns[i])
+		}
+	}
+}
+
+// ── buildRawStreamingRow ──────────────────────────────────────────────────────
+
+// TestBuildRawStreamingRow_Insert verifies that an INSERT record produces a raw row
+// with recordType=0, empty matchData, empty unchangedToast, and the correct destination.
+func TestBuildRawStreamingRow_Insert(t *testing.T) {
+	items := model.NewRecordItems(2)
+	items.AddColumn("id", types.QValueInt32{Val: 42})
+	items.AddColumn("name", types.QValueString{Val: "Alice"})
+
+	rec := &model.InsertRecord[model.RecordItems]{
+		Items:                items,
+		DestinationTableName: "public.users",
+	}
+
+	rowBytes, err := buildRawStreamingRow(rec, 7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Must end with newline (NDJSON format)
+	if len(rowBytes) == 0 || rowBytes[len(rowBytes)-1] != '\n' {
+		t.Error("expected NDJSON row to end with newline")
+	}
+
+	var row rawRow
+	if err := json.Unmarshal(rowBytes[:len(rowBytes)-1], &row); err != nil {
+		t.Fatalf("failed to unmarshal row: %v", err)
+	}
+
+	if row.UID == "" {
+		t.Error("expected non-empty UID")
+	}
+	if row.Timestamp == 0 {
+		t.Error("expected non-zero Timestamp")
+	}
+	if row.DestinationTable != "public.users" {
+		t.Errorf("expected DestinationTable=public.users, got %q", row.DestinationTable)
+	}
+	if row.RecordType != 0 {
+		t.Errorf("expected RecordType=0 (INSERT), got %d", row.RecordType)
+	}
+	if row.MatchData != "" {
+		t.Errorf("expected empty MatchData for INSERT, got %q", row.MatchData)
+	}
+	if row.UnchangedToast != "" {
+		t.Errorf("expected empty UnchangedToast for INSERT, got %q", row.UnchangedToast)
+	}
+	if row.BatchID != 7 {
+		t.Errorf("expected BatchID=7, got %d", row.BatchID)
+	}
+	// Data must be non-empty JSON
+	if row.Data == "" || row.Data == "null" {
+		t.Errorf("expected non-empty Data JSON, got %q", row.Data)
+	}
+}
+
+// TestBuildRawStreamingRow_Update verifies that an UPDATE record produces a raw row
+// with recordType=1, matchData=oldItems, and unchangedToast set.
+func TestBuildRawStreamingRow_Update(t *testing.T) {
+	newItems := model.NewRecordItems(2)
+	newItems.AddColumn("id", types.QValueInt32{Val: 1})
+	newItems.AddColumn("status", types.QValueString{Val: "shipped"})
+
+	oldItems := model.NewRecordItems(2)
+	oldItems.AddColumn("id", types.QValueInt32{Val: 1})
+	oldItems.AddColumn("status", types.QValueString{Val: "pending"})
+
+	rec := &model.UpdateRecord[model.RecordItems]{
+		NewItems:              newItems,
+		OldItems:              oldItems,
+		UnchangedToastColumns: map[string]struct{}{"notes": {}, "metadata": {}},
+		DestinationTableName:  "public.orders",
+	}
+
+	rowBytes, err := buildRawStreamingRow(rec, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var row rawRow
+	if err := json.Unmarshal(rowBytes[:len(rowBytes)-1], &row); err != nil {
+		t.Fatalf("failed to unmarshal row: %v", err)
+	}
+
+	if row.RecordType != 1 {
+		t.Errorf("expected RecordType=1 (UPDATE), got %d", row.RecordType)
+	}
+	if row.MatchData == "" {
+		t.Error("expected non-empty MatchData for UPDATE (old items)")
+	}
+	if row.Data == "" {
+		t.Error("expected non-empty Data for UPDATE (new items)")
+	}
+	// Data and MatchData must differ when old != new
+	if row.Data == row.MatchData {
+		t.Error("expected Data != MatchData when old and new items differ")
+	}
+	// UnchangedToast must be a sorted comma-separated list of the unchanged columns
+	if row.UnchangedToast != "metadata,notes" {
+		t.Errorf("expected UnchangedToast=metadata,notes, got %q", row.UnchangedToast)
+	}
+	if row.DestinationTable != "public.orders" {
+		t.Errorf("expected DestinationTable=public.orders, got %q", row.DestinationTable)
+	}
+}
+
+// TestBuildRawStreamingRow_Delete verifies that a DELETE record produces a raw row
+// with recordType=2 and matchData == data (standard convention for deletes).
+func TestBuildRawStreamingRow_Delete(t *testing.T) {
+	items := model.NewRecordItems(1)
+	items.AddColumn("id", types.QValueInt32{Val: 99})
+
+	rec := &model.DeleteRecord[model.RecordItems]{
+		Items:                items,
+		UnchangedToastColumns: nil,
+		DestinationTableName:  "public.products",
+	}
+
+	rowBytes, err := buildRawStreamingRow(rec, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var row rawRow
+	if err := json.Unmarshal(rowBytes[:len(rowBytes)-1], &row); err != nil {
+		t.Fatalf("failed to unmarshal row: %v", err)
+	}
+
+	if row.RecordType != 2 {
+		t.Errorf("expected RecordType=2 (DELETE), got %d", row.RecordType)
+	}
+	if row.Data == "" {
+		t.Error("expected non-empty Data for DELETE")
+	}
+	// For DELETE, matchData == data (MERGE uses matchData to identify the row to delete)
+	if row.MatchData != row.Data {
+		t.Errorf("expected MatchData == Data for DELETE, got matchData=%q data=%q", row.MatchData, row.Data)
+	}
+	if row.UnchangedToast != "" {
+		t.Errorf("expected empty UnchangedToast for DELETE with nil unchanged cols, got %q", row.UnchangedToast)
+	}
+}
+
+// TestBuildRawStreamingRow_ProducesNDJSON verifies the output always ends with '\n'.
+func TestBuildRawStreamingRow_ProducesNDJSON(t *testing.T) {
+	items := model.NewRecordItems(1)
+	items.AddColumn("x", types.QValueInt32{Val: 1})
+	rec := &model.InsertRecord[model.RecordItems]{
+		Items:                items,
+		DestinationTableName: "t",
+	}
+	b, err := buildRawStreamingRow(rec, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b[len(b)-1] != '\n' {
+		t.Error("expected output to end with newline (NDJSON)")
+	}
+}
+
+// TestBuildRawStreamingRow_UniqueUIDs verifies that two calls produce different UIDs.
+func TestBuildRawStreamingRow_UniqueUIDs(t *testing.T) {
+	items := model.NewRecordItems(1)
+	items.AddColumn("x", types.QValueInt32{Val: 1})
+	rec := &model.InsertRecord[model.RecordItems]{
+		Items:                items,
+		DestinationTableName: "t",
+	}
+
+	b1, err := buildRawStreamingRow(rec, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := buildRawStreamingRow(rec, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var row1, row2 rawRow
+	if err := json.Unmarshal(b1[:len(b1)-1], &row1); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(b2[:len(b2)-1], &row2); err != nil {
+		t.Fatal(err)
+	}
+	if row1.UID == row2.UID {
+		t.Errorf("expected unique UIDs per call, both got %q", row1.UID)
+	}
+}
+
+// ── offsetToken format ────────────────────────────────────────────────────────
+
+// TestOffsetToken_Format verifies that the offsetToken format produced by flushRawBuffer
+// is "<syncBatchID>-<chunkIndex>", which uniquely identifies each chunk across retries.
+func TestOffsetToken_Format(t *testing.T) {
+	syncBatchID := int64(42)
+	flushIndex := 0
+	token := fmt.Sprintf("%d-%d", syncBatchID, flushIndex)
+	if token != "42-0" {
+		t.Errorf("expected offsetToken=42-0, got %q", token)
+	}
+
+	flushIndex++
+	token = fmt.Sprintf("%d-%d", syncBatchID, flushIndex)
+	if token != "42-1" {
+		t.Errorf("expected offsetToken=42-1 after increment, got %q", token)
+	}
+}
+
+// ── channel and manager tests (unchanged from original) ───────────────────────
+
+func TestChannelReopenErrorCodes(t *testing.T) {
+	knownCodes := []string{
+		"ERR_CHANNEL_HAS_INVALID_ROW_SEQUENCER",
+		"ERR_CHANNEL_HAS_INVALID_CLIENT_SEQUENCER",
+		"ERR_CHANNEL_MUST_BE_REOPENED",
+		"ERR_CHANNEL_MUST_BE_REOPENED_DUE_TO_ROW_SEQ_GAP",
+		"ERR_CHANNEL_DOES_NOT_EXIST_OR_IS_NOT_AUTHORIZED",
+		"STALE_PIPE_CACHE",
+	}
+
+	for _, code := range knownCodes {
+		errResp := &StreamingErrorResponse{Code: code, Message: "test"}
+		if !errResp.IsChannelReopenError() {
+			t.Errorf("expected %s to be a channel reopen error", code)
+		}
+	}
+
+	unknownCodes := []string{
+		"SOME_OTHER_ERROR",
+		"INTERNAL_ERROR",
+		"",
+	}
+
+	for _, code := range unknownCodes {
+		errResp := &StreamingErrorResponse{Code: code, Message: "test"}
+		if errResp.IsChannelReopenError() {
+			t.Errorf("expected %s to NOT be a channel reopen error", code)
+		}
+	}
+}
+
+func TestStreamingErrorResponse_Error(t *testing.T) {
+	errResp := &StreamingErrorResponse{
+		Code:    "ERR_CHANNEL_MUST_BE_REOPENED",
+		Message: "channel needs reopen",
+	}
+
+	expected := "snowpipe streaming error ERR_CHANNEL_MUST_BE_REOPENED (http 0): channel needs reopen"
+	if errResp.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, errResp.Error())
+	}
+}
+
+func TestStreamingErrorResponse_ResultHandler(t *testing.T) {
+	raw := `{"code":"ERR_CHANNEL_MUST_BE_REOPENED","message":"channel stale","result_handler":"REOPEN"}`
+	var errResp StreamingErrorResponse
+	if err := json.Unmarshal([]byte(raw), &errResp); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if errResp.Code != "ERR_CHANNEL_MUST_BE_REOPENED" {
+		t.Errorf("expected code ERR_CHANNEL_MUST_BE_REOPENED, got %q", errResp.Code)
+	}
+	if errResp.ResultHandler != "REOPEN" {
+		t.Errorf("expected result_handler=REOPEN, got %q", errResp.ResultHandler)
+	}
+	if !errResp.IsChannelReopenError() {
+		t.Error("expected IsChannelReopenError to be true")
+	}
+}
+
+func TestChannelStatus_JSONParsing(t *testing.T) {
+	raw := `{
+		"channel_statuses": {
+			"peerdb-myjob-raw-0": {
+				"channel_status_code": "OPENED",
+				"rows_inserted": 250,
+				"rows_parsed": 250,
+				"rows_error_count": 3,
+				"last_error_message": "failed to cast TIMESTAMP_TZ to BOOLEAN",
+				"snowflake_avg_processing_latency_ms": 120
+			}
+		}
+	}`
+
+	var response struct {
+		ChannelStatuses map[string]ChannelStatus `json:"channel_statuses"`
+	}
+	if err := json.Unmarshal([]byte(raw), &response); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	status, ok := response.ChannelStatuses["peerdb-myjob-raw-0"]
+	if !ok {
+		t.Fatal("expected channel key not found in response")
+	}
+	if status.RowsInserted != 250 {
+		t.Errorf("expected RowsInserted=250, got %d", status.RowsInserted)
+	}
+	if status.RowsErrorCount != 3 {
+		t.Errorf("expected RowsErrorCount=3, got %d", status.RowsErrorCount)
+	}
+	if status.LastErrorMessage != "failed to cast TIMESTAMP_TZ to BOOLEAN" {
+		t.Errorf("unexpected LastErrorMessage: %q", status.LastErrorMessage)
+	}
+	if status.SnowflakeAvgProcessingLatencyMs != 120 {
+		t.Errorf("expected SnowflakeAvgProcessingLatencyMs=120, got %d", status.SnowflakeAvgProcessingLatencyMs)
+	}
+}
+
+func TestChannelStatus_HasNoErrors(t *testing.T) {
+	status := ChannelStatus{
+		RowsInserted:     10,
+		RowsErrorCount:   0,
+		LastErrorMessage: "",
+	}
+
+	baseline := 5
+	if !(status.RowsInserted >= baseline+5) {
+		t.Error("expected RowsInserted >= baseline+rowsSent for success case")
+	}
+	if status.RowsErrorCount > 0 && status.LastErrorMessage != "" {
+		t.Error("unexpected error in no-error case")
+	}
+}
+
+// TestStreamingChannel_RowsInsertedTracking verifies that the rowsInserted counter is
+// correctly managed through set, get, and invalidate operations.
+func TestStreamingChannel_RowsInsertedTracking(t *testing.T) {
+	ch := &StreamingChannel{}
+
+	if got := ch.getRowsInserted(); got != 0 {
+		t.Errorf("expected initial rowsInserted=0, got %d", got)
+	}
+
+	ch.setRowsInserted(42)
+	if got := ch.getRowsInserted(); got != 42 {
+		t.Errorf("expected rowsInserted=42 after set, got %d", got)
+	}
+
+	ch.setRowsInserted(100)
+	if got := ch.getRowsInserted(); got != 100 {
+		t.Errorf("expected rowsInserted=100 after second set, got %d", got)
+	}
+
+	ch.invalidate()
+	if got := ch.getRowsInserted(); got != 0 {
+		t.Errorf("expected rowsInserted=0 after invalidate, got %d", got)
+	}
+
+	ch.setContinuationToken("tok123")
+	ch.setRowsInserted(55)
+	ch.invalidate()
+	if got := ch.getContinuationToken(); got != "" {
+		t.Errorf("expected empty continuation token after invalidate, got %q", got)
+	}
+	if got := ch.getRowsInserted(); got != 0 {
+		t.Errorf("expected rowsInserted=0 after invalidate (with token), got %d", got)
+	}
+}
+
+// TestStreamingChannelManager_HttpClientTimeout verifies that NewStreamingChannelManager
+// initialises a non-nil httpClient with a configured timeout.
+func TestStreamingChannelManager_HttpClientTimeout(t *testing.T) {
+	m := NewStreamingChannelManager(&gosnowflake.Config{}, nil, 0, 0, DefaultIngestTimeoutSeconds)
+	if m.httpClient == nil {
+		t.Fatal("expected httpClient to be non-nil")
+	}
+	if m.httpClient.Timeout == 0 {
+		t.Error("expected httpClient.Timeout to be non-zero")
+	}
+	if m.httpClient.Transport == nil {
+		t.Error("expected httpClient.Transport to be explicitly configured")
+	}
+	transport, ok := m.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", m.httpClient.Transport)
+	}
+	if transport.MaxIdleConns == 0 {
+		t.Error("expected MaxIdleConns to be configured")
+	}
+}
+
+// TestSyncResponse_NumRecordsSynced verifies the correct sum logic for NumRecordsSynced:
+// it must total InsertCount + UpdateCount + DeleteCount across all tables.
+func TestSyncResponse_NumRecordsSynced(t *testing.T) {
+	tableNameRowsMapping := map[string]*model.RecordTypeCounts{
+		"public.orders":    {},
+		"public.customers": {},
+		"public.products":  {},
+	}
+	tableNameRowsMapping["public.orders"].InsertCount.Store(100)
+	tableNameRowsMapping["public.customers"].UpdateCount.Store(50)
+	tableNameRowsMapping["public.products"].DeleteCount.Store(25)
+
+	var totalRows int64
+	for _, counts := range tableNameRowsMapping {
+		totalRows += int64(counts.InsertCount.Load()) +
+			int64(counts.UpdateCount.Load()) +
+			int64(counts.DeleteCount.Load())
+	}
+	if totalRows != 175 {
+		t.Errorf("expected totalRows=175, got %d", totalRows)
+	}
+}
+
+// TestSyncRecordsViaStreaming_BatchIdGuard documents the idempotency guard logic:
+// when syncBatchID <= lastCommittedBatchID the batch must be skipped.
+func TestSyncRecordsViaStreaming_BatchIdGuard(t *testing.T) {
+	cases := []struct {
+		name        string
+		syncBatchID int64
+		lastBatchID int64
+		shouldSkip  bool
+	}{
+		{"equal_already_committed", 5, 5, true},
+		{"lower_already_committed", 4, 5, true},
+		{"new_batch", 6, 5, false},
+		{"first_batch", 1, 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			skip := tc.syncBatchID <= tc.lastBatchID
+			if skip != tc.shouldSkip {
+				t.Errorf("syncBatchID=%d, lastBatchID=%d: expected shouldSkip=%v, got %v",
+					tc.syncBatchID, tc.lastBatchID, tc.shouldSkip, skip)
+			}
+		})
+	}
+}
+
+// ── StreamingChannel.invalidate ──────────────────────────────────────────────
+
+// TestStreamingChannel_Invalidate_ResetsBoth covers LEARNINGS §1.5: invalidate must
+// clear BOTH continuationToken AND rowsInserted, because Snowflake resets the
+// per-channel rows_inserted counter when the channel is reopened.
+func TestStreamingChannel_Invalidate_ResetsBoth(t *testing.T) {
+	ch := &StreamingChannel{}
+	ch.setContinuationToken("ctok-abc")
+	ch.setRowsInserted(42)
+
+	ch.invalidate()
+
+	if ch.getContinuationToken() != "" {
+		t.Errorf("expected continuationToken to be cleared, got %q", ch.getContinuationToken())
+	}
+	if ch.getRowsInserted() != 0 {
+		t.Errorf("expected rowsInserted to be reset to 0, got %d", ch.getRowsInserted())
+	}
+}
+
+// ── Channel pool routing (B1) ────────────────────────────────────────────────
+
+// TestRouteChannelIdx_BackCompat verifies that with a single channel (default), all
+// rows route to channel 0 — preserving the original "peerdb-{job}-raw-0" channel
+// name and durable offsetTokens for existing mirrors.
+func TestRouteChannelIdx_BackCompat(t *testing.T) {
+	for _, table := range []string{"public.users", "public.orders", "schema.x"} {
+		if got := routeChannelIdx(table, 1); got != 0 {
+			t.Errorf("routeChannelIdx(%q, 1) = %d; want 0", table, got)
+		}
+	}
+}
+
+// TestRouteChannelIdx_ZeroOrNegative defends against misconfiguration: any
+// channel count <= 1 must collapse to channel 0 (no panic, no modulo-by-zero).
+func TestRouteChannelIdx_ZeroOrNegative(t *testing.T) {
+	for _, n := range []int{0, -1, -100} {
+		if got := routeChannelIdx("public.users", n); got != 0 {
+			t.Errorf("routeChannelIdx with channelCount=%d: got %d; want 0", n, got)
+		}
+	}
+}
+
+// TestRouteChannelIdx_PerTableStability verifies that the SAME destination table
+// always routes to the SAME channel index. This is the per-table ordering guarantee
+// required by NormalizeRecords MERGE.
+func TestRouteChannelIdx_PerTableStability(t *testing.T) {
+	const channels = 4
+	for _, table := range []string{"public.users", "public.orders", "schema.events"} {
+		first := routeChannelIdx(table, channels)
+		for i := 0; i < 100; i++ {
+			if got := routeChannelIdx(table, channels); got != first {
+				t.Errorf("routeChannelIdx(%q, %d) not stable: got %d, expected %d", table, channels, got, first)
+			}
+		}
+	}
+}
+
+// TestRouteChannelIdx_Distribution asserts that for a realistic table count, the
+// hash distribution is "reasonable" — at least 2 distinct channels are used when
+// 8 distinct tables route across 4 channels. Strict uniformity is not required;
+// catastrophic skew (everything on one channel) is.
+func TestRouteChannelIdx_Distribution(t *testing.T) {
+	const channels = 4
+	tables := []string{
+		"public.users", "public.orders", "public.products", "public.events",
+		"public.sessions", "public.audit", "public.kv", "public.notifications",
+	}
+	seen := make(map[int]bool, channels)
+	for _, table := range tables {
+		seen[routeChannelIdx(table, channels)] = true
+	}
+	if len(seen) < 2 {
+		t.Errorf("hash distribution catastrophically skewed: only %d/%d channels used across %d tables", len(seen), channels, len(tables))
+	}
+}
+
+// TestRouteChannelIdx_BoundedToCount ensures the returned index is always in [0, n).
+func TestRouteChannelIdx_BoundedToCount(t *testing.T) {
+	const channels = 7
+	for _, table := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"} {
+		idx := routeChannelIdx(table, channels)
+		if idx < 0 || idx >= channels {
+			t.Errorf("routeChannelIdx(%q, %d) = %d; out of bounds", table, channels, idx)
+		}
+	}
+}

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -159,6 +159,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_SNOWFLAKE,
 	},
 	{
+		Name:             "PEERDB_SNOWFLAKE_STREAMING_CHANNELS_PER_FLOW",
+		Description:      "Number of Snowpipe Streaming channels per CDC flow. Rows are dispatched across channels by destination-table-name hash, preserving per-table order while parallelising writes. Default 1; raise (e.g. 4–8) for high-throughput flows. Bounded by Snowflake's 2000 channels/pipe limit.",
+		DefaultValue:     "1",
+		ValueType:        protos.DynconfValueType_INT,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
+		TargetForSetting: protos.DynconfTarget_SNOWFLAKE,
+	},
+	{
 		Name:             "PEERDB_CLICKHOUSE_BINARY_FORMAT",
 		Description:      "Binary field encoding on clickhouse destination; either raw, hex, or base64",
 		DefaultValue:     "raw",
@@ -704,6 +712,13 @@ func PeerDBSnowflakeSkipCompression(ctx context.Context, env map[string]string) 
 
 func PeerDBSnowflakeAutoCompress(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_SNOWFLAKE_AUTO_COMPRESS")
+}
+
+// PeerDBSnowflakeStreamingChannelsPerFlow returns the configured channel-pool size
+// for the Snowpipe Streaming raw-table pipe. Defaults to 1; bounded at runtime by
+// Snowflake's 2000-channels-per-pipe ceiling.
+func PeerDBSnowflakeStreamingChannelsPerFlow(ctx context.Context, env map[string]string) (int64, error) {
+	return dynamicConfSigned[int64](ctx, env, "PEERDB_SNOWFLAKE_STREAMING_CHANNELS_PER_FLOW")
 }
 
 func PeerDBClickHouseAWSS3BucketName(ctx context.Context, env map[string]string) (string, error) {

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -701,6 +701,19 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .get("s3_integration")
                     .map(|s| s.to_string())
                     .unwrap_or_default(),
+                enable_streaming: opts
+                    .get("enable_streaming")
+                    .map(|s| s.parse::<bool>().unwrap_or_default())
+                    .unwrap_or_default(),
+                streaming_rate_limit_per_second: opts
+                    .get("streaming_rate_limit_per_second")
+                    .and_then(|s| s.parse::<i32>().ok()),
+                streaming_max_chunk_bytes: opts
+                    .get("streaming_max_chunk_bytes")
+                    .and_then(|s| s.parse::<i32>().ok()),
+                streaming_ingest_timeout_seconds: opts
+                    .get("streaming_ingest_timeout_seconds")
+                    .and_then(|s| s.parse::<i32>().ok()),
             };
             Config::SnowflakeConfig(snowflake_config)
         }

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -29,6 +29,19 @@ message SnowflakeConfig {
   optional string password = 10 [(peerdb_redacted) = true];
   // defaults to _PEERDB_INTERNAL
   optional string metadata_schema = 11;
+  // When true, CDC records are streamed to the raw staging table via the Snowpipe
+  // Streaming REST API instead of the Avro/S3 COPY INTO path. Requires keypair auth.
+  bool enable_streaming = 12;
+  reserved 13;
+  reserved "streaming_max_channels";
+  // Maximum Snowpipe Streaming API requests per second. Defaults to 10.
+  // Lower this if the Snowflake account quota is below the default.
+  optional int32 streaming_rate_limit_per_second = 14;
+  // Maximum bytes per Snowpipe Streaming chunk. Defaults to 4194304 (4MB — Snowflake hard limit).
+  optional int32 streaming_max_chunk_bytes = 15;
+  // Maximum seconds to wait for Snowflake to confirm row ingestion per flush.
+  // Defaults to 120s. Increase for slow accounts or very large batches.
+  optional int32 streaming_ingest_timeout_seconds = 16;
 }
 
 message GcpServiceAccount {

--- a/scripts/test-snowpipe-streaming.sh
+++ b/scripts/test-snowpipe-streaming.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# test-snowpipe-streaming.sh
+#
+# Exercises the Snowpipe Streaming CDC path end-to-end.
+# Runs against the local dev Postgres (localhost:5436) and prints
+# the expected Snowflake state after each stage so you can verify manually.
+#
+# Usage:
+#   ./scripts/test-snowpipe-streaming.sh [--reset]
+#
+#   --reset   Drop and recreate the test schema before running.
+#
+# Prerequisites:
+#   - peerdb-postgres container healthy (tilt up)
+#   - A PeerDB mirror already created pointing at streaming_test.orders
+#     (see output of --reset for the CREATE MIRROR template)
+
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+PG_HOST="${PG_HOST:-localhost}"
+PG_PORT="${PG_PORT:-5436}"
+PG_USER="${PG_USER:-postgres}"
+PG_PASSWORD="${PG_PASSWORD:-postgres}"
+PG_DATABASE="${PG_DATABASE:-postgres}"
+
+SCHEMA="streaming_test"
+TABLE="orders"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+PSQL="psql -h $PG_HOST -p $PG_PORT -U $PG_USER -d $PG_DATABASE --no-psqlrc -v ON_ERROR_STOP=1"
+
+pg() { PGPASSWORD="$PG_PASSWORD" $PSQL -c "$1"; }
+pg_file() { PGPASSWORD="$PG_PASSWORD" $PSQL -f "$1"; }
+
+step() { echo; echo "────────────────────────────────────────"; echo "▶ $*"; echo "────────────────────────────────────────"; }
+expect() { echo "  EXPECT in Snowflake → $*"; }
+
+# ── Reset (optional) ──────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--reset" ]]; then
+    step "Resetting schema $SCHEMA"
+    pg "DROP SCHEMA IF EXISTS $SCHEMA CASCADE;"
+    pg "CREATE SCHEMA $SCHEMA;"
+
+    pg "
+CREATE TABLE $SCHEMA.$TABLE (
+    id            BIGSERIAL        PRIMARY KEY,
+    order_uuid    UUID             NOT NULL DEFAULT gen_random_uuid(),
+    customer_id   INT              NOT NULL,
+    product_name  TEXT             NOT NULL,
+    quantity      INT              NOT NULL DEFAULT 1,
+    unit_price    NUMERIC(12,4)    NOT NULL,
+    is_fulfilled  BOOLEAN          NOT NULL DEFAULT FALSE,
+    status        VARCHAR(32)      NOT NULL DEFAULT 'pending',
+    notes         TEXT,
+    metadata      JSONB,
+    created_at    TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ      NOT NULL DEFAULT now()
+);
+ALTER TABLE $SCHEMA.$TABLE REPLICA IDENTITY FULL;
+"
+    echo "Schema ready."
+    echo
+    echo "Create the PeerDB mirror now, then rerun without --reset:"
+    echo
+    echo "  CREATE MIRROR streaming_orders_mirror"
+    echo "  FROM pg_source TO sf_streaming"
+    echo "  FOR TABLES ($SCHEMA.$TABLE)"
+    echo "  WITH ("
+    echo "      do_initial_snapshot   = true,"
+    echo "      publication_name      = 'streaming_orders_pub',"
+    echo "      replication_slot_name = 'streaming_orders_slot'"
+    echo "  );"
+    echo
+    exit 0
+fi
+
+# ── Stage 0: initial snapshot seed ────────────────────────────────────────────
+step "Stage 0 — Seed rows (initial snapshot baseline)"
+pg "
+TRUNCATE $SCHEMA.$TABLE RESTART IDENTITY;
+INSERT INTO $SCHEMA.$TABLE (customer_id, product_name, quantity, unit_price, status, notes, metadata)
+VALUES
+    (101, 'Laptop Pro 16\"',        1, 1899.9900, 'pending',    NULL,                  '{\"source\":\"web\",\"promo\":\"SAVE10\"}'),
+    (102, 'Wireless Mouse',          2,   29.9900, 'shipped',   'Handle with care',    '{\"source\":\"mobile\",\"gift\":true}'),
+    (103, 'USB-C Hub',               3,   49.9900, 'pending',    NULL,                  NULL),
+    (104, 'Mechanical Keyboard',     1,  129.9900, 'pending',   'Cherry MX Blue',      '{\"source\":\"web\"}'),
+    (105, 'Monitor 4K 27\"',         2,  499.9900, 'processing', NULL,                 '{\"source\":\"api\",\"batch_id\":42}');
+"
+expect "5 rows, ids 1-5, all statuses as seeded"
+
+# ── Stage 1: plain inserts ─────────────────────────────────────────────────────
+step "Stage 1 — INSERT new rows (CDC INSERT path)"
+pg "
+INSERT INTO $SCHEMA.$TABLE (customer_id, product_name, quantity, unit_price, status, notes, metadata)
+VALUES
+    (201, 'Thunderbolt Dock',           1, 199.9900, 'pending',    NULL,                 '{\"source\":\"web\"}'),
+    (202, 'Webcam 4K',                  1,  89.9900, 'pending',    NULL,                 '{\"source\":\"mobile\"}'),
+    (203, 'NVMe SSD 2TB',               1, 149.9900, 'processing', 'Expedited shipping', '{\"source\":\"api\",\"batch_id\":1}'),
+    (204, 'Noise-Cancelling Headset',   1, 249.9900, 'pending',    NULL,                 NULL),
+    (205, 'Portable Charger 20000mAh',  2,  39.9900, 'pending',    NULL,                 '{\"source\":\"web\",\"promo\":\"BUNDLE5\"}');
+"
+expect "10 rows total, ids 1-10"
+
+# ── Stage 2: updates (TOAST carry-forward) ────────────────────────────────────
+step "Stage 2 — UPDATE status only (TOAST carry-forward: notes must survive)"
+pg "
+UPDATE $SCHEMA.$TABLE SET status = 'shipped',   updated_at = now() WHERE id = 1;
+UPDATE $SCHEMA.$TABLE SET status = 'delivered', updated_at = now() WHERE id = 2;
+"
+expect "id=1: status='shipped',   notes still NULL"
+expect "id=2: status='delivered', notes still 'Handle with care'"
+
+# ── Stage 3: multi-column update ──────────────────────────────────────────────
+step "Stage 3 — UPDATE multiple columns (boolean + text)"
+pg "
+UPDATE $SCHEMA.$TABLE
+SET    is_fulfilled = TRUE, notes = 'Delivered to locker', updated_at = now()
+WHERE  id = 2;
+"
+expect "id=2: is_fulfilled=TRUE, notes='Delivered to locker'"
+
+# ── Stage 4: hard delete ──────────────────────────────────────────────────────
+step "Stage 4 — DELETE (hard-delete path in executeHardDeletes)"
+pg "DELETE FROM $SCHEMA.$TABLE WHERE id = 3;"
+expect "9 rows total; id=3 ABSENT"
+
+# ── Stage 5: batch update ─────────────────────────────────────────────────────
+step "Stage 5 — Batch UPDATE multiple rows"
+pg "
+UPDATE $SCHEMA.$TABLE
+SET    quantity = quantity + 1, updated_at = now()
+WHERE  customer_id IN (104, 105);
+"
+expect "id=4 (customer 104): quantity=2"
+expect "id=5 (customer 105): quantity=3"
+
+# ── Stage 6: special characters in PK-hashed text (Fix 7) ─────────────────────
+step "Stage 6 — INSERT with pipe/quote chars in text (PK hash collision guard)"
+pg "
+INSERT INTO $SCHEMA.$TABLE (customer_id, product_name, quantity, unit_price, status, notes)
+VALUES (301, 'Cable | Adapter \"combo\"', 1, 15.9900, 'pending', 'SKU: A|B\"C');
+"
+expect "id=11: product_name='Cable | Adapter \"combo\"', notes='SKU: A|B\"C' — distinct from any collision"
+
+# ── Stage 7: upsert collision (duplicate PK update) ──────────────────────────
+step "Stage 7 — UPDATE then re-UPDATE same row (idempotency)"
+pg "
+UPDATE $SCHEMA.$TABLE SET status = 'processing', updated_at = now() WHERE id = 6;
+UPDATE $SCHEMA.$TABLE SET status = 'shipped',    updated_at = now() WHERE id = 6;
+"
+expect "id=6: final status='shipped' (last write wins)"
+
+# ── Stage 8: NULL → value and value → NULL ────────────────────────────────────
+step "Stage 8 — NULL <-> value transitions"
+pg "
+UPDATE $SCHEMA.$TABLE SET notes = 'Now has notes', updated_at = now() WHERE id = 7;  -- NULL → value
+UPDATE $SCHEMA.$TABLE SET metadata = NULL,          updated_at = now() WHERE id = 8;  -- value → NULL
+"
+expect "id=7: notes='Now has notes' (was NULL)"
+expect "id=8: metadata=NULL (was JSON object)"
+
+# ── Stage 9: second delete ────────────────────────────────────────────────────
+step "Stage 9 — DELETE another row"
+pg "DELETE FROM $SCHEMA.$TABLE WHERE id = 9;"
+expect "8 rows total; ids 3 and 9 ABSENT"
+
+# ── Final source state ────────────────────────────────────────────────────────
+step "Final Postgres state"
+PGPASSWORD="$PG_PASSWORD" $PSQL -c "
+SELECT id, customer_id, product_name, quantity, status, is_fulfilled,
+       left(notes, 25)    AS notes,
+       left(metadata::text, 30) AS metadata
+FROM   $SCHEMA.$TABLE
+ORDER BY id;
+"
+
+echo
+echo "════════════════════════════════════════"
+echo "All stages applied. Now verify in Snowflake:"
+echo
+echo "  SELECT id, customer_id, product_name, quantity, status, is_fulfilled, notes"
+echo "  FROM   <DB>.STREAMING_TEST.ORDERS"
+echo "  ORDER BY id;"
+echo
+echo "  -- Missing rows (hard-deleted): 3, 9"
+echo "  SELECT id FROM <DB>.STREAMING_TEST.ORDERS WHERE id IN (3, 9);"
+echo "════════════════════════════════════════"

--- a/ui/app/peers/create/[peerType]/helpers/sf.ts
+++ b/ui/app/peers/create/[peerType]/helpers/sf.ts
@@ -65,6 +65,15 @@ export const snowflakeSetting: PeerSetting[] = [
     tips: 'This is needed only if the private key you provided is encrypted.',
     helpfulLink: 'https://docs.snowflake.com/en/user-guide/key-pair-auth',
   },
+  {
+    label: 'Enable Snowpipe Streaming',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, enableStreaming: value as boolean })),
+    type: 'switch',
+    optional: true,
+    tips: 'When enabled, CDC records are streamed to the raw staging table via the Snowpipe Streaming REST API, then merged into the destination table via the standard normalize step. Eliminates the Avro→S3→COPY staging hop, reducing CDC latency from minutes to seconds. Requires keypair auth.',
+    helpfulLink: 'https://docs.snowflake.com/en/user-guide/snowpipe-streaming',
+  },
 ];
 
 export const blankSnowflakeSetting: SnowflakeConfig = {
@@ -76,4 +85,5 @@ export const blankSnowflakeSetting: SnowflakeConfig = {
   role: '',
   queryTimeout: 30,
   s3Integration: '',
+  enableStreaming: false,
 };

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -257,6 +257,7 @@ export const sfSchema = z.object({
     })
     .max(255, 's3Integration must be less than 255 characters')
     .optional(),
+  enableStreaming: z.boolean().optional(),
 });
 
 export const bqSchema = z.object({

--- a/ui/components/PeerForms/SnowflakeForm.tsx
+++ b/ui/components/PeerForms/SnowflakeForm.tsx
@@ -4,7 +4,9 @@ import { PeerSetter } from '@/app/dto/PeersDTO';
 import { PeerSetting } from '@/app/peers/create/[peerType]/helpers/common';
 import InfoPopover from '@/components/InfoPopover';
 import { Label } from '@/lib/Label';
-import { RowWithTextField } from '@/lib/Layout';
+
+import { RowWithSwitch, RowWithTextField } from '@/lib/Layout';
+import { Switch } from '@/lib/Switch';
 import { TextField } from '@/lib/TextField';
 import { Tooltip } from '@/lib/Tooltip';
 import { handleFieldChange } from './common';
@@ -18,7 +20,38 @@ export default function SnowflakeForm(props: ConfigProps) {
   return (
     <>
       {props.settings.map((setting, id) => {
-        return (
+        return setting.type === 'switch' ? (
+          <RowWithSwitch
+            key={id}
+            label={
+              <Label>
+                {setting.label}{' '}
+                {!setting.optional && (
+                  <Tooltip
+                    style={{ width: '100%' }}
+                    content='This is a required field.'
+                  >
+                    <Label colorName='lowContrast' colorSet='destructive'>
+                      *
+                    </Label>
+                  </Tooltip>
+                )}
+              </Label>
+            }
+            action={
+              <div>
+                <Switch
+                  onCheckedChange={(val: boolean) =>
+                    setting.stateHandler(val, props.setter)
+                  }
+                />
+                {setting.tips && (
+                  <InfoPopover tips={setting.tips} link={setting.helpfulLink} />
+                )}
+              </div>
+            }
+          />
+        ) : (
           <RowWithTextField
             key={id}
             label={


### PR DESCRIPTION
## Motivation

This feature aims to reduce Snowflake compute costs and end-to-end CDC latency by leveraging Snowpipe Streaming v2 capabilities. Instead of staging AVRO files and running costly MERGE operations, CDC rows are streamed to a raw table and merged efficiently. This approach takes advantage of Snowpipe Streaming's lower-latency, cost-effective ingestion path, but needs further assessment for production reliability and performance.
## Summary

**Experimental:** This PR adds initial support for Snowpipe Streaming to the Snowflake connector as an opt-in CDC sync path. When `enable_streaming` is set on a Snowflake peer, CDC rows are written to a raw staging table in the `_INTERNAL` schema via the [Snowpipe Streaming REST API](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-overview), and then merged into the destination table by PeerDB's standard normalize step. This bypasses the AVRO/S3 staging flow.

## Notes

- This feature is experimental and open to feedback or suggestions.
- CDC rows are written to a raw table in the `_PEERDB_INTERNAL` schema (`_PEERDB_STREAMING_<job>`) and then merged into the destination table by the existing normalize step (not direct-to-destination yet).
- **Initial snapshot is unchanged** — bulk loads still use the Avro/COPY path. Only the CDC path uses Snowpipe Streaming.
- **Pipe lifecycle:** the per-mirror pipe (`<JOB>_STREAMING_PIPE`) is created once via `CREATE PIPE IF NOT EXISTS` against a fixed raw-table column list. The DDL is idempotent across sync batches and does not invalidate channels — channel `offsetToken`s remain valid for retry idempotency.
- **Schema evolution:** source-schema changes do not touch the streaming pipe. New columns are absorbed by the JSON `_PEERDB_DATA` blob on the raw table and projected into destination tables by the MERGE step (which adds new columns via `ALTER TABLE … ADD COLUMN IF NOT EXISTS`).
- **TOAST carry-forward** is supported via `_PEERDB_UNCHANGED_TOAST_COLUMNS` — when an UPDATE doesn't touch a TOAST'd column, the prior destination value is preserved.
- The streaming path is only used if `enable_streaming` is set on the peer; existing AVRO-based flows are unaffected.

## Usage

1. Create or update a Snowflake peer with `enable_streaming = true`.
2. Grant the Snowflake role:
   ```sql
   GRANT CREATE PIPE   ON SCHEMA <DB>.<SCHEMA> TO ROLE <ROLE>;
   GRANT EVOLVE SCHEMA ON SCHEMA <DB>.<SCHEMA> TO ROLE <ROLE>;
   GRANT USAGE         ON DATABASE <DB>        TO ROLE <ROLE>;
   ```
3. Create a CDC mirror targeting that peer.

## Testing

**Unit tests:**

```bash
cd flow && go test ./connectors/snowflake/... \
  -run "TestRaw|TestBuild|TestOffset|TestChannel|TestSync|TestStreaming|TestPrepare|TestExtract|TestRoute"
```

**Integration (full smoke test):**

The repository ships an opt-in skill at `.claude/skills/skills/peerdb-snowpipe-test/` that drives the full Postgres → Snowflake CDC quickstart against a real Snowflake account using `dev-peerdb.sh`. It covers preflight, mirror creation, the standard CDC workload, TOAST carry-forward (via `scripts/toast_carry_forward.sql`), schema evolution, and idempotency on worker restart.

Manual checklist:

1. Create a CDC mirror with `enable_streaming = true` on the Snowflake peer.
2. Insert rows on the source — confirm they appear in Snowflake within a couple of minutes.
3. Run `ALTER TABLE … ADD COLUMN` on the source — confirm the new column is populated in Snowflake on the batch after the schema change.
4. Issue DELETEs — confirm soft-delete rows appear with `_PEERDB_IS_DELETED = true`.
5. UPDATE only a non-TOAST column on a row whose TOAST column holds a >2 KB blob — confirm the blob is preserved on the destination side.
6. Kill the flow-worker mid-activity and restart — confirm no duplicate rows after recovery (`syncRecordsViaStreaming` short-circuits on already-committed batches via `GetLastSyncBatchID`).

---

Please review and share any opinions or concerns. All feedback is welcome!
