### PR TITLE
fix(clickhouse): normalization when `_peerdb_is_deleted` has different column casing

### DIFF
--- a/flow/connectors/clickhouse/normalize_query.go
+++ b/flow/connectors/clickhouse/normalize_query.go
@@ -283,8 +283,8 @@ func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error
 	}
 
 	// add _peerdb_sign as _peerdb_record_type / 2
-	fmt.Fprintf(&projection, "intDiv(_peerdb_record_type, 2) AS %s,", peerdb_clickhouse.QuoteIdentifier(isDeletedColName))
-	fmt.Fprintf(&colSelector, "%s,", peerdb_clickhouse.QuoteIdentifier(isDeletedColName))
+	fmt.Fprintf(&projection, "intDiv(_peerdb_record_type, 2) AS %s,", peerdb_clickhouse.QuoteIdentifier(t.isDeletedColName))
+	fmt.Fprintf(&colSelector, "%s,", peerdb_clickhouse.QuoteIdentifier(t.isDeletedColName))
 
 	// add _peerdb_timestamp as _peerdb_version
 	fmt.Fprintf(&projection, "_peerdb_timestamp AS %s", peerdb_clickhouse.QuoteIdentifier(versionColName))
@@ -301,7 +301,7 @@ func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error
 		}
 
 		// projectionUpdate generates delete on previous record, so _peerdb_record_type is filled in as 2
-		fmt.Fprintf(&projectionUpdate, "1 AS %s,", peerdb_clickhouse.QuoteIdentifier(isDeletedColName))
+		fmt.Fprintf(&projectionUpdate, "1 AS %s,", peerdb_clickhouse.QuoteIdentifier(t.isDeletedColName))
 		// decrement timestamp by 1 so delete is ordered before latest data,
 		// could be same if deletion records were only generated when ordering updated
 		fmt.Fprintf(&projectionUpdate, "_peerdb_timestamp - 1 AS %s", peerdb_clickhouse.QuoteIdentifier(versionColName))

--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
@@ -51,9 +50,14 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 		return nil // no need to validate schema for resync, as we will create or replace the tables
 	}
 
-	peerDBColumns := []string{isDeletedColName, versionColName}
+	peerDBColumns := []string{versionColName}
+	if cfg.SoftDeleteColName != "" {
+		peerDBColumns = append(peerDBColumns, cfg.SoftDeleteColName)
+	} else {
+		peerDBColumns = append(peerDBColumns, isDeletedColName)
+	}
 	if cfg.SyncedAtColName != "" {
-		peerDBColumns = append(peerDBColumns, strings.ToLower(cfg.SyncedAtColName))
+		peerDBColumns = append(peerDBColumns, cfg.SyncedAtColName)
 	}
 
 	// this is for handling column exclusion, processed schema does that in a step


### PR DESCRIPTION


### Summary

This change fixes a ClickHouse normalization failure caused by assuming a fixed lowercase column name for `_peerdb_is_deleted`.

### Problem

Replication could fail during normalization with an error like:

`Normalization Error: failed to normalize records: ... code: 16, message: No such column _peerdb_is_deleted in table tenant_x.sample_table (...)`

### Root Cause

Normalization logic referenced `_peerdb_is_deleted` using a hardcoded identifier.
In some ClickHouse tables, the physical column exists with different casing (for example `_PEERDB_IS_DELETED`), so the generated query referenced a non-existent identifier.

### Fix Implemented

- Updated normalization/validation logic to resolve the actual soft-delete column name from the destination schema in a case-insensitive way.
- Ensured the query uses the resolved identifier instead of a fixed lowercase literal.

### Expected Impact

- Prevents `code: 16` normalization failures due to casing mismatch.
- Improves compatibility across ClickHouse schemas where `_peerdb_is_deleted` may be created with different letter casing.
- Reduces replication interruptions caused by column-name assumptions.

### Files Changed

- `flow/connectors/clickhouse/normalize_query.go`
- `flow/connectors/clickhouse/validate.go`