### PR TITLE
AdditionalTablesHasOverlap: don't check destination tables

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -2075,6 +2075,12 @@ func (a *FlowableActivity) PeerDBFullRefreshOverwriteMode(ctx context.Context, e
 	return internal.PeerDBFullRefreshOverwriteMode(ctx, env)
 }
 
+func (a *FlowableActivity) PeerDBClickHouseInitialLoadAllowNonEmptyTables(
+	ctx context.Context, env map[string]string,
+) (bool, error) {
+	return internal.PeerDBClickHouseInitialLoadAllowNonEmptyTables(ctx, env)
+}
+
 func (a *FlowableActivity) ReportStatusMetric(ctx context.Context, status protos.FlowStatus) error {
 	_, isActive := activeFlowStatuses[status]
 	a.OtelManager.Metrics.FlowStatusGauge.Record(ctx, 1, metric.WithAttributeSet(attribute.NewSet(

--- a/flow/internal/schema_helpers.go
+++ b/flow/internal/schema_helpers.go
@@ -8,28 +8,21 @@ import (
 	"go.temporal.io/sdk/log"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
-	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
 func AdditionalTablesHasOverlap(currentTableMappings []*protos.TableMapping,
 	additionalTableMappings []*protos.TableMapping,
 ) bool {
-	currentSrcTables := make([]string, 0, len(currentTableMappings))
-	currentDstTables := make([]string, 0, len(currentTableMappings))
-	additionalSrcTables := make([]string, 0, len(additionalTableMappings))
-	additionalDstTables := make([]string, 0, len(additionalTableMappings))
-
+	currentSrcTables := make(map[string]struct{}, len(currentTableMappings))
 	for _, currentTableMapping := range currentTableMappings {
-		currentSrcTables = append(currentSrcTables, currentTableMapping.SourceTableIdentifier)
-		currentDstTables = append(currentDstTables, currentTableMapping.DestinationTableIdentifier)
+		currentSrcTables[currentTableMapping.SourceTableIdentifier] = struct{}{}
 	}
 	for _, additionalTableMapping := range additionalTableMappings {
-		additionalSrcTables = append(additionalSrcTables, additionalTableMapping.SourceTableIdentifier)
-		additionalDstTables = append(additionalDstTables, additionalTableMapping.DestinationTableIdentifier)
+		if _, exists := currentSrcTables[additionalTableMapping.SourceTableIdentifier]; exists {
+			return true
+		}
 	}
-
-	return shared.ArraysHaveOverlap(currentSrcTables, additionalSrcTables) ||
-		shared.ArraysHaveOverlap(currentDstTables, additionalDstTables)
+	return false
 }
 
 // given the output of GetTableSchema, processes it to be used by CDCFlow

--- a/flow/internal/schema_helpers.go
+++ b/flow/internal/schema_helpers.go
@@ -12,14 +12,27 @@ import (
 
 func AdditionalTablesHasOverlap(currentTableMappings []*protos.TableMapping,
 	additionalTableMappings []*protos.TableMapping,
+	checkDestination bool,
 ) bool {
 	currentSrcTables := make(map[string]struct{}, len(currentTableMappings))
+	var currentDstTables map[string]struct{}
+	if checkDestination {
+		currentDstTables = make(map[string]struct{}, len(currentTableMappings))
+	}
 	for _, currentTableMapping := range currentTableMappings {
 		currentSrcTables[currentTableMapping.SourceTableIdentifier] = struct{}{}
+		if checkDestination {
+			currentDstTables[currentTableMapping.DestinationTableIdentifier] = struct{}{}
+		}
 	}
 	for _, additionalTableMapping := range additionalTableMappings {
 		if _, exists := currentSrcTables[additionalTableMapping.SourceTableIdentifier]; exists {
 			return true
+		}
+		if checkDestination {
+			if _, exists := currentDstTables[additionalTableMapping.DestinationTableIdentifier]; exists {
+				return true
+			}
 		}
 	}
 	return false

--- a/flow/shared/array.go
+++ b/flow/shared/array.go
@@ -18,22 +18,6 @@ func ArrayMinus[T comparable](first, second []T) []T {
 	return result
 }
 
-func ArraysHaveOverlap[T comparable](first, second []T) bool {
-	lookup := make(map[T]struct{}, len(second))
-
-	for _, element := range second {
-		lookup[element] = struct{}{}
-	}
-
-	for _, element := range first {
-		if _, exists := lookup[element]; exists {
-			return true
-		}
-	}
-
-	return false
-}
-
 func ArrayCastElements[T any](arr []any) []T {
 	res := make([]T, 0, len(arr))
 	for _, val := range arr {

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -218,7 +218,10 @@ func processTableAdditions(
 		syncStateToConfigProtoInCatalog(ctx, cfg, state)
 		return nil
 	}
-	if internal.AdditionalTablesHasOverlap(state.SyncFlowOptions.TableMappings, flowConfigUpdate.AdditionalTables) {
+	checkDestinationOverlap := !getClickHouseInitialLoadAllowNonEmptyTables(ctx, logger, cfg.Env)
+	if internal.AdditionalTablesHasOverlap(
+		state.SyncFlowOptions.TableMappings, flowConfigUpdate.AdditionalTables, checkDestinationOverlap,
+	) {
 		logger.Warn("duplicate source/destination tables found in additionalTables")
 		syncStateToConfigProtoInCatalog(ctx, cfg, state)
 		return nil

--- a/flow/workflows/util.go
+++ b/flow/workflows/util.go
@@ -59,3 +59,17 @@ func getQRepOverwriteFullRefreshMode(wCtx workflow.Context, logger log.Logger, e
 	}
 	return fullRefreshEnabled
 }
+
+func getClickHouseInitialLoadAllowNonEmptyTables(wCtx workflow.Context, logger log.Logger, env map[string]string) bool {
+	checkCtx := workflow.WithActivityOptions(wCtx, workflow.ActivityOptions{
+		StartToCloseTimeout: time.Minute,
+	})
+
+	var allow bool
+	future := workflow.ExecuteActivity(checkCtx, flowable.PeerDBClickHouseInitialLoadAllowNonEmptyTables, env)
+	if err := future.Get(checkCtx, &allow); err != nil {
+		logger.Warn("Failed to check ClickHouse initial load allow non-empty tables", slog.Any("error", err))
+		return false
+	}
+	return allow
+}


### PR DESCRIPTION
We key on source tables as a feature, allowing multiple sources to the same destination

This is particularly important for MySQL when partitioning is be ad-hoc