### PR TITLE
DBI-757: Safe event decoding in MongoDB replication

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -133,6 +133,17 @@ func (c *MongoConnector) SetupReplication(ctx context.Context, input *protos.Set
 	return model.SetupReplicationResult{}, nil
 }
 
+func decodeEvent(
+	rawEvent bson.Raw,
+	changeEvent *ChangeEvent,
+) error {
+	// TODO: Protect against `null` `fullDocument`
+	if err := bson.Unmarshal(rawEvent, changeEvent); err != nil {
+		return fmt.Errorf("failed to decode change stream document: %w", err)
+	}
+	return nil
+}
+
 func (c *MongoConnector) PullRecords(
 	ctx context.Context,
 	catalogPool shared.CatalogPool,
@@ -380,8 +391,8 @@ func (c *MongoConnector) PullRecords(
 		cumulativeBytesProcessed.Add(changeEventSize)
 
 		var changeEvent ChangeEvent
-		if err := bson.Unmarshal(current, &changeEvent); err != nil {
-			return fmt.Errorf("failed to decode change stream document: %w", err)
+		if err := decodeEvent(current, &changeEvent); err != nil {
+			return err
 		}
 
 		clusterTime := time.Unix(int64(changeEvent.ClusterTime.T), 0)

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -29,10 +29,10 @@ type Namespace struct {
 }
 
 type ChangeEvent struct {
-	FullDocument  *bson.Raw      `bson:"fullDocument,omitempty"`
 	Ns            Namespace      `bson:"ns"`
 	OperationType string         `bson:"operationType"`
 	DocumentKey   bson.Raw       `bson:"documentKey,omitempty"`
+	FullDocument  *bson.Raw      `bson:"fullDocument,omitempty"`
 	ClusterTime   bson.Timestamp `bson:"clusterTime"`
 }
 

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -29,10 +29,10 @@ type Namespace struct {
 }
 
 type ChangeEvent struct {
+	FullDocument  *bson.Raw      `bson:"fullDocument,omitempty"`
 	Ns            Namespace      `bson:"ns"`
 	OperationType string         `bson:"operationType"`
 	DocumentKey   bson.Raw       `bson:"documentKey,omitempty"`
-	FullDocument  bson.Raw       `bson:"fullDocument,omitempty"`
 	ClusterTime   bson.Timestamp `bson:"clusterTime"`
 }
 
@@ -133,11 +133,11 @@ func (c *MongoConnector) SetupReplication(ctx context.Context, input *protos.Set
 	return model.SetupReplicationResult{}, nil
 }
 
+// This function implements raw events decoding logic into typed `ChangeEvent` values.
 func decodeEvent(
 	rawEvent bson.Raw,
 	changeEvent *ChangeEvent,
 ) error {
-	// TODO: Protect against `null` `fullDocument`
 	if err := bson.Unmarshal(rawEvent, changeEvent); err != nil {
 		return fmt.Errorf("failed to decode change stream document: %w", err)
 	}
@@ -260,7 +260,7 @@ func (c *MongoConnector) PullRecords(
 	}
 
 	converter := NewDirectBsonConverter()
-	addRecordItems := func(documentKey bson.Raw, fullDocument bson.Raw, items *model.RecordItems, tableName string) error {
+	addRecordItems := func(documentKey bson.Raw, maybeFullDocument *bson.Raw, items *model.RecordItems, tableName string) error {
 		if len(documentKey) > 0 {
 			rv := documentKey.Lookup(DefaultDocumentKeyColumnName)
 			if rv.IsZero() || rv.Type == bson.TypeNull {
@@ -275,8 +275,8 @@ func (c *MongoConnector) PullRecords(
 			return fmt.Errorf("document key is nil")
 		}
 
-		if len(fullDocument) > 0 {
-			qValue, err := converter.QValueJSONFromDocument(fullDocument)
+		if maybeFullDocument != nil && len(*maybeFullDocument) > 0 {
+			qValue, err := converter.QValueJSONFromDocument(*maybeFullDocument)
 			if err != nil {
 				return fmt.Errorf("failed to convert document: %w", err)
 			}

--- a/flow/connectors/mongo/cdc_test.go
+++ b/flow/connectors/mongo/cdc_test.go
@@ -177,3 +177,104 @@ func TestResumeTokenHelpersRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, toBsonTs(ts), bsonTs)
 }
+
+func TestDecodeEvent(t *testing.T) {
+	id := bson.NewObjectID()
+	insertTs := time.Now().UTC()
+	deleteTs := time.Now().Add(time.Second).UTC()
+
+	mustMarshal := func(v any) bson.Raw {
+		t.Helper()
+		raw, err := bson.Marshal(v)
+		require.NoError(t, err)
+		return raw
+	}
+
+	deleteRaw := mustMarshal(bson.D{
+		{Key: "ns", Value: bson.D{
+			{Key: "db", Value: "db"},
+			{Key: "coll", Value: "coll"},
+		}},
+		{Key: "operationType", Value: "delete"},
+		{Key: "documentKey", Value: bson.D{{Key: "_id", Value: id}}},
+		{Key: "clusterTime", Value: toBsonTs(deleteTs)},
+	})
+
+	deleteWithNullFullDocRaw := mustMarshal(bson.D{
+		{Key: "ns", Value: bson.D{
+			{Key: "db", Value: "db"},
+			{Key: "coll", Value: "coll"},
+		}},
+		{Key: "operationType", Value: "delete"},
+		{Key: "documentKey", Value: bson.D{{Key: "_id", Value: id}}},
+		{Key: "fullDocument", Value: nil},
+		{Key: "clusterTime", Value: toBsonTs(deleteTs)},
+	})
+
+	cases := []struct {
+		name    string
+		raw     bson.Raw
+		want    ChangeEvent
+		wantErr string
+	}{
+		{
+			name: "insert populates every field",
+			raw:  newInsertChangeEvent(id, insertTs),
+			want: ChangeEvent{
+				Ns:            Namespace{Db: "db", Coll: "coll"},
+				OperationType: "insert",
+				DocumentKey:   mustMarshal(bson.D{{Key: "_id", Value: id}}),
+				FullDocument: mustMarshal(bson.D{
+					{Key: "_id", Value: id},
+					{Key: "val", Value: "test"},
+				}),
+				ClusterTime: toBsonTs(insertTs),
+			},
+		},
+		{
+			name: "delete omits fullDocument",
+			raw:  deleteRaw,
+			want: ChangeEvent{
+				Ns:            Namespace{Db: "db", Coll: "coll"},
+				OperationType: "delete",
+				DocumentKey:   mustMarshal(bson.D{{Key: "_id", Value: id}}),
+				FullDocument:  nil,
+				ClusterTime:   toBsonTs(deleteTs),
+			},
+		},
+		{ // Behaviour before go.mongodb.org/mongo-driver/v2 v2.6.0
+			name: "delete with null fullDocument decodes as a delete with an empty fullDocument",
+			raw:  deleteWithNullFullDocRaw,
+			want: ChangeEvent{
+				Ns:            Namespace{Db: "db", Coll: "coll"},
+				OperationType: "delete",
+				DocumentKey:   mustMarshal(bson.D{{Key: "_id", Value: id}}),
+				FullDocument:  bson.Raw{},
+				ClusterTime:   toBsonTs(deleteTs),
+			},
+		},
+		{
+			name: "empty document decodes to zero value",
+			raw:  mustMarshal(bson.D{}),
+			want: ChangeEvent{},
+		},
+		{
+			name:    "invalid bson returns wrapped error",
+			raw:     bson.Raw{0x05, 0x00, 0x00, 0x00, 0xff},
+			wantErr: "failed to decode change stream document",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got ChangeEvent
+			err := decodeEvent(tc.raw, &got)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/flow/connectors/mongo/cdc_test.go
+++ b/flow/connectors/mongo/cdc_test.go
@@ -211,11 +211,16 @@ func TestDecodeEvent(t *testing.T) {
 		{Key: "clusterTime", Value: toBsonTs(deleteTs)},
 	})
 
+	fullDocument := mustMarshal(bson.D{
+		{Key: "_id", Value: id},
+		{Key: "val", Value: "test"},
+	})
+
 	cases := []struct {
 		name    string
+		wantErr string
 		raw     bson.Raw
 		want    ChangeEvent
-		wantErr string
 	}{
 		{
 			name: "insert populates every field",
@@ -224,11 +229,8 @@ func TestDecodeEvent(t *testing.T) {
 				Ns:            Namespace{Db: "db", Coll: "coll"},
 				OperationType: "insert",
 				DocumentKey:   mustMarshal(bson.D{{Key: "_id", Value: id}}),
-				FullDocument: mustMarshal(bson.D{
-					{Key: "_id", Value: id},
-					{Key: "val", Value: "test"},
-				}),
-				ClusterTime: toBsonTs(insertTs),
+				FullDocument:  &fullDocument,
+				ClusterTime:   toBsonTs(insertTs),
 			},
 		},
 		{
@@ -249,7 +251,7 @@ func TestDecodeEvent(t *testing.T) {
 				Ns:            Namespace{Db: "db", Coll: "coll"},
 				OperationType: "delete",
 				DocumentKey:   mustMarshal(bson.D{{Key: "_id", Value: id}}),
-				FullDocument:  bson.Raw{},
+				FullDocument:  nil,
 				ClusterTime:   toBsonTs(deleteTs),
 			},
 		},

--- a/flow/connectors/mongo/cdc_test.go
+++ b/flow/connectors/mongo/cdc_test.go
@@ -245,7 +245,7 @@ func TestDecodeEvent(t *testing.T) {
 			},
 		},
 		{ // Behaviour before go.mongodb.org/mongo-driver/v2 v2.6.0
-			name: "delete with null fullDocument decodes as a delete with an empty fullDocument",
+			name: "delete with null fullDocument decodes as a delete with nil fullDocument",
 			raw:  deleteWithNullFullDocRaw,
 			want: ChangeEvent{
 				Ns:            Namespace{Db: "db", Coll: "coll"},

--- a/flow/go.mod
+++ b/flow/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/xdg-go/scram v1.2.0
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	github.com/yuin/gopher-lua v1.1.2
-	go.mongodb.org/mongo-driver/v2 v2.5.0
+	go.mongodb.org/mongo-driver/v2 v2.6.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0

--- a/flow/go.sum
+++ b/flow/go.sum
@@ -718,8 +718,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.9 h1:T8nuk8Lz64C+Hzb0coBFLMSlVSQZBpAtFk46swdM
 go.etcd.io/etcd/client/pkg/v3 v3.6.9/go.mod h1:WEy3PpwbbEBVRdh1NVJYsuUe/8eyI21PNJRazeD8z/Y=
 go.etcd.io/etcd/client/v3 v3.6.9 h1:3X555hQXmhRr27O37wls53g68CpUiPOiHXrZfz2Al+o=
 go.etcd.io/etcd/client/v3 v3.6.9/go.mod h1:KO7H1HLYh1qaljuVZJQwBFk1lRce6pJzt+C81GEnrlM=
-go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
-go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.mongodb.org/mongo-driver/v2 v2.6.0 h1:b9sJOYrkmt4l8bY43ZenFBcPlhYIjaOfYHLtbB/5qi8=
+go.mongodb.org/mongo-driver/v2 v2.6.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/flow/pkg/go.mod
+++ b/flow/pkg/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/stretchr/testify v1.11.1
-	go.mongodb.org/mongo-driver/v2 v2.5.0
+	go.mongodb.org/mongo-driver/v2 v2.6.0
 	go.temporal.io/sdk v1.43.0
 	google.golang.org/api v0.279.0
 )

--- a/flow/pkg/go.sum
+++ b/flow/pkg/go.sum
@@ -204,8 +204,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
-go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
-go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.mongodb.org/mongo-driver/v2 v2.6.0 h1:b9sJOYrkmt4l8bY43ZenFBcPlhYIjaOfYHLtbB/5qi8=
+go.mongodb.org/mongo-driver/v2 v2.6.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK26LAGkNFw7RHv1DhE=


### PR DESCRIPTION
This PR:

- Bumps mongo client library to 2.6.0
- Protects pull records code for MongoDB against lack of leniency on replication events decoding.
- Isolates event decoding in a testable function.
- Adds unit tests validating events deserialization.

Closes: https://linear.app/clickhouse/issue/DBI-757