### PR TITLE
Fix off-by-one error for bigquery snapshot

### DIFF
--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -100,6 +100,8 @@ func (c *BigQueryConnector) PullQRepObjects(
 		return 0, totalBytes, nil
 	}
 
+	// Partition ranges are inclusive on both ends, but GCS EndOffset is exclusive.
+	// We must explicitly fetch endOffSet below.
 	it := bucket.Objects(ctx, &storage.Query{
 		Prefix:      prefix,
 		Delimiter:   "/", // to avoid listing "folders"
@@ -129,6 +131,15 @@ func (c *BigQueryConnector) PullQRepObjects(
 		if err := processObject(attrs); err != nil {
 			return 0, totalBytes, err
 		}
+	}
+
+	endAttrs, err := bucket.Object(endOffset).Attrs(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get end object attrs for bucket %s with prefix %s and object %s: %w",
+			bucketName, prefix, endOffset, err)
+	}
+	if err := processObject(endAttrs); err != nil {
+		return 0, totalBytes, err
 	}
 
 	c.logger.Info("finished pulling downloadable objects",


### PR DESCRIPTION
In the BigQuery -> ClickHouse initial snapshot path, the last parquet file of each snapshot partition was silently dropped. This is triggered only if both are true: (1) the data exceeds 1GB which triggers multi-file partition ([ref](https://docs.cloud.google.com/bigquery/docs/exporting-data)) (2) there are more than 1 file/object to process per snapshot partition. 

BigQuery's bucket.Objects API accepts a query with StartOffset and EndOffset that are inclusive-exclusive:
```
	it := bucket.Objects(ctx, &storage.Query{
		Prefix:      prefix,
		Delimiter:   "/", // to avoid listing "folders"
		StartOffset: objectRange.Start,
		EndOffset:   objectRange.End,
	})
```

However our objectRange.Start and objectRange.End are inclusive-inclusive. This led the End file not replicated per snapshot partition if the partition has multiple files/objects (single-file partition and  is unaffected). 

Fix is to exclusively fetch the boundary End file. 

Testing this requires the file to be > 1GB in size in order to trigger multi-file partitions, therefore not added it to e2e test. 