### PR TITLE
Make CI properly test external PRs

### DIFF
--- a/.github/actions/genprotos/action.yml
+++ b/.github/actions/genprotos/action.yml
@@ -3,7 +3,6 @@ description: 'Install buf with local plugins, generate protos and cache'
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: check cache
       id: cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5


### PR DESCRIPTION
Generating protos does a second checkout, which is the same as the first one on internal PRs but actually grabs main on the external ones. As a result, the tests end up running against the main bits and not the change itself.

Repro - #4375 adds an always-fail code but checks are green