### PR TITLE
error classification: classify a transient mysql error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -1089,17 +1089,14 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
-	if mysqlStreamingError, ok := errors.AsType[*exceptions.MySQLStreamingError](err); ok {
-		if mysqlStreamingError.Retryable {
-			return ErrorRetryRecoverable, ErrorInfo{
-				Source: ErrorSourceMySQL,
-				Code:   "STREAMING_TRANSIENT_ERROR",
-			}
-		} else {
-			return ErrorOther, ErrorInfo{
-				Source: ErrorSourceMySQL,
-				Code:   "UNKNOWN",
-			}
+	if mysqlExecuteError, ok := errors.AsType[*exceptions.MySQLExecuteError](err); ok {
+		errClass := ErrorOther
+		if mysqlExecuteError.Retryable {
+			errClass = ErrorRetryRecoverable
+		}
+		return errClass, ErrorInfo{
+			Source: ErrorSourceMySQL,
+			Code:   "EXECUTE_ERROR",
 		}
 	}
 

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -829,41 +829,51 @@ func TestAuroraMySQLZeroDowntimeRestartErrorShouldBeRecoverable(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
-func TestMySQLStreamingTLSHandshakeErrorShouldBeRecoverable(t *testing.T) {
-	err := exceptions.NewMySQLStreamingError(
+func TestMySQLExecuteError(t *testing.T) {
+	err := exceptions.NewMySQLExecuteError(
 		tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"})
 	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("mysql error: %w", err))
 	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceMySQL,
-		Code:   "STREAMING_TRANSIENT_ERROR",
+		Code:   "EXECUTE_ERROR",
 	}, errInfo, "Unexpected error info")
 
-	err = exceptions.NewMySQLStreamingError(
+	err = exceptions.NewMySQLExecuteError(
 		tls.RecordHeaderError{Msg: "unsupported SSLv2 handshake received"})
 	errorClass, errInfo = GetErrorClass(t.Context(), fmt.Errorf("mysql error: %w", err))
 	assert.Equal(t, ErrorOther, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceMySQL,
-		Code:   "UNKNOWN",
+		Code:   "EXECUTE_ERROR",
 	}, errInfo, "Unexpected error info")
 
-	err = exceptions.NewMySQLStreamingError(context.DeadlineExceeded)
+	err = exceptions.NewMySQLExecuteError(context.DeadlineExceeded)
 	errorClass, errInfo = GetErrorClass(t.Context(), fmt.Errorf("mysql error: %w", err))
 	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceMySQL,
-		Code:   "STREAMING_TRANSIENT_ERROR",
+		Code:   "EXECUTE_ERROR",
 	}, errInfo, "Unexpected error info")
 
 	tlsErr := tls.RecordHeaderError{Msg: "remote error: tls: error decoding message"}
 	innerErr := pErrors.Wrapf(mysql.ErrBadConn, "io.ReadFull(header) failed. err %v", tlsErr)
-	err = exceptions.NewMySQLStreamingError(pErrors.Errorf("failed to set @slave_gtid_strict_mode=1: %v", innerErr))
+	err = exceptions.NewMySQLExecuteError(pErrors.Errorf("failed to set @slave_gtid_strict_mode=1: %v", innerErr))
 	errorClass, errInfo = GetErrorClass(t.Context(), err)
 	assert.Equal(t, ErrorRetryRecoverable, errorClass)
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceMySQL,
-		Code:   "STREAMING_TRANSIENT_ERROR",
+		Code:   "EXECUTE_ERROR",
+	}, errInfo)
+
+	err = exceptions.NewMySQLExecuteError(fmt.Errorf("invalid compressed sequence 0 != 1"))
+	wrappedErrInner := fmt.Errorf("failed to get schema for watermark table eesb.customers: %w", err)
+	wrappedErrOuter := fmt.Errorf("failed to sync records: %w", wrappedErrInner)
+	errorClass, errInfo = GetErrorClass(t.Context(), wrappedErrOuter)
+	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMySQL,
+		Code:   "EXECUTE_ERROR",
 	}, errInfo)
 }
 

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -319,7 +319,7 @@ func (c *MySqlConnector) startCdcStreamingFilePos(
 	stream, err := syncer.StartSync(pos)
 	if err != nil {
 		syncer.Close()
-		return nil, nil, nil, mysql.Position{}, exceptions.NewMySQLStreamingError(err)
+		return nil, nil, nil, mysql.Position{}, exceptions.NewMySQLExecuteError(err)
 	}
 	return syncer, stream, nil, pos, nil
 }
