### PR TITLE
Pin pgx to v5.9.1

### DIFF
--- a/flow/cmd/check_pinned_versions/main.go
+++ b/flow/cmd/check_pinned_versions/main.go
@@ -22,6 +22,7 @@ var pinnedVersions = map[string]string{
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager": "v1.21.0",
 	"google.golang.org/api":                           "v0.257.0",
 	"github.com/tikv/pd/client":                       "v0.0.0-20251229071808-6173d50c004c",
+	"github.com/jackc/pgx/v5":                         "v5.9.1",
 }
 
 func main() {

--- a/flow/go.mod
+++ b/flow/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/hamba/avro/v2 v2.31.0
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pglogrepl v0.0.0-20251213150135-2e8d0df862c1
-	github.com/jackc/pgx/v5 v5.9.1
+	github.com/jackc/pgx/v5 v5.9.1 // PINNED: v5.9.2 enables Postgres wire protocol v3.2 by default which changes macaddr[] decoding
 	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12
 	github.com/lestrrat-go/httprc/v3 v3.0.5
@@ -338,6 +338,7 @@ exclude (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.15
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.17
+	github.com/jackc/pgx/v5 v5.9.2
 	google.golang.org/api v0.258.0
 	google.golang.org/api v0.259.0
 	google.golang.org/api v0.260.0

--- a/renovate.json5
+++ b/renovate.json5
@@ -78,6 +78,11 @@
       "matchPackageNames": ["github.com/tikv/pd/client"],
       "allowedVersions": "v0.0.0-20251229071808-6173d50c004c"
     },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/jackc/pgx/v5"],
+      "allowedVersions": "v5.9.1"
+    },
     // This package rule instruct renovate to require approval from
     // the dependency dashboard before proposing major upgrades.
     // This sets a default is approval mindset for automatic proposals.


### PR DESCRIPTION
## Summary
- Pin `github.com/jackc/pgx/v5` to `v5.9.1` and exclude `v5.9.2` in `flow/go.mod`.
- v5.9.2 flips the `max_protocol_version` default to auto-upgrade to Postgres wire protocol v3.2 (jackc/pgx@2f81f1fc, PR [#2526](https://github.com/jackc/pgx/pull/2526)), which changes decoding of `macaddr[]` — elements come back as raw 6-byte strings via `pgtype.Array[string]`.
- Add `github.com/jackc/pgx/v5` to the pinned-versions checker and Renovate `allowedVersions` rule so future upgrades stay capped at v5.9.1.

Created a task under Maintenance to upgrade