### PR TITLE
validation: add validation to block Yugabyte

### DIFF
--- a/flow/connectors/postgres/validate.go
+++ b/flow/connectors/postgres/validate.go
@@ -19,6 +19,10 @@ import (
 )
 
 func (c *PostgresConnector) ValidateCheck(ctx context.Context) error {
+	if err := pkg_pg.CheckUnsupportedDatabase(ctx, c.conn); err != nil {
+		return err
+	}
+
 	pgversion, err := c.MajorVersion(ctx)
 	if err != nil {
 		return err

--- a/flow/pkg/postgres/validation.go
+++ b/flow/pkg/postgres/validation.go
@@ -1,0 +1,28 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/jackc/pgx/v5"
+)
+
+var yugabyteVersionPattern = regexp.MustCompile(`^PostgreSQL \d+(?:\.\d+)*-YB-\d+(?:\.\d+)*-`)
+
+func IsYugabyteVersion(version string) bool {
+	return yugabyteVersionPattern.MatchString(version)
+}
+
+func CheckUnsupportedDatabase(ctx context.Context, conn *pgx.Conn) error {
+	var version string
+	if err := conn.QueryRow(ctx, "SELECT version()").Scan(&version); err != nil {
+		return fmt.Errorf("failed to get postgres version: %w", err)
+	}
+
+	if IsYugabyteVersion(version) {
+		return fmt.Errorf("YugabyteDB is not supported")
+	}
+
+	return nil
+}

--- a/flow/pkg/postgres/validation_test.go
+++ b/flow/pkg/postgres/validation_test.go
@@ -1,0 +1,45 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsYugabyteVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{
+			name:    "Yugabyte example 1",
+			version: "PostgreSQL 15.11.0-YB-2025.2.2.1-b0 on x86_64-pc-linux-gnu, YugabyteDB, 64-bit",
+			want:    true,
+		},
+		{
+			name:    "Yugabyte example 2",
+			version: "PostgreSQL 15.12-YB-2025.2.2.2-b0 on x86_64-pc-linux-gnu, compiled by clang version 19.1.0 (https://github.com/yugabyte/llvm-project.git a2a6b655e14e7fa1fcf1011a6cb29cb8575249c0), 64-bit",
+			want:    true,
+		},
+		{
+			name:    "Yugabyte example 3",
+			version: "PostgreSQL 16-YB-2025.2.2.2-customer-build on x86_64-pc-linux-gnu, compiled by clang version 19.1.0 (https://github.com/yugabyte/llvm-project.git a2a6b655e14e7fa1fcf1011a6cb29cb8575249c0), 64-bit",
+			want:    true,
+		},
+		{
+			name:    "Generic Postgres",
+			version: "PostgreSQL 15.12 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsYugabyteVersion(tt.version))
+		})
+	}
+}


### PR DESCRIPTION
We do not Yugabyte. Its implementations has a few limitations that makes CDC tricky. Rather than failing during snapshot/CDC, block on validation.  

Fixes DBI-635