### PR TITLE
update broken tests due to single-column PARTITION BY / ORDER BY change in latest CH

### DIFF
--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -3025,8 +3025,9 @@ func (s ClickHouseSuite) Test_PartitionBy() {
 		)).Scan(&partitionKey, &sortingKey),
 	)
 	require.NoError(s.t, ch.Close())
-	require.Equal(s.t, "num", partitionKey)
-	require.Equal(s.t, "val", sortingKey)
+	// ClickHouse 26.5+ preserves the parens around single-column PARTITION BY / ORDER BY in system.tables; older versions unwrap them.
+	require.Contains(s.t, []string{"num", "(num)"}, partitionKey)
+	require.Contains(s.t, []string{"val", "(val)"}, sortingKey)
 
 	env.Cancel(s.t.Context())
 	RequireEnvCanceled(s.t, env)


### PR DESCRIPTION
Fix [e2e test failures](https://github.com/PeerDB-io/peerdb/actions/runs/25718948064/job/75518084196):

ClickHouse 26.5+ preserves the parens around single-column PARTITION BY / ORDER BY in system.tables; older versions unwrap them. 