### PR TITLE
Add 90-day TTL on ClickHouse _peerdb_raw table

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -70,7 +71,12 @@ func (c *ClickHouseConnector) CreateRawTable(ctx context.Context, req *protos.Cr
 		rawTableName += "_shard"
 	}
 
-	createRawTableSQL := `CREATE TABLE IF NOT EXISTS %s%s %s ENGINE = %s ORDER BY (_peerdb_batch_id, _peerdb_destination_table_name)`
+	ttlDays, err := internal.PeerDBClickHouseRawTableTTLDays(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load raw table TTL days: %w", err)
+	}
+	createRawTableSQL := `CREATE TABLE IF NOT EXISTS %s%s %s ENGINE = %s ORDER BY (_peerdb_batch_id, _peerdb_destination_table_name)` +
+		` TTL fromUnixTimestamp64Nano(_peerdb_timestamp) + INTERVAL ` + strconv.FormatUint(uint64(ttlDays), 10) + ` DAY`
 	if err := c.execWithLogging(ctx,
 		fmt.Sprintf(createRawTableSQL, peerdb_clickhouse.QuoteIdentifier(rawTableName), onCluster, rawColumns, engine),
 	); err != nil {

--- a/flow/connectors/clickhouse/cdc_test.go
+++ b/flow/connectors/clickhouse/cdc_test.go
@@ -1,9 +1,16 @@
 package connclickhouse
 
 import (
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
+	peerdb_clickhouse "github.com/PeerDB-io/peerdb/flow/pkg/clickhouse"
 )
 
 func TestExtractSingleQuotedStrings(t *testing.T) {
@@ -73,6 +80,62 @@ func TestExtractSingleQuotedStrings(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := extractSingleQuotedStrings(tt.input)
 			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCreateRawTableHasTTL(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		overrideDays string
+		expectedDays int
+	}{
+		{name: "default 90-day TTL", overrideDays: "", expectedDays: 90},
+		{name: "env override applies", overrideDays: "42", expectedDays: 42},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const ttlKey = "PEERDB_CLICKHOUSE_RAW_TABLE_TTL_DAYS"
+			if tc.overrideDays != "" {
+				t.Setenv(ttlKey, tc.overrideDays)
+			} else {
+				// t.Setenv records the prior value and restores on cleanup; Unsetenv ensures the dyn
+				// config falls back to its registered default for this subtest.
+				t.Setenv(ttlKey, "")
+				require.NoError(t, os.Unsetenv(ttlKey))
+			}
+			// NewClickHouseConnector requires a staging bucket; CreateRawTable itself doesn't use it.
+			t.Setenv("PEERDB_CLICKHOUSE_AWS_S3_BUCKET_NAME", "dummy-bucket-for-ttl-test")
+
+			ctx := t.Context()
+			conn, err := NewClickHouseConnector(ctx, nil, &protos.ClickhouseConfig{
+				Host:       internal.ClickHouseTestHost(),
+				Port:       internal.ClickHouseTestPort(),
+				Database:   "default",
+				DisableTls: true,
+			})
+			require.NoError(t, err)
+			defer conn.Close()
+
+			flowName := fmt.Sprintf("test_raw_table_ttl_%d_%d", tc.expectedDays, time.Now().UnixNano())
+			table, err := conn.CreateRawTable(ctx, &protos.CreateRawTableInput{FlowJobName: flowName})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = conn.execWithLogging(ctx,
+					"DROP TABLE IF EXISTS "+peerdb_clickhouse.QuoteIdentifier(table.TableIdentifier))
+			})
+
+			var engineFull string
+			require.NoError(t, conn.queryRow(ctx, fmt.Sprintf(
+				"SELECT engine_full FROM system.tables WHERE database = %s AND name = %s",
+				peerdb_clickhouse.QuoteLiteral("default"),
+				peerdb_clickhouse.QuoteLiteral(table.TableIdentifier),
+			)).Scan(&engineFull))
+
+			require.Contains(t, engineFull, "TTL", "engine_full should declare a TTL: %s", engineFull)
+			require.Contains(t, engineFull, "fromUnixTimestamp64Nano(_peerdb_timestamp)",
+				"TTL should reference _peerdb_timestamp: %s", engineFull)
+			require.Contains(t, engineFull, fmt.Sprintf("toIntervalDay(%d)", tc.expectedDays),
+				"TTL interval should be %d days: %s", tc.expectedDays, engineFull)
 		})
 	}
 }

--- a/flow/connectors/clickhouse/s3_iam_role_test.go
+++ b/flow/connectors/clickhouse/s3_iam_role_test.go
@@ -35,6 +35,8 @@ func TestIAMRoleCanIssueSelectFromS3(t *testing.T) {
 	}
 	internal.SetupFlowAWSCredentialsFromEnv(t)
 	t.Setenv("PEERDB_CLICKHOUSE_AWS_S3_BUCKET_NAME", os.Getenv(bucketNameEnvVar))
+	// Fixture rows have _peerdb_timestamp values from 2025; neuter the raw-table TTL so it doesn't evict them.
+	t.Setenv("PEERDB_CLICKHOUSE_RAW_TABLE_TTL_DAYS", "36500")
 	ctx := t.Context()
 
 	conn, err := NewClickHouseConnector(ctx, nil,

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -313,6 +313,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 	{
+		Name:             "PEERDB_CLICKHOUSE_RAW_TABLE_TTL_DAYS",
+		Description:      "Days to retain rows in the ClickHouse _peerdb_raw table before TTL eviction. Applies to newly created raw tables",
+		DefaultValue:     "90",
+		ValueType:        protos.DynconfValueType_UINT,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
+		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
+	},
+	{
 		Name:             "PEERDB_INTERVAL_SINCE_LAST_NORMALIZE_THRESHOLD_MINUTES",
 		Description:      "Duration in minutes since last normalize to start alerting, 0 disables all alerting entirely",
 		DefaultValue:     "240",
@@ -691,6 +699,10 @@ func PeerDBEnableClickHouseJSON(ctx context.Context, env map[string]string) (boo
 
 func PeerDBClickHouseClientName(ctx context.Context, env map[string]string) (string, error) {
 	return dynLookup(ctx, env, "PEERDB_CLICKHOUSE_CLIENT_NAME")
+}
+
+func PeerDBClickHouseRawTableTTLDays(ctx context.Context, env map[string]string) (uint32, error) {
+	return dynamicConfUnsigned[uint32](ctx, env, "PEERDB_CLICKHOUSE_RAW_TABLE_TTL_DAYS")
 }
 
 func PeerDBSnowflakeMergeParallelism(ctx context.Context, env map[string]string) (int64, error) {


### PR DESCRIPTION
## Summary
- Adds `TTL fromUnixTimestamp64Nano(_peerdb_timestamp) + INTERVAL 90 DAY` to the `_peerdb_raw_*` MergeTree CREATE statement so raw-table rows expire after 90 days.
- Addresses customer reports of the raw table growing unbounded over time.

There will be a followup to expose this via a setting in both clickpipes UI and PeerDB UI

Resolves DBI-149

## Test plan
- [ ] Create a new ClickHouse mirror and confirm `SHOW CREATE TABLE _peerdb_raw_*` shows the TTL clause