### PR TITLE
setting standard_conforming_strings on the client side

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -70,6 +70,9 @@ func NewPostgresConnector(ctx context.Context, env map[string]string, pgConfig *
 	connConfig.Config.RuntimeParams["idle_in_transaction_session_timeout"] = "0"
 	connConfig.Config.RuntimeParams["statement_timeout"] = "0"
 	connConfig.Config.RuntimeParams["DateStyle"] = "ISO, DMY"
+	// Required for QueryExecModeSimpleProtocol, which is set in some places while querying;
+	// pgx refuses simple protocol when the server reports standard_conforming_strings=off.
+	connConfig.Config.RuntimeParams["standard_conforming_strings"] = "on"
 
 	tunnel, err := utils.NewSSHTunnel(ctx, pgConfig.SshConfig)
 	if err != nil {

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -49,6 +49,9 @@ func (c *PostgresConnector) CreateReplConn(ctx context.Context, env map[string]s
 	replConfig.Config.RuntimeParams["bytea_output"] = "hex"
 	replConfig.Config.RuntimeParams["intervalstyle"] = "postgres"
 	replConfig.Config.RuntimeParams["DateStyle"] = "ISO, DMY"
+	// Required for QueryExecModeSimpleProtocol below; pgx refuses simple
+	// protocol when the server reports standard_conforming_strings=off.
+	replConfig.Config.RuntimeParams["standard_conforming_strings"] = "on"
 	replConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 
 	walSenderTimeout, err := internal.PeerDBPostgresWalSenderTimeout(ctx, env)


### PR DESCRIPTION
Setting this on the client-side to avoid needing to validate this on the server. 

Fixes: DBI-739