### PR TITLE
add 'log_replica_updates' validation for mysql replica sources

### DIFF
--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -463,14 +463,15 @@ func (c *MySqlConnector) GetMasterGTIDSet(ctx context.Context) (mysql.GTIDSet, e
 }
 
 func (c *MySqlConnector) GetVersion(ctx context.Context) (string, error) {
-	conn, err := c.connect(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to connect: %w", err)
+	for conn, err := range c.withRetries(ctx) {
+		if err != nil {
+			return "", err
+		}
+		version := conn.GetServerVersion()
+		c.logger.Info("[mysql] version", slog.String("version", version))
+		return version, nil
 	}
-
-	version := conn.GetServerVersion()
-	c.logger.Info("[mysql] version", slog.String("version", version))
-	return version, nil
+	return "", fmt.Errorf("failed to connect")
 }
 
 func (c *MySqlConnector) StatActivity(

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -463,15 +463,14 @@ func (c *MySqlConnector) GetMasterGTIDSet(ctx context.Context) (mysql.GTIDSet, e
 }
 
 func (c *MySqlConnector) GetVersion(ctx context.Context) (string, error) {
-	for conn, err := range c.withRetries(ctx) {
-		if err != nil {
-			return "", err
-		}
-		version := conn.GetServerVersion()
-		c.logger.Info("[mysql] version", slog.String("version", version))
-		return version, nil
+	conn, err := c.connect(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to connect: %w", err)
 	}
-	return "", fmt.Errorf("failed to connect")
+
+	version := conn.GetServerVersion()
+	c.logger.Info("[mysql] version", slog.String("version", version))
+	return version, nil
 }
 
 func (c *MySqlConnector) StatActivity(

--- a/flow/connectors/mysql/validate.go
+++ b/flow/connectors/mysql/validate.go
@@ -111,7 +111,7 @@ func (c *MySqlConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.F
 
 	conn, err := c.connect(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to set connect: %w", err)
+		return fmt.Errorf("unable to connect: %w", err)
 	}
 
 	if isVitess, err := mysql_validation.IsVitess(conn); err != nil {

--- a/flow/connectors/mysql/validate.go
+++ b/flow/connectors/mysql/validate.go
@@ -53,38 +53,36 @@ func (c *MySqlConnector) CheckReplicationConnectivity(ctx context.Context) error
 }
 
 func (c *MySqlConnector) CheckBinlogSettings(ctx context.Context, requireRowMetadata bool) error {
-	for conn, err := range c.withRetries(ctx) {
-		if err != nil {
-			return err
-		}
-
-		switch c.config.Flavor {
-		case protos.MySqlFlavor_MYSQL_MARIA:
-			// check if binlog_row_metadata is supported is done inside this function
-			return mysql_validation.CheckMariaDBBinlogSettings(conn, c.logger, requireRowMetadata)
-		case protos.MySqlFlavor_MYSQL_MYSQL:
-			cmp, err := c.CompareServerVersion(ctx, mysql_validation.MySQLMinVersionForBinlogRowMetadata)
-			if err != nil {
-				return fmt.Errorf("failed to get server version: %w", err)
-			}
-			if cmp < 0 {
-				// as we're dispatching to a function that doesn't know about binlog_row_metadata,
-				// perform the check here instead of inside
-				if requireRowMetadata {
-					return fmt.Errorf("MySQL version too old for column exclusion support, "+
-						"please disable it or upgrade to >=%s (binlog_row_metadata needed)",
-						mysql_validation.MySQLMinVersionForBinlogRowMetadata)
-				}
-				c.logger.Warn("Falling back to MySQL 5.7 check")
-				return mysql_validation.CheckMySQL5BinlogSettings(conn, c.logger)
-			} else {
-				return mysql_validation.CheckMySQL8BinlogSettings(conn, c.logger)
-			}
-		default:
-			return fmt.Errorf("unsupported MySQL flavor: %s", c.config.Flavor.String())
-		}
+	conn, err := c.connect(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
 	}
-	return fmt.Errorf("failed to connect to MySQL server")
+
+	switch c.config.Flavor {
+	case protos.MySqlFlavor_MYSQL_MARIA:
+		// check if binlog_row_metadata is supported is done inside this function
+		return mysql_validation.CheckMariaDBBinlogSettings(conn, c.logger, requireRowMetadata)
+	case protos.MySqlFlavor_MYSQL_MYSQL:
+		cmp, err := c.CompareServerVersion(ctx, mysql_validation.MySQLMinVersionForBinlogRowMetadata)
+		if err != nil {
+			return fmt.Errorf("failed to get server version: %w", err)
+		}
+		if cmp < 0 {
+			// as we're dispatching to a function that doesn't know about binlog_row_metadata,
+			// perform the check here instead of inside
+			if requireRowMetadata {
+				return fmt.Errorf("MySQL version too old for column exclusion support, "+
+					"please disable it or upgrade to >=%s (binlog_row_metadata needed)",
+					mysql_validation.MySQLMinVersionForBinlogRowMetadata)
+			}
+			c.logger.Warn("Falling back to MySQL 5.7 check")
+			return mysql_validation.CheckMySQL5BinlogSettings(conn, c.logger)
+		} else {
+			return mysql_validation.CheckMySQL8BinlogSettings(conn, c.logger)
+		}
+	default:
+		return fmt.Errorf("unsupported MySQL flavor: %s", c.config.Flavor.String())
+	}
 }
 
 func (c *MySqlConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.FlowConnectionConfigsCore) error {
@@ -123,7 +121,7 @@ func (c *MySqlConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.F
 		return fmt.Errorf("binlog configuration error: %w", err)
 	}
 	if err := mysql_validation.CheckLogReplicaUpdates(conn); err != nil {
-		return fmt.Errorf("binlog configuration error: %w", err)
+		return fmt.Errorf("check log replica updates error: %w", err)
 	}
 
 	requireRowMetadata := false
@@ -145,13 +143,12 @@ func (c *MySqlConnector) ValidateCheck(ctx context.Context) error {
 		return fmt.Errorf("flavor is set to unknown")
 	}
 
-	for conn, err := range c.withRetries(ctx) {
-		if err != nil {
-			return err
-		}
-		return c.validateFlavor(conn)
+	conn, err := c.connect(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
 	}
-	return fmt.Errorf("failed to connect to MySQL server")
+
+	return c.validateFlavor(conn)
 }
 
 func (c *MySqlConnector) validateFlavor(conn *client.Conn) error {

--- a/flow/connectors/mysql/validate.go
+++ b/flow/connectors/mysql/validate.go
@@ -109,16 +109,21 @@ func (c *MySqlConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.F
 		return fmt.Errorf("unable to establish replication connectivity: %w", err)
 	}
 
-	for conn, err := range c.withRetries(ctx) {
-		if err != nil {
-			return err
-		}
+	conn, err := c.connect(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to set connect: %w", err)
+	}
 
-		if isVitess, err := mysql_validation.IsVitess(conn); err != nil {
-			return err
-		} else if isVitess && !(cfg.DoInitialSnapshot && cfg.InitialSnapshotOnly) {
-			return fmt.Errorf("vitess is currently not supported for MySQL mirrors in CDC")
-		}
+	if isVitess, err := mysql_validation.IsVitess(conn); err != nil {
+		return err
+	} else if isVitess && !(cfg.DoInitialSnapshot && cfg.InitialSnapshotOnly) {
+		return fmt.Errorf("vitess is currently not supported for MySQL mirrors in CDC")
+	}
+	if err := mysql_validation.CheckRDSBinlogSettings(conn, c.logger); err != nil {
+		return fmt.Errorf("binlog configuration error: %w", err)
+	}
+	if err := mysql_validation.CheckLogReplicaUpdates(conn); err != nil {
+		return fmt.Errorf("binlog configuration error: %w", err)
 	}
 
 	requireRowMetadata := false
@@ -130,14 +135,6 @@ func (c *MySqlConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.F
 	}
 	if err := c.CheckBinlogSettings(ctx, requireRowMetadata); err != nil {
 		return fmt.Errorf("binlog configuration error: %w", err)
-	}
-	for conn, err := range c.withRetries(ctx) {
-		if err != nil {
-			return err
-		}
-		if err := mysql_validation.CheckRDSBinlogSettings(conn, c.logger); err != nil {
-			return fmt.Errorf("binlog configuration error: %w", err)
-		}
 	}
 
 	return nil

--- a/flow/pkg/mysql/validation.go
+++ b/flow/pkg/mysql/validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -230,6 +231,57 @@ func CheckRDSBinlogSettings(conn *client.Conn, logger log.Logger) error {
 	}
 
 	return nil
+}
+
+// CheckLogReplicaUpdates verifies that a source acting as a replica records replicated
+// events in its own binary log. Without this, rows applied to the replica through its own
+// upstream replication are not written to the replica's binlog, leaving gaps that surface
+// as errors when PeerDB reconnects and resumes from a binlog position/GTID.
+func CheckLogReplicaUpdates(conn *client.Conn) error {
+	isReplica, err := ServerIsReplica(conn)
+	if err != nil {
+		return fmt.Errorf("failed to determine whether source is a replica: %w", err)
+	}
+	if !isReplica {
+		return nil
+	}
+
+	rs, err := conn.Execute("SHOW VARIABLES WHERE Variable_name IN ('log_slave_updates', 'log_replica_updates')")
+	if err != nil {
+		return fmt.Errorf("failed to retrieve log_replica_updates setting: %w", err)
+	}
+	if len(rs.Values) == 0 {
+		// every MySQL/MariaDB exposes one of these variables, so a replica that reports
+		// neither is unexpected and we cannot confirm it records replicated events
+		return fmt.Errorf("could not read log_replica_updates/log_slave_updates on replica source")
+	}
+	for _, row := range rs.Values {
+		name := string(row[0].AsString())
+		value := string(row[1].AsString())
+		if !strings.EqualFold(value, "ON") && value != "1" {
+			return fmt.Errorf(
+				"%s must be enabled when replicating from a replica so replicated events are written to its binlog, currently %s",
+				name, value)
+		}
+	}
+
+	return nil
+}
+
+// ServerIsReplica reports whether the server is configured as a replica of an upstream primary.
+func ServerIsReplica(conn *client.Conn) (bool, error) {
+	rs, err := conn.Execute("SHOW REPLICA STATUS")
+	if err != nil {
+		// older MySQL (<8.0.22) and MariaDB (<10.5.1) don't recognize SHOW REPLICA STATUS
+		if mErr, ok := errors.AsType[*mysql.MyError](err); ok && mErr.Code == mysql.ER_PARSE_ERROR {
+			if rs, err = conn.Execute("SHOW SLAVE STATUS"); err != nil {
+				return false, fmt.Errorf("failed to check replica status: %w", err)
+			}
+		} else {
+			return false, fmt.Errorf("failed to check replica status: %w", err)
+		}
+	}
+	return len(rs.Values) > 0, nil
 }
 
 // check if the server is a Vitess server, currently only works for initial load only


### PR DESCRIPTION
This PR resolves DBI-214.
It adds additional validation for mysql replica sources (either `SHOW REPLICA STATUS` or `SHOW SLAVE STATUS` returns not empty result).
New validation checks whether replica writes cdc records to binlog or not. If not - we return an error.
The plan is to merge this PR and use the same validation helper in the caller service.