@@ -335,7 +335,7 @@ func (c *MySqlConnector) startCdcStreamingGtid(
 	stream, err := syncer.StartSyncGTID(gset)
 	if err != nil {
 		syncer.Close()
-		return nil, nil, nil, mysql.Position{}, exceptions.NewMySQLStreamingError(err)
+		return nil, nil, nil, mysql.Position{}, exceptions.NewMySQLExecuteError(err)
 	}
 	return syncer, stream, gset, mysql.Position{}, nil
 }
@@ -521,7 +521,7 @@ func (c *MySqlConnector) PullRecords(
 			}
 
 			c.logger.Error("[mysql] PullRecords failed to get event", slog.Any("error", err))
-			return exceptions.NewMySQLStreamingError(err)
+			return exceptions.NewMySQLExecuteError(err)
 		}
 
 		lastEventAt = time.Now()

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -302,20 +302,25 @@ func (c *MySqlConnector) Execute(ctx context.Context, cmd string, args ...any) (
 	var retryableErr error
 	for conn, err := range c.withRetries(ctx) {
 		if err != nil {
-			return nil, err
+			return nil, exceptions.NewMySQLExecuteError(err)
 		}
 
 		if rs, err := conn.Execute(cmd, args...); err != nil {
-			if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
+			if mysql.ErrorEqual(err, mysql.ErrBadConn) ||
+				exceptions.InvalidSequenceRe.MatchString(err.Error()) ||
+				exceptions.InvalidCompressedSequenceRe.MatchString(err.Error()) {
 				retryableErr = err
 				continue
 			}
-			return nil, err
+			return nil, exceptions.NewMySQLExecuteError(err)
 		} else {
 			return rs, nil
 		}
 	}
-	return nil, retryableErr
+	if retryableErr != nil {
+		return nil, exceptions.NewMySQLExecuteError(retryableErr)
+	}
+	return nil, nil
 }
 
 func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string, result *mysql.Result,
@@ -326,39 +331,48 @@ func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string,
 	var retryableErr error
 	for conn, err := range c.withRetries(ctx) {
 		if err != nil {
-			return err
+			return exceptions.NewMySQLExecuteError(err)
 		}
 
 		if len(args) == 0 {
 			if err := conn.ExecuteSelectStreaming(cmd, result, rowCb, resultCb); err != nil {
-				if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
+				if mysql.ErrorEqual(err, mysql.ErrBadConn) ||
+					exceptions.InvalidSequenceRe.MatchString(err.Error()) ||
+					exceptions.InvalidCompressedSequenceRe.MatchString(err.Error()) {
 					retryableErr = err
 					continue
 				}
-				return err
+				return exceptions.NewMySQLExecuteError(err)
 			}
 		} else {
 			stmt, err := conn.Prepare(cmd)
 			if err != nil {
-				if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
+				if mysql.ErrorEqual(err, mysql.ErrBadConn) ||
+					exceptions.InvalidSequenceRe.MatchString(err.Error()) ||
+					exceptions.InvalidCompressedSequenceRe.MatchString(err.Error()) {
 					retryableErr = err
 					continue
 				}
-				return err
+				return exceptions.NewMySQLExecuteError(err)
 			}
 			err = stmt.ExecuteSelectStreaming(result, rowCb, resultCb, args...)
 			_ = stmt.Close()
 			if err != nil {
-				if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
+				if mysql.ErrorEqual(err, mysql.ErrBadConn) ||
+					exceptions.InvalidSequenceRe.MatchString(err.Error()) ||
+					exceptions.InvalidCompressedSequenceRe.MatchString(err.Error()) {
 					retryableErr = err
 					continue
 				}
-				return err
+				return exceptions.NewMySQLExecuteError(err)
 			}
 		}
 		return nil
 	}
