### PR TITLE
Classify BigQuery googleapi errors in alerting

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -23,6 +23,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology"
 	"go.temporal.io/sdk/temporal"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/api/googleapi"
 
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	peerdb_clickhouse "github.com/PeerDB-io/peerdb/flow/pkg/clickhouse"
@@ -81,6 +82,7 @@ const (
 	ErrorSourcePostgres        ErrorSource = "postgres"
 	ErrorSourceMySQL           ErrorSource = "mysql"
 	ErrorSourceMongoDB         ErrorSource = "mongodb"
+	ErrorSourceBigQuery        ErrorSource = "bigquery"
 	ErrorSourcePostgresCatalog ErrorSource = "postgres_catalog"
 	ErrorSourceSSH             ErrorSource = "ssh_tunnel"
 	ErrorSourceNet             ErrorSource = "net"
@@ -870,6 +872,20 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorRetryRecoverable, mongoErrorInfo
 		}
 		return ErrorRetryRecoverable, mongoErrorInfo
+	}
+
+	if apiErr, ok := errors.AsType[*googleapi.Error](err); ok {
+		bqErrorInfo := ErrorInfo{
+			Source: ErrorSourceBigQuery,
+			Code:   strconv.Itoa(apiErr.Code),
+		}
+		switch apiErr.Code {
+		case 401, // Unauthorized
+			403, // Forbidden
+			404: // Not Found (e.g. missing dataset/table/staging bucket)
+			return ErrorNotifyConnectivity, bqErrorInfo
+		}
+		return ErrorOther, bqErrorInfo
 	}
 
 	if chException, ok := errors.AsType[*clickhouse.Exception](err); ok {

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"testing"
 
+	"cloud.google.com/go/storage"
 	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -23,6 +24,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver"
 	"go.temporal.io/sdk/temporal"
+	"google.golang.org/api/googleapi"
 
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	peerdb_clickhouse "github.com/PeerDB-io/peerdb/flow/pkg/clickhouse"
@@ -1013,5 +1015,54 @@ func TestMySQLGeometryParseErrorUnknownShouldFallThrough(t *testing.T) {
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceOther,
 		Code:   "UNKNOWN",
+	}, errInfo)
+}
+
+func TestGoogleAPIAuthAndAccessErrorsShouldBeConnectivity(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []int{401, 403, 404} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			t.Parallel()
+
+			apiErr := &googleapi.Error{Code: code, Message: "boom"}
+			errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed to access staging bucket: %w", apiErr))
+			assert.Equal(t, ErrorNotifyConnectivity, errorClass)
+			assert.Equal(t, ErrorInfo{
+				Source: ErrorSourceBigQuery,
+				Code:   strconv.Itoa(code),
+			}, errInfo)
+		})
+	}
+}
+
+// Mirrors the cloud.google.com/go/storage wrapping of 404 from `formatBucketError`:
+//
+//	return fmt.Errorf("%w: %w", ErrBucketNotExist, err)
+//
+// `it.Next()` on a missing staging bucket surfaces this exact shape at
+// connectors/bigquery/source.go:59.
+func TestGCSBucketNotExistShouldBeConnectivity(t *testing.T) {
+	t.Parallel()
+
+	apiErr := &googleapi.Error{Code: 404, Message: "Not Found"}
+	wrapped := fmt.Errorf("%w: %w", storage.ErrBucketNotExist, apiErr)
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed to access staging bucket: %w", wrapped))
+	assert.Equal(t, ErrorNotifyConnectivity, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceBigQuery,
+		Code:   "404",
+	}, errInfo)
+}
+
+func TestGoogleAPIUnclassifiedCodeShouldBeOther(t *testing.T) {
+	t.Parallel()
+
+	apiErr := &googleapi.Error{Code: 500, Message: "internal"}
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("export job failed: %w", apiErr))
+	assert.Equal(t, ErrorOther, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceBigQuery,
+		Code:   "500",
 	}, errInfo)
 }


### PR DESCRIPTION
Adds a *googleapi.Error branch to GetErrorClass with a new ErrorSourceBigQuery: 401/403/404 map to ErrorNotifyConnectivity (catches the staging-bucket access failure raised at connectors/bigquery/source.go:59, including the storage library's ErrBucketNotExist-wrapped 404), and other codes fall through to ErrorOther with the BigQuery source preserved.

Resolves DBI-742.