### PR TITLE
CI: Bump e2e timeout to 20'

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -557,7 +557,7 @@ jobs:
           ./peer-flow worker > ../logs/peer-flow-worker.log 2>&1 &
           ./peer-flow snapshot-worker > ../logs/peer-flow-snapshot-worker.log 2>&1 &
           ./peer-flow api --port 8112 --gateway-port 8113 > ../logs/peer-flow-api.log 2>&1 &
-          gotestsum --format standard-quiet --no-color --junitfile ../logs/test-results.xml -- -cover -coverpkg github.com/PeerDB-io/peerdb/flow/... -p 32 ./... -timeout 900s -args -test.gocoverdir="$PWD/coverage"
+          gotestsum --format standard-quiet --no-color --junitfile ../logs/test-results.xml -- -cover -coverpkg github.com/PeerDB-io/peerdb/flow/... -p 32 ./... -timeout 1200s -args -test.gocoverdir="$PWD/coverage"
           killall peer-flow
           sleep 1
           go tool covdata textfmt -i=coverage -o ../coverage.out


### PR DESCRIPTION
Most of our successful CI e2e executions finish in the last 10'' before the 900'' (15') timeout.
This means that  most of the runs are close to hit the timeout and the slightest delay leads to a failed e2e run which.

<img width="1808" height="1386" alt="image" src="https://github.com/user-attachments/assets/3aa0a5a3-9676-4f3a-b1b1-b814e04028b2" />

This process repeats  several times until a run is fast enough per commit, per PR.

This PR bumps the timeout to 20' with the expectation of ending up with faster (no retries) and more predictable builds.