-	return retryableErr
+	if retryableErr != nil {
+		return exceptions.NewMySQLExecuteError(retryableErr)
+	}
+	return nil
 }
 
 func (c *MySqlConnector) GetGtidModeOn(ctx context.Context) (bool, error) {

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -306,9 +306,7 @@ func (c *MySqlConnector) Execute(ctx context.Context, cmd string, args ...any) (
 		}
 
 		if rs, err := conn.Execute(cmd, args...); err != nil {
-			if mysql.ErrorEqual(err, mysql.ErrBadConn) ||
-				exceptions.InvalidSequenceRe.MatchString(err.Error()) ||
-				exceptions.InvalidCompressedSequenceRe.MatchString(err.Error()) {
+			if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
 				retryableErr = err
 				continue
 			}
@@ -336,9 +334,7 @@ func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string,
 
 		if len(args) == 0 {
 			if err := conn.ExecuteSelectStreaming(cmd, result, rowCb, resultCb); err != nil {
-				if mysql.ErrorEqual(err, mysql.ErrBadConn) ||
-					exceptions.InvalidSequenceRe.MatchString(err.Error()) ||
-					exceptions.InvalidCompressedSequenceRe.MatchString(err.Error()) {
+				if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
 					retryableErr = err
 					continue
 				}
@@ -347,9 +343,7 @@ func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string,
 		} else {
 			stmt, err := conn.Prepare(cmd)
 			if err != nil {
-				if mysql.ErrorEqual(err, mysql.ErrBadConn) ||
-					exceptions.InvalidSequenceRe.MatchString(err.Error()) ||
-					exceptions.InvalidCompressedSequenceRe.MatchString(err.Error()) {
+				if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
 					retryableErr = err
 					continue
 				}
@@ -358,9 +352,7 @@ func (c *MySqlConnector) ExecuteSelectStreaming(ctx context.Context, cmd string,
 			err = stmt.ExecuteSelectStreaming(result, rowCb, resultCb, args...)
 			_ = stmt.Close()
 			if err != nil {
-				if mysql.ErrorEqual(err, mysql.ErrBadConn) ||
-					exceptions.InvalidSequenceRe.MatchString(err.Error()) ||
-					exceptions.InvalidCompressedSequenceRe.MatchString(err.Error()) {
+				if mysql.ErrorEqual(err, mysql.ErrBadConn) || exceptions.InvalidSequenceRe.MatchString(err.Error()) {
 					retryableErr = err
 					continue
 				}

--- a/flow/connectors/mysql/qrep.go
+++ b/flow/connectors/mysql/qrep.go
@@ -18,7 +18,6 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 	"github.com/PeerDB-io/peerdb/flow/shared"
-	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
@@ -282,7 +281,7 @@ func (c *MySqlConnector) PullQRepRecords(
 		}
 
 		if err := c.ExecuteSelectStreaming(ctx, query, &rs, onRow, onResult); err != nil {
-			return 0, 0, exceptions.NewMySQLStreamingError(err)
+			return 0, 0, err
 		}
 	} else {
 		var rangeStart string
@@ -330,7 +329,7 @@ func (c *MySqlConnector) PullQRepRecords(
 		}
 
 		if err := c.ExecuteSelectStreaming(ctx, query, &rs, onRow, onResult); err != nil {
-			return 0, 0, exceptions.NewMySQLStreamingError(err)
+			return 0, 0, err
 		}
 	}
 

--- a/flow/shared/exceptions/mysql.go
+++ b/flow/shared/exceptions/mysql.go
@@ -12,14 +12,9 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
-var (
-	// InvalidSequenceRe go-mysql-org returns "invalid sequence X != Y" when the TCP packet sequence
-	// is out of sync — always transient, safe to retry.
-	InvalidSequenceRe = regexp.MustCompile(`invalid sequence \d+ != \d+`)
-	// InvalidCompressedSequenceRe happens when the compressed packet header's sequence byte is out of sync. This is
-	// the compressed-protocol equivalent of the above error; also transient and safe to retry.
-	InvalidCompressedSequenceRe = regexp.MustCompile(`invalid compressed sequence \d+ != \d+`)
-)
+// InvalidSequenceRe go-mysql-org returns "invalid sequence X != Y" (or "invalid compressed sequence X != Y"
+// for the compressed protocol) when the packet sequence byte is out of sync — always transient, safe to retry.
+var InvalidSequenceRe = regexp.MustCompile(`invalid (compressed )?sequence \d+ != \d+`)
 
 type MySQLIncompatibleColumnTypeError struct {
 	TableName  string
@@ -112,7 +107,7 @@ func NewMySQLExecuteError(err error) *MySQLExecuteError {
 		return &MySQLExecuteError{err, true}
 	}
 
-	if InvalidSequenceRe.MatchString(err.Error()) || InvalidCompressedSequenceRe.MatchString(err.Error()) {
+	if InvalidSequenceRe.MatchString(err.Error()) {
 		return &MySQLExecuteError{err, true}
 	}
 

--- a/flow/shared/exceptions/mysql.go
+++ b/flow/shared/exceptions/mysql.go
@@ -12,9 +12,14 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
-// InvalidSequenceRe go-mysql-org returns "invalid sequence X != Y" when the TCP packet sequence
-// is out of sync — always transient, safe to retry.
-var InvalidSequenceRe = regexp.MustCompile(`invalid sequence \d+ != \d+`)
+var (
+	// InvalidSequenceRe go-mysql-org returns "invalid sequence X != Y" when the TCP packet sequence
+	// is out of sync — always transient, safe to retry.
+	InvalidSequenceRe = regexp.MustCompile(`invalid sequence \d+ != \d+`)
+	// InvalidCompressedSequenceRe happens when the compressed packet header's sequence byte is out of sync. This is
+	// the compressed-protocol equivalent of the above error; also transient and safe to retry.
+	InvalidCompressedSequenceRe = regexp.MustCompile(`invalid compressed sequence \d+ != \d+`)
+)
 
 type MySQLIncompatibleColumnTypeError struct {
 	TableName  string
@@ -87,38 +92,38 @@ func (e *MySQLGeometryParseError) Unwrap() error {
 	return e.error
 }
 
-type MySQLStreamingError struct {
+type MySQLExecuteError struct {
 	error
 	Retryable bool
 }
 
-func NewMySQLStreamingError(err error) *MySQLStreamingError {
+func NewMySQLExecuteError(err error) *MySQLExecuteError {
 	if errors.Is(err, context.DeadlineExceeded) {
-		return &MySQLStreamingError{err, true}
+		return &MySQLExecuteError{err, true}
 	}
 
 	if recordHeaderError, ok := errors.AsType[tls.RecordHeaderError](err); ok {
 		if recordHeaderError.Msg == "first record does not look like a TLS handshake" {
-			return &MySQLStreamingError{err, true}
+			return &MySQLExecuteError{err, true}
 		}
 	}
 
 	if strings.Contains(err.Error(), mysql.ErrBadConn.Error()) {
-		return &MySQLStreamingError{err, true}
+		return &MySQLExecuteError{err, true}
 	}
 
-	if InvalidSequenceRe.MatchString(err.Error()) {
-		return &MySQLStreamingError{err, true}
+	if InvalidSequenceRe.MatchString(err.Error()) || InvalidCompressedSequenceRe.MatchString(err.Error()) {
+		return &MySQLExecuteError{err, true}
 	}
 
-	return &MySQLStreamingError{err, false}
+	return &MySQLExecuteError{err, false}
 }
 
-func (e *MySQLStreamingError) Error() string {
-	return "MySQL streaming error: " + e.error.Error()
+func (e *MySQLExecuteError) Error() string {
+	return "MySQL execute error: " + e.error.Error()
 }
 
-func (e *MySQLStreamingError) Unwrap() error {
+func (e *MySQLExecuteError) Unwrap() error {
 	return e.error
 }
 


### PR DESCRIPTION
- Rename to from `MySQLStreamingError` to `MySQLExecuteError` to be more general (this covers `Execute`, `ExecuteSelectStreaming`, as well errors coming from `syncer.StartSync` and ` syncer.StartSyncGTID`), basically upstream execution protocol related errors
- Make the `invalid compressed sequence` error retryable (both at the query level, and at the error classification level, in case the states in the existing conn is broken and recreating the connector is required)
- Make functions like `Execute` and `ExecuteSelectStreaming` in mysql.go return`MySQLExecuteError`, instead of having to wrap it at every caller. 

Fixes: DBI-769