### PR TITLE
feat(api): add endpoint for resetting sequences for PG PG mirrors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,7 @@ flow/connectors/postgres/pgdump_schema_test.go          @PeerDB-io/ch-postgres
 flow/connectors/postgres/sink_pg.go                     @PeerDB-io/ch-postgres
 flow/model/pg_items.go                                  @PeerDB-io/ch-postgres
 flow/pkg/postgres/dest_validation.go                    @PeerDB-io/ch-postgres
+flow/cmd/reset_sequences.go                             @PeerDB-io/ch-postgres
 
 flow/e2e/pg_schema_dump_test.go                         @PeerDB-io/ch-postgres
 flow/e2e/postgres*.go                                   @PeerDB-io/ch-postgres

--- a/flow/cmd/reset_sequences.go
+++ b/flow/cmd/reset_sequences.go
@@ -6,8 +6,6 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/jackc/pgx/v5"
-
 	"github.com/PeerDB-io/peerdb/flow/connectors"
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
@@ -59,7 +57,7 @@ func (h *FlowRequestHandler) ResetMirrorSequences(
 	arrayLiteral := "ARRAY[" + strings.Join(quotedTables, ",") + "]::text[]"
 
 	// Single PL/pgSQL block runs entirely server-side: discovers sequences on all tables,
-	// resets each to MAX(column), and writes results to a temp table for retrieval.
+	// resets each to MAX(column).
 	doBlock := strings.Replace(`
 	DO $$
 	DECLARE
@@ -68,13 +66,6 @@ func (h *FlowRequestHandler) ResetMirrorSequences(
 	v_seq text;
 	v_max bigint;
 	BEGIN
-	CREATE TEMP TABLE IF NOT EXISTS _peerdb_seq_reset_results (
-		table_name text,
-		column_name text,
-		sequence_name text,
-		new_value bigint
-	) ON COMMIT DROP;
-
 	FOREACH v_table IN ARRAY $1
 	LOOP
 		FOR v_col, v_seq IN
@@ -86,22 +77,15 @@ func (h *FlowRequestHandler) ResetMirrorSequences(
 			AND pg_get_serial_sequence(v_table, a.attname) IS NOT NULL
 		LOOP
 		EXECUTE format('SELECT COALESCE(MAX(%I), 0) FROM %s', v_col, v_table) INTO v_max;
-		PERFORM setval(v_seq, v_max, v_max > 0);
-		INSERT INTO _peerdb_seq_reset_results VALUES (v_table, v_col, v_seq, v_max);
+		IF v_max > 0 THEN
+			PERFORM setval(v_seq, v_max, true);
+		END IF;
 		END LOOP;
 	END LOOP;
 	END;
 	$$`, "$1", arrayLiteral, 1)
 
-	// Run DO block and SELECT in the same transaction so the ON COMMIT DROP temp table
-	// is visible to the results query.
-	tx, err := conn.Begin(ctx)
-	if err != nil {
-		return nil, NewInternalApiError(fmt.Errorf("failed to begin transaction: %w", err))
-	}
-	defer tx.Rollback(ctx) //nolint:errcheck
-
-	if _, err := tx.Exec(ctx, doBlock); err != nil {
+	if _, err := conn.Exec(ctx, doBlock); err != nil {
 		slog.ErrorContext(ctx, "failed to reset sequences", slog.Any("error", err))
 		return &protos.ResetMirrorSequencesResponse{
 			Ok:           false,
@@ -109,45 +93,7 @@ func (h *FlowRequestHandler) ResetMirrorSequences(
 		}, nil
 	}
 
-	rows, err := tx.Query(ctx,
-		"SELECT table_name, column_name, sequence_name, new_value FROM _peerdb_seq_reset_results")
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to read sequence reset results", slog.Any("error", err))
-		return &protos.ResetMirrorSequencesResponse{
-			Ok:           false,
-			ErrorMessage: fmt.Sprintf("failed to read results: %v", err),
-		}, nil
-	}
-
-	var results []string
-	var tableName, colName, seqName string
-	var newVal int64
-	_, err = pgx.ForEachRow(rows, []any{&tableName, &colName, &seqName, &newVal}, func() error {
-		result := fmt.Sprintf("Reset %s to %d (column %s of %s)", seqName, newVal, colName, tableName)
-		results = append(results, result)
-		slog.InfoContext(ctx, "reset sequence",
-			slog.String("sequence", seqName), slog.Int64("value", newVal),
-			slog.String("table", tableName), slog.String("column", colName))
-		return nil
-	})
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to iterate sequence reset results", slog.Any("error", err))
-		return &protos.ResetMirrorSequencesResponse{
-			Ok:           false,
-			ErrorMessage: fmt.Sprintf("failed to read results: %v", err),
-		}, nil
-	}
-
-	if err := tx.Commit(ctx); err != nil {
-		return nil, NewInternalApiError(fmt.Errorf("failed to commit transaction: %w", err))
-	}
-
-	if len(results) == 0 {
-		results = append(results, "No serial or identity sequences found on destination tables")
-	}
-
 	return &protos.ResetMirrorSequencesResponse{
-		Ok:             true,
-		ResetSequences: results,
+		Ok: true,
 	}, nil
 }

