### PR TITLE
Address expensive attributes in metrics

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -449,9 +449,7 @@ func (a *FlowableActivity) SyncFlow(
 			totalRecordsSynced.Add(syncResponse.NumRecordsSynced)
 			logger.Info("synced records", slog.Int64("numRecordsSynced", syncResponse.NumRecordsSynced),
 				slog.Int64("totalRecordsSynced", totalRecordsSynced.Load()))
-			a.OtelManager.Metrics.RecordsSyncedGauge.Record(ctx, syncResponse.NumRecordsSynced, metric.WithAttributeSet(attribute.NewSet(
-				attribute.String(otel_metrics.BatchIdKey, strconv.FormatInt(syncResponse.CurrentSyncBatchID, 10)),
-			)))
+			a.OtelManager.Metrics.RecordsSyncedGauge.Record(ctx, syncResponse.NumRecordsSynced)
 			a.OtelManager.Metrics.RecordsSyncedCounter.Add(ctx, syncResponse.NumRecordsSynced)
 		}
 		if reconnectAfterBatches > 0 && syncNum >= reconnectAfterBatches {

--- a/flow/connectors/utils/monitoring/monitoring.go
+++ b/flow/connectors/utils/monitoring/monitoring.go
@@ -232,9 +232,6 @@ func AddCDCBatchTablesForFlow(
 		return fmt.Errorf("error while committing transaction for inserting and updating statistics: %w", err)
 	}
 
-	otelManager.Metrics.SyncedTablesPerBatchGauge.Record(ctx, syncedTablesCount, metric.WithAttributeSet(attribute.NewSet(
-		attribute.Int64(otel_metrics.BatchIdKey, batchID))))
-
 	for destinationTableName, operations := range tableNameOperations {
 		for _, opAndCount := range operations {
 			otelManager.Metrics.RecordsSyncedPerTableCounter.Add(ctx, int64(opAndCount.count), metric.WithAttributeSet(attribute.NewSet(

--- a/flow/otel_metrics/attributes.go
+++ b/flow/otel_metrics/attributes.go
@@ -13,7 +13,6 @@ const (
 	PeerDBVersionKey           = "peerDBVersion"
 	DeploymentVersionKey       = "deploymentVersion"
 	WorkflowTypeKey            = "workflowType"
-	BatchIdKey                 = "batchId"
 	SourcePeerType             = "sourcePeerType"
 	sourcePeerHostname         = "sourcePeerHostname"
 	SourcePeerVariant          = "sourcePeerVariant"

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -64,7 +64,6 @@ const (
 	RecordsSyncedPerTableGaugeName       = "records_synced_per_table"
 	RecordsSyncedPerTableCounterName     = "records_synced_per_table_counter"
 	SyncedTablesGaugeName                = "synced_tables"
-	SyncedTablesPerBatchGaugeName        = "synced_tables_per_batch"
 	InstanceStatusGaugeName              = "instance_status"
 	MaintenanceStatusGaugeName           = "maintenance_status"
 	FlowStatusGaugeName                  = "flow_status"
@@ -120,7 +119,6 @@ type Metrics struct {
 	RecordsSyncedPerTableGauge       metric.Int64Gauge
 	RecordsSyncedPerTableCounter     metric.Int64Counter
 	SyncedTablesGauge                metric.Int64Gauge
-	SyncedTablesPerBatchGauge        metric.Int64Gauge
 	InstanceStatusGauge              metric.Int64Gauge
 	MaintenanceStatusGauge           metric.Int64Gauge
 	FlowStatusGauge                  metric.Int64Gauge
@@ -492,12 +490,6 @@ func (om *OtelManager) setupMetrics(ctx context.Context) error {
 
 	if om.Metrics.SyncedTablesGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(SyncedTablesGaugeName),
 		metric.WithDescription("Number of tables synced"),
-	); err != nil {
-		return err
-	}
-
-	if om.Metrics.SyncedTablesPerBatchGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(SyncedTablesPerBatchGaugeName),
-		metric.WithDescription("Number of tables synced for every Sync batch"),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
- The batchId cardinality of RecordsSyncedGauge is too high, affecting downstream Prometheus memory usage
- SyncedTablesPerBatchGauge is not used