### PR TITLE
log parsed msg type on parse error

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -913,7 +913,11 @@ func processMessage[Items model.Items](
 	logger := internal.LoggerFromCtx(ctx)
 	logicalMsg, err := pglogrepl.Parse(xld.WALData)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing logical message: %w", err)
+		var msgType string
+		if len(xld.WALData) > 0 {
+			msgType = string(xld.WALData[0])
+		}
+		return nil, fmt.Errorf("error parsing logical message (msgType=%q, walStart=%s): %w", msgType, xld.WALStart.String(), err)
 	}
 	customTypeMapping, err := p.fetchCustomTypeMapping(ctx)
 	if err != nil {

--- a/flow/connectors/postgres/cdc_test.go
+++ b/flow/connectors/postgres/cdc_test.go
@@ -1,0 +1,37 @@
+package connpostgres
+
+import (
+	"testing"
+
+	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
+	"github.com/jackc/pglogrepl"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCDCSource(t *testing.T) *PostgresCDCSource {
+	t.Helper()
+	return &PostgresCDCSource{
+		PostgresConnector: &PostgresConnector{},
+		otelManager:       &otel_metrics.OtelManager{},
+	}
+}
+
+func TestProcessMessageInvalidMessage(t *testing.T) {
+	t.Parallel()
+
+	p := newTestCDCSource(t)
+	batch := model.NewCDCStream[model.RecordItems](0)
+
+	xld := pglogrepl.XLogData{
+		WALStart:     pglogrepl.LSN(0x01),
+		ServerWALEnd: pglogrepl.LSN(0x02),
+		// 'S' is a v2 Stream Start tag — not handled by pglogrepl.Parse (v1)
+		WALData: []byte{'S', 0, 1, 0, 1 /*arbitrary bytes*/},
+	}
+
+	rec, err := processMessage(t.Context(), p, batch, xld, xld.WALStart, qProcessor{})
+	require.Nil(t, rec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error parsing logical message (msgType=\"S\", walStart=0/1)")
+}

--- a/flow/connectors/postgres/cdc_test.go
+++ b/flow/connectors/postgres/cdc_test.go
@@ -3,10 +3,11 @@ package connpostgres
 import (
 	"testing"
 
-	"github.com/PeerDB-io/peerdb/flow/model"
-	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/jackc/pglogrepl"
 	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 )
 
 func newTestCDCSource(t *testing.T) *PostgresCDCSource {


### PR DESCRIPTION
Make the error message included the parsed message type and wal start LSN on error. 

Since we specify logical replication v1, we should not be getting messages from v2 or v3, but might be useful to see if what we are stuck on when we can't parse the event. 