### PR TITLE
Work around ClickHouse changes by which `CREATE OR REPLACE` orphans existing views

### DIFF
--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -2642,6 +2642,12 @@ func (s ClickHouseSuite) Test_NullEngine() {
 	require.NoError(s.t, err)
 	require.NoError(s.t, ch.Exec(s.t.Context(), "TRUNCATE TABLE nulltarget"))
 	require.NoError(s.t, ch.Close())
+	// TODO: Revert this block after future CH behaviour is clarified.
+	// Work around CH 26.5+ behavior: EXCHANGE TABLES and CREATE OR REPLACE on a source table
+	// orphan its dependent materialized views.
+	require.NoError(s.t, s.source.Exec(s.t.Context(), `TRUNCATE TABLE `+srcFullName))
+	// end of workaround block
+
 	flowConnConfig.DoInitialSnapshot = true
 	flowConnConfig.Resync = true
 	env = ExecutePeerflow(s.t, tc, flowConnConfig)
@@ -2656,8 +2662,6 @@ func (s ClickHouseSuite) Test_NullEngine() {
 	require.NoError(s.t, ch.Exec(s.t.Context(),
 		`create materialized view nullmv to nulltarget as select id, "key", _peerdb_is_deleted from test_nullengine`))
 	require.NoError(s.t, ch.Close())
-
-	require.NoError(s.t, s.source.Exec(s.t.Context(), `TRUNCATE TABLE `+srcFullName))
 	// end of workaround block
 
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, "nulltarget", "id,\"key\"")

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -2647,17 +2647,17 @@ func (s ClickHouseSuite) Test_NullEngine() {
 	env = ExecutePeerflow(s.t, tc, flowConnConfig)
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
-	// Block to work around changes in ClickHouse by which EXCHANGE and CREARE OR REPLACE orphan source tables.
+	// TODO: Revert this block after future CH behaviour is clarified.
+	// Work around CH 26.5+ behavior: EXCHANGE TABLES and CREATE OR REPLACE on a source table
+	// orphan its dependent materialized views.
 	ch, err = connclickhouse.Connect(s.t.Context(), nil, chPeer)
 	require.NoError(s.t, err)
-	require.NoError(s.t, ch.Exec(s.t.Context(),
-		`drop view nullmv`))
+	require.NoError(s.t, ch.Exec(s.t.Context(), `DROP VIEW IF EXISTS nullmv`))
 	require.NoError(s.t, ch.Exec(s.t.Context(),
 		`create materialized view nullmv to nulltarget as select id, "key", _peerdb_is_deleted from test_nullengine`))
 	require.NoError(s.t, ch.Close())
 
-	require.NoError(s.t, s.source.Exec(s.t.Context(),
-		fmt.Sprintf(`TRUNCATE TABLE %s`, srcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(), `TRUNCATE TABLE `+srcFullName))
 	// end of workaround block
 
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, "nulltarget", "id,\"key\"")

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -2646,6 +2646,20 @@ func (s ClickHouseSuite) Test_NullEngine() {
 	flowConnConfig.Resync = true
 	env = ExecutePeerflow(s.t, tc, flowConnConfig)
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	// Block to work around changes in ClickHouse by which EXCHANGE and CREARE OR REPLACE orphan source tables.
+	ch, err = connclickhouse.Connect(s.t.Context(), nil, chPeer)
+	require.NoError(s.t, err)
+	require.NoError(s.t, ch.Exec(s.t.Context(),
+		`drop view nullmv`))
+	require.NoError(s.t, ch.Exec(s.t.Context(),
+		`create materialized view nullmv to nulltarget as select id, "key", _peerdb_is_deleted from test_nullengine`))
+	require.NoError(s.t, ch.Close())
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf(`TRUNCATE TABLE %s`, srcFullName)))
+	// end of workaround block
+
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, "nulltarget", "id,\"key\"")
 
 	require.NoError(s.t, s.source.Exec(s.t.Context(),


### PR DESCRIPTION

Related to: https://linear.app/clickhouse/issue/DBI-738