### PR TITLE
Add required permissions for Claude reviews on Renovate PRs to be able to search for breaking changes and fetch external repositories for analysis

### DIFF
--- a/.github/workflows/claude-code-review-dependencies-updates.yml
+++ b/.github/workflows/claude-code-review-dependencies-updates.yml
@@ -31,6 +31,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model claude-opus-4-6
+            --allowed-tools "Bash(gh:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),WebFetch,WebSearch"
           prompt: |
             Review PR ${{ github.repository }}#${{ github.event.pull_request.number }}.
             You MUST FOLLOW the instructions at `.claude/REVIEW.md` always respecting the principles


### PR DESCRIPTION
This PR adds the required permissions for dependency regression analysis instructions to work:

https://github.com/PeerDB-io/peerdb/blob/4b9c9b0356fa0e23ed5228da3a04ed7118bc216a/.claude/REVIEW.md?plain=1#L2

As indicated in the following error example:

```json
 {
    "type": "assistant",
    "message": {
      "model": "claude-opus-4-6",
      "id": "msg_01DfwGmchrEsb3oF9t6hKajp",
      "type": "message",
      "role": "assistant",
      "content": [
        {
          "type": "text",
          "text": "I'm unable to proceed because all external access tools (gh CLI, git fetch, WebFetch) require permission that hasn't been granted. Without access to at least one of these, I cannot fetch the PR diff or metadata needed to review PR #4354.\n\nCould you grant permission for one of the following so I can complete the review:\n1. **`gh` CLI commands** (e.g., `gh pr view`, `gh pr diff`) \n2. **`git fetch`** to deepen the shallow clone and access parent commits\n3. **`WebFetch`** to read the PR page on GitHub\n\nAny one of these would be sufficient to proceed."
```

Extracted from: https://github.com/PeerDB-io/peerdb/actions/runs/26441867199/job/77838078127?pr=4354 