### PR TITLE
feat: add postgresql-client to flow-worker image

### DIFF
--- a/stacks/flow.Dockerfile
+++ b/stacks/flow.Dockerfile
@@ -43,6 +43,10 @@ ENTRYPOINT ["./peer-flow", "api", "--port", "8112", "--gateway-port", "8113"]
 
 FROM flow-base AS flow-worker
 
+USER root
+RUN apk add --no-cache postgresql-client
+USER peerdb
+
 # Sane defaults for OpenTelemetry
 ENV OTEL_METRIC_EXPORT_INTERVAL=10000
 ENV OTEL_EXPORTER_OTLP_COMPRESSION=gzip


### PR DESCRIPTION
- Adds postgresql-client to the flow-worker image.

This is a preparatory PR for an upcoming PG to PG schema migration feature, for which we will be using psql, pg_dump and pg_dumpall.

This should add roughly 4-5MB of size to the flow-worker image