### PR TITLE
use heartbeat to detect stale mysql connection 

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -1087,6 +1087,13 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
+	if _, ok := errors.AsType[*exceptions.MySQLStaleConnectionError](err); ok {
+		return ErrorRetryRecoverable, ErrorInfo{
+			Source: ErrorSourceMySQL,
+			Code:   "CONNECTION_STALE",
+		}
+	}
+
 	if mysqlGeometryParseError, ok := errors.AsType[*exceptions.MySQLGeometryParseError](err); ok &&
 		strings.Contains(mysqlGeometryParseError.Error(), mysqlGeometryLinearRingNotClosedError) {
 		return ErrorUnsupportedDatatype, ErrorInfo{

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -32,6 +32,15 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
+const (
+	defaultBinlogHeartbeatPeriod = 30 * time.Second
+	binlogStalenessMultiplier    = 3
+)
+
+func (c *MySqlConnector) binlogStalenessThreshold() time.Duration {
+	return binlogStalenessMultiplier * c.binlogHeartbeatPeriod
+}
+
 func (c *MySqlConnector) GetTableSchema(
 	ctx context.Context,
 	env map[string]string,
@@ -264,6 +273,7 @@ func (c *MySqlConnector) startSyncer(ctx context.Context) (*replication.BinlogSy
 		UseDecimal:       true,
 		ParseTime:        true,
 		TLSConfig:        tlsConfig,
+		HeartbeatPeriod:  c.binlogHeartbeatPeriod,
 	}), nil
 }
 
@@ -413,7 +423,7 @@ func (c *MySqlConnector) PullRecords(
 	})
 	defer shutdown()
 
