### PR TITLE
feat: classify enum value missing

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -172,6 +172,9 @@ var (
 	ErrorNotifyInvalidSnapshotIdentifier = ErrorClass{
 		Class: "NOTIFY_INVALID_SNAPSHOT_IDENTIFIER", action: NotifyUser,
 	}
+	ErrorNotifyInvalidEnumValue = ErrorClass{
+		Class: "NOTIFY_INVALID_ENUM_VALUE", action: NotifyUser,
+	}
 	ErrorNotifyInvalidSynchronizedStandbySlots = ErrorClass{
 		Class: "NOTIFY_INVALID_SYNCHRONIZED_STANDBY_SLOTS", action: NotifyUser,
 	}
@@ -650,6 +653,13 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 
 			if strings.Contains(pgErr.Message, "synchronized_standby_slots") {
 				return ErrorNotifyInvalidSynchronizedStandbySlots, pgErrorInfo
+			}
+
+		case pgerrcode.InvalidTextRepresentation:
+			// e.g. `invalid input value for enum pr_status: "closed"` when source
+			// has an enum label that the destination's enum type is missing.
+			if strings.Contains(pgErr.Message, "invalid input value for enum") {
+				return ErrorNotifyInvalidEnumValue, pgErrorInfo
 			}
 
 		case pgerrcode.TooManyConnections, // Maybe we can return something else?

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -338,6 +338,21 @@ func TestPostgresInvalidValueForSynchronizedStandbySlots(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresInvalidEnumValueOnNormalize(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.InvalidTextRepresentation,
+		Message:  `invalid input value for enum worker_status: "merged"`,
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("failed to normalize records: error executing normalize statement for table public.workers: %w", err))
+	assert.Equal(t, ErrorNotifyInvalidEnumValue, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.InvalidTextRepresentation,
+	}, errInfo, "Unexpected error info")
+}
+
 func TestPostgresLogicalDecodingNotSupportedOnStandby(t *testing.T) {
 	err := &pgconn.PgError{
 		Severity: "ERROR",


### PR DESCRIPTION
In PG to PG mirrors, when an enum value is added to an enum definition on source, the mirror can fail in normalize with an error like:
```
failed to normalize records: error executing normalize statement for table public.prs: ERROR: invalid input value for enum pr_status: "closed" (SQLSTATE 22P02)
```

This PR classifies these types of errors to notify the user