### PR TITLE
fix: clone map race condition in UpdateIfNotExists

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -822,7 +822,9 @@ func PullCdcRecords[Items model.Items](
 								if latestRecord, found, err := cdcRecordsStorage.Get(tablePkeyVal); err != nil {
 									return err
 								} else if found {
-									r.Items = latestRecord.GetItems()
+									// use UpdateIfNotExists to copy columns from the stored record,
+									// which clones the map to avoid concurrent access with the sync goroutine
+									r.Items.UpdateIfNotExists(latestRecord.GetItems())
 									if updateRecord, ok := latestRecord.(*model.UpdateRecord[Items]); ok {
 										r.UnchangedToastColumns = updateRecord.UnchangedToastColumns
 										backfilled = true

--- a/flow/model/pg_items.go
+++ b/flow/model/pg_items.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strconv"
 
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -33,8 +34,11 @@ func (r PgItems) GetColumnValue(col string) []byte {
 // We return the slice of col names that were updated.
 func (r PgItems) UpdateIfNotExists(input_ Items) []string {
 	input := input_.(PgItems)
-	updatedCols := make([]string, 0, len(input.ColToVal))
-	for col, val := range input.ColToVal {
+	// clone input map to avoid concurrent map access, since input may reference
+	// a record that was already sent to the CDCStream channel for the sync goroutine
+	inputColToVal := maps.Clone(input.ColToVal)
+	updatedCols := make([]string, 0, len(inputColToVal))
+	for col, val := range inputColToVal {
 		if _, ok := r.ColToVal[col]; !ok {
 			r.ColToVal[col] = val
 			updatedCols = append(updatedCols, col)

--- a/flow/model/record_items.go
+++ b/flow/model/record_items.go
@@ -59,8 +59,11 @@ func (r RecordItems) GetColumnValue(col string) types.QValue {
 // We return the slice of col names that were updated.
 func (r RecordItems) UpdateIfNotExists(input_ Items) []string {
 	input := input_.(RecordItems)
-	updatedCols := make([]string, 0, len(input.ColToVal))
-	for col, val := range input.ColToVal {
+	// clone input map to avoid concurrent map access, since input may reference
+	// a record that was already sent to the CDCStream channel for the sync goroutine
+	inputColToVal := maps.Clone(input.ColToVal)
+	updatedCols := make([]string, 0, len(inputColToVal))
+	for col, val := range inputColToVal {
 		if _, ok := r.ColToVal[col]; !ok {
 			r.ColToVal[col] = val
 			updatedCols = append(updatedCols, col)


### PR DESCRIPTION
## The problem
The pull and sync goroutines share record objects — addRecordWithKey stores a record in CDCStore and sends the same pointer to the CDCStream channel. Since RecordItems/PgItems are value types wrapping a map, copies share the underlying ColToVal map. When a later update/delete arrives for the same primary key, the pull goroutine retrieves the stored record and iterates its ColToVal via UpdateIfNotExists, while the sync goroutine concurrently iterates the same map for JSON serialization or numeric truncation.

## The fix
Clone the input's ColToVal map at the start of UpdateIfNotExists in both RecordItems and PgItems, so the pull goroutine iterates a private copy. Additionally, the delete backfill path now uses UpdateIfNotExists (which clones internally) instead of directly assigning r.Items = latestRecord.GetItems(), which would have aliased the shared map.