-	timeoutCtx, cancelTimeout := context.WithTimeout(ctx, time.Hour)
+	timeoutCtx, cancelTimeout := context.WithTimeout(ctx, c.binlogStalenessThreshold())
 	//nolint:gocritic // cancelTimeout is rebound, do not defer cancelTimeout()
 	defer func() {
 		cancelTimeout()
@@ -441,6 +451,7 @@ func (c *MySqlConnector) PullRecords(
 		return nil
 	}
 
+	lastEventAt := time.Now()
 	var mysqlParser *parser.Parser
 	for inTx || (!overtime && recordCount < req.MaxBatchSize) {
 		var event *replication.BinlogEvent
@@ -456,6 +467,10 @@ func (c *MySqlConnector) PullRecords(
 				return ctxErr
 			} else if errors.Is(err, context.DeadlineExceeded) {
 				if recordCount == 0 {
+					if since := time.Since(lastEventAt); since > c.binlogStalenessThreshold() {
+						return exceptions.NewMySQLStaleConnectionError(since, c.binlogHeartbeatPeriod)
+					}
+
 					// progress offset while no records read to avoid falling behind when all tables inactive
 					if updatedOffset != "" {
 						c.logger.Info("[mysql] updating inactive offset", slog.Any("offset", updatedOffset))
@@ -468,7 +483,7 @@ func (c *MySqlConnector) PullRecords(
 
 					// reset timer for next offset update
 					cancelTimeout()
-					timeoutCtx, cancelTimeout = context.WithTimeout(ctx, time.Hour)
+					timeoutCtx, cancelTimeout = context.WithTimeout(ctx, c.binlogStalenessThreshold())
 				} else if inTx {
 					c.logger.Info("[mysql] timeout reached, but still in transaction, waiting for inTx false",
 						slog.Uint64("records", uint64(recordCount)),
@@ -490,6 +505,8 @@ func (c *MySqlConnector) PullRecords(
 			}
 			return exceptions.NewMySQLStreamingError(err)
 		}
+
+		lastEventAt = time.Now()
 
 		allFetchedBytes.Add(int64(len(event.RawData)))
 

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	defaultBinlogHeartbeatPeriod = 30 * time.Second
+	defaultBinlogHeartbeatPeriod = time.Minute
 	binlogStalenessMultiplier    = 3
 )
 
@@ -428,6 +428,10 @@ func (c *MySqlConnector) PullRecords(
 	defer func() {
 		cancelTimeout()
 	}()
+	resetTimeout := func(d time.Duration) {
+		cancelTimeout()
+		timeoutCtx, cancelTimeout = context.WithTimeout(ctx, d)
+	}
 
 	addRecord := func(ctx context.Context, record model.Record[model.RecordItems]) error {
 		recordCount += 1
@@ -436,8 +440,7 @@ func (c *MySqlConnector) PullRecords(
 		}
 		if recordCount == 1 {
 			req.RecordStream.SignalAsNotEmpty()
-			cancelTimeout()
-			timeoutCtx, cancelTimeout = context.WithTimeout(ctx, req.IdleTimeout)
+			resetTimeout(req.IdleTimeout)
 		}
 		if recordCount%50000 == 0 {
 			c.logger.Info("[mysql] PullRecords streaming",
@@ -463,46 +466,43 @@ func (c *MySqlConnector) PullRecords(
 		if err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				c.logger.Info("[mysql] PullRecords context canceled, stopping streaming", slog.Any("error", err))
-				//nolint:govet // cancelTimeout called by defer, spurious lint
 				return ctxErr
-			} else if errors.Is(err, context.DeadlineExceeded) {
-				if recordCount == 0 {
+			}
+
+			if errors.Is(err, context.DeadlineExceeded) {
+				if recordCount == 0 || inTx {
 					if since := time.Since(lastEventAt); since > c.binlogStalenessThreshold() {
 						return exceptions.NewMySQLStaleConnectionError(since, c.binlogHeartbeatPeriod)
 					}
 
-					// progress offset while no records read to avoid falling behind when all tables inactive
-					if updatedOffset != "" {
-						c.logger.Info("[mysql] updating inactive offset", slog.Any("offset", updatedOffset))
-						if err := c.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{Text: updatedOffset}); err != nil {
-							c.logger.Error("[mysql] failed to update offset, ignoring", slog.Any("error", err))
-						} else {
-							updatedOffset = ""
+					if recordCount == 0 {
+						// progress offset while no records read to avoid falling behind when all tables inactive
+						if updatedOffset != "" {
+							c.logger.Info("[mysql] updating inactive offset", slog.Any("offset", updatedOffset))
+							if err := c.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{Text: updatedOffset}); err != nil {
+								c.logger.Error("[mysql] failed to update offset, ignoring", slog.Any("error", err))
+							} else {
+								updatedOffset = ""
+							}
 						}
+						resetTimeout(c.binlogStalenessThreshold())
+					} else {
+						c.logger.Info("[mysql] timeout reached, but still in transaction, waiting for inTx false",
+							slog.Uint64("records", uint64(recordCount)),
+							slog.Int64("bytes", totalFetchedBytes.Load()),
+							slog.Int("channelLen", req.RecordStream.ChannelLen()),
+							slog.Float64("elapsedMinutes", time.Since(pullStart).Minutes()))
+						resetTimeout(time.Minute)
+						overtime = true
 					}
 
-					// reset timer for next offset update
-					cancelTimeout()
-					timeoutCtx, cancelTimeout = context.WithTimeout(ctx, c.binlogStalenessThreshold())
-				} else if inTx {
-					c.logger.Info("[mysql] timeout reached, but still in transaction, waiting for inTx false",
-						slog.Uint64("records", uint64(recordCount)),
-						slog.Int64("bytes", totalFetchedBytes.Load()),
-						slog.Int("channelLen", req.RecordStream.ChannelLen()),
-						slog.Float64("elapsedMinutes", time.Since(pullStart).Minutes()))
-					// reset timeoutCtx to a low value and wait for inTx to become false
-					cancelTimeout()
-					//nolint:govet // cancelTimeout called by defer, spurious lint
-					timeoutCtx, cancelTimeout = context.WithTimeout(ctx, time.Minute)
-					overtime = true
-				} else {
-					return nil
+					continue
 				}
 
-				continue
-			} else {
-				c.logger.Error("[mysql] PullRecords failed to get event", slog.Any("error", err))
+				return nil
 			}
+
+			c.logger.Error("[mysql] PullRecords failed to get event", slog.Any("error", err))
 			return exceptions.NewMySQLStreamingError(err)
 		}
 

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -29,15 +29,16 @@ import (
 
 type MySqlConnector struct {
 	*metadataStore.PostgresMetadata
-	config         *protos.MySqlConfig
-	ssh            *utils.SSHTunnel
-	conn           atomic.Pointer[client.Conn] // atomic used for internal concurrency, connector interface is not threadsafe
-	contexts       atomic.Pointer[chan context.Context]
-	logger         log.Logger
-	rdsAuth        *utils.RDSAuth
-	serverVersion  string
-	totalBytesRead atomic.Int64
-	deltaBytesRead atomic.Int64
+	config                *protos.MySqlConfig
+	ssh                   *utils.SSHTunnel
+	conn                  atomic.Pointer[client.Conn] // atomic used for internal concurrency, connector interface is not threadsafe
+	contexts              atomic.Pointer[chan context.Context]
+	logger                log.Logger
+	rdsAuth               *utils.RDSAuth
+	serverVersion         string
+	binlogHeartbeatPeriod time.Duration
+	totalBytesRead        atomic.Int64
+	deltaBytesRead        atomic.Int64
 }
 
 func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlConnector, error) {
@@ -62,12 +63,13 @@ func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlC
 	}
 	contexts := make(chan context.Context)
 	c := &MySqlConnector{
-		PostgresMetadata: pgMetadata,
-		config:           config,
-		ssh:              ssh,
-		conn:             atomic.Pointer[client.Conn]{},
-		logger:           logger,
-		rdsAuth:          rdsAuth,
+		PostgresMetadata:      pgMetadata,
+		config:                config,
+		ssh:                   ssh,
+		conn:                  atomic.Pointer[client.Conn]{},
+		logger:                logger,
+		rdsAuth:               rdsAuth,
+		binlogHeartbeatPeriod: defaultBinlogHeartbeatPeriod,
 	}
 	c.contexts.Store(&contexts)
 	go func() { //nolint:gosec // G118: long-lived goroutine, not request-scoped

--- a/flow/connectors/mysql/ssh_keepalive_test.go
+++ b/flow/connectors/mysql/ssh_keepalive_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/concurrency"
+	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 )
 
 const (
@@ -26,6 +27,7 @@ const (
 	toxiproxyCDCHangProxyPort           = 42004
 	toxiproxyCDCCloseHangProxyPort      = 42005
 	toxiproxyCloseSyncerWithTimeoutPort = 42006
+	toxiproxyBinlogStalenessPort        = 42007
 )
 
 func resolveMySQL(t *testing.T) (string, uint32, string) {
@@ -341,5 +343,55 @@ func TestMySQLCloseSyncerWithTimeout(t *testing.T) {
 		require.Less(t, elapsed, syncerCloseTimeout+time.Second)
 	case <-time.After(10 * time.Second):
 		t.Fatal("closeSyncerWithTimeout did not return on timeout")
+	}
+}
+
+// TestMySQLBinlogStalenessThreshold verifies that when bytes stop flowing from MySQL, PullRecords
+// returns MySQLStaleConnectionError once time.Since(lastEventAt) exceeds the staleness threshold.
+func TestMySQLBinlogStalenessThreshold(t *testing.T) {
+	t.Parallel()
+	if internal.MySQLTestVersionIsMaria() {
+		t.Skip("Skipping for MariaDB")
+	}
+
+	ctx := t.Context()
+	connector, mysqlProxy := setupMySQLConnectorWithMySQLProxy(ctx, t, "my-binlog-staleness-test", toxiproxyBinlogStalenessPort)
+	defer connector.Close()
+
+	// use a short staleness threshold (3x heartbeat period) to make test faster
+	connector.binlogHeartbeatPeriod = 1 * time.Second
+
+	req, otelManager := setupCDCPullRecords(ctx, t, connector, "test_binlog_staleness")
+
+	pullDone := concurrency.NewLatch[error]()
+	go func() {
+		pullDone.Set(connector.PullRecords(ctx, shared.CatalogPool{}, otelManager, req))
+	}()
+	go func() {
+		for range req.RecordStream.GetRecords() {
+		}
+	}()
+
+	// Let CDC streaming + heartbeats establish
+	time.Sleep(2 * time.Second)
+
+	t.Log("Adding latency toxic to silence the bastion <-> MySQL link")
+	_, err := mysqlProxy.AddToxic("staleness-latency", "latency", "", 1.0, toxiproxy.Attributes{
+		"latency": 120000,
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-pullDone.Chan():
+		pullErr := pullDone.Wait()
+		require.Error(t, pullErr)
+		var staleErr *exceptions.MySQLStaleConnectionError
+		require.ErrorAs(t, pullErr, &staleErr)
+		require.GreaterOrEqual(t, staleErr.Since, connector.binlogStalenessThreshold())
+		require.Equal(t, connector.binlogHeartbeatPeriod, staleErr.HeartbeatPeriod)
+		t.Logf("PullRecords returned staleness error after %v (heartbeat=%v)",
+			staleErr.Since, staleErr.HeartbeatPeriod)
+	case <-time.After(30 * time.Second):
+		t.Fatal("PullRecords did not return MySQLStaleConnectionError within staleness budget")
 	}
 }

--- a/flow/shared/exceptions/mysql.go
+++ b/flow/shared/exceptions/mysql.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 )
@@ -119,4 +120,20 @@ func (e *MySQLStreamingError) Error() string {
 
 func (e *MySQLStreamingError) Unwrap() error {
 	return e.error
+}
+
+// MySQLStaleConnectionError indicates that no events (rows or heartbeats) have arrived
+// from the MySQL master in longer than the configured staleness window.
+type MySQLStaleConnectionError struct {
+	Since           time.Duration
+	HeartbeatPeriod time.Duration
+}
+
+func NewMySQLStaleConnectionError(since, heartbeatPeriod time.Duration) *MySQLStaleConnectionError {
+	return &MySQLStaleConnectionError{Since: since, HeartbeatPeriod: heartbeatPeriod}
+}
+
+func (e *MySQLStaleConnectionError) Error() string {
+	return fmt.Sprintf("MySQL connection is stale: no events received in %v (heartbeat=%v)",
+		e.Since, e.HeartbeatPeriod)
 }


### PR DESCRIPTION
When connecting to a MySQL server via SSH, the existing SSH keepalive can detect connectivity issues if connectivity drops between peerdb <-> bastion server; however, we have observed scenarios where the the peerdb <-> bastion host ssh tunnel is healthy (keepalive loop did not detect any issues), but events are not received even though there are writes to the replicated table; the connector waits on `mystream.GetEvent` (not receiving error or EOF). Then upon pause/resume, the pipe resumes processing from the last recorded offset. 

This fix enables `HeartbeatPeriod` (passed in as a client-side config). Every 30s, we ask MySQL server to send  a HeartbeatEvent if it's idle. This allow us to detect connectivity issue end-to-end if we don't receive heartbeat within the configured time (set as 3*heartbeat period, so 90s). Note that heartbeat events are only submitted when service is idle, tracking the time delta from the last event rather than from the last heartbeat event for detection. 

An additional benefit of heartbeat event is it prevents the connection from being stale and getting terminated somewhere upstream, especially with ssh tunnel where we don't directly connect to the server.

Fixes: DBI-750