### PR TITLE
add index creation to migration scripts

### DIFF
--- a/nexus/Cargo.lock
+++ b/nexus/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "postgres-connection",
  "pt",
  "refinery",
+ "reqwest",
  "serde_json",
  "sqlparser",
  "tokio",

--- a/nexus/catalog/migrations/V53__cdc_batches_open_index.sql
+++ b/nexus/catalog/migrations/V53__cdc_batches_open_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_cdc_batches_flow_name_batch_id_open ON peerdb_stats.cdc_batches (flow_name, batch_id) WHERE end_time IS NULL;

--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -151,20 +151,6 @@ async fn run_migrations(client: &mut Client) -> anyhow::Result<()> {
             migration.version()
         );
     }
-    run_non_transactional_migrations(client).await?;
-    Ok(())
-}
-
-async fn run_non_transactional_migrations(client: &Client) -> anyhow::Result<()> {
-    const STATEMENTS: &[&str] = &[
-        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cdc_batches_flow_name_batch_id_open ON peerdb_stats.cdc_batches (flow_name, batch_id) WHERE end_time IS NULL",
-    ];
-    for stmt in STATEMENTS {
-        client
-            .batch_execute(stmt)
-            .await
-            .with_context(|| format!("Failed to apply non-transactional migration: {stmt}"))?;
-    }
     Ok(())
 }
 


### PR DESCRIPTION
and remove the one-off `run_non_transactional_migrations`.

For existing prod DBs this is a no-op; for fresh DBs the table is empty, so a non-concurrent build is fine.

Will add a comment in the next release note about this so anyone using this in prod can also create this index before performing the upgrade. 

