### PR TITLE
Automatic dependencies updates: pull_request_target won't produce the right running environment

### DIFF
--- a/.github/workflows/claude-code-review-dependencies-updates.yml
+++ b/.github/workflows/claude-code-review-dependencies-updates.yml
@@ -9,9 +9,8 @@ jobs:
     if: |
       !github.event.pull_request.draft &&
       github.event.pull_request.user.login == 'renovate[bot]' &&
-      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-       (github.event_name == 'pull_request_target'))
-    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'external-contributor' || null }}
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    environment: null
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review-dependencies-updates.yml
+++ b/.github/workflows/claude-code-review-dependencies-updates.yml
@@ -3,8 +3,6 @@ name: Claude Code Review for dependencies updates
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-  pull_request_target:
-    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:

--- a/.github/workflows/claude-code-review-dependencies-updates.yml
+++ b/.github/workflows/claude-code-review-dependencies-updates.yml
@@ -10,7 +10,6 @@ jobs:
       !github.event.pull_request.draft &&
       github.event.pull_request.user.login == 'renovate[bot]' &&
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    environment: null
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Dropping this target since all PRs from renovate are opened in the same repository