### PR TITLE
fix: avoid duplicate normalize error logs

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -673,7 +673,7 @@ func (a *FlowableActivity) startNormalize(
 		normalizeResponses.Update(batchID)
 		return monitoring.UpdateEndTimeForCDCBatch(ctx, a.CatalogPool, config.FlowJobName, batchID)
 	} else if err != nil {
-		return a.Alerter.LogFlowError(ctx, config.FlowJobName, fmt.Errorf("failed to get normalize connector: %w", err))
+		return fmt.Errorf("failed to get normalize connector: %w", err)
 	}
 	defer dstClose(ctx)
 
@@ -696,8 +696,7 @@ func (a *FlowableActivity) startNormalize(
 			Flags:                  config.Flags,
 		})
 		if err != nil {
-			return a.Alerter.LogFlowError(ctx, config.FlowJobName,
-				exceptions.NewNormalizationError(fmt.Errorf("failed to normalize records: %w", err)))
+			return exceptions.NewNormalizationError(fmt.Errorf("failed to normalize records: %w", err))
 		}
 		if _, dstPg := dstConn.(*connpostgres.PostgresConnector); dstPg {
 			if err := monitoring.UpdateEndTimeForCDCBatch(ctx, a.CatalogPool, config.FlowJobName, batchID); err != nil {


### PR DESCRIPTION
## Summary
- `startNormalize` was calling `Alerter.LogFlowError` on normalize failures, but the outer activity error handler already logs the returned error. Result: every normalize failure showed up 2× in the mirror logs view.
- Return the wrapped/`NormalizationError` directly and let the activity handler do the single log.

Low pri but had an active repro during local testing.

<img width="1296" height="226" alt="Screenshot 2026-05-22 at 11 06 36 PM" src="https://github.com/user-attachments/assets/d67019af-1c49-4d87-afba-c1bf20324b2b" />

Closes DBI-402