### PR TITLE
adding index to improve query performance

### DIFF
--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -77,7 +77,19 @@ async fn run_migrations(client: &mut Client) -> anyhow::Result<()> {
             migration.version()
         );
     }
-    Ok(())
+    run_non_transactional_migrations(client).await?;
+}
+
+async fn run_non_transactional_migrations(client: &Client) -> anyhow::Result<()> {
+    const STATEMENTS: &[&str] = &[
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cdc_batches_flow_name_batch_id_open ON peerdb_stats.cdc_batches (flow_name, batch_id) WHERE end_time IS NULL",
+    ];
+    for stmt in STATEMENTS {
+        client
+            .batch_execute(stmt)
+            .await
+            .with_context(|| format!("Failed to apply non-transactional migration: {stmt}"))?;
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -78,6 +78,7 @@ async fn run_migrations(client: &mut Client) -> anyhow::Result<()> {
         );
     }
     run_non_transactional_migrations(client).await?;
+    Ok(())
 }
 
 async fn run_non_transactional_migrations(client: &Client) -> anyhow::Result<()> {
@@ -90,6 +91,7 @@ async fn run_non_transactional_migrations(client: &Client) -> anyhow::Result<()>
             .await
             .with_context(|| format!("Failed to apply non-transactional migration: {stmt}"))?;
     }
+    Ok(())
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Adding an index to speed up the following query, which can be expensive for long-running services with high batch volumes.

`UPDATE peerdb_stats.cdc_batches SET end_time = NOW() WHERE flow_name = $1 AND batch_id <= $2 AND end_time IS NULL`

We cannot directly add this to the .sql migration script because the refinery library wrap all migrations in transactions and would not support `concurrently`. So instead the plan is to introduce a temporary workaround:

  1. create the non-transactional concurrent index dynamically in code 
  2. deploy the change
  3. add 'CREATE INDEX IF NOT EXISTS' with the same index name via sql migration script (should no-op)
  4. delete the code change