### PR TITLE
classifier: notify on consecutive WaitQueueTimeoutError

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -847,7 +847,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 	}
 
 	if _, ok := errors.AsType[topology.WaitQueueTimeoutError](err); ok {
-		return ErrorRetryRecoverable, ErrorInfo{
+		return ErrorNotifyConnectivity, ErrorInfo{
 			Source: ErrorSourceMongoDB,
 			Code:   "WAIT_QUEUE_TIMEOUT_ERROR",
 		}


### PR DESCRIPTION
This is to address the error:

> failed to create change stream: timed out while checking out a connection from connection pool: context deadline exceeded; total connections: 1, maxPoolSize: 100, idle connections: 0, wait duration: 30.000507625s

We did not actually hit the limit on the connection pool because there is only 1 connection (the one we are attempting to establish connection to) and it's failing; and given this error is intermittent this indicates a server-side issue (likely server is overloaded).

Thought the 30s timeout is coming from server-side defaults; but actually it's coming from client-side via `ServerSelectionTimeout` which defaults to 30s. Assessed using a context timeout for change stream creation but the driver select the minimum of  context deadline and ServerSelectionTimeout to determine this timeout, so setting a context deadline greater than 30s is essentially a no-op. We could explicitly set a higher `ServerSelectionTimeout`, but it will have other implications as well, like making a invalid connection longer to timeout, which makes validation less pleasant.

Given this error indicates "server is overloaded", it would make sense to classify as notify user. 
