### PR TITLE
feat(resync): Add support to update snapshot config (max_parallel_workers, num_tables, rows_per_partition) during resync signal

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -503,10 +503,9 @@ func (h *FlowRequestHandler) FlowStateChange(
 
 				config.Resync = true
 				config.DoInitialSnapshot = true
-				// Override Snapshot Parameters
-				overrideSnapshotParametersInResync(req, config)
 
 				// validate mirror first because once the mirror is dropped, there's no going back
+				// Note: We do not validate snapshot parameters (SnapshotNumRowsPerPartition, etc)
 				if _, err := h.ValidateCDCMirror(ctx, &protos.CreateCDCFlowRequest{
 					ConnectionConfigs: config,
 				}); err != nil {

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -422,7 +422,6 @@ func (h *FlowRequestHandler) FlowStateChange(
 	ctx context.Context,
 	req *protos.FlowStateChangeRequest,
 ) (*protos.FlowStateChangeResponse, APIError) {
-	// Flow-API
 	logs := slog.String(string(shared.FlowNameKey), req.FlowJobName)
 	slog.InfoContext(ctx, "FlowStateChange called", logs, slog.Any("req", req))
 	if underMaintenance, err := internal.PeerDBMaintenanceModeEnabled(ctx, nil); err != nil {
@@ -554,16 +553,15 @@ func (h *FlowRequestHandler) FlowStateChange(
 }
 
 func overrideSnapshotParametersInResync(req *protos.FlowStateChangeRequest, configs *protos.FlowConnectionConfigs) {
-	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil {
-		cdcConfigUpdate := req.FlowConfigUpdate.GetCdcFlowConfigUpdate()
-		if cdcConfigUpdate.SnapshotMaxParallelWorkers > 0 {
-			configs.SnapshotMaxParallelWorkers = cdcConfigUpdate.SnapshotMaxParallelWorkers
+	if u := req.GetFlowConfigUpdate().GetCdcFlowConfigUpdate(); u != nil {
+		if u.SnapshotMaxParallelWorkers > 0 {
+			configs.SnapshotMaxParallelWorkers = u.SnapshotMaxParallelWorkers
 		}
-		if cdcConfigUpdate.SnapshotNumTablesInParallel > 0 {
-			configs.SnapshotNumTablesInParallel = cdcConfigUpdate.SnapshotNumTablesInParallel
+		if u.SnapshotNumTablesInParallel > 0 {
+			configs.SnapshotNumTablesInParallel = u.SnapshotNumTablesInParallel
 		}
-		if cdcConfigUpdate.SnapshotNumRowsPerPartition > 0 {
-			configs.SnapshotNumRowsPerPartition = cdcConfigUpdate.SnapshotNumRowsPerPartition
+		if u.SnapshotNumRowsPerPartition > 0 {
+			configs.SnapshotNumRowsPerPartition = u.SnapshotNumRowsPerPartition
 		}
 	}
 }

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -447,8 +447,12 @@ func (h *FlowRequestHandler) FlowStateChange(
 	}
 
 	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil &&
-		// Don't allow config updates if the flow is already in a terminal state since it can lead to confusion where the config is updated but the flow is not reflecting those changes since it's already completed/failed
-		(currState != protos.FlowStatus_STATUS_TERMINATED && currState != protos.FlowStatus_STATUS_TERMINATING && currState != protos.FlowStatus_STATUS_FAILED && currState != protos.FlowStatus_STATUS_COMPLETED) {
+		// Don't allow config updates if the flow is already in a terminal state since it can lead to confusion
+		//  where the config is updated but the flow is not reflecting those changes since it's already completed/failed
+		(currState != protos.FlowStatus_STATUS_TERMINATED &&
+			currState != protos.FlowStatus_STATUS_TERMINATING &&
+			currState != protos.FlowStatus_STATUS_FAILED &&
+			currState != protos.FlowStatus_STATUS_COMPLETED) {
 		if err := model.CDCDynamicPropertiesSignal.SignalClientWorkflow(
 			ctx,
 			h.temporalClient,

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -446,7 +446,9 @@ func (h *FlowRequestHandler) FlowStateChange(
 		return nil, NewInternalApiError(err)
 	}
 
-	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil {
+	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil &&
+		// Don't allow config updates if the flow is already in a terminal state since it can lead to confusion where the config is updated but the flow is not reflecting those changes since it's already completed/failed
+		(currState != protos.FlowStatus_STATUS_TERMINATED && currState != protos.FlowStatus_STATUS_TERMINATING && currState != protos.FlowStatus_STATUS_FAILED && currState != protos.FlowStatus_STATUS_COMPLETED) {
 		if err := model.CDCDynamicPropertiesSignal.SignalClientWorkflow(
 			ctx,
 			h.temporalClient,
@@ -484,7 +486,8 @@ func (h *FlowRequestHandler) FlowStateChange(
 			}
 		case protos.FlowStatus_STATUS_RESYNC:
 			if currState == protos.FlowStatus_STATUS_COMPLETED || currState == protos.FlowStatus_STATUS_FAILED {
-				changeErr = h.resyncByRecreatingFlow(ctx, req.FlowJobName, req.DropMirrorStats)
+				changeErr = h.resyncByRecreatingFlow(ctx, req.FlowJobName, req.DropMirrorStats,
+					req.FlowConfigUpdate.GetCdcFlowConfigUpdate())
 				if changeErr == nil {
 					telemetry.LogActivityResyncFlow(ctx, req.FlowJobName)
 					h.alerter.LogFlowInfo(ctx, req.FlowJobName, "Mirror resync signaled")
@@ -651,10 +654,29 @@ func (h *FlowRequestHandler) getWorkflowID(ctx context.Context, flowJobName stri
 	return workflowID, nil
 }
 
+func applySnapshotConfigOverrides(config *protos.FlowConnectionConfigs, update *protos.CDCFlowConfigUpdate) {
+	if update == nil {
+		return
+	}
+	if update.SnapshotNumRowsPerPartition > 0 {
+		config.SnapshotNumRowsPerPartition = update.SnapshotNumRowsPerPartition
+	}
+	if update.SnapshotNumPartitionsOverride > 0 {
+		config.SnapshotNumPartitionsOverride = update.SnapshotNumPartitionsOverride
+	}
+	if update.SnapshotMaxParallelWorkers > 0 {
+		config.SnapshotMaxParallelWorkers = update.SnapshotMaxParallelWorkers
+	}
+	if update.SnapshotNumTablesInParallel > 0 {
+		config.SnapshotNumTablesInParallel = update.SnapshotNumTablesInParallel
+	}
+}
+
 func (h *FlowRequestHandler) resyncByRecreatingFlow(
 	ctx context.Context,
 	flowName string,
 	dropStats bool,
+	cdcConfigUpdate *protos.CDCFlowConfigUpdate,
 ) error {
 	if underMaintenance, err := internal.PeerDBMaintenanceModeEnabled(ctx, nil); err != nil {
 		return fmt.Errorf("unable to get maintenance mode status: %w", err)
@@ -682,6 +704,7 @@ func (h *FlowRequestHandler) resyncByRecreatingFlow(
 
 	config.Resync = true
 	config.DoInitialSnapshot = true
+	applySnapshotConfigOverrides(config, cdcConfigUpdate)
 	// validate mirror first because once the mirror is dropped, there's no going back
 	if _, err := h.ValidateCDCMirror(ctx, &protos.CreateCDCFlowRequest{
 		ConnectionConfigs: config,

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -422,6 +422,7 @@ func (h *FlowRequestHandler) FlowStateChange(
 	ctx context.Context,
 	req *protos.FlowStateChangeRequest,
 ) (*protos.FlowStateChangeResponse, APIError) {
+	// Flow-API
 	logs := slog.String(string(shared.FlowNameKey), req.FlowJobName)
 	slog.InfoContext(ctx, "FlowStateChange called", logs, slog.Any("req", req))
 	if underMaintenance, err := internal.PeerDBMaintenanceModeEnabled(ctx, nil); err != nil {
@@ -503,6 +504,9 @@ func (h *FlowRequestHandler) FlowStateChange(
 
 				config.Resync = true
 				config.DoInitialSnapshot = true
+				// Override Snapshot Parameters
+				overrideSnapshotParametersInResync(req, config)
+
 				// validate mirror first because once the mirror is dropped, there's no going back
 				if _, err := h.ValidateCDCMirror(ctx, &protos.CreateCDCFlowRequest{
 					ConnectionConfigs: config,
@@ -547,6 +551,21 @@ func (h *FlowRequestHandler) FlowStateChange(
 	}
 
 	return &protos.FlowStateChangeResponse{}, nil
+}
+
+func overrideSnapshotParametersInResync(req *protos.FlowStateChangeRequest, configs *protos.FlowConnectionConfigs) {
+	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil {
+		cdcConfigUpdate := req.FlowConfigUpdate.GetCdcFlowConfigUpdate()
+		if cdcConfigUpdate.SnapshotMaxParallelWorkers > 0 {
+			configs.SnapshotMaxParallelWorkers = cdcConfigUpdate.SnapshotMaxParallelWorkers
+		}
+		if cdcConfigUpdate.SnapshotNumTablesInParallel > 0 {
+			configs.SnapshotNumTablesInParallel = cdcConfigUpdate.SnapshotNumTablesInParallel
+		}
+		if cdcConfigUpdate.SnapshotNumRowsPerPartition > 0 {
+			configs.SnapshotNumRowsPerPartition = cdcConfigUpdate.SnapshotNumRowsPerPartition
+		}
+	}
 }
 
 func (h *FlowRequestHandler) handleCancelWorkflow(ctx context.Context, workflowID, runID string) error {

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -551,20 +551,6 @@ func (h *FlowRequestHandler) FlowStateChange(
 	return &protos.FlowStateChangeResponse{}, nil
 }
 
-func overrideSnapshotParametersInResync(req *protos.FlowStateChangeRequest, configs *protos.FlowConnectionConfigs) {
-	if u := req.GetFlowConfigUpdate().GetCdcFlowConfigUpdate(); u != nil {
-		if u.SnapshotMaxParallelWorkers > 0 {
-			configs.SnapshotMaxParallelWorkers = u.SnapshotMaxParallelWorkers
-		}
-		if u.SnapshotNumTablesInParallel > 0 {
-			configs.SnapshotNumTablesInParallel = u.SnapshotNumTablesInParallel
-		}
-		if u.SnapshotNumRowsPerPartition > 0 {
-			configs.SnapshotNumRowsPerPartition = u.SnapshotNumRowsPerPartition
-		}
-	}
-}
-
 func (h *FlowRequestHandler) handleCancelWorkflow(ctx context.Context, workflowID, runID string) error {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()

--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -658,24 +658,6 @@ func (h *FlowRequestHandler) getWorkflowID(ctx context.Context, flowJobName stri
 	return workflowID, nil
 }
 
-func applySnapshotConfigOverrides(config *protos.FlowConnectionConfigs, update *protos.CDCFlowConfigUpdate) {
-	if update == nil {
-		return
-	}
-	if update.SnapshotNumRowsPerPartition > 0 {
-		config.SnapshotNumRowsPerPartition = update.SnapshotNumRowsPerPartition
-	}
-	if update.SnapshotNumPartitionsOverride > 0 {
-		config.SnapshotNumPartitionsOverride = update.SnapshotNumPartitionsOverride
-	}
-	if update.SnapshotMaxParallelWorkers > 0 {
-		config.SnapshotMaxParallelWorkers = update.SnapshotMaxParallelWorkers
-	}
-	if update.SnapshotNumTablesInParallel > 0 {
-		config.SnapshotNumTablesInParallel = update.SnapshotNumTablesInParallel
-	}
-}
-
 func (h *FlowRequestHandler) resyncByRecreatingFlow(
 	ctx context.Context,
 	flowName string,
@@ -708,11 +690,16 @@ func (h *FlowRequestHandler) resyncByRecreatingFlow(
 
 	config.Resync = true
 	config.DoInitialSnapshot = true
-	applySnapshotConfigOverrides(config, cdcConfigUpdate)
 	// validate mirror first because once the mirror is dropped, there's no going back
-	if _, err := h.ValidateCDCMirror(ctx, &protos.CreateCDCFlowRequest{
-		ConnectionConfigs: config,
-	}); err != nil {
+	if internalVersion, err := internal.PeerDBForceInternalVersion(ctx, config.Env); err != nil {
+		return NewInternalApiError(err)
+	} else {
+		config.Version = internalVersion
+	}
+	configCore := pconv.FlowConnectionConfigsToCore(config, 0)
+	internal.ApplySnapshotConfigOverrides(configCore, cdcConfigUpdate)
+
+	if _, err := h.validateCDCMirrorImpl(ctx, configCore, false); err != nil {
 		return err
 	}
 
@@ -721,7 +708,6 @@ func (h *FlowRequestHandler) resyncByRecreatingFlow(
 	}
 
 	workflowID := getWorkflowID(config.FlowJobName)
-	configCore := pconv.FlowConnectionConfigsToCore(config, 0)
 	if _, err := h.createCDCFlow(ctx, configCore, workflowID); err != nil {
 		return err
 	}

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -1487,6 +1487,141 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnRunningPipe() {
 	})
 }
 
+// TestResyncWithSnapshotConfigOnResyningPipe verifies that snapshot tuning
+// parameters supplied via FlowConfigUpdate on a RESYNC state change are
+// applied and persisted even when the target pipe is already in the middle
+// of a previous resync (snapshot phase), not yet back to STATUS_RUNNING.
+func (s APITestSuite) TestResyncWithSnapshotConfigOnResyningPipe() {
+	tableName := "resync_snap_cfg_resyncing"
+	var cols string
+	switch s.source.(type) {
+	case *PostgresSource, *MySqlSource:
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", AttachSchema(s, tableName))))
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("INSERT INTO %s(id, val) values (1,'first')", AttachSchema(s, tableName))))
+		cols = "id,val"
+	case *MongoSource:
+		res, err := s.Source().(*MongoSource).AdminClient().
+			Database(Schema(s)).Collection(tableName).
+			InsertOne(s.t.Context(), bson.D{bson.E{Key: "id", Value: 1}, bson.E{Key: "val", Value: "first"}}, options.InsertOne())
+		require.NoError(s.t, err)
+		require.True(s.t, res.Acknowledged)
+		cols = fmt.Sprintf("%s,%s", connmongo.DefaultDocumentKeyColumnName, connmongo.DefaultFullDocumentColumnName)
+	default:
+		require.Fail(s.t, fmt.Sprintf("unknown source type %T", s.source))
+	}
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      "resync_snap_cfg_resyncing_" + s.suffix,
+		TableNameMapping: map[string]string{AttachSchema(s, tableName): tableName},
+		Destination:      s.ch.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.InitialSnapshotOnly = false
+	flowConnConfig.SnapshotMaxParallelWorkers = 1
+	flowConnConfig.SnapshotNumTablesInParallel = 1
+	flowConnConfig.SnapshotNumRowsPerPartition = 100
+	flowConnConfig.SnapshotNumPartitionsOverride = 1
+
+	response, err := s.CreateCDCFlow(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+
+	tc := NewTemporalClient(s.t)
+	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitFor(s.t, env, 3*time.Minute, "wait for mirror to be in cdc", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RUNNING
+	})
+	RequireEqualTables(s.ch, tableName, cols)
+
+	// add a row so the resync has something to snapshot
+	switch s.source.(type) {
+	case *PostgresSource, *MySqlSource:
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("INSERT INTO %s(id, val) values (2,'resync')", AttachSchema(s, tableName))))
+	case *MongoSource:
+		res, err := s.Source().(*MongoSource).AdminClient().
+			Database(Schema(s)).Collection(tableName).
+			InsertOne(s.t.Context(), bson.D{bson.E{Key: "id", Value: 2}, bson.E{Key: "val", Value: "resync"}}, options.InsertOne())
+		require.NoError(s.t, err)
+		require.True(s.t, res.Acknowledged)
+	}
+
+	// First resync: no config override. We do NOT wait for it to complete —
+	// the next resync should land while this one is still resyncing.
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
+	})
+	require.NoError(s.t, err)
+
+	// Wait until the flow has actually entered the resync workflow (i.e. it is
+	// no longer in STATUS_RUNNING) before issuing the second resync, so that we
+	// are exercising the "resync-on-resyncing-pipe" path rather than racing the
+	// first resync into existence.
+	EnvWaitFor(s.t, env, time.Minute, "wait for pipe to leave running state for resync", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_SNAPSHOT || env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RESYNC
+	})
+
+	const (
+		newMaxParallelWorkers    uint32 = 4
+		newNumTablesInParallel   uint32 = 2
+		newNumRowsPerPartition   uint32 = 500
+		newNumPartitionsOverride uint32 = 7
+	)
+
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
+		FlowConfigUpdate: &protos.FlowConfigUpdate{
+			Update: &protos.FlowConfigUpdate_CdcFlowConfigUpdate{
+				CdcFlowConfigUpdate: &protos.CDCFlowConfigUpdate{
+					SnapshotMaxParallelWorkers:    newMaxParallelWorkers,
+					SnapshotNumTablesInParallel:   newNumTablesInParallel,
+					SnapshotNumRowsPerPartition:   newNumRowsPerPartition,
+					SnapshotNumPartitionsOverride: newNumPartitionsOverride,
+				},
+			},
+		},
+	})
+	require.NoError(s.t, err)
+
+	EnvWaitForEqualTables(env, s.ch, "resync with snapshot config override on resyncing pipe", tableName, cols)
+	env, err = GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	EnvWaitFor(s.t, env, 3*time.Minute, "wait for mirror to be in cdc", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RESYNC
+	})
+
+	configAfterResync, err := s.loadConfigFromCatalog(s.t.Context(), flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	require.EqualValues(s.t, newMaxParallelWorkers, configAfterResync.SnapshotMaxParallelWorkers,
+		"SnapshotMaxParallelWorkers should be overridden after resync-on-resyncing")
+	require.EqualValues(s.t, newNumTablesInParallel, configAfterResync.SnapshotNumTablesInParallel,
+		"SnapshotNumTablesInParallel should be overridden after resync-on-resyncing")
+	require.EqualValues(s.t, newNumRowsPerPartition, configAfterResync.SnapshotNumRowsPerPartition,
+		"SnapshotNumRowsPerPartition should be overridden after resync-on-resyncing")
+	require.EqualValues(s.t, newNumPartitionsOverride, configAfterResync.SnapshotNumPartitionsOverride,
+		"SnapshotNumPartitionsOverride should be overridden after resync-on-resyncing")
+
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_TERMINATING,
+	})
+	require.NoError(s.t, err)
+	EnvWaitFor(s.t, env, time.Minute, "wait for flow dropped", func() bool {
+		var workflowID string
+		err := s.catalog.QueryRow(
+			s.t.Context(), "select workflow_id from flows where name = $1", flowConnConfig.FlowJobName,
+		).Scan(&workflowID)
+		return errors.Is(err, pgx.ErrNoRows)
+	})
+}
+
 func (s APITestSuite) TestResyncSourceTableMissing() {
 	tableNames := []string{"missing_src_a", "missing_src_b"}
 	qualifiedSourceTables := []string{AttachSchema(s, tableNames[0]), AttachSchema(s, tableNames[1])}

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -1371,12 +1371,12 @@ func (s APITestSuite) TestResyncCompleted() {
 	require.Equal(s.t, "test", tagMap[common.PipeNameTag])
 }
 
-// TestResyncWithSnapshotConfigOverride verifies that snapshot tuning parameters
+// TestResyncWithSnapshotConfigOnRunningPipe verifies that snapshot tuning parameters
 // (max_parallel_workers, num_tables_in_parallel, num_rows_per_partition,
 // num_partitions_override) supplied via FlowConfigUpdate on a RESYNC state
 // change are applied to the resynced flow and persisted in the catalog config.
-func (s APITestSuite) TestResyncWithSnapshotConfigOverride() {
-	tableName := "resync_snap_cfg"
+func (s APITestSuite) TestResyncWithSnapshotConfigOnRunningPipe() {
+	tableName := "resync_snap_run_cfg"
 	var cols string
 	switch s.source.(type) {
 	case *PostgresSource, *MySqlSource:
@@ -1403,7 +1403,7 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOverride() {
 	}
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
 	flowConnConfig.DoInitialSnapshot = true
-	flowConnConfig.InitialSnapshotOnly = true
+	flowConnConfig.InitialSnapshotOnly = false
 	flowConnConfig.SnapshotMaxParallelWorkers = 1
 	flowConnConfig.SnapshotNumTablesInParallel = 1
 	flowConnConfig.SnapshotNumRowsPerPartition = 100
@@ -1417,7 +1417,9 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOverride() {
 	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
 	require.NoError(s.t, err)
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
-	EnvWaitForFinished(s.t, env, 3*time.Minute)
+	EnvWaitFor(s.t, env, 3*time.Minute, "wait for mirror to be in cdc", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RUNNING
+	})
 	RequireEqualTables(s.ch, tableName, cols)
 
 	// add a row so the resync has something to snapshot
@@ -1434,10 +1436,10 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOverride() {
 	}
 
 	const (
-		newMaxParallelWorkers      uint32 = 4
-		newNumTablesInParallel     uint32 = 2
-		newNumRowsPerPartition     uint32 = 500
-		newNumPartitionsOverride   uint32 = 7
+		newMaxParallelWorkers    uint32 = 4
+		newNumTablesInParallel   uint32 = 2
+		newNumRowsPerPartition   uint32 = 500
+		newNumPartitionsOverride uint32 = 7
 	)
 
 	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
@@ -1459,7 +1461,6 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOverride() {
 	EnvWaitForEqualTables(env, s.ch, "resync with snapshot config override", tableName, cols)
 	env, err = GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
 	require.NoError(s.t, err)
-	EnvWaitForFinished(s.t, env, time.Minute)
 
 	configAfterResync, err := s.loadConfigFromCatalog(s.t.Context(), flowConnConfig.FlowJobName)
 	require.NoError(s.t, err)
@@ -1471,6 +1472,19 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOverride() {
 		"SnapshotNumRowsPerPartition should be overridden after resync")
 	require.EqualValues(s.t, newNumPartitionsOverride, configAfterResync.SnapshotNumPartitionsOverride,
 		"SnapshotNumPartitionsOverride should be overridden after resync")
+
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_TERMINATING,
+	})
+	require.NoError(s.t, err)
+	EnvWaitFor(s.t, env, time.Minute, "wait for flow dropped", func() bool {
+		var workflowID string
+		err := s.catalog.QueryRow(
+			s.t.Context(), "select workflow_id from flows where name = $1", flowConnConfig.FlowJobName,
+		).Scan(&workflowID)
+		return errors.Is(err, pgx.ErrNoRows)
+	})
 }
 
 func (s APITestSuite) TestResyncSourceTableMissing() {

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -1371,6 +1371,108 @@ func (s APITestSuite) TestResyncCompleted() {
 	require.Equal(s.t, "test", tagMap[common.PipeNameTag])
 }
 
+// TestResyncWithSnapshotConfigOverride verifies that snapshot tuning parameters
+// (max_parallel_workers, num_tables_in_parallel, num_rows_per_partition,
+// num_partitions_override) supplied via FlowConfigUpdate on a RESYNC state
+// change are applied to the resynced flow and persisted in the catalog config.
+func (s APITestSuite) TestResyncWithSnapshotConfigOverride() {
+	tableName := "resync_snap_cfg"
+	var cols string
+	switch s.source.(type) {
+	case *PostgresSource, *MySqlSource:
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", AttachSchema(s, tableName))))
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("INSERT INTO %s(id, val) values (1,'first')", AttachSchema(s, tableName))))
+		cols = "id,val"
+	case *MongoSource:
+		res, err := s.Source().(*MongoSource).AdminClient().
+			Database(Schema(s)).Collection(tableName).
+			InsertOne(s.t.Context(), bson.D{bson.E{Key: "id", Value: 1}, bson.E{Key: "val", Value: "first"}}, options.InsertOne())
+		require.NoError(s.t, err)
+		require.True(s.t, res.Acknowledged)
+		cols = fmt.Sprintf("%s,%s", connmongo.DefaultDocumentKeyColumnName, connmongo.DefaultFullDocumentColumnName)
+	default:
+		require.Fail(s.t, fmt.Sprintf("unknown source type %T", s.source))
+	}
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      "resync_snap_cfg_" + s.suffix,
+		TableNameMapping: map[string]string{AttachSchema(s, tableName): tableName},
+		Destination:      s.ch.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.InitialSnapshotOnly = true
+	flowConnConfig.SnapshotMaxParallelWorkers = 1
+	flowConnConfig.SnapshotNumTablesInParallel = 1
+	flowConnConfig.SnapshotNumRowsPerPartition = 100
+	flowConnConfig.SnapshotNumPartitionsOverride = 1
+
+	response, err := s.CreateCDCFlow(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+
+	tc := NewTemporalClient(s.t)
+	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitForFinished(s.t, env, 3*time.Minute)
+	RequireEqualTables(s.ch, tableName, cols)
+
+	// add a row so the resync has something to snapshot
+	switch s.source.(type) {
+	case *PostgresSource, *MySqlSource:
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("INSERT INTO %s(id, val) values (2,'resync')", AttachSchema(s, tableName))))
+	case *MongoSource:
+		res, err := s.Source().(*MongoSource).AdminClient().
+			Database(Schema(s)).Collection(tableName).
+			InsertOne(s.t.Context(), bson.D{bson.E{Key: "id", Value: 2}, bson.E{Key: "val", Value: "resync"}}, options.InsertOne())
+		require.NoError(s.t, err)
+		require.True(s.t, res.Acknowledged)
+	}
+
+	const (
+		newMaxParallelWorkers      uint32 = 4
+		newNumTablesInParallel     uint32 = 2
+		newNumRowsPerPartition     uint32 = 500
+		newNumPartitionsOverride   uint32 = 7
+	)
+
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
+		FlowConfigUpdate: &protos.FlowConfigUpdate{
+			Update: &protos.FlowConfigUpdate_CdcFlowConfigUpdate{
+				CdcFlowConfigUpdate: &protos.CDCFlowConfigUpdate{
+					SnapshotMaxParallelWorkers:    newMaxParallelWorkers,
+					SnapshotNumTablesInParallel:   newNumTablesInParallel,
+					SnapshotNumRowsPerPartition:   newNumRowsPerPartition,
+					SnapshotNumPartitionsOverride: newNumPartitionsOverride,
+				},
+			},
+		},
+	})
+	require.NoError(s.t, err)
+
+	EnvWaitForEqualTables(env, s.ch, "resync with snapshot config override", tableName, cols)
+	env, err = GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	EnvWaitForFinished(s.t, env, time.Minute)
+
+	configAfterResync, err := s.loadConfigFromCatalog(s.t.Context(), flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	require.EqualValues(s.t, newMaxParallelWorkers, configAfterResync.SnapshotMaxParallelWorkers,
+		"SnapshotMaxParallelWorkers should be overridden after resync")
+	require.EqualValues(s.t, newNumTablesInParallel, configAfterResync.SnapshotNumTablesInParallel,
+		"SnapshotNumTablesInParallel should be overridden after resync")
+	require.EqualValues(s.t, newNumRowsPerPartition, configAfterResync.SnapshotNumRowsPerPartition,
+		"SnapshotNumRowsPerPartition should be overridden after resync")
+	require.EqualValues(s.t, newNumPartitionsOverride, configAfterResync.SnapshotNumPartitionsOverride,
+		"SnapshotNumPartitionsOverride should be overridden after resync")
+}
+
 func (s APITestSuite) TestResyncSourceTableMissing() {
 	tableNames := []string{"missing_src_a", "missing_src_b"}
 	qualifiedSourceTables := []string{AttachSchema(s, tableNames[0]), AttachSchema(s, tableNames[1])}

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -1417,7 +1417,7 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnRunningPipe() {
 	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
 	require.NoError(s.t, err)
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
-	EnvWaitFor(s.t, env, 3*time.Minute, "wait for mirror to be in cdc", func() bool {
+	EnvWaitFor(s.t, env, 5*time.Minute, "wait for mirror to be in cdc", func() bool {
 		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RUNNING
 	})
 	RequireEqualTables(s.ch, tableName, cols)
@@ -1458,19 +1458,22 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnRunningPipe() {
 	})
 	require.NoError(s.t, err)
 
+	EnvWaitFor(s.t, env, 5*time.Minute, "wait for mirror to be in cdc", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RUNNING
+	})
 	EnvWaitForEqualTables(env, s.ch, "resync with snapshot config override", tableName, cols)
 	env, err = GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
 	require.NoError(s.t, err)
 
 	configAfterResync, err := s.loadConfigFromCatalog(s.t.Context(), flowConnConfig.FlowJobName)
 	require.NoError(s.t, err)
-	require.EqualValues(s.t, newMaxParallelWorkers, configAfterResync.SnapshotMaxParallelWorkers,
+	require.Equal(s.t, newMaxParallelWorkers, configAfterResync.SnapshotMaxParallelWorkers,
 		"SnapshotMaxParallelWorkers should be overridden after resync")
-	require.EqualValues(s.t, newNumTablesInParallel, configAfterResync.SnapshotNumTablesInParallel,
+	require.Equal(s.t, newNumTablesInParallel, configAfterResync.SnapshotNumTablesInParallel,
 		"SnapshotNumTablesInParallel should be overridden after resync")
-	require.EqualValues(s.t, newNumRowsPerPartition, configAfterResync.SnapshotNumRowsPerPartition,
+	require.Equal(s.t, newNumRowsPerPartition, configAfterResync.SnapshotNumRowsPerPartition,
 		"SnapshotNumRowsPerPartition should be overridden after resync")
-	require.EqualValues(s.t, newNumPartitionsOverride, configAfterResync.SnapshotNumPartitionsOverride,
+	require.Equal(s.t, newNumPartitionsOverride, configAfterResync.SnapshotNumPartitionsOverride,
 		"SnapshotNumPartitionsOverride should be overridden after resync")
 
 	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
@@ -1487,12 +1490,11 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnRunningPipe() {
 	})
 }
 
-// TestResyncWithSnapshotConfigOnResyningPipe verifies that snapshot tuning
-// parameters supplied via FlowConfigUpdate on a RESYNC state change are
-// applied and persisted even when the target pipe is already in the middle
-// of a previous resync (snapshot phase), not yet back to STATUS_RUNNING.
-func (s APITestSuite) TestResyncWithSnapshotConfigOnResyningPipe() {
-	tableName := "resync_snap_cfg_resyncing"
+// TestResyncWithSnapshotConfigOnCompletedSnapshotOnlyPipe verifies that snapshot tuning parameters
+// supplied via FlowConfigUpdate on a RESYNC state change are applied to an InitialSnapshotOnly
+// flow that has already completed, and that the override is persisted in the catalog config.
+func (s APITestSuite) TestResyncWithSnapshotConfigOnCompletedSnapshotOnlyPipe() {
+	tableName := "resync_snap_done_cfg"
 	var cols string
 	switch s.source.(type) {
 	case *PostgresSource, *MySqlSource:
@@ -1513,7 +1515,231 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnResyningPipe() {
 	}
 
 	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      "resync_snap_cfg_resyncing_" + s.suffix,
+		FlowJobName:      "resync_snap_done_cfg_" + s.suffix,
+		TableNameMapping: map[string]string{AttachSchema(s, tableName): tableName},
+		Destination:      s.ch.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.InitialSnapshotOnly = true
+	flowConnConfig.SnapshotMaxParallelWorkers = 1
+	flowConnConfig.SnapshotNumTablesInParallel = 1
+	flowConnConfig.SnapshotNumRowsPerPartition = 100
+	flowConnConfig.SnapshotNumPartitionsOverride = 1
+
+	response, err := s.CreateCDCFlow(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+
+	tc := NewTemporalClient(s.t)
+	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitForFinished(s.t, env, 3*time.Minute)
+	RequireEqualTables(s.ch, tableName, cols)
+
+	// add a row so the resync has something to snapshot
+	switch s.source.(type) {
+	case *PostgresSource, *MySqlSource:
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("INSERT INTO %s(id, val) values (2,'resync')", AttachSchema(s, tableName))))
+	case *MongoSource:
+		res, err := s.Source().(*MongoSource).AdminClient().
+			Database(Schema(s)).Collection(tableName).
+			InsertOne(s.t.Context(), bson.D{bson.E{Key: "id", Value: 2}, bson.E{Key: "val", Value: "resync"}}, options.InsertOne())
+		require.NoError(s.t, err)
+		require.True(s.t, res.Acknowledged)
+	}
+
+	const (
+		newMaxParallelWorkers    uint32 = 4
+		newNumTablesInParallel   uint32 = 2
+		newNumRowsPerPartition   uint32 = 500
+		newNumPartitionsOverride uint32 = 7
+	)
+
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
+		FlowConfigUpdate: &protos.FlowConfigUpdate{
+			Update: &protos.FlowConfigUpdate_CdcFlowConfigUpdate{
+				CdcFlowConfigUpdate: &protos.CDCFlowConfigUpdate{
+					SnapshotMaxParallelWorkers:    newMaxParallelWorkers,
+					SnapshotNumTablesInParallel:   newNumTablesInParallel,
+					SnapshotNumRowsPerPartition:   newNumRowsPerPartition,
+					SnapshotNumPartitionsOverride: newNumPartitionsOverride,
+				},
+			},
+		},
+	})
+	require.NoError(s.t, err)
+
+	EnvWaitForEqualTables(env, s.ch, "resync completed snapshot-only with config override", tableName, cols)
+	env, err = GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	EnvWaitForFinished(s.t, env, time.Minute)
+
+	configAfterResync, err := s.loadConfigFromCatalog(s.t.Context(), flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	require.Equal(s.t, newMaxParallelWorkers, configAfterResync.SnapshotMaxParallelWorkers,
+		"SnapshotMaxParallelWorkers should be overridden after resync")
+	require.Equal(s.t, newNumTablesInParallel, configAfterResync.SnapshotNumTablesInParallel,
+		"SnapshotNumTablesInParallel should be overridden after resync")
+	require.Equal(s.t, newNumRowsPerPartition, configAfterResync.SnapshotNumRowsPerPartition,
+		"SnapshotNumRowsPerPartition should be overridden after resync")
+	require.Equal(s.t, newNumPartitionsOverride, configAfterResync.SnapshotNumPartitionsOverride,
+		"SnapshotNumPartitionsOverride should be overridden after resync")
+
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_TERMINATING,
+	})
+	require.NoError(s.t, err)
+	EnvWaitFor(s.t, env, time.Minute, "wait for flow dropped", func() bool {
+		var workflowID string
+		err := s.catalog.QueryRow(
+			s.t.Context(), "select workflow_id from flows where name = $1", flowConnConfig.FlowJobName,
+		).Scan(&workflowID)
+		return errors.Is(err, pgx.ErrNoRows)
+	})
+}
+
+// TestResyncWithSnapshotConfigDuringSnapshot verifies that snapshot tuning parameters supplied via
+// FlowConfigUpdate on a RESYNC state change issued while the flow is still in STATUS_SNAPSHOT
+// (initial snapshot in-flight) are applied to the resynced flow and persisted in the catalog.
+func (s APITestSuite) TestResyncWithSnapshotConfigDuringSnapshot() {
+	tableName := "resync_during_snap_cfg"
+	var cols string
+	const initialRowCount = 2000
+	switch s.source.(type) {
+	case *PostgresSource, *MySqlSource:
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", AttachSchema(s, tableName))))
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("INSERT INTO %s(id, val) SELECT g, 'v'||g FROM generate_series(1,%d) g",
+				AttachSchema(s, tableName), initialRowCount)))
+		cols = "id,val"
+	case *MongoSource:
+		docs := make([]any, 0, initialRowCount)
+		for i := 1; i <= initialRowCount; i++ {
+			docs = append(docs, bson.D{bson.E{Key: "id", Value: i}, bson.E{Key: "val", Value: fmt.Sprintf("v%d", i)}})
+		}
+		_, err := s.Source().(*MongoSource).AdminClient().
+			Database(Schema(s)).Collection(tableName).
+			InsertMany(s.t.Context(), docs, options.InsertMany())
+		require.NoError(s.t, err)
+		cols = fmt.Sprintf("%s,%s", connmongo.DefaultDocumentKeyColumnName, connmongo.DefaultFullDocumentColumnName)
+	default:
+		require.Fail(s.t, fmt.Sprintf("unknown source type %T", s.source))
+	}
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      "resync_during_snap_cfg_" + s.suffix,
+		TableNameMapping: map[string]string{AttachSchema(s, tableName): tableName},
+		Destination:      s.ch.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.InitialSnapshotOnly = false
+	flowConnConfig.SnapshotMaxParallelWorkers = 1
+	flowConnConfig.SnapshotNumTablesInParallel = 1
+	flowConnConfig.SnapshotNumRowsPerPartition = 10
+	flowConnConfig.SnapshotNumPartitionsOverride = 0
+
+	response, err := s.CreateCDCFlow(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+
+	tc := NewTemporalClient(s.t)
+	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+
+	EnvWaitFor(s.t, env, 5*time.Minute, "wait for mirror to enter snapshot", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_SNAPSHOT
+	})
+
+	const (
+		newMaxParallelWorkers    uint32 = 4
+		newNumTablesInParallel   uint32 = 2
+		newNumRowsPerPartition   uint32 = 500
+		newNumPartitionsOverride uint32 = 7
+	)
+
+	// Trigger resync while initial snapshot is still running.
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
+		FlowConfigUpdate: &protos.FlowConfigUpdate{
+			Update: &protos.FlowConfigUpdate_CdcFlowConfigUpdate{
+				CdcFlowConfigUpdate: &protos.CDCFlowConfigUpdate{
+					SnapshotMaxParallelWorkers:    newMaxParallelWorkers,
+					SnapshotNumTablesInParallel:   newNumTablesInParallel,
+					SnapshotNumRowsPerPartition:   newNumRowsPerPartition,
+					SnapshotNumPartitionsOverride: newNumPartitionsOverride,
+				},
+			},
+		},
+	})
+	require.NoError(s.t, err)
+
+	EnvWaitFor(s.t, env, 5*time.Minute, "wait for mirror to be in cdc", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RUNNING
+	})
+	EnvWaitForEqualTables(env, s.ch, "resync during snapshot with config override", tableName, cols)
+	env, err = GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+
+	configAfterResync, err := s.loadConfigFromCatalog(s.t.Context(), flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	require.Equal(s.t, newMaxParallelWorkers, configAfterResync.SnapshotMaxParallelWorkers,
+		"SnapshotMaxParallelWorkers should be overridden after resync")
+	require.Equal(s.t, newNumTablesInParallel, configAfterResync.SnapshotNumTablesInParallel,
+		"SnapshotNumTablesInParallel should be overridden after resync")
+	require.Equal(s.t, newNumRowsPerPartition, configAfterResync.SnapshotNumRowsPerPartition,
+		"SnapshotNumRowsPerPartition should be overridden after resync")
+	require.Equal(s.t, newNumPartitionsOverride, configAfterResync.SnapshotNumPartitionsOverride,
+		"SnapshotNumPartitionsOverride should be overridden after resync")
+
+	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_TERMINATING,
+	})
+	require.NoError(s.t, err)
+	EnvWaitFor(s.t, env, time.Minute, "wait for flow dropped", func() bool {
+		var workflowID string
+		err := s.catalog.QueryRow(
+			s.t.Context(), "select workflow_id from flows where name = $1", flowConnConfig.FlowJobName,
+		).Scan(&workflowID)
+		return errors.Is(err, pgx.ErrNoRows)
+	})
+}
+
+// TestResyncWithSnapshotConfigOnPausedPipe verifies that snapshot tuning parameters supplied via
+// FlowConfigUpdate on a RESYNC state change issued while the flow is PAUSED are applied to the
+// resynced flow and persisted in the catalog.
+func (s APITestSuite) TestResyncWithSnapshotConfigOnPausedPipe() {
+	tableName := "resync_paused_snap_cfg"
+	var cols string
+	switch s.source.(type) {
+	case *PostgresSource, *MySqlSource:
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", AttachSchema(s, tableName))))
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("INSERT INTO %s(id, val) values (1,'first')", AttachSchema(s, tableName))))
+		cols = "id,val"
+	case *MongoSource:
+		res, err := s.Source().(*MongoSource).AdminClient().
+			Database(Schema(s)).Collection(tableName).
+			InsertOne(s.t.Context(), bson.D{bson.E{Key: "id", Value: 1}, bson.E{Key: "val", Value: "first"}}, options.InsertOne())
+		require.NoError(s.t, err)
+		require.True(s.t, res.Acknowledged)
+		cols = fmt.Sprintf("%s,%s", connmongo.DefaultDocumentKeyColumnName, connmongo.DefaultFullDocumentColumnName)
+	default:
+		require.Fail(s.t, fmt.Sprintf("unknown source type %T", s.source))
+	}
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      "resync_paused_snap_cfg_" + s.suffix,
 		TableNameMapping: map[string]string{AttachSchema(s, tableName): tableName},
 		Destination:      s.ch.Peer().Name,
 	}
@@ -1551,20 +1777,14 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnResyningPipe() {
 		require.True(s.t, res.Acknowledged)
 	}
 
-	// First resync: no config override. We do NOT wait for it to complete —
-	// the next resync should land while this one is still resyncing.
+	// Pause the flow.
 	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
 		FlowJobName:        flowConnConfig.FlowJobName,
-		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
+		RequestedFlowState: protos.FlowStatus_STATUS_PAUSED,
 	})
 	require.NoError(s.t, err)
-
-	// Wait until the flow has actually entered the resync workflow (i.e. it is
-	// no longer in STATUS_RUNNING) before issuing the second resync, so that we
-	// are exercising the "resync-on-resyncing-pipe" path rather than racing the
-	// first resync into existence.
-	EnvWaitFor(s.t, env, time.Minute, "wait for pipe to leave running state for resync", func() bool {
-		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_SNAPSHOT || env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RESYNC
+	EnvWaitFor(s.t, env, time.Minute, "wait for mirror to pause", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_PAUSED
 	})
 
 	const (
@@ -1574,6 +1794,7 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnResyningPipe() {
 		newNumPartitionsOverride uint32 = 7
 	)
 
+	// Issue resync while paused, with snapshot config overrides.
 	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
 		FlowJobName:        flowConnConfig.FlowJobName,
 		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
@@ -1590,23 +1811,20 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnResyningPipe() {
 	})
 	require.NoError(s.t, err)
 
-	EnvWaitForEqualTables(env, s.ch, "resync with snapshot config override on resyncing pipe", tableName, cols)
+	EnvWaitForEqualTables(env, s.ch, "resync from paused with snapshot config override", tableName, cols)
 	env, err = GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
 	require.NoError(s.t, err)
-	EnvWaitFor(s.t, env, 3*time.Minute, "wait for mirror to be in cdc", func() bool {
-		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RESYNC
-	})
 
 	configAfterResync, err := s.loadConfigFromCatalog(s.t.Context(), flowConnConfig.FlowJobName)
 	require.NoError(s.t, err)
-	require.EqualValues(s.t, newMaxParallelWorkers, configAfterResync.SnapshotMaxParallelWorkers,
-		"SnapshotMaxParallelWorkers should be overridden after resync-on-resyncing")
-	require.EqualValues(s.t, newNumTablesInParallel, configAfterResync.SnapshotNumTablesInParallel,
-		"SnapshotNumTablesInParallel should be overridden after resync-on-resyncing")
-	require.EqualValues(s.t, newNumRowsPerPartition, configAfterResync.SnapshotNumRowsPerPartition,
-		"SnapshotNumRowsPerPartition should be overridden after resync-on-resyncing")
-	require.EqualValues(s.t, newNumPartitionsOverride, configAfterResync.SnapshotNumPartitionsOverride,
-		"SnapshotNumPartitionsOverride should be overridden after resync-on-resyncing")
+	require.Equal(s.t, newMaxParallelWorkers, configAfterResync.SnapshotMaxParallelWorkers,
+		"SnapshotMaxParallelWorkers should be overridden after resync")
+	require.Equal(s.t, newNumTablesInParallel, configAfterResync.SnapshotNumTablesInParallel,
+		"SnapshotNumTablesInParallel should be overridden after resync")
+	require.Equal(s.t, newNumRowsPerPartition, configAfterResync.SnapshotNumRowsPerPartition,
+		"SnapshotNumRowsPerPartition should be overridden after resync")
+	require.Equal(s.t, newNumPartitionsOverride, configAfterResync.SnapshotNumPartitionsOverride,
+		"SnapshotNumPartitionsOverride should be overridden after resync")
 
 	_, err = s.FlowStateChange(s.t.Context(), &protos.FlowStateChangeRequest{
 		FlowJobName:        flowConnConfig.FlowJobName,

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -1615,9 +1615,13 @@ func (s APITestSuite) TestResyncWithSnapshotConfigDuringSnapshot() {
 	case *PostgresSource, *MySqlSource:
 		require.NoError(s.t, s.source.Exec(s.t.Context(),
 			fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", AttachSchema(s, tableName))))
+		values := make([]string, 0, initialRowCount)
+		for i := 1; i <= initialRowCount; i++ {
+			values = append(values, fmt.Sprintf("(%d,'v%d')", i, i))
+		}
 		require.NoError(s.t, s.source.Exec(s.t.Context(),
-			fmt.Sprintf("INSERT INTO %s(id, val) SELECT g, 'v'||g FROM generate_series(1,%d) g",
-				AttachSchema(s, tableName), initialRowCount)))
+			fmt.Sprintf("INSERT INTO %s(id, val) VALUES %s",
+				AttachSchema(s, tableName), strings.Join(values, ","))))
 		cols = "id,val"
 	case *MongoSource:
 		docs := make([]any, 0, initialRowCount)

--- a/flow/internal/flow_configuration_helpers.go
+++ b/flow/internal/flow_configuration_helpers.go
@@ -26,3 +26,21 @@ func FetchConfigFromDB(ctx context.Context, catalogPool shared.CatalogPool, flow
 
 	return &cfgFromDB, nil
 }
+
+func ApplySnapshotConfigOverrides(config *protos.FlowConnectionConfigsCore, update *protos.CDCFlowConfigUpdate) {
+	if update == nil {
+		return
+	}
+	if update.SnapshotNumRowsPerPartition > 0 {
+		config.SnapshotNumRowsPerPartition = update.SnapshotNumRowsPerPartition
+	}
+	if update.SnapshotNumPartitionsOverride > 0 {
+		config.SnapshotNumPartitionsOverride = update.SnapshotNumPartitionsOverride
+	}
+	if update.SnapshotMaxParallelWorkers > 0 {
+		config.SnapshotMaxParallelWorkers = update.SnapshotMaxParallelWorkers
+	}
+	if update.SnapshotNumTablesInParallel > 0 {
+		config.SnapshotNumTablesInParallel = update.SnapshotNumTablesInParallel
+	}
+}

--- a/flow/shared/telemetry/activity_logging.go
+++ b/flow/shared/telemetry/activity_logging.go
@@ -93,6 +93,16 @@ func LogActivityStartFlowConfigUpdate(ctx context.Context, flowName string, upda
 		changes = append(changes, fmt.Sprintf("tables removed: %v", removedTables))
 	}
 
+	if update.SnapshotMaxParallelWorkers > 0 {
+		changes = append(changes, fmt.Sprintf("snapshotMaxParallelWorkers: %v", update.SnapshotMaxParallelWorkers))
+	}
+	if update.SnapshotNumTablesInParallel > 0 {
+		changes = append(changes, fmt.Sprintf("snapshotNumTablesInParallel: %v", update.SnapshotNumTablesInParallel))
+	}
+	if update.SnapshotNumRowsPerPartition > 0 {
+		changes = append(changes, fmt.Sprintf("snapshotNumRowsPerPartition: %v", update.SnapshotNumRowsPerPartition))
+	}
+
 	logActivity(ctx, ActionStartFlowConfigUpdate,
 		slog.String("flowName", flowName),
 		slog.String("activityDetails", strings.Join(changes, ", ")))

--- a/flow/shared/telemetry/activity_logging.go
+++ b/flow/shared/telemetry/activity_logging.go
@@ -93,25 +93,6 @@ func LogActivityStartFlowConfigUpdate(ctx context.Context, flowName string, upda
 		changes = append(changes, fmt.Sprintf("tables removed: %v", removedTables))
 	}
 
-	if update.BatchSize > 0 {
-		changes = append(changes, fmt.Sprintf("batchSize: %v", update.BatchSize))
-	}
-	if update.IdleTimeout > 0 {
-		changes = append(changes, fmt.Sprintf("idleTimeout: %v", update.IdleTimeout))
-	}
-	if update.SnapshotNumPartitionsOverride > 0 {
-		changes = append(changes, fmt.Sprintf("snapshotNumPartitionsOverride: %v", update.SnapshotNumPartitionsOverride))
-	}
-	if update.SnapshotMaxParallelWorkers > 0 {
-		changes = append(changes, fmt.Sprintf("snapshotMaxParallelWorkers: %v", update.SnapshotMaxParallelWorkers))
-	}
-	if update.SnapshotNumTablesInParallel > 0 {
-		changes = append(changes, fmt.Sprintf("snapshotNumTablesInParallel: %v", update.SnapshotNumTablesInParallel))
-	}
-	if update.SnapshotNumRowsPerPartition > 0 {
-		changes = append(changes, fmt.Sprintf("snapshotNumRowsPerPartition: %v", update.SnapshotNumRowsPerPartition))
-	}
-
 	logActivity(ctx, ActionStartFlowConfigUpdate,
 		slog.String("flowName", flowName),
 		slog.String("activityDetails", strings.Join(changes, ", ")))

--- a/flow/shared/telemetry/activity_logging.go
+++ b/flow/shared/telemetry/activity_logging.go
@@ -93,6 +93,15 @@ func LogActivityStartFlowConfigUpdate(ctx context.Context, flowName string, upda
 		changes = append(changes, fmt.Sprintf("tables removed: %v", removedTables))
 	}
 
+	if update.BatchSize > 0 {
+		changes = append(changes, fmt.Sprintf("batchSize: %v", update.BatchSize))
+	}
+	if update.IdleTimeout > 0 {
+		changes = append(changes, fmt.Sprintf("idleTimeout: %v", update.IdleTimeout))
+	}
+	if update.SnapshotNumPartitionsOverride > 0 {
+		changes = append(changes, fmt.Sprintf("snapshotNumPartitionsOverride: %v", update.SnapshotNumPartitionsOverride))
+	}
 	if update.SnapshotMaxParallelWorkers > 0 {
 		changes = append(changes, fmt.Sprintf("snapshotMaxParallelWorkers: %v", update.SnapshotMaxParallelWorkers))
 	}

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -209,33 +209,22 @@ func handleFlowSignalStateChange(
 	}
 }
 
-func overrideSnapshotParametersInState(req *protos.FlowStateChangeRequest, state *cdc_state.CDCFlowWorkflowState) {
-	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil {
-		cdcConfigUpdate := req.FlowConfigUpdate.GetCdcFlowConfigUpdate()
-		if cdcConfigUpdate.SnapshotMaxParallelWorkers > 0 {
-			state.SnapshotMaxParallelWorkers = cdcConfigUpdate.SnapshotMaxParallelWorkers
-		}
-		if cdcConfigUpdate.SnapshotNumTablesInParallel > 0 {
-			state.SnapshotNumTablesInParallel = cdcConfigUpdate.SnapshotNumTablesInParallel
-		}
-		if cdcConfigUpdate.SnapshotNumRowsPerPartition > 0 {
-			state.SnapshotNumRowsPerPartition = cdcConfigUpdate.SnapshotNumRowsPerPartition
-		}
+func overrideSnapshotParametersInState(req *protos.FlowStateChangeRequest, s *cdc_state.CDCFlowWorkflowState) {
+	u := req.GetFlowConfigUpdate().GetCdcFlowConfigUpdate()
+	if u == nil {
+		return
 	}
-}
-
-func overrideSnapshotParametersInConfig(req *protos.FlowStateChangeRequest, cfg *protos.FlowConnectionConfigsCore) {
-	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil {
-		cdcConfigUpdate := req.FlowConfigUpdate.GetCdcFlowConfigUpdate()
-		if cdcConfigUpdate.SnapshotMaxParallelWorkers > 0 {
-			cfg.SnapshotMaxParallelWorkers = cdcConfigUpdate.SnapshotMaxParallelWorkers
-		}
-		if cdcConfigUpdate.SnapshotNumTablesInParallel > 0 {
-			cfg.SnapshotNumTablesInParallel = cdcConfigUpdate.SnapshotNumTablesInParallel
-		}
-		if cdcConfigUpdate.SnapshotNumRowsPerPartition > 0 {
-			cfg.SnapshotNumRowsPerPartition = cdcConfigUpdate.SnapshotNumRowsPerPartition
-		}
+	if u.SnapshotMaxParallelWorkers > 0 {
+		s.SnapshotMaxParallelWorkers = u.SnapshotMaxParallelWorkers
+	}
+	if u.SnapshotNumTablesInParallel > 0 {
+		s.SnapshotNumTablesInParallel = u.SnapshotNumTablesInParallel
+	}
+	if u.SnapshotNumRowsPerPartition > 0 {
+		s.SnapshotNumRowsPerPartition = u.SnapshotNumRowsPerPartition
+	}
+	if u.SnapshotNumPartitionsOverride > 0 {
+		s.SnapshotNumPartitionsOverride = u.SnapshotNumPartitionsOverride
 	}
 }
 
@@ -664,7 +653,8 @@ func CDCFlowWorkflow(
 				// so we need to NOT sync the tableMappings to catalog to preserve original names
 
 				// We still override the snapshot parameters (when resync with updated values)
-				overrideSnapshotParametersInConfig(val, cfg)
+				overrideSnapshotParametersInState(val, state)
+				syncStateToConfigProtoInCatalog(ctx, cfg, state)
 				uploadConfigToCatalog(ctx, cfg)
 				state.DropFlowInput = &protos.DropFlowInput{
 					FlowJobName:           cfg.FlowJobName,

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -224,6 +224,21 @@ func overrideSnapshotParametersInState(req *protos.FlowStateChangeRequest, state
 	}
 }
 
+func overrideSnapshotParametersInConfig(req *protos.FlowStateChangeRequest, cfg *protos.FlowConnectionConfigsCore) {
+	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil {
+		cdcConfigUpdate := req.FlowConfigUpdate.GetCdcFlowConfigUpdate()
+		if cdcConfigUpdate.SnapshotMaxParallelWorkers > 0 {
+			cfg.SnapshotMaxParallelWorkers = cdcConfigUpdate.SnapshotMaxParallelWorkers
+		}
+		if cdcConfigUpdate.SnapshotNumTablesInParallel > 0 {
+			cfg.SnapshotNumTablesInParallel = cdcConfigUpdate.SnapshotNumTablesInParallel
+		}
+		if cdcConfigUpdate.SnapshotNumRowsPerPartition > 0 {
+			cfg.SnapshotNumRowsPerPartition = cdcConfigUpdate.SnapshotNumRowsPerPartition
+		}
+	}
+}
+
 func processTableAdditions(
 	ctx workflow.Context,
 	logger log.Logger,
@@ -649,7 +664,7 @@ func CDCFlowWorkflow(
 				// so we need to NOT sync the tableMappings to catalog to preserve original names
 
 				// We still override the snapshot parameters (when resync with updated values)
-				overrideSnapshotParametersInState(val, state)
+				overrideSnapshotParametersInConfig(val, cfg)
 				uploadConfigToCatalog(ctx, cfg)
 				state.DropFlowInput = &protos.DropFlowInput{
 					FlowJobName:           cfg.FlowJobName,

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -655,7 +655,6 @@ func CDCFlowWorkflow(
 				// We still override the snapshot parameters (when resync with updated values)
 				overrideSnapshotParametersInState(val, state)
 				syncStateToConfigProtoInCatalog(ctx, cfg, state)
-				uploadConfigToCatalog(ctx, cfg)
 				state.DropFlowInput = &protos.DropFlowInput{
 					FlowJobName:           cfg.FlowJobName,
 					FlowConnectionConfigs: cfg,

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -654,10 +654,10 @@ func CDCFlowWorkflow(
 
 				// We still override the snapshot parameters (when resync with updated values)
 				overrideSnapshotParametersInState(val, state)
-				syncStateToConfigProtoInCatalog(ctx, cfg, state)
+				resyncCfg := syncStateToConfigProtoInCatalog(ctx, cfg, state)
 				state.DropFlowInput = &protos.DropFlowInput{
-					FlowJobName:           cfg.FlowJobName,
-					FlowConnectionConfigs: cfg,
+					FlowJobName:           resyncCfg.FlowJobName,
+					FlowConnectionConfigs: resyncCfg,
 					DropFlowStats:         val.DropMirrorStats,
 					SkipDestinationDrop:   val.SkipDestinationDrop,
 					Resync:                true,

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -653,11 +653,12 @@ func CDCFlowWorkflow(
 				// so we need to NOT sync the tableMappings to catalog to preserve original names
 
 				// We still override the snapshot parameters (when resync with updated values)
-				overrideSnapshotParametersInState(val, state)
-				resyncCfg := syncStateToConfigProtoInCatalog(ctx, cfg, state)
+				internal.ApplySnapshotConfigOverrides(cfg, val.GetFlowConfigUpdate().GetCdcFlowConfigUpdate())
+				uploadConfigToCatalog(ctx, cfg)
+
 				state.DropFlowInput = &protos.DropFlowInput{
-					FlowJobName:           resyncCfg.FlowJobName,
-					FlowConnectionConfigs: resyncCfg,
+					FlowJobName:           cfg.FlowJobName,
+					FlowConnectionConfigs: cfg,
 					DropFlowStats:         val.DropMirrorStats,
 					SkipDestinationDrop:   val.SkipDestinationDrop,
 					Resync:                true,

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -192,6 +192,9 @@ func handleFlowSignalStateChange(
 			// we should ContinueAsNew after the first signal in the selector, but just in case
 			cfg.Resync = true
 			cfg.DoInitialSnapshot = true
+			// This is just for in-memory
+			// Override Snapshot Parameters if request in State Change request
+			overrideSnapshotParametersInState(val, state)
 			state.DropFlowInput = &protos.DropFlowInput{
 				// to be filled in just before ContinueAsNew
 				FlowJobName:           cfg.FlowJobName,
@@ -202,6 +205,21 @@ func handleFlowSignalStateChange(
 			}
 		case protos.FlowStatus_STATUS_PAUSED:
 			logger.Info("pause requested while busy, ignoring for now", slog.String("operation", op))
+		}
+	}
+}
+
+func overrideSnapshotParametersInState(req *protos.FlowStateChangeRequest, state *cdc_state.CDCFlowWorkflowState) {
+	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil {
+		cdcConfigUpdate := req.FlowConfigUpdate.GetCdcFlowConfigUpdate()
+		if cdcConfigUpdate.SnapshotMaxParallelWorkers > 0 {
+			state.SnapshotMaxParallelWorkers = cdcConfigUpdate.SnapshotMaxParallelWorkers
+		}
+		if cdcConfigUpdate.SnapshotNumTablesInParallel > 0 {
+			state.SnapshotNumTablesInParallel = cdcConfigUpdate.SnapshotNumTablesInParallel
+		}
+		if cdcConfigUpdate.SnapshotNumRowsPerPartition > 0 {
+			state.SnapshotNumRowsPerPartition = cdcConfigUpdate.SnapshotNumRowsPerPartition
 		}
 	}
 }
@@ -494,6 +512,8 @@ func CDCFlowWorkflow(
 				state.ActiveSignal = model.ResyncSignal
 				cfg.Resync = true
 				cfg.DoInitialSnapshot = true
+				// Update State with snapshot parameters
+				overrideSnapshotParametersInState(val, state)
 				resyncCfg := syncStateToConfigProtoInCatalog(ctx, cfg, state)
 				state.DropFlowInput = &protos.DropFlowInput{
 					FlowJobName:           resyncCfg.FlowJobName,
@@ -627,6 +647,9 @@ func CDCFlowWorkflow(
 				cfg.TableMappings = originalTableMappings
 				// this is the only place where we can have a resync during a resync
 				// so we need to NOT sync the tableMappings to catalog to preserve original names
+
+				// We still override the snapshot parameters (when resync with updated values)
+				overrideSnapshotParametersInState(val, state)
 				uploadConfigToCatalog(ctx, cfg)
 				state.DropFlowInput = &protos.DropFlowInput{
 					FlowJobName:           cfg.FlowJobName,
@@ -862,6 +885,7 @@ func CDCFlowWorkflow(
 			state.ActiveSignal = model.ResyncSignal
 			cfg.Resync = true
 			cfg.DoInitialSnapshot = true
+			overrideSnapshotParametersInState(val, state)
 			resyncCfg := syncStateToConfigProtoInCatalog(ctx, cfg, state)
 			state.DropFlowInput = &protos.DropFlowInput{
 				FlowJobName:           resyncCfg.FlowJobName,


### PR DESCRIPTION
## Tested scenarios:
### Initial + CDC Pipes:
* Running pipe -> Resync (working)
* Paused Pipe -> Resync (working)
* Snapshot -> Resync (working)
### Initial only Pipes:
* Completed -> Resync (working)
* Failed -> Resync (working)
* Snapshot -> Resync (working)
### CDC Only Pipes:
* Running -> Resync (working) [Does snapshot]
* Paused -> Resync (working) [Does snapshot]