### PR TITLE
fix(clickhouse): exact microsecond->Time64 conversion on snapshot path

### DIFF
--- a/flow/connectors/clickhouse/table_function.go
+++ b/flow/connectors/clickhouse/table_function.go
@@ -76,8 +76,8 @@ func timeFieldExpressionConverter(
 	}
 
 	// QValueTime is stored as time-micro logical type in Avro, toTime64 accepts a
-	// fractional second, so conversion is necessary
-	return fmt.Sprintf("toTime64(%s / 1000000.0, 6)", sourceFieldIdentifier), nil
+	// fractional second, so conversion is necessary. Trip through Decimal64 to preserve precision.
+	return fmt.Sprintf("toTime64(toDecimal64(%s, 6) / 1000000, 6)", sourceFieldIdentifier), nil
 }
 
 var defaultFieldExpressionConverters = []fieldExpressionConverter{

--- a/flow/e2e/clickhouse.go
+++ b/flow/e2e/clickhouse.go
@@ -175,7 +175,7 @@ func (s ClickHouseSuite) GetRows(table string, cols string) (*model.QRecordBatch
 
 	batch := &model.QRecordBatch{}
 	colTypes := rows.ColumnTypes()
-	row := make([]any, 0, len(colTypes))
+	scanTypes := make([]reflect.Type, len(colTypes))
 	tableSchema, err := connclickhouse.GetTableSchemaForTable(&protos.TableMapping{SourceTableIdentifier: table}, colTypes)
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func (s ClickHouseSuite) GetRows(table string, cols string) (*model.QRecordBatch
 
 	for idx, ty := range colTypes {
 		fieldDesc := tableSchema.Columns[idx]
-		row = append(row, reflect.New(ty.ScanType()).Interface())
+		scanTypes[idx] = ty.ScanType()
 		batch.Schema.Fields = append(batch.Schema.Fields, types.QField{
 			Name:      ty.Name(),
 			Type:      types.QValueKind(fieldDesc.Type),
@@ -194,6 +194,13 @@ func (s ClickHouseSuite) GetRows(table string, cols string) (*model.QRecordBatch
 	}
 
 	for rows.Next() {
+		// Allocate fresh scan targets per row: clickhouse-go does not reset a
+		// nullable destination to nil when scanning a NULL, so a reused buffer
+		// would make a NULL row inherit the previous row's value.
+		row := make([]any, len(scanTypes))
+		for idx, st := range scanTypes {
+			row[idx] = reflect.New(st).Interface()
+		}
 		if err := rows.Scan(row...); err != nil {
 			return nil, err
 		}

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -1350,7 +1350,7 @@ func (s ClickHouseSuite) Test_Time64() {
 		`INSERT INTO %s (t, t_nullable, t_nullable_2) VALUES ('14:21:00', '08:30:00.123456', NULL)`, srcFullName)))
 	// Regression test for precise conversion - these values were losing 1us when tripped through floating point
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
-		`INSERT INTO %s (t, t_nullable, t_nullable_2) VALUES ('00:00:00.000249', '00:00:00.000251', '00:00:00.000493')`, srcFullName)))
+		`INSERT INTO %s (t, t_nullable, t_nullable_2) VALUES ('00:00:00.000249', '00:00:00.000251', NULL)`, srcFullName)))
 
 	connectionGen := FlowConnectionGenerationConfig{
 		FlowJobName:      s.attachSuffix(srcTableName),

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -1350,7 +1350,7 @@ func (s ClickHouseSuite) Test_Time64() {
 		`INSERT INTO %s (t, t_nullable, t_nullable_2) VALUES ('14:21:00', '08:30:00.123456', NULL)`, srcFullName)))
 	// Regression test for precise conversion - these values were losing 1us when tripped through floating point
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
-		`INSERT INTO %s (t, t_nullable, t_nullable_2) VALUES ('00:00:00.000249', '00:00:00.000251', NULL)`, srcFullName)))
+		`INSERT INTO %s (t, t_nullable, t_nullable_2) VALUES ('00:00:00.000249', '00:00:00.000251', '00:00:00.000493')`, srcFullName)))
 
 	connectionGen := FlowConnectionGenerationConfig{
 		FlowJobName:      s.attachSuffix(srcTableName),

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -1348,6 +1348,9 @@ func (s ClickHouseSuite) Test_Time64() {
 	`, srcFullName)))
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
 		`INSERT INTO %s (t, t_nullable, t_nullable_2) VALUES ('14:21:00', '08:30:00.123456', NULL)`, srcFullName)))
+	// Regression test for precise conversion - these values were losing 1us when tripped through floating point
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
+		`INSERT INTO %s (t, t_nullable, t_nullable_2) VALUES ('00:00:00.000249', '00:00:00.000251', '00:00:00.000493')`, srcFullName)))
 
 	connectionGen := FlowConnectionGenerationConfig{
 		FlowJobName:      s.attachSuffix(srcTableName),


### PR DESCRIPTION
## Problem

On the snapshot/QRep path, TIME/TIMETZ columns are converted from Avro time-micros (int64 microseconds) to ClickHouse `Time64(6)` via:

```
toTime64(<micros> / 1000000.0, 6)
```

The integer microsecond count is divided by a **Float64** literal. Float64 is binary, so many decimal microsecond fractions (e.g. `0.000249`) have no exact representation and land just *below* the true value; `toTime64` then **truncates**, dropping 1µs. ~11,549 of 1,000,000 sub-second values are affected — value-dependent, which is why `now()`-based tests flake intermittently.

Affects Postgres `TIME`/`TIMETZ` and MySQL `TIME` on the initial-snapshot/QRep load, only with `Flag_ClickHouseTime64Enabled`. The CDC path parses the value from a string (`toTime64OrNull`) and is lossless.

Failure repro (new test without a fix): https://github.com/PeerDB-io/peerdb/actions/runs/26849534704/job/79177892814?pr=4378

## Fix

`toTime64(toDecimal64(<micros>, 6) / 1000000, 6)` — exact base-10 division

Also fix a test helper that was handling nulls inconsistently.