### PR TITLE
feat: add second postgres instance for local testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,12 @@ PG_USER=postgres
 PG_PASSWORD=postgres
 PG_DATABASE=postgres
 
+PG2_HOST=host.docker.internal
+PG2_PORT=5437
+PG2_USER=postgres
+PG2_PASSWORD=postgres
+PG2_DATABASE=postgres
+
 PEERDB_CATALOG_HOST=host.docker.internal
 PEERDB_CATALOG_PORT=9901
 PEERDB_CATALOG_USER=postgres

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -54,6 +54,20 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      catalog2:
+        image: imresamu/postgis:${{ matrix.db-version.pg }}-3.5-alpine
+        ports:
+          - 5437:5432
+        env:
+          PGUSER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_INITDB_ARGS: --locale=C.UTF-8
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       redpanda:
         image: redpandadata/redpanda@sha256:12ddbd8e5572210a48d39afecac44db61503ce1cbdae50ee9b1ff5998a8d91e1
         ports:
@@ -111,11 +125,23 @@ jobs:
           go-version: '1.26.2'
           cache-dependency-path: flow/go.sum
 
-      - name: install lib-geos
+      - name: install lib-geos and pg_dump
         run: |
           # No need to update man pages on package install
           sudo apt-get remove --purge man-db
-          sudo apt-get install libgeos-dev
+          # Add PGDG apt repo for latest PostgreSQL client packages
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+            https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y libgeos-dev
+          # pg_dump must be >= the server major version; install v18 so it
+          # can dump PG 16, 17, and 18 (backward compatible).
+          sudo apt-get install -y postgresql-client-18
+          echo /usr/lib/postgresql/18/bin >> $GITHUB_PATH
 
       - name: install retry tool
         run: |
@@ -272,6 +298,17 @@ jobs:
           -c "ALTER SYSTEM SET max_connections=2048;" &&
           (cat ./nexus/catalog/migrations/V{?,??}__* | docker exec -i "${{ job.services.catalog.id }}" psql -U postgres) &&
           docker restart "${{ job.services.catalog.id }}"
+        env:
+          PGPASSWORD: postgres
+
+      - name: prepare secondary postgres for cross-cluster schema-dump tests
+        run: >
+          docker exec "${{ job.services.catalog2.id }}" psql -U postgres
+          -c "ALTER SYSTEM SET wal_level=logical;"
+          -c "ALTER SYSTEM SET max_replication_slots=192;"
+          -c "ALTER SYSTEM SET max_wal_senders=256;"
+          -c "ALTER SYSTEM SET max_connections=2048;" &&
+          docker restart "${{ job.services.catalog2.id }}"
         env:
           PGPASSWORD: postgres
 
@@ -561,6 +598,11 @@ jobs:
           PG_USER: postgres
           PG_PASSWORD: postgres
           PG_DATABASE: postgres
+          PG2_HOST: localhost
+          PG2_PORT: 5437
+          PG2_USER: postgres
+          PG2_PASSWORD: postgres
+          PG2_DATABASE: postgres
           PEERDB_SWITCHBOARD_ENABLED: "true"
           PEERDB_QUEUE_FORCE_TOPIC_CREATION: "true"
           ELASTICSEARCH_TEST_ADDRESS: http://localhost:9200

--- a/Tiltfile
+++ b/Tiltfile
@@ -113,6 +113,13 @@ local_resource(
     resource_deps=['postgres']
 )
 
+local_resource(
+    'provision-postgres2',
+    cmd='./local_provision_scripts/postgres.sh peerdb-postgres2',
+    labels=['Ancillary-DB-Provisioning'],
+    resource_deps=['postgres2']
+)
+
 # This is not defined as a resource as we need the file to be present
 # when `docker_compose` loads the configuration (next line).
 local('./generate-test-environment.sh')
@@ -148,6 +155,10 @@ dc_resource('mariadb', labels=['Ancillary-DB'], links=[
 
 dc_resource('postgres', labels=['Ancillary-DB'], links=[
     link('http://localhost:5432', 'PostgreSQL'),
+], auto_init=False)
+
+dc_resource('postgres2', labels=['Ancillary-DB'], links=[
+    link('http://localhost:5437', 'PostgreSQL (secondary)'),
 ], auto_init=False)
 
 local_resource(

--- a/ancillary-docker-compose.yml
+++ b/ancillary-docker-compose.yml
@@ -125,6 +125,27 @@ services:
       timeout: 10s
       retries: 5
 
+  postgres2:
+    container_name: peerdb-postgres2
+    image: ${POSTGRES_IMAGE}
+    restart: unless-stopped
+    volumes:
+      - postgres2_data:/var/lib/postgresql/data
+    ports:
+      - "${PG2_PORT}:5432"
+    environment:
+      PGUSER: ${PG2_USER}
+      POSTGRES_PASSWORD: ${PG2_PASSWORD}
+      POSTGRES_DB: ${PG2_DATABASE}
+      POSTGRES_INITDB_ARGS: --locale=C.UTF-8
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 2s
+      timeout: 10s
+      retries: 5
+
   dozzle:
     container_name: dozzle-compose-monitor
     image: amir20/dozzle:latest
@@ -185,6 +206,7 @@ services:
 
 volumes:
   postgres_data:
+  postgres2_data:
   clickhouse_data:
   mongo_data:
   mysql_gtid_data:

--- a/local_provision_scripts/postgres.sh
+++ b/local_provision_scripts/postgres.sh
@@ -6,7 +6,23 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../.env"
 
 DOCKER="docker"
-CONTAINER="peerdb-postgres"
+CONTAINER="${1:-peerdb-postgres}"
+
+# select per-instance vars based on container name
+case "$CONTAINER" in
+  peerdb-postgres2)
+    PG_INSTANCE_USER="$PG2_USER"
+    PG_INSTANCE_DATABASE="$PG2_DATABASE"
+    PG_INSTANCE_HOST="$PG2_HOST"
+    PG_INSTANCE_PORT="$PG2_PORT"
+    ;;
+  *)
+    PG_INSTANCE_USER="$PG_USER"
+    PG_INSTANCE_DATABASE="$PG_DATABASE"
+    PG_INSTANCE_HOST="$PG_HOST"
+    PG_INSTANCE_PORT="$PG_PORT"
+    ;;
+esac
 
 echo "install pgvector extension"
 if ! $DOCKER exec "$CONTAINER" test -d /tmp/pgvector; then
@@ -16,7 +32,7 @@ if ! $DOCKER exec "$CONTAINER" test -d /tmp/pgvector; then
 fi
 
 echo "create extensions and configure replication"
-$DOCKER exec "$CONTAINER" psql -U "$PG_USER" -d "$PG_DATABASE" \
+$DOCKER exec "$CONTAINER" psql -U "$PG_INSTANCE_USER" -d "$PG_INSTANCE_DATABASE" \
   -c "CREATE EXTENSION IF NOT EXISTS hstore;" \
   -c "CREATE EXTENSION IF NOT EXISTS vector;" \
   -c "ALTER SYSTEM SET wal_level=logical;" \
@@ -25,9 +41,9 @@ $DOCKER exec "$CONTAINER" psql -U "$PG_USER" -d "$PG_DATABASE" \
   -c "ALTER SYSTEM SET max_connections=2048;"
 
 echo "restart postgres to apply config changes"
-CURRENT_WAL=$($DOCKER exec "$CONTAINER" psql -U "$PG_USER" -d "$PG_DATABASE" -tAc "SHOW wal_level;")
+CURRENT_WAL=$($DOCKER exec "$CONTAINER" psql -U "$PG_INSTANCE_USER" -d "$PG_INSTANCE_DATABASE" -tAc "SHOW wal_level;")
 if [ "$CURRENT_WAL" != "logical" ]; then
   $DOCKER restart "$CONTAINER"
 fi
 
-echo "PostgreSQL is ready at ${PG_HOST}:${PG_PORT}"
+echo "PostgreSQL is ready at ${PG_INSTANCE_HOST}:${PG_INSTANCE_PORT}"


### PR DESCRIPTION
For testing Postgres to Postgres mirrors, it would be good to have a second Postgres instance rather than have source and destination be same, for testing things like roles being copied over