### PR TITLE
fix(tests): use different application name for catalog access

### DIFF
--- a/flow/e2e/congen.go
+++ b/flow/e2e/congen.go
@@ -10,7 +10,6 @@ import (
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
-	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
@@ -40,9 +39,9 @@ func TableMappings(s GenericSuite, tables ...string) []*protos.TableMapping {
 
 func CreatePeer(t *testing.T, peer *protos.Peer) {
 	t.Helper()
-	pool, err := internal.GetCatalogConnectionPoolFromEnv(t.Context())
+	pool, err := catalogTestAccessPool()
 	require.NoError(t, err)
-	res, err := utils.CreatePeerNoValidate(t.Context(), pool, peer, false)
+	res, err := utils.CreatePeerNoValidate(t.Context(), shared.CatalogPool{Pool: pool}, peer, false)
 	require.NoError(t, err)
 	if res.Status != protos.CreatePeerStatus_CREATED {
 		require.Fail(t, res.Message)

--- a/flow/e2e/test_utils.go
+++ b/flow/e2e/test_utils.go
@@ -8,12 +8,14 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/client"
@@ -724,11 +726,26 @@ func (env WorkflowRun) Query(ctx context.Context, queryType string, args ...any)
 	return env.c.QueryWorkflow(ctx, env.GetID(), "", queryType, args...)
 }
 
+// catalogTestAccessPool is a pgxpool with application_name="catalog_test_access"
+// so test-side catalog reads are not collateral damage when other tests issue
+// pg_terminate_backend WHERE application_name='peerdb' (see api_test.go).
+var catalogTestAccessPool = sync.OnceValues(func() (*pgxpool.Pool, error) {
+	ctx := context.Background()
+	connStr := internal.GetCatalogConnectionStringFromEnv(ctx)
+	cfg, err := pgxpool.ParseConfig(connStr)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ConnConfig.RuntimeParams["application_name"] = "catalog_test_access"
+	cfg.MaxConns = 3
+	return pgxpool.NewWithConfig(ctx, cfg)
+})
+
 func (env WorkflowRun) GetFlowStatus(t *testing.T) protos.FlowStatus {
 	t.Helper()
-	pool, err := internal.GetCatalogConnectionPoolFromEnv(t.Context())
+	pool, err := catalogTestAccessPool()
 	EnvNoError(t, env, err)
-	status, err := internal.GetWorkflowStatus(t.Context(), pool, env.GetID())
+	status, err := internal.GetWorkflowStatus(t.Context(), shared.CatalogPool{Pool: pool}, env.GetID())
 	EnvNoError(t, env, err)
 	return status
 }


### PR DESCRIPTION
Noticed that E2E tests were flaking due to another test running pg_terminate_backend on catalog peer via peerdb application name, affecting catalog accesses of other tests.

This PR changes the catalog access connection for flow status in E2E to use a different application name