### PR TITLE
QoL: renaming private methods for readability

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -421,10 +421,10 @@ func (a *FlowableActivity) SyncFlow(
 		var syncResponse *model.SyncResponse
 		var syncErr error
 		if config.System == protos.TypeSystem_Q {
-			syncResponse, syncErr = a.syncRecords(groupCtx, config, options, srcConn.(connectors.CDCPullConnector),
+			syncResponse, syncErr = a.pullAndSync(groupCtx, config, options, srcConn.(connectors.CDCPullConnector),
 				normRequests, normResponses, normBufferSize, idleTimeout, &syncingBatchID, &syncState)
 		} else {
-			syncResponse, syncErr = a.syncPg(groupCtx, config, options, srcConn.(connectors.CDCPullPgConnector),
+			syncResponse, syncErr = a.pullAndSyncPg(groupCtx, config, options, srcConn.(connectors.CDCPullPgConnector),
 				normRequests, normResponses, normBufferSize, idleTimeout, &syncingBatchID, &syncState)
 		}
 
@@ -467,7 +467,7 @@ func (a *FlowableActivity) SyncFlow(
 	return nil
 }
 
-func (a *FlowableActivity) syncRecords(
+func (a *FlowableActivity) pullAndSync(
 	ctx context.Context,
 	config *protos.FlowConnectionConfigsCore,
 	options *protos.SyncFlowOptions,
@@ -508,14 +508,14 @@ func (a *FlowableActivity) syncRecords(
 			return stream, nil
 		}
 	}
-	return syncCore(ctx, a, config, options, srcConn,
+	return pullAndSyncCore(ctx, a, config, options, srcConn,
 		normRequests, normResponses, normBufferSize, idleTimeout,
 		syncingBatchID, syncWaiting, adaptStream,
 		connectors.CDCPullConnector.PullRecords,
 		connectors.CDCSyncConnector.SyncRecords)
 }
 
-func (a *FlowableActivity) syncPg(
+func (a *FlowableActivity) pullAndSyncPg(
 	ctx context.Context,
 	config *protos.FlowConnectionConfigsCore,
 	options *protos.SyncFlowOptions,
@@ -527,7 +527,7 @@ func (a *FlowableActivity) syncPg(
 	syncingBatchID *atomic.Int64,
 	syncWaiting *atomic.Pointer[string],
 ) (*model.SyncResponse, error) {
-	return syncCore(ctx, a, config, options, srcConn,
+	return pullAndSyncCore(ctx, a, config, options, srcConn,
 		normRequests, normResponses, normBufferSize, idleTimeout,
 		syncingBatchID, syncWaiting, nil,
 		connectors.CDCPullPgConnector.PullPg,

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -118,7 +118,7 @@ func (a *FlowableActivity) applySchemaDeltas(
 	return nil
 }
 
-func syncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncConnectorCore, Items model.Items](
+func pullAndSyncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDCSyncConnectorCore, Items model.Items](
 	ctx context.Context,
 	a *FlowableActivity,
 	config *protos.FlowConnectionConfigsCore,


### PR DESCRIPTION
Rename the following private methods:
- `syncRecords` -> `pullAndSync`
- `syncPg` -> `pullAndSyncPg`
- `syncCore` -> `pullAndSyncCore`

I frequently mixed up these private methods with connector's `PullRecords` and `SyncRecords` methods, making the code more confusing than it needs to be. 