--- a/flow/cmd/reset_sequences.go
+++ b/flow/cmd/reset_sequences.go
@@ -48,15 +48,13 @@ func (h *FlowRequestHandler) ResetMirrorSequences(
 		destTables = append(destTables, tm.DestinationTableIdentifier)
 	}
 
-	// Build a safe array literal from table names for inlining into a PL/pgSQL DO block.
-	// DO blocks don't accept parameterized arguments, so we escape single quotes manually.
 	quotedTables := make([]string, 0, len(destTables))
 	for _, t := range destTables {
 		quotedTables = append(quotedTables, "'"+strings.ReplaceAll(t, "'", "''")+"'")
 	}
 	arrayLiteral := "ARRAY[" + strings.Join(quotedTables, ",") + "]::text[]"
 
-	// Single PL/pgSQL block runs entirely server-side: discovers sequences on all tables,
+	// Discover sequences on all tables all server-side
 	// resets each to MAX(column).
 	doBlock := strings.Replace(`
 	DO $$

--- a/flow/cmd/reset_sequences.go
+++ b/flow/cmd/reset_sequences.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/PeerDB-io/peerdb/flow/connectors"
+	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+)
+
+func (h *FlowRequestHandler) ResetMirrorSequences(
+	ctx context.Context,
+	req *protos.ResetMirrorSequencesRequest,
+) (*protos.ResetMirrorSequencesResponse, APIError) {
+	config, err := h.getFlowConfigFromCatalog(ctx, req.FlowJobName)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("failed to get flow config: %w", err))
+	}
+
+	dstType, err := connectors.LoadPeerType(ctx, h.pool, config.DestinationName)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("failed to load destination peer type: %w", err))
+	}
+
+	if dstType != protos.DBType_POSTGRES {
+		return nil, NewFailedPreconditionApiError(
+			fmt.Errorf("reset sequences is only supported for PostgreSQL destinations"))
+	}
+
+	if config.System != protos.TypeSystem_PG {
+		return nil, NewFailedPreconditionApiError(
+			fmt.Errorf("reset sequences is only supported for mirrors using the PG type system"))
+	}
+
+	dstConn, dstClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, h.pool, config.DestinationName)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("failed to get destination postgres connector: %w", err))
+	}
+	defer dstClose(ctx)
+
+	conn := dstConn.Conn()
+
+	destTables := make([]string, 0, len(config.TableMappings))
+	for _, tm := range config.TableMappings {
+		destTables = append(destTables, tm.DestinationTableIdentifier)
+	}
+
+	// Build a safe array literal from table names for inlining into a PL/pgSQL DO block.
+	// DO blocks don't accept parameterized arguments, so we escape single quotes manually.
+	quotedTables := make([]string, 0, len(destTables))
+	for _, t := range destTables {
+		quotedTables = append(quotedTables, "'"+strings.ReplaceAll(t, "'", "''")+"'")
+	}
+	arrayLiteral := "ARRAY[" + strings.Join(quotedTables, ",") + "]::text[]"
+
+	// Single PL/pgSQL block runs entirely server-side: discovers sequences on all tables,
+	// resets each to MAX(column), and writes results to a temp table for retrieval.
+	doBlock := strings.Replace(`
+	DO $$
+	DECLARE
+	v_table text;
+	v_col text;
+	v_seq text;
+	v_max bigint;
+	BEGIN
+	CREATE TEMP TABLE IF NOT EXISTS _peerdb_seq_reset_results (
+		table_name text,
+		column_name text,
+		sequence_name text,
+		new_value bigint
+	) ON COMMIT DROP;
+
+	FOREACH v_table IN ARRAY $1
+	LOOP
+		FOR v_col, v_seq IN
+		SELECT a.attname, pg_get_serial_sequence(v_table, a.attname)
+		FROM pg_attribute a
+		WHERE a.attrelid = v_table::regclass
+			AND a.attnum > 0
+			AND NOT a.attisdropped
+			AND pg_get_serial_sequence(v_table, a.attname) IS NOT NULL
+		LOOP
+		EXECUTE format('SELECT COALESCE(MAX(%I), 0) FROM %s', v_col, v_table) INTO v_max;
+		PERFORM setval(v_seq, v_max, v_max > 0);
+		INSERT INTO _peerdb_seq_reset_results VALUES (v_table, v_col, v_seq, v_max);
+		END LOOP;
+	END LOOP;
+	END;
+	$$`, "$1", arrayLiteral, 1)
+
+	// Run DO block and SELECT in the same transaction so the ON COMMIT DROP temp table
+	// is visible to the results query.
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("failed to begin transaction: %w", err))
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	if _, err := tx.Exec(ctx, doBlock); err != nil {
+		slog.ErrorContext(ctx, "failed to reset sequences", slog.Any("error", err))
+		return &protos.ResetMirrorSequencesResponse{
+			Ok:           false,
+			ErrorMessage: fmt.Sprintf("failed to reset sequences: %v", err),
+		}, nil
+	}
+
+	rows, err := tx.Query(ctx,
+		"SELECT table_name, column_name, sequence_name, new_value FROM _peerdb_seq_reset_results")
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to read sequence reset results", slog.Any("error", err))
+		return &protos.ResetMirrorSequencesResponse{
+			Ok:           false,
+			ErrorMessage: fmt.Sprintf("failed to read results: %v", err),
+		}, nil
+	}
+
+	var results []string
+	var tableName, colName, seqName string
+	var newVal int64
+	_, err = pgx.ForEachRow(rows, []any{&tableName, &colName, &seqName, &newVal}, func() error {
+		result := fmt.Sprintf("Reset %s to %d (column %s of %s)", seqName, newVal, colName, tableName)
+		results = append(results, result)
+		slog.InfoContext(ctx, "reset sequence",
+			slog.String("sequence", seqName), slog.Int64("value", newVal),
+			slog.String("table", tableName), slog.String("column", colName))
+		return nil
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to iterate sequence reset results", slog.Any("error", err))
+		return &protos.ResetMirrorSequencesResponse{
+			Ok:           false,
+			ErrorMessage: fmt.Sprintf("failed to read results: %v", err),
+		}, nil
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("failed to commit transaction: %w", err))
+	}
+
+	if len(results) == 0 {
+		results = append(results, "No serial or identity sequences found on destination tables")
+	}
+
+	return &protos.ResetMirrorSequencesResponse{
+		Ok:             true,
+		ResetSequences: results,
+	}, nil
+}

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -3537,7 +3537,7 @@ func (s APITestSuite) TestResetMirrorSequences() {
 	// Verify data arrived
 	var rowCount int64
 	err = s.pg.Conn().QueryRow(s.t.Context(),
-		fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable)).Scan(&rowCount)
+		"SELECT COUNT(*) FROM "+dstTable).Scan(&rowCount)
 	require.NoError(s.t, err)
 	require.Equal(s.t, int64(5), rowCount)
 

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -3487,6 +3487,134 @@ func (s APITestSuite) TestCreateCDCFlowAttachIdempotentAfterContinueAsNew() {
 	RequireEnvCanceled(s.t, env)
 }
 
+func (s APITestSuite) TestResetMirrorSequences() {
+	_, ok := s.source.(*PostgresSource)
+	if !ok {
+		s.t.Skip("only for PostgreSQL source")
+	}
+
+	srcTable := AttachSchema(s, "seq_src")
+	dstTable := AttachSchema(s, "seq_dst")
+
+	// Create source table with a serial column and insert rows
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("CREATE TABLE %s(id SERIAL PRIMARY KEY, val TEXT)", srcTable)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s(val) VALUES ('a'),('b'),('c'),('d'),('e')", srcTable)))
+
+	// Create destination table with same structure (serial column)
+	_, err := s.pg.Conn().Exec(s.t.Context(),
+		fmt.Sprintf("CREATE TABLE %s(id SERIAL PRIMARY KEY, val TEXT)", dstTable))
+	require.NoError(s.t, err)
+
+	// Create PG-to-PG mirror with initial snapshot only
+	flowJobName := "reset_seq_" + s.suffix
+	flowConnConfig := &protos.FlowConnectionConfigs{
+		FlowJobName:     flowJobName,
+		SourceName:      s.source.GeneratePeer(s.t).Name,
+		DestinationName: s.pg.GeneratePeer(s.t).Name,
+		TableMappings: []*protos.TableMapping{{
+			SourceTableIdentifier:      srcTable,
+			DestinationTableIdentifier: dstTable,
+		}},
+		DoInitialSnapshot:   true,
+		InitialSnapshotOnly: true,
+		System:              protos.TypeSystem_PG,
+		IdleTimeoutSeconds:  15,
+		Version:             shared.InternalVersion_Latest,
+	}
+
+	response, err := s.CreateCDCFlow(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+
+	tc := NewTemporalClient(s.t)
+	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowJobName)
+	require.NoError(s.t, err)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitForFinished(s.t, env, 3*time.Minute)
+
+	// Verify data arrived
+	var rowCount int64
+	err = s.pg.Conn().QueryRow(s.t.Context(),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s", dstTable)).Scan(&rowCount)
+	require.NoError(s.t, err)
+	require.Equal(s.t, int64(5), rowCount)
+
+	// Before reset: destination sequence has not been advanced by the snapshot (ids were copied
+	// explicitly), so it is not yet at the max id. pg_sequence_last_value is NULL until the
+	// sequence is first used, so coalesce to 0.
+	var seqValBefore int64
+	err = s.pg.Conn().QueryRow(s.t.Context(),
+		fmt.Sprintf("SELECT COALESCE(pg_sequence_last_value(pg_get_serial_sequence('%s', 'id')), 0)", dstTable)).Scan(&seqValBefore)
+	require.NoError(s.t, err)
+	require.NotEqual(s.t, int64(5), seqValBefore)
+
+	// Call ResetMirrorSequences
+	resetResp, err := s.ResetMirrorSequences(s.t.Context(), &protos.ResetMirrorSequencesRequest{
+		FlowJobName: flowJobName,
+	})
+	require.NoError(s.t, err)
+	require.True(s.t, resetResp.Ok)
+	require.NotEmpty(s.t, resetResp.ResetSequences)
+	require.Contains(s.t, resetResp.ResetSequences[0], "Reset")
+	require.Contains(s.t, resetResp.ResetSequences[0], "5")
+
+	// After reset: sequence should be at 5 (max id)
+	var seqValAfter int64
+	err = s.pg.Conn().QueryRow(s.t.Context(),
+		fmt.Sprintf("SELECT pg_sequence_last_value(pg_get_serial_sequence('%s', 'id'))", dstTable)).Scan(&seqValAfter)
+	require.NoError(s.t, err)
+	require.Equal(s.t, int64(5), seqValAfter)
+
+	// nextval should return 6
+	var nextVal int64
+	err = s.pg.Conn().QueryRow(s.t.Context(),
+		fmt.Sprintf("SELECT nextval(pg_get_serial_sequence('%s', 'id'))", dstTable)).Scan(&nextVal)
+	require.NoError(s.t, err)
+	require.Equal(s.t, int64(6), nextVal)
+}
+
+func (s APITestSuite) TestResetMirrorSequences_NonPgDestination() {
+	_, ok := s.source.(*PostgresSource)
+	if !ok {
+		s.t.Skip("only for PostgreSQL source")
+	}
+
+	tableName := "seq_ch"
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("CREATE TABLE %s(id SERIAL PRIMARY KEY, val TEXT)", AttachSchema(s, tableName))))
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      "reset_seq_ch_" + s.suffix,
+		TableNameMapping: map[string]string{AttachSchema(s, tableName): tableName},
+		Destination:      s.ch.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.InitialSnapshotOnly = true
+
+	response, err := s.CreateCDCFlow(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+
+	tc := NewTemporalClient(s.t)
+	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowConnConfig.FlowJobName)
+	require.NoError(s.t, err)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitForFinished(s.t, env, 3*time.Minute)
+
+	// ResetMirrorSequences should fail for non-PG destination
+	_, err = s.ResetMirrorSequences(s.t.Context(), &protos.ResetMirrorSequencesRequest{
+		FlowJobName: flowConnConfig.FlowJobName,
+	})
+	require.Error(s.t, err)
+	grpcStatus, ok := status.FromError(err)
+	require.True(s.t, ok)
+	require.Equal(s.t, codes.FailedPrecondition, grpcStatus.Code())
+	require.Contains(s.t, grpcStatus.Message(), "PostgreSQL to PostgreSQL")
+}
+
 func (s APITestSuite) TestSnapshotNullPartitionKey() {
 	switch s.source.(type) {
 	case *PostgresSource, *MySqlSource:

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -3612,7 +3612,7 @@ func (s APITestSuite) TestResetMirrorSequences_NonPgDestination() {
 	grpcStatus, ok := status.FromError(err)
 	require.True(s.t, ok)
 	require.Equal(s.t, codes.FailedPrecondition, grpcStatus.Code())
-	require.Contains(s.t, grpcStatus.Message(), "PostgreSQL to PostgreSQL")
+	require.Contains(s.t, grpcStatus.Message(), "only supported for PostgreSQL destinations")
 }
 
 func (s APITestSuite) TestSnapshotNullPartitionKey() {

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -3556,9 +3556,6 @@ func (s APITestSuite) TestResetMirrorSequences() {
 	})
 	require.NoError(s.t, err)
 	require.True(s.t, resetResp.Ok)
-	require.NotEmpty(s.t, resetResp.ResetSequences)
-	require.Contains(s.t, resetResp.ResetSequences[0], "Reset")
-	require.Contains(s.t, resetResp.ResetSequences[0], "5")
 
 	// After reset: sequence should be at 5 (max id)
 	var seqValAfter int64
@@ -3573,6 +3570,58 @@ func (s APITestSuite) TestResetMirrorSequences() {
 		fmt.Sprintf("SELECT nextval(pg_get_serial_sequence('%s', 'id'))", dstTable)).Scan(&nextVal)
 	require.NoError(s.t, err)
 	require.Equal(s.t, int64(6), nextVal)
+}
+
+func (s APITestSuite) TestResetMirrorSequences_EmptyTable() {
+	_, ok := s.source.(*PostgresSource)
+	if !ok {
+		s.t.Skip("only for PostgreSQL source")
+	}
+
+	srcTable := AttachSchema(s, "seq_empty_src")
+	dstTable := AttachSchema(s, "seq_empty_dst")
+
+	// Create source table with a serial column but NO rows
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("CREATE TABLE %s(id SERIAL PRIMARY KEY, val TEXT)", srcTable)))
+
+	// Create destination table with same structure
+	_, err := s.pg.Conn().Exec(s.t.Context(),
+		fmt.Sprintf("CREATE TABLE %s(id SERIAL PRIMARY KEY, val TEXT)", dstTable))
+	require.NoError(s.t, err)
+
+	flowJobName := "reset_seq_empty_" + s.suffix
+	flowConnConfig := &protos.FlowConnectionConfigs{
+		FlowJobName:     flowJobName,
+		SourceName:      s.source.GeneratePeer(s.t).Name,
+		DestinationName: s.pg.GeneratePeer(s.t).Name,
+		TableMappings: []*protos.TableMapping{{
+			SourceTableIdentifier:      srcTable,
+			DestinationTableIdentifier: dstTable,
+		}},
+		DoInitialSnapshot:   true,
+		InitialSnapshotOnly: true,
+		System:              protos.TypeSystem_PG,
+		IdleTimeoutSeconds:  15,
+		Version:             shared.InternalVersion_Latest,
+	}
+
+	response, err := s.CreateCDCFlow(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+
+	tc := NewTemporalClient(s.t)
+	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowJobName)
+	require.NoError(s.t, err)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitForFinished(s.t, env, 3*time.Minute)
+
+	// ResetMirrorSequences should succeed even with empty tables (no setval error)
+	resetResp, err := s.ResetMirrorSequences(s.t.Context(), &protos.ResetMirrorSequencesRequest{
+		FlowJobName: flowJobName,
+	})
+	require.NoError(s.t, err)
+	require.True(s.t, resetResp.Ok)
 }
 
 func (s APITestSuite) TestResetMirrorSequences_NonPgDestination() {

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -528,6 +528,16 @@ message CancelTableAdditionOutput {
   string run_id = 3;
 }
 
+message ResetMirrorSequencesRequest {
+  string flow_job_name = 1;
+}
+
+message ResetMirrorSequencesResponse {
+  bool ok = 1;
+  string error_message = 2;
+  repeated string reset_sequences = 3;
+}
+
 service FlowService {
   rpc ValidatePeer(ValidatePeerRequest) returns (ValidatePeerResponse) {
     option (google.api.http) = {
@@ -816,6 +826,13 @@ service FlowService {
   rpc CancelTableAddition(CancelTableAdditionInput) returns (CancelTableAdditionOutput) {
     option (google.api.http) = {
       post : "/v1/flows/cdc/cancel_table_addition",
+      body : "*"
+    };
+  }
+
+  rpc ResetMirrorSequences(ResetMirrorSequencesRequest) returns (ResetMirrorSequencesResponse) {
+    option (google.api.http) = {
+      post : "/v1/mirrors/sequences/reset",
       body : "*"
     };
   }

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -535,7 +535,6 @@ message ResetMirrorSequencesRequest {
 message ResetMirrorSequencesResponse {
   bool ok = 1;
   string error_message = 2;
-  repeated string reset_sequences = 3;
 }
 
 service FlowService {


### PR DESCRIPTION
For Postgres to Postgres migrations, PeerDB ingests to target tables in a way where sequences do not get incremented. If a future insert uses DEFAULT, it can cause violations.

This PR adds an API endpoint to reset sequences in a target Postgres peer for a mirror's destination table set. This endpoint is gated to PG type system PG to PG mirrors.

A couple of tests also added.

The query is quite cheap:
```
 Index Scan using pg_attribute_relid_attnum_index on pg_attribute a  (cost=0.28..12.18 rows=3 width=96) (actual t
ime=0.046..0.046 rows=0.00 loops=1)
   Index Cond: ((attrelid = '21074'::oid) AND (attnum > 0))
   Filter: ((NOT attisdropped) AND (pg_get_serial_sequence('public.t1'::text, (attname)::text) IS NOT NULL))
   Rows Removed by Filter: 1
   Index Searches: 1
   Buffers: shared hit=6
 Planning Time: 0.071 ms
 Execution Time: 0.064 ms
```