### PR TITLE
chore: rebrand fork to peerflake (public-facing only)

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,58 @@
+# Fork policy
+
+## Background
+
+Peerflake is a community fork of [PeerDB](https://github.com/PeerDB-io/peerdb), maintained independently as a non-commercial open-source project. The fork exists to:
+
+- Qualify for [LocalStack's free OSS license](https://www.localstack.cloud/localstack-open-source) to enable Snowflake destination testing without a paid Snowflake account.
+- Provide a non-commercial home for community contributions, especially around testing infrastructure (LocalStack Snowflake emulator integration).
+
+## Goals
+
+- Track upstream PeerDB closely
+- Stay byte-identical internally to enable easy syncing and upstreaming
+- Maintain AGPLv3 compliance
+- Enable LocalStack-based Snowflake emulator testing in CI
+
+## What's different from upstream
+
+- Repository name, branding, Docker image name
+- Additional CI workflows for LocalStack-based testing
+- This `FORK.md`, `NOTICE`, and updated `README.md`
+
+Everything else should match upstream.
+
+## Sync schedule
+
+Upstream PeerDB is merged into `main` on demand (weekly or when important fixes land).
+
+```bash
+# Weekly sync
+git fetch upstream
+git checkout main
+git merge upstream/main
+# Conflicts should be minimal — only in README, NOTICE, Dockerfile,
+# docker-bake.hcl, and CI workflow files (the things we renamed).
+# Resolve by keeping fork's branding and upstream's logic.
+git push origin main
+```
+
+## Contribution flow
+
+1. Bug fixes and improvements developed here are upstreamed to PeerDB when applicable (clean diffs, no rename noise).
+2. Fork-specific changes (CI, LocalStack integration, branding) live only in this repo.
+
+## Upstreaming workflow
+
+```bash
+# Develop fix on a feature branch
+git checkout -b fix/some-bug
+# ... make changes to internal code (which is identical to upstream) ...
+git commit
+
+# Push to upstream PeerDB
+git push origin fix/some-bug
+# Open PR against PeerDB-io/peerdb on GitHub
+```
+
+Because internal naming is unchanged, the diff is clean and ready for upstream review.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+Peerflake
+Copyright (c) 2025 Peerflake contributors
+
+This product is a fork of PeerDB (https://github.com/PeerDB-io/peerdb),
+originally developed by PeerDB Inc. and currently maintained by ClickHouse Inc.
+
+The original PeerDB project is licensed under the GNU Affero General Public
+License v3.0 (AGPLv3). This fork retains the same license.
+
+All copyright notices in source files belong to their respective original
+authors and have been preserved.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
+# Peerflake
 
-<div align="center">
+> Peerflake is a community fork of [PeerDB](https://github.com/PeerDB-io/peerdb),
+> originally created by the PeerDB team (now part of ClickHouse Inc.).
+>
+> This fork is maintained independently as a non-commercial open-source project,
+> primarily to enable Snowflake destination testing via LocalStack's free OSS tier.
+>
+> Internal code, package names, and environment variables remain identical to
+> upstream PeerDB to keep the fork easy to sync and to allow contributions to
+> flow back upstream.
 
-<img src="images/banner.jpg" alt="PeerDB Banner" width="512" />
+## What is Peerflake / PeerDB?
 
-#### Frustratingly simple ETL for Postgres
+A fast, simple and cost effective way to stream data from Postgres to Data Warehouses, Queues and Storage engines. If you are running Postgres at the heart of your data-stack and move data at scale from Postgres to any of the above targets, Peerflake can provide value.
 
-[![Workflow Status](https://github.com/PeerDB-io/peerdb/actions/workflows/ci.yml/badge.svg)](https://github.com/Peerdb-io/peerdb/actions/workflows/ci.yml)
-[![ElV2 License](https://badgen.net/badge/License/Elv2/green?icon=github)](https://github.com/PeerDB-io/peerdb/blob/main/LICENSE.md)
-[![Slack Community](https://img.shields.io/badge/slack-peerdb-brightgreen.svg?logo=slack)](https://slack.peerdb.io)
+We support different modes of streaming — log based (CDC), cursor based (timestamp or integer) and XMIN based. Performance wise, we are 10x faster than existing tools. Features wise, we support native Postgres features such as comprehensive set of data-types incl. jsonb/arrays/geospatial, efficiently streaming TOAST columns, schema changes and so on.
 
-</div>
-
-## PeerDB
-
-At PeerDB, we are building a fast, simple and the most cost effective way to stream data from Postgres to Data Warehouses, Queues and Storage engines. If you are running Postgres at the heart of your data-stack and move data at scale from Postgres to any of the above targets, PeerDB can provide value.
-
-We support different modes of streaming - log based (CDC), cursor based (timestamp or integer) and XMIN based. Performance wise, we are 10x faster than existing tools. Features wise, we support native Postgres features such as comprehensive set of data-types incl. jsonb/arrays/geospatial, efficiently streaming TOAST columns, schema changes and so on.
+For detailed upstream documentation, see the [PeerDB docs](https://docs.peerdb.io/introduction).
 
 ## Get started
 
 ```bash
-git clone git@github.com:PeerDB-io/peerdb.git
-cd peerdb
+git clone git@github.com:JGustavo0/peerflake.git
+cd peerflake
 
-# Run docker containers: postgres as catalog, temporal, PeerDB server, PeerDB flow API + workers, PeerDB UI
+# Run docker containers: postgres as catalog, temporal, server, flow API + workers, UI
 # Requires docker and docker-compose installed: https://docs.docker.com/engine/install/
 bash ./run-peerdb.sh
 # OR for local development, images will be built locally.
@@ -32,64 +33,20 @@ bash ./run-peerdb.sh
 bash ./generate-protos.sh
 bash ./dev-peerdb.sh
 
-# connect to peerdb and query away (Use psql version >=14.0)
+# connect and query away (Use psql version >=14.0)
 psql "port=9900 host=localhost password=peerdb"
 ```
 
-<img src="images/peerdb-demo.gif" width="512" />
-
 ### **IMPORTANT: Ensuring ClickHouse Access to MinIO**
 
-If your ClickHouse DB runs outside Docker (e.g., on VMs or ClickHouse Cloud), it may not have access to MinIO, which is used by PeerDB internally to stage files before loading them. Ensure ClickHouse has network access to MinIO.
+If your ClickHouse DB runs outside Docker (e.g., on VMs or ClickHouse Cloud), it may not have access to MinIO, which is used internally to stage files before loading them. Ensure ClickHouse has network access to MinIO.
 
-PeerDB stages PostgreSQL data in MinIO within the Docker stack. Since ClickHouse is outside Docker, it needs a resolvable hostname for MinIO.
-
-Update `docker-compose.yml` and set `AWS_ENDPOINT_URL_S3` to MinIO's accessible IP (from both PeerDB and ClickHouse):
+Update `docker-compose.yml` and set `AWS_ENDPOINT_URL_S3` to MinIO's accessible IP:
 ```yaml
-AWS_ENDPOINT_URL_S3: http://172.31.26.57:9001 # Change this to IP/host which is accessible by both PeerDB and ClickHouse
+AWS_ENDPOINT_URL_S3: http://172.31.26.57:9001 # Change this to IP/host which is accessible by both Peerflake and ClickHouse
 ```
 
 Rerun Docker Compose to apply changes. On AWS/GCP/Azure, also ensure the security group allows inbound access to MinIO.
-
-Follow this 5-minute [Quickstart Guide](https://docs.peerdb.io/quickstart#quickstart) to see PeerDB in action i.e. streaming data in real-time across stores.
-
-## Why PeerDB
-
-Current data tools prioritize a wide range of connectors, often neglecting to optimize for Postgres users. This can be problematic for those storing large amounts of data in Postgres and frequently transferring it. As a result, many resort to building custom pipelines when existing tools don't meet their needs. We've developed this project to provide a straightforward and reliable solution specifically for Postgres.
-
-### Postgres-first Approach
-
-PeerDB is an ETL/ELT tool built for PostgreSQL. We implement multiple Postgres native and infrastructural optimizations to provide a fast, reliable and a feature-rich experience for moving data in/out of PostgreSQL.
-
-**For performance** -  we can parallelize initial load for a large table, still ensuring consistency. Syncing 100s of GB reduces from days to minutes. Our architecture is designed for real-time syncs and implements multiple logical replication related optimizations (e.g., tuning Postgres configs, parallel reading of slot). This enables 10x faster Change Data Capture with data-freshness of a few 10s of seconds even at large throughputs (10k+ tps).
-
-**For reliability**, we have mechanisms in place for fault tolerance - state management, automatic retries, handling idempotency and consistency and so on (<https://blog.peerdb.io/using-temporal-to-scale-data-synchronization-at-peerdb>). Configurable batching and parallelism prevent out of memory (OOMs) and crashes.
-
-**From a feature richness standpoint**, we support efficient syncing of tables with large (TOAST) columns. We support multiple streaming modes - log based (CDC), cursor based (timestamp or integer) and XMIN based. We provide rich data-type mapping and plan to support every possible type (incl. Custom types) that Postgres supports to the best extent possible on the target data-store.
-
-### Now available natively in ClickHouse Cloud (Generally Available)
-
-PeerDB is now available natively in ClickHouse Cloud (Generally Available). Learn more about it [here](https://clickhouse.com/cloud/clickpipes/postgres-cdc-connector).
-
-<a href="https://clickhouse.com/cloud/clickpipes/postgres-cdc-connector">
-<img src="images/in-clickpipes.png" width="512" />
-</a>
-
-#### **Postgres-compatible SQL interface to do ETL**
-
-The Postgres-compatible SQL interface for ETL is unique to PeerDB and enables you to operate in a language you are familiar with. You can do ETL the same way you work with your databases.
-
-You can use Postgres’ ecosystem to manage your ETL —
-
-1. Client tools like pgAdmin, psql to run SQL commands.
-2. BI tools like Grafana, Tableau to visually monitor syncs and transforms.
-3. Database migration and versioning tools like Flyway to manage your ETL.
-4. Any language (e.g., Python, Go, Node.js) and Scheduler (Airflow) for development.
-5. And many more.
-
-## Status
-
-We have expanded our connector ecosystem to support multiple source connectors beyond Postgres, including MySQL and MongoDB. You can check the status of connectors [here](https://docs.peerdb.io/sql/commands/supported-connectors)
 
 ## Local End to End testing
 
@@ -105,7 +62,7 @@ go test -v -run TestGenericCH_MySQL ./e2e/
 
 Or local debugging sessions.
 
-These tests require both PeerDB services, source and destination stores to be running. We provide a local environment with all the necessary services and dependencies to run these tests.
+These tests require both Peerflake services, source and destination stores to be running. We provide a local environment with all the necessary services and dependencies to run these tests.
 
 This is done through [Tilt](https://tilt.dev/) orchestrated Docker compose.
 
@@ -201,11 +158,12 @@ MONGODB_VERSION=4.4
 CLICKHOUSE_VERSION=21.8
 ```
 
-## Support
+## Upstream
 
-Our docs can be found [here](https://docs.peerdb.io/introduction). If you have any questions, feel free to drop by our [Slack](https://slack.peerdb.io/)!
+This is a fork of [PeerDB](https://github.com/PeerDB-io/peerdb). See [FORK.md](FORK.md) for fork policy and sync workflow.
 
+For upstream docs, visit [docs.peerdb.io](https://docs.peerdb.io/introduction). For upstream community, join the [PeerDB Slack](https://slack.peerdb.io/).
 
 ## License
 
-PeerDB is licensed under GNU Affero General Public License v3.0 (AGPLv3). Please see the LICENSE file for additional information. If you have any licensing questions please email **<db-integrations-support@clickhouse.com>**
+Peerflake is licensed under GNU Affero General Public License v3.0 (AGPLv3), the same license as the original PeerDB project. Please see the [LICENSE](LICENSE) file for additional information.


### PR DESCRIPTION
- Renames README, NOTICE, Docker image registry/names

- Internal code (Go packages, imports, env vars, UI) intentionally unchanged to preserve sync compatibility with upstream PeerDB

- See FORK.md for fork policy