### PR TITLE
Expose environment variables to adjust workflow timeouts

### DIFF
--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 func (h *FlowRequestHandler) ValidatePeer(
@@ -30,7 +31,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 	validatePeerDeadline := 15 * time.Second
 	if req.Peer.Type == protos.DBType_CLICKHOUSE {
 		// if instance is overloaded, DDL can take longer than 15s to execute
-		validatePeerDeadline = 1 * time.Minute
+		validatePeerDeadline = time.Second * time.Duration(internal.PeerDBSetupFlowWorkflowTaskTimeoutSeconds())
 	}
 
 	ctx, cancelCtx := context.WithTimeout(ctx, validatePeerDeadline)

--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -77,13 +77,9 @@ func NewClickHouseConnector(
 func (c *ClickHouseConnector) ValidateCheck(ctx context.Context) error {
 	allowedDomains := internal.PeerDBClickHouseAllowedDomains()
 
-	if err := peerdb_clickhouse.ValidateClickHousePeer(
+	return peerdb_clickhouse.ValidateClickHousePeer(
 		ctx, c.logger, allowedDomains, c.Config.Host, c.database, c.staging.Validate,
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
 // configureDirectoryTLS configures the tls.Config by loading certificate files

--- a/flow/internal/config.go
+++ b/flow/internal/config.go
@@ -191,6 +191,18 @@ func PeerDBMaintenanceModeWaitAlertSeconds() int {
 	return getEnvConvert("PEERDB_MAINTENANCE_MODE_WAIT_ALERT_SECONDS", 600, strconv.Atoi)
 }
 
+// PEERDB_SETUP_FLOW_HEARTBEAT_TIMEOUT_SECONDS overrides heartbeat timeout for SetupTableSchema
+// and CreateNormalizedTable activities. Raise when destination DDLs are slow
+func PeerDBSetupFlowHeartbeatTimeoutSeconds() int {
+	return getEnvConvert("PEERDB_SETUP_FLOW_HEARTBEAT_TIMEOUT_SECONDS", 60, strconv.Atoi)
+}
+
+// PEERDB_SETUP_FLOW_WORKFLOW_TASK_TIMEOUT_SECONDS overrides WorkflowTaskTimeout for SetupFlow child
+// workflow. Raise for mirrors with many tables where default 60s causes context deadline exceeded
+func PeerDBSetupFlowWorkflowTaskTimeoutSeconds() int {
+	return getEnvConvert("PEERDB_SETUP_FLOW_WORKFLOW_TASK_TIMEOUT_SECONDS", 60, strconv.Atoi)
+}
+
 // PEERDB_TELEMETRY_SENDER_SEND_ERROR_ALERTS_ENABLED is whether to send error alerts to the telemetry sender
 func PeerDBTelemetrySenderSendErrorAlertsEnabled(ctx context.Context) bool {
 	enabled, err := strconv.ParseBool(GetEnvString("PEERDB_TELEMETRY_SENDER_SEND_ERROR_ALERTS_ENABLED", "false"))

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -642,8 +642,9 @@ func CDCFlowWorkflow(
 		})
 
 		childSetupFlowOpts := workflow.ChildWorkflowOptions{
-			WorkflowID:        setupFlowID,
-			ParentClosePolicy: enums.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+			WorkflowID:          setupFlowID,
+			ParentClosePolicy:   enums.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+			WorkflowTaskTimeout: GetSetupFlowWorkflowTaskTimeout(ctx),
 			RetryPolicy: &temporal.RetryPolicy{
 				MaximumAttempts: 20,
 			},

--- a/flow/workflows/setup_flow.go
+++ b/flow/workflows/setup_flow.go
@@ -185,7 +185,7 @@ func (s *SetupFlowExecution) setupTableSchema(
 
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 1 * time.Hour,
-		HeartbeatTimeout:    time.Minute,
+		HeartbeatTimeout:    GetSetupFlowHeartbeatTimeout(ctx),
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval: 1 * time.Minute,
 		},
@@ -215,7 +215,7 @@ func (s *SetupFlowExecution) createNormalizedTables(
 
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 1 * time.Hour,
-		HeartbeatTimeout:    time.Minute,
+		HeartbeatTimeout:    GetSetupFlowHeartbeatTimeout(ctx),
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval: 1 * time.Minute,
 		},

--- a/flow/workflows/util.go
+++ b/flow/workflows/util.go
@@ -40,6 +40,18 @@ func GetFlowMetadataContext(
 	return workflow.WithValue(ctx, internal.FlowMetadataKey, metadata), nil
 }
 
+func GetSetupFlowHeartbeatTimeout(ctx workflow.Context) time.Duration {
+	return time.Duration(GetSideEffect(ctx, func(workflow.Context) int {
+		return internal.PeerDBSetupFlowHeartbeatTimeoutSeconds()
+	})) * time.Second
+}
+
+func GetSetupFlowWorkflowTaskTimeout(ctx workflow.Context) time.Duration {
+	return time.Duration(GetSideEffect(ctx, func(workflow.Context) int {
+		return internal.PeerDBSetupFlowWorkflowTaskTimeoutSeconds()
+	})) * time.Second
+}
+
 func ShouldWorkflowContinueAsNew(ctx workflow.Context) bool {
 	info := workflow.GetInfo(ctx)
 	return info.GetContinueAsNewSuggested() &&


### PR DESCRIPTION
These can timeout on requests involving 1000+ tables

Only implementing as environment variable for now, could be expanded to dynamic conf in future