### PR TITLE
fix case sensitivity behavior in MariaDB when fetching schema

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -70,14 +70,32 @@ func (c *MySqlConnector) getTableSchemaForTable(
 		return nil, err
 	}
 
+	pkSeqRs, err := c.Execute(ctx, fmt.Sprintf(`
+		select column_name, seq_in_index
+		from information_schema.statistics
+		where table_schema = '%s' and table_name = '%s' and index_name = 'PRIMARY'`,
+		mysql.Escape(qualifiedTable.Namespace), mysql.Escape(qualifiedTable.Table)))
+	if err != nil {
+		return nil, err
+	}
+	pkSeqMap := make(map[string]int64, pkSeqRs.RowNumber())
+	for idx := range pkSeqRs.RowNumber() {
+		name, err := pkSeqRs.GetString(idx, 0)
+		if err != nil {
+			return nil, err
+		}
+		seq, err := pkSeqRs.GetInt(idx, 1)
+		if err != nil {
+			return nil, err
+		}
+		pkSeqMap[name] = seq
+	}
+
 	rs, err := c.Execute(ctx, fmt.Sprintf(`
-		select c.column_name, c.column_type, c.is_nullable, c.numeric_precision, c.numeric_scale, s.seq_in_index
-		from information_schema.columns c
-		left join information_schema.statistics s
-			on c.table_schema = s.table_schema and c.table_name = s.table_name
-			and c.column_name = s.column_name and s.index_name = 'PRIMARY'
-		where c.table_schema = '%s' and c.table_name = '%s'
-		order by c.ordinal_position`,
+		select column_name, column_type, is_nullable, numeric_precision, numeric_scale
+		from information_schema.columns
+		where table_schema = '%s' and table_name = '%s'
+		order by ordinal_position`,
 		mysql.Escape(qualifiedTable.Namespace), mysql.Escape(qualifiedTable.Table)))
 	if err != nil {
 		return nil, err
@@ -132,15 +150,7 @@ func (c *MySqlConnector) getTableSchemaForTable(
 		}
 		columns = append(columns, column)
 
-		seqIsNull, err := rs.IsNull(idx, 5)
-		if err != nil {
-			return nil, err
-		}
-		if !seqIsNull {
-			seq, err := rs.GetInt(idx, 5)
-			if err != nil {
-				return nil, err
-			}
+		if seq, ok := pkSeqMap[columnName]; ok {
 			primaryEntries = append(primaryEntries, pkEntry{name: columnName, seqInIndex: seq})
 		}
 	}

--- a/flow/connectors/mysql/cdc_test.go
+++ b/flow/connectors/mysql/cdc_test.go
@@ -50,16 +50,6 @@ func createTestDB(t *testing.T, ctx context.Context, c *MySqlConnector, dbName s
 	})
 }
 
-func assertSchema(t *testing.T, schema *protos.TableSchema, pk []string, cols ...string) {
-	t.Helper()
-	require.NotNil(t, schema)
-	require.Equal(t, pk, schema.PrimaryKeyColumns)
-	require.Len(t, schema.Columns, len(cols))
-	for i, name := range cols {
-		require.Equal(t, name, schema.Columns[i].Name)
-	}
-}
-
 func TestGetTableSchemaCaseSensitiveIdentifiers(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -88,6 +78,16 @@ func TestGetTableSchemaCaseSensitiveIdentifiers(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	assertSchema := func(schema *protos.TableSchema, pk []string, cols ...string) {
+		t.Helper()
+		require.NotNil(t, schema)
+		require.Equal(t, pk, schema.PrimaryKeyColumns)
+		require.Len(t, schema.Columns, len(cols))
+		for i, name := range cols {
+			require.Equal(t, name, schema.Columns[i].Name)
+		}
+	}
+
 	exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, ll TEXT)", llTable))
 	exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, lu TEXT)", luTable))
 	exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, ul TEXT)", ulTable))
@@ -101,8 +101,8 @@ func TestGetTableSchemaCaseSensitiveIdentifiers(t *testing.T) {
 			{SourceTableIdentifier: uuTable},
 		})
 	require.NoError(t, err)
-	assertSchema(t, schemas[llTable], []string{"id"}, "id", "ll")
-	assertSchema(t, schemas[luTable], []string{"id"}, "id", "lu")
-	assertSchema(t, schemas[ulTable], []string{"id"}, "id", "ul")
-	assertSchema(t, schemas[uuTable], []string{"id"}, "id", "uu")
+	assertSchema(schemas[llTable], []string{"id"}, "id", "ll")
+	assertSchema(schemas[luTable], []string{"id"}, "id", "lu")
+	assertSchema(schemas[ulTable], []string{"id"}, "id", "ul")
+	assertSchema(schemas[uuTable], []string{"id"}, "id", "uu")
 }

--- a/flow/connectors/mysql/cdc_test.go
+++ b/flow/connectors/mysql/cdc_test.go
@@ -1,0 +1,108 @@
+package connmysql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
+	"github.com/PeerDB-io/peerdb/flow/shared"
+)
+
+func newTestConnector(t *testing.T, ctx context.Context) *MySqlConnector {
+	t.Helper()
+	flavor := protos.MySqlFlavor_MYSQL_MYSQL
+	if internal.MySQLTestVersionIsMaria() {
+		flavor = protos.MySqlFlavor_MYSQL_MARIA
+	}
+	connector, err := NewMySqlConnector(ctx, &protos.MySqlConfig{
+		Host:       internal.MySQLTestHost(),
+		Port:       internal.MySQLTestPort(),
+		User:       "root",
+		Password:   internal.MySQLTestRootPasswordWithFallback("cipass"),
+		Database:   "mysql",
+		DisableTls: true,
+		Flavor:     flavor,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := connector.Close(); err != nil {
+			t.Logf("connector close failed: %v", err)
+		}
+	})
+	return connector
+}
+
+func createTestDB(t *testing.T, ctx context.Context, c *MySqlConnector, dbName string) {
+	t.Helper()
+	quoted := "`" + dbName + "`"
+	_, err := c.Execute(ctx, "DROP DATABASE IF EXISTS "+quoted)
+	require.NoError(t, err)
+	_, err = c.Execute(ctx, "CREATE DATABASE "+quoted)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if _, err := c.Execute(context.Background(), "DROP DATABASE IF EXISTS "+quoted); err != nil {
+			t.Logf("drop test db %s failed: %v", dbName, err)
+		}
+	})
+}
+
+func assertSchema(t *testing.T, schema *protos.TableSchema, pk []string, cols ...string) {
+	t.Helper()
+	require.NotNil(t, schema)
+	require.Equal(t, pk, schema.PrimaryKeyColumns)
+	require.Len(t, schema.Columns, len(cols))
+	for i, name := range cols {
+		require.Equal(t, name, schema.Columns[i].Name)
+	}
+}
+
+func TestGetTableSchemaCaseSensitiveIdentifiers(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	connector := newTestConnector(t, ctx)
+
+	// make sure case-sensitive identifiers are supported server-side by the test db
+	rs, err := connector.Execute(ctx, "SELECT @@lower_case_table_names")
+	require.NoError(t, err)
+	lctn, err := rs.GetInt(0, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), lctn)
+
+	lowerDB := "cs"
+	upperDB := "CS_IDS_TEST"
+	createTestDB(t, ctx, connector, lowerDB)
+	createTestDB(t, ctx, connector, upperDB)
+
+	llTable := lowerDB + ".cs_t"
+	luTable := lowerDB + ".CS_T"
+	ulTable := upperDB + ".cs_t"
+	uuTable := upperDB + ".CS_T"
+
+	exec := func(sql string) {
+		t.Helper()
+		_, err := connector.Execute(ctx, sql)
+		require.NoError(t, err)
+	}
+
+	exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, ll TEXT)", llTable))
+	exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, lu TEXT)", luTable))
+	exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, ul TEXT)", ulTable))
+	exec(fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, uu TEXT)", uuTable))
+
+	schemas, err := connector.GetTableSchema(ctx, nil, shared.InternalVersion_Latest, protos.TypeSystem_Q,
+		[]*protos.TableMapping{
+			{SourceTableIdentifier: llTable},
+			{SourceTableIdentifier: luTable},
+			{SourceTableIdentifier: ulTable},
+			{SourceTableIdentifier: uuTable},
+		})
+	require.NoError(t, err)
+	assertSchema(t, schemas[llTable], []string{"id"}, "id", "ll")
+	assertSchema(t, schemas[luTable], []string{"id"}, "id", "lu")
+	assertSchema(t, schemas[ulTable], []string{"id"}, "id", "ul")
+	assertSchema(t, schemas[uuTable], []string{"id"}, "id", "uu")
+}


### PR DESCRIPTION
In MySQL, collation for information_schema.* tables/views are decided by `lower_case_table_names`:

```
mysql> SELECT @@lower_case_table_names;
+--------------------------+
| @@lower_case_table_names |
+--------------------------+
|                        0 |
+--------------------------+
1 row in set (0.001 sec)

mysql> SELECT COLLATION(table_name) FROM information_schema.columns LIMIT 1;
+-----------------------+
| COLLATION(table_name) |
+-----------------------+
| utf8mb3_bin           |
+-----------------------+
1 row in set (0.003 sec)
```

In MySQL 5.X, this was not the case:
```
mysql> SELECT @@lower_case_table_names;
+--------------------------+
| @@lower_case_table_names |
+--------------------------+
|                        0 |
+--------------------------+
1 row in set (0.00 sec)

mysql> SELECT COLLATION(table_name) FROM information_schema.columns LIMIT 1;
+-----------------------+
| COLLATION(table_name) |
+-----------------------+
| utf8_general_ci       |
+-----------------------+
1 row in set (0.09 sec)
```
And In MariaDB, they are hard-coded to `utf8mb3_general_ci`:

```
MariaDB [test]> SELECT @@lower_case_table_names;
+--------------------------+
| @@lower_case_table_names |
+--------------------------+
|                        0 |
+--------------------------+
1 row in set (0.000 sec)

MariaDB [test]> SELECT COLLATION(table_name) FROM information_schema.columns LIMIT 1;
+-----------------------+
| COLLATION(table_name) |
+-----------------------+
| utf8mb3_general_ci    |
+-----------------------+
1 row in set (0.088 sec)
```

And when creating a table `A` and `a`, our query returns primary key from both tables:
```
MariaDB [test]> create table A (name int primary key);
Query OK, 0 rows affected (0.006 sec)

MariaDB [test]> create table a (name int primary key);
Query OK, 0 rows affected (0.145 sec)

MariaDB [test]> select c.column_name, c.column_type, c.is_nullable, c.numeric_precision, c.numeric_scale, s.seq_in_index from information_schema.columns c left join information_schema.statistics s on c.table_schema = s.table_schema and c.table_name = s.table_name and c.column_name = s.column_name and s.index_name = 'PRIMARY' where c.table_schema = 'test' and c.table_name = 'a' order by c.ordinal_position;
+-------------+-------------+-------------+-------------------+---------------+--------------+
| column_name | column_type | is_nullable | numeric_precision | numeric_scale | seq_in_index |
+-------------+-------------+-------------+-------------------+---------------+--------------+
| name        | int(11)     | NO          |                10 |             0 |            1 |
| name        | int(11)     | NO          |                10 |             0 |            1 |
+-------------+-------------+-------------+-------------------+---------------+--------------+
```

(same issue with mysql 5.X)


The fix is based on [[ref](https://dev.mysql.com/doc/refman/9.1/en/charset-collation-information-schema.html)]:
> String columns in INFORMATION_SCHEMA tables have a collation of utf8mb3_general_ci, which is case-insensitive. However, for values that correspond to objects that are represented in the file system, such as databases and tables, searches in INFORMATION_SCHEMA string columns can be case-sensitive or case-insensitive, depending on the characteristics of the underlying file system and the [lower_case_table_names](https://dev.mysql.com/doc/refman/9.1/en/server-system-variables.html#sysvar_lower_case_table_names) system variable setting. For example, searches may be case-sensitive if the file system is case-sensitive. 

Instead of JOIN, use WHERE which matches the table using file-system semantics directly, honoring the `lower_case_table_names` system variable setting and bypasses the view's `utf8mb3_general_ci` setting.

For MariaDBs that have lower_case_table_names > 0 set, duplicated table name is not allowed, so this bug is not possible. 

Test: 
- validated behavior locally
- added e2e test, failed before code change, succeeded after. 

Fixes DBI-753