### PR TITLE
Serialize and guard Postgres connector connection close

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -48,6 +48,7 @@ type PostgresConnector struct {
 	connStr                string
 	metadataSchema         string
 	replLock               sync.Mutex
+	closeLock              sync.Mutex
 	pgVersion              shared.PGVersion
 }
 
@@ -132,20 +133,8 @@ func NewPostgresConnector(ctx context.Context, env map[string]string, pgConfig *
 
 	tunnel.StartKeepalive(context.Background(), func() {
 		connector.logger.Info("SSH keepalive failed, closing connections")
-		bgCtx := context.Background()
-		timeout, cancel := context.WithTimeout(bgCtx, 5*time.Second)
-		defer cancel()
-		if err := connector.conn.Close(timeout); err != nil {
-			connector.logger.Error("Failed to close Postgres connection on SSH keepalive failure",
-				slog.Any("error", err))
-		}
-		if connector.replConn != nil {
-			timeout2, cancel2 := context.WithTimeout(bgCtx, 5*time.Second)
-			defer cancel2()
-			if err := connector.replConn.Close(timeout2); err != nil {
-				connector.logger.Error("Failed to close Postgres replication connection on SSH keepalive failure",
-					slog.Any("error", err))
-			}
+		for _, err := range connector.closePostgresConnections(5 * time.Second) {
+			connector.logger.Error("Failed to close Postgres connection on SSH keepalive failure", slog.Any("error", err))
 		}
 	})
 
@@ -182,21 +171,7 @@ func (c *PostgresConnector) fetchCustomTypeMapping(ctx context.Context) (map[uin
 func (c *PostgresConnector) Close() error {
 	var errs []error
 	if c != nil {
-		timeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if err := c.conn.Close(timeout); err != nil {
-			c.logger.Error("failed to close Postgres connection", slog.Any("error", err))
-			errs = append(errs, fmt.Errorf("failed to close Postgres connection: %w", err))
-		}
-
-		if c.replConn != nil {
-			timeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			if err := c.replConn.Close(timeout); err != nil {
-				c.logger.Error("failed to close Postgres replication connection", slog.Any("error", err))
-				errs = append(errs, fmt.Errorf("failed to close Postgres replication connection: %w", err))
-			}
-		}
+		errs = append(errs, c.closePostgresConnections(30*time.Second)...)
 
 		if err := c.ssh.Close(); err != nil {
 			c.logger.Error("[postgres] failed to close SSH tunnel", slog.Any("error", err))
@@ -204,6 +179,32 @@ func (c *PostgresConnector) Close() error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (c *PostgresConnector) closePostgresConnections(timeoutDuration time.Duration) []error {
+	c.closeLock.Lock()
+	defer c.closeLock.Unlock()
+
+	var errs []error
+	if c.conn != nil && !c.conn.IsClosed() {
+		timeout, cancel := context.WithTimeout(context.Background(), timeoutDuration)
+		if err := c.conn.Close(timeout); err != nil {
+			c.logger.Error("failed to close Postgres connection", slog.Any("error", err))
+			errs = append(errs, fmt.Errorf("failed to close Postgres connection: %w", err))
+		}
+		cancel()
+	}
+
+	if c.replConn != nil && !c.replConn.IsClosed() {
+		timeout, cancel := context.WithTimeout(context.Background(), timeoutDuration)
+		if err := c.replConn.Close(timeout); err != nil {
+			c.logger.Error("failed to close Postgres replication connection", slog.Any("error", err))
+			errs = append(errs, fmt.Errorf("failed to close Postgres replication connection: %w", err))
+		}
+		cancel()
+	}
+
+	return errs
 }
 
 func (c *PostgresConnector) Conn() *pgx.Conn {


### PR DESCRIPTION
Codex find from #4364 

### Problem

Under SSH-tunneled Postgres connections, the connector can close the same `pgx.Conn` from two places at once:

- the SSH keepalive callback, which tears the connections down the moment it detects a dead tunnel, and
- the connector's own `Close()`, invoked during normal teardown.

When a keepalive failure and a teardown race — common under CI load and flaky networks — both paths call `conn.Close()` on the same connection concurrently. `pgx.Conn` is not safe for concurrent close, so this surfaces as an intermittent panic that takes down the worker and cascades into unrelated test failures.

### Fix

Both paths now funnel through a single helper, `closePostgresConnections(timeout)`, guarded by a per-connector `closeLock` mutex. The helper:

- serializes all close attempts, so the keepalive callback and `Close()` can never close the same connection simultaneously, and
- checks `IsClosed()` on the regular and replication connections before closing each, making a second call a no-op rather than a double free.

`Close()` and the keepalive callback keep their original timeouts (30s and 5s respectively); the only behavioral change is that closing is now mutually exclusive and idempotent.