### PR TITLE
validation: classify error encountered during NeonWALPageRead

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -581,8 +581,13 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			}
 
 			// Handle Neon's custom WAL reading error
-			if pgErr.Routine == "NeonWALPageRead" && strings.Contains(pgErr.Message, "server closed the connection unexpectedly") {
-				return ErrorNotifyConnectivity, pgErrorInfo
+			if pgErr.Routine == "NeonWALPageRead" {
+				if strings.Contains(pgErr.Message, "server closed the connection unexpectedly") {
+					return ErrorNotifyConnectivity, pgErrorInfo
+				}
+				if strings.Contains(pgErr.Message, "lost synchronization with server") {
+					return ErrorRetryRecoverable, pgErrorInfo
+				}
 			}
 
 			if strings.Contains(pgErr.Message, "invalid memory alloc request size") {


### PR DESCRIPTION
Error message encountered in the NeonWALPageRead Routine:

> get copydata failed: cannot allocate memory for input buffer
lost synchronization with server: got message type "d", length 131101

Pipe recovered on its own, so assume this is is a recoverable error (the message length is 0.1MB which is pretty small, so not related to large payload).

