### PR TITLE
PSQL CDC: PeerDB driven WAL replication connection activity keeping it alive

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -413,12 +413,6 @@ func (a *FlowableActivity) SyncFlow(
 		a.normalizeLoop(normalizeCtx, logger, config, syncDone, normRequests, normResponses, &normalizingBatchID, &normalizeWaiting)
 		return nil
 	})
-	group.Go(func() error {
-		if err := a.maintainReplConn(groupCtx, config.FlowJobName, srcConn, syncDone); err != nil {
-			return a.Alerter.LogFlowError(groupCtx, config.FlowJobName, err)
-		}
-		return nil
-	})
 
 	for groupCtx.Err() == nil {
 		syncNum := currentSyncFlowNum.Add(1)

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -635,26 +635,6 @@ func replicateXminPartition[TRead any, TWrite QRepStreamCloser, TSync connectors
 	return currentSnapshotXmin, nil
 }
 
-func (a *FlowableActivity) maintainReplConn(
-	ctx context.Context, flowName string, srcConn connectors.CDCPullConnectorCore, syncDone <-chan struct{},
-) error {
-	ticker := time.NewTicker(15 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			if err := srcConn.ReplPing(ctx); err != nil {
-				return a.Alerter.LogFlowError(ctx, flowName, fmt.Errorf("connection to source down: %w", err))
-			}
-		case <-syncDone:
-			return nil
-		case <-ctx.Done():
-			return nil
-		}
-	}
-}
-
 func (a *FlowableActivity) startNormalize(
 	ctx context.Context,
 	config *protos.FlowConnectionConfigsCore,

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pgvector/pgvector-go"
-	"github.com/pingcap/tidb/pkg/parser/duration"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.temporal.io/sdk/log"
@@ -480,16 +479,6 @@ func PullCdcRecords[Items model.Items](
 ) error {
 	logger := internal.LoggerFromCtx(ctx)
 
-	walSenderTimeout, err := duration.ParseDuration(
-		p.PostgresConnector.conn.Config().RuntimeParams["wal_sender_timeout"],
-	)
-	if err != nil {
-		return fmt.Errorf("failed to get WAL sender timeout: %w", err)
-	}
-
-	// This value controls for how long the main message loop is blocked waiting for new messages from Postgres.
-	messageWaitPeriod := min(req.IdleTimeout, walSenderTimeout/2)
-
 	// use only with taking replLock
 	conn := p.replConn.PgConn()
 	sendStandbyAfterReplLock := func(updateType string) error {
@@ -502,6 +491,26 @@ func PullCdcRecords[Items model.Items](
 		}
 		return nil
 	}
+
+	// determine message wait period in function of idle and wal_sender timeouts
+	var walSenderTimeout time.Duration
+	if walSenderTimeoutStr, err := internal.PeerDBPostgresWalSenderTimeout(ctx, req.Env); err != nil {
+		return fmt.Errorf("could't get wal_sender_timeout parameter: %w", err)
+	} else {
+		if walSenderTimeout, err = time.ParseDuration(walSenderTimeoutStr); err != nil {
+			return fmt.Errorf("failed to parse wal_sender_timeout value: %w", err)
+		} else if walSenderTimeout <= 0 {
+			return fmt.Errorf("invalid wal_sender_timeout value: %s", walSenderTimeout)
+		}
+	}
+	// this value controls for how long the main message loop is blocked waiting for new messages from Postgres.
+	messageWaitPeriod := min(req.IdleTimeout, walSenderTimeout/2)
+
+	logger.Debug("Message wait period determined",
+		slog.Duration("messageWaitPeriod", messageWaitPeriod),
+		slog.Duration("wal_sender_timeout", walSenderTimeout),
+		slog.Duration("req.IdleTimeout", req.IdleTimeout),
+	)
 
 	records := req.RecordStream
 	var totalRecords int64

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -488,7 +488,7 @@ func PullCdcRecords[Items model.Items](
 	}
 
 	// This value controls for how long the main message loop is blocked waiting for new messages from Postgres.
-	var messageWaitPeriod time.Duration = min(req.IdleTimeout, walSenderTimeout/2)
+	messageWaitPeriod := min(req.IdleTimeout, walSenderTimeout/2)
 
 	// use only with taking replLock
 	conn := p.replConn.PgConn()

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -601,7 +601,7 @@ func PullCdcRecords[Items model.Items](
 	defer shutdown()
 
 	var standByLastLogged time.Time
-	nextStandbyMessageDeadline := time.Now().Add(messageWaitPeriod)
+	nextStandbyMessageDeadline := time.Now().Add(req.IdleTimeout)
 	pkmRequiresResponse := false
 
 	addRecordWithKey := func(key model.TableWithPkey, rec model.Record[Items]) error {
@@ -618,7 +618,7 @@ func PullCdcRecords[Items model.Items](
 
 		if totalRecords == 1 {
 			records.SignalAsNotEmpty()
-			nextStandbyMessageDeadline = time.Now().Add(messageWaitPeriod)
+			nextStandbyMessageDeadline = time.Now().Add(req.IdleTimeout)
 			logger.Info(fmt.Sprintf("pushing the standby deadline to %s", nextStandbyMessageDeadline))
 		}
 		if totalRecords%50000 == 0 {
@@ -706,14 +706,17 @@ func PullCdcRecords[Items model.Items](
 			} else {
 				logger.Info(("standby deadline reached, no records accumulated, continuing to wait"))
 			}
-			nextStandbyMessageDeadline = time.Now().Add(messageWaitPeriod)
+			nextStandbyMessageDeadline = time.Now().Add(req.IdleTimeout)
 		}
 
-		var receiveCtx context.Context
-		var cancel context.CancelFunc
-
-		receiveCtx, cancel = context.WithDeadline(ctx, nextStandbyMessageDeadline)
-
+		// Since we are interrupting the receive message call as soon as `messageWaitPeriod` is over
+		// to send a ping to Postgres, now()+messageWaitPeriod might overshoot `nextStandbyMessageDeadline`
+		// this check prevents that situation.
+		receiveDeadline := time.Now().Add(messageWaitPeriod)
+		if receiveDeadline.After(nextStandbyMessageDeadline) {
+			receiveDeadline = nextStandbyMessageDeadline
+		}
+		receiveCtx, cancel := context.WithDeadline(ctx, receiveDeadline)
 		rawMsg, err := func() (pgproto3.BackendMessage, error) {
 			replLock.Lock()
 			defer replLock.Unlock()
@@ -726,12 +729,21 @@ func PullCdcRecords[Items model.Items](
 		}
 
 		if err != nil && pgconn.Timeout(err) {
-			// Send ping to make sure the connection is held alive.
-			if err := p.ReplPing(ctx); err != nil {
-				return fmt.Errorf("ReplPing failed: %w", err)
+			// If we have hit timeout, either we just need to ping to keep the connection alive
+			// or we are actually hitting `nextStandbyMessageDeadline`.
+			if !time.Now().After(nextStandbyMessageDeadline) {
+				// The timeout is not hit, hence we just send a ping before moving on to read more packages.
+				if err := p.ReplPing(ctx); err != nil {
+					return fmt.Errorf("ReplPing failed: %w", err)
+				}
 			}
+			// After that, we let the condition checks at the beginging of the loop,
+			// specifically "if we are past the next standby deadline (?)" to
+			// handle having reached the standby deadline.
 			continue
-		} else if err != nil {
+		}
+
+		if err != nil {
 			return fmt.Errorf("ReceiveMessage failed: %w", err)
 		}
 

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -469,6 +470,12 @@ func (p *PostgresCDCSource) decodeColumnData(
 	return types.QValueString{Val: string(data)}, nil
 }
 
+func clientSidePingPeriod(walSenderTimeout time.Duration) time.Duration {
+	return 3 * walSenderTimeout / 4
+}
+
+const NoWALSenderTimeoutSetting = "NONE"
+
 // PullCdcRecords pulls records from req's cdc stream
 func PullCdcRecords[Items model.Items](
 	ctx context.Context,
@@ -496,15 +503,27 @@ func PullCdcRecords[Items model.Items](
 	var walSenderTimeout time.Duration
 	if walSenderTimeoutStr, err := internal.PeerDBPostgresWalSenderTimeout(ctx, req.Env); err != nil {
 		return fmt.Errorf("could't get wal_sender_timeout parameter: %w", err)
-	} else {
+	} else if walSenderTimeoutStr != NoWALSenderTimeoutSetting {
+		// If no units are provided, milliseconds are assumed
+		if regexp.MustCompile(`^\d+$`).MatchString(walSenderTimeoutStr) {
+			walSenderTimeoutStr += "ms"
+		}
 		if walSenderTimeout, err = time.ParseDuration(walSenderTimeoutStr); err != nil {
 			return fmt.Errorf("failed to parse wal_sender_timeout value: %w", err)
-		} else if walSenderTimeout <= 0 {
+		}
+		if walSenderTimeout < 0 {
 			return fmt.Errorf("invalid wal_sender_timeout value: %s", walSenderTimeout)
 		}
 	}
 	// this value controls for how long the main message loop is blocked waiting for new messages from Postgres.
-	messageWaitPeriod := min(req.IdleTimeout, walSenderTimeout/2)
+	var messageWaitPeriod time.Duration
+	if walSenderTimeout <= 0 {
+		// If no WAL sender timeout is set
+		messageWaitPeriod = req.IdleTimeout
+	} else {
+		// If set, consider for ping interval
+		messageWaitPeriod = min(req.IdleTimeout, clientSidePingPeriod(walSenderTimeout))
+	}
 
 	logger.Debug("Message wait period determined",
 		slog.Duration("messageWaitPeriod", messageWaitPeriod),

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -601,7 +601,7 @@ func PullCdcRecords[Items model.Items](
 	defer shutdown()
 
 	var standByLastLogged time.Time
-	nextStandbyMessageDeadline := time.Now().Add(req.IdleTimeout)
+	nextRecordDeadline := time.Now().Add(req.IdleTimeout)
 	pkmRequiresResponse := false
 
 	addRecordWithKey := func(key model.TableWithPkey, rec model.Record[Items]) error {
@@ -618,8 +618,8 @@ func PullCdcRecords[Items model.Items](
 
 		if totalRecords == 1 {
 			records.SignalAsNotEmpty()
-			nextStandbyMessageDeadline = time.Now().Add(req.IdleTimeout)
-			logger.Info(fmt.Sprintf("pushing the standby deadline to %s", nextStandbyMessageDeadline))
+			nextRecordDeadline = time.Now().Add(req.IdleTimeout)
+			logger.Info(fmt.Sprintf("pushing the standby deadline to %s", nextRecordDeadline))
 		}
 		if totalRecords%50000 == 0 {
 			logger.Info("pulling records",
@@ -684,7 +684,7 @@ func PullCdcRecords[Items model.Items](
 		}
 
 		// if we are past the next standby deadline (?)
-		if time.Now().After(nextStandbyMessageDeadline) {
+		if time.Now().After(nextRecordDeadline) {
 			if totalRecords != 0 {
 				logger.Info("standby deadline reached", slog.Int64("records", totalRecords))
 
@@ -706,15 +706,15 @@ func PullCdcRecords[Items model.Items](
 			} else {
 				logger.Info(("standby deadline reached, no records accumulated, continuing to wait"))
 			}
-			nextStandbyMessageDeadline = time.Now().Add(req.IdleTimeout)
+			nextRecordDeadline = time.Now().Add(req.IdleTimeout)
 		}
 
 		// Since we are interrupting the receive message call as soon as `messageWaitPeriod` is over
-		// to send a ping to Postgres, now()+messageWaitPeriod might overshoot `nextStandbyMessageDeadline`
+		// to send a ping to Postgres, now()+messageWaitPeriod might overshoot `nextRecordDeadline`
 		// this check prevents that situation.
 		receiveDeadline := time.Now().Add(messageWaitPeriod)
-		if receiveDeadline.After(nextStandbyMessageDeadline) {
-			receiveDeadline = nextStandbyMessageDeadline
+		if receiveDeadline.After(nextRecordDeadline) {
+			receiveDeadline = nextRecordDeadline
 		}
 		receiveCtx, cancel := context.WithDeadline(ctx, receiveDeadline)
 		rawMsg, err := func() (pgproto3.BackendMessage, error) {
@@ -730,8 +730,8 @@ func PullCdcRecords[Items model.Items](
 
 		if err != nil && pgconn.Timeout(err) {
 			// If we have hit timeout, either we just need to ping to keep the connection alive
-			// or we are actually hitting `nextStandbyMessageDeadline`.
-			if !time.Now().After(nextStandbyMessageDeadline) {
+			// or we are actually hitting `nextRecordDeadline`.
+			if !time.Now().After(nextRecordDeadline) {
 				// The timeout is not hit, hence we just send a ping before moving on to read more packages.
 				if err := p.ReplPing(ctx); err != nil {
 					return fmt.Errorf("ReplPing failed: %w", err)

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pgvector/pgvector-go"
+	"github.com/pingcap/tidb/pkg/parser/duration"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.temporal.io/sdk/log"
@@ -479,6 +480,16 @@ func PullCdcRecords[Items model.Items](
 ) error {
 	logger := internal.LoggerFromCtx(ctx)
 
+	walSenderTimeout, err := duration.ParseDuration(
+		p.PostgresConnector.conn.Config().RuntimeParams["wal_sender_timeout"],
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get WAL sender timeout: %w", err)
+	}
+
+	// This value controls for how long the main message loop is blocked waiting for new messages from Postgres.
+	var messageWaitPeriod time.Duration = min(req.IdleTimeout, walSenderTimeout/2)
+
 	// use only with taking replLock
 	conn := p.replConn.PgConn()
 	sendStandbyAfterReplLock := func(updateType string) error {
@@ -562,7 +573,7 @@ func PullCdcRecords[Items model.Items](
 	defer shutdown()
 
 	var standByLastLogged time.Time
-	nextStandbyMessageDeadline := time.Now().Add(req.IdleTimeout)
+	nextStandbyMessageDeadline := time.Now().Add(messageWaitPeriod)
 	pkmRequiresResponse := false
 
 	addRecordWithKey := func(key model.TableWithPkey, rec model.Record[Items]) error {
@@ -579,7 +590,7 @@ func PullCdcRecords[Items model.Items](
 
 		if totalRecords == 1 {
 			records.SignalAsNotEmpty()
-			nextStandbyMessageDeadline = time.Now().Add(req.IdleTimeout)
+			nextStandbyMessageDeadline = time.Now().Add(messageWaitPeriod)
 			logger.Info(fmt.Sprintf("pushing the standby deadline to %s", nextStandbyMessageDeadline))
 		}
 		if totalRecords%50000 == 0 {
@@ -667,16 +678,14 @@ func PullCdcRecords[Items model.Items](
 			} else {
 				logger.Info(("standby deadline reached, no records accumulated, continuing to wait"))
 			}
-			nextStandbyMessageDeadline = time.Now().Add(req.IdleTimeout)
+			nextStandbyMessageDeadline = time.Now().Add(messageWaitPeriod)
 		}
 
 		var receiveCtx context.Context
 		var cancel context.CancelFunc
-		if totalRecords == 0 {
-			receiveCtx, cancel = context.WithCancel(ctx)
-		} else {
-			receiveCtx, cancel = context.WithDeadline(ctx, nextStandbyMessageDeadline)
-		}
+
+		receiveCtx, cancel = context.WithDeadline(ctx, nextStandbyMessageDeadline)
+
 		rawMsg, err := func() (pgproto3.BackendMessage, error) {
 			replLock.Lock()
 			defer replLock.Unlock()
@@ -689,13 +698,17 @@ func PullCdcRecords[Items model.Items](
 		}
 
 		if err != nil && p.commitLock == nil {
-			if pgconn.Timeout(err) {
+			if totalRecords != 0 && pgconn.Timeout(err) {
 				logger.Info("Stand-by deadline reached, returning currently accumulated records",
 					slog.Int64("records", totalRecords),
 					slog.Int64("bytes", totalFetchedBytes.Load()),
 					slog.Int("channelLen", records.ChannelLen()),
 					slog.Float64("elapsedMinutes", time.Since(pullStart).Minutes()))
 				return nil
+			} else if pgconn.Timeout(err) {
+				if err := p.ReplPing(ctx); err != nil {
+					return fmt.Errorf("ReplPing failed: %w", err)
+				}
 			} else {
 				return fmt.Errorf("ReceiveMessage failed: %w", err)
 			}

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -706,21 +706,14 @@ func PullCdcRecords[Items model.Items](
 			return fmt.Errorf("consumeStream preempted: %w", ctxErr)
 		}
 
-		if err != nil && p.commitLock == nil {
-			if totalRecords != 0 && pgconn.Timeout(err) {
-				logger.Info("Stand-by deadline reached, returning currently accumulated records",
-					slog.Int64("records", totalRecords),
-					slog.Int64("bytes", totalFetchedBytes.Load()),
-					slog.Int("channelLen", records.ChannelLen()),
-					slog.Float64("elapsedMinutes", time.Since(pullStart).Minutes()))
-				return nil
-			} else if pgconn.Timeout(err) {
-				if err := p.ReplPing(ctx); err != nil {
-					return fmt.Errorf("ReplPing failed: %w", err)
-				}
-			} else {
-				return fmt.Errorf("ReceiveMessage failed: %w", err)
+		if err != nil && pgconn.Timeout(err) {
+			// Send ping to make sure the connection is held alive.
+			if err := p.ReplPing(ctx); err != nil {
+				return fmt.Errorf("ReplPing failed: %w", err)
 			}
+			continue
+		} else if err != nil {
+			return fmt.Errorf("ReceiveMessage failed: %w", err)
 		}
 
 		switch msg := rawMsg.(type) {

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -732,7 +732,7 @@ func PullCdcRecords[Items model.Items](
 			// If we have hit timeout, either we just need to ping to keep the connection alive
 			// or we are actually hitting `nextRecordDeadline`.
 			if !time.Now().After(nextRecordDeadline) {
-				// The timeout is not hit, hence we just send a ping before moving on to read more packages.
+				// The timeout is not hit, hence we just send a ping before moving on to read more messages.
 				if err := p.ReplPing(ctx); err != nil {
 					return fmt.Errorf("ReplPing failed: %w", err)
 				}

--- a/local_provision_scripts/postgres.sh
+++ b/local_provision_scripts/postgres.sh
@@ -26,7 +26,23 @@ esac
 
 echo "install pgvector extension"
 if ! $DOCKER exec "$CONTAINER" test -d /tmp/pgvector; then
-  $DOCKER exec "$CONTAINER" apk add --no-cache build-base git
+  OS=$($DOCKER exec "$CONTAINER" cat /etc/os-release | grep '^NAME=' | awk -F '"' '{print $2}')
+  case "$OS" in
+    "Alpine Linux")
+      echo "Installing build dependencies for Alpine Linux"
+      $DOCKER exec "$CONTAINER" apk add --no-cache build-base git
+      ;;
+    "Ubuntu")
+      echo "Installing build dependencies for Ubuntu"
+      $DOCKER exec "$CONTAINER" whoami
+      $DOCKER exec "$CONTAINER" apt update
+      $DOCKER exec "$CONTAINER" apt install -y build-essential git
+      ;;
+    *)
+      echo "Unsupported OS: $OS"
+      exit 1
+      ;;
+  esac
   $DOCKER exec "$CONTAINER" git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git /tmp/pgvector
   $DOCKER exec "$CONTAINER" sh -c 'cd /tmp/pgvector && make with_llvm=no && make with_llvm=no install'
 fi


### PR DESCRIPTION
WAL Replication connection in PSQL needs activity so it doesn't get closed. 
Usually, PSQL itself sends keepalive messages to prevent disconnections but there are cases where a busy server fail to do so in a timely fashion, thus leading to disconnections.

To avoid that, PeerDB set a ticket in a separate go-routine to send ping messages over this connection. However, this mechanism was not working as the connection resource was never available for this go-routine to use.

This PR:
- Moves the ping logic form the ticker, which is removed, to the `PullCdcRecords` packages loop.
- The loop lock period is reduced to `min(idle_timeout, wal_sender_timeout/")` fit in the pings required frequency to avoid disconnections.

Closes: https://linear.app/clickhouse/issue/DBI-721