### PR TITLE
fix(ci): isolate dev docker PR builds from secrets

### DIFF
--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -7,8 +7,10 @@ on:
     branches: [main]
 
 jobs:
-  docker-build:
-    if: github.event_name == 'pull_request'
+  docker-build-external:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         # ubuntu-latest leverages larger GH runner pool & completes in ~30s instead of ~3m
@@ -37,8 +39,10 @@ jobs:
           SHA_SHORT: dev-${{ steps.vars.outputs.sha_short }}
           TAG: latest-dev
 
-  docker-publish:
-    if: github.event_name == 'push'
+  docker-build:
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       matrix:
         # ubuntu-latest leverages larger GH runner pool & completes in ~30s instead of ~3m
@@ -72,7 +76,7 @@ jobs:
         with:
           token: ${{ secrets.DEPOT_TOKEN }}
           files: ./docker-bake.hcl
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
         env:
           SHA_SHORT: dev-${{ steps.vars.outputs.sha_short }}
           TAG: latest-dev

--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -5,16 +5,40 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  pull_request_target:
-    branches: [main]
 
 jobs:
   docker-build:
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
-      github.event_name == 'push'
-    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'external-contributor' || null }}
+    if: github.event_name == 'pull_request'
+    strategy:
+      matrix:
+        # ubuntu-latest leverages larger GH runner pool & completes in ~30s instead of ~3m
+        runner: [ubuntu-latest]
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: generate or hydrate protos
+        uses: ./.github/actions/genprotos
+
+      - name: Set Short Commit Hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build PeerDB Images
+        run: |
+          docker buildx bake \
+            --file ./docker-bake.hcl \
+            --set '*.platform=linux/amd64' \
+            --set '*.output=type=cacheonly'
+        env:
+          SHA_SHORT: dev-${{ steps.vars.outputs.sha_short }}
+          TAG: latest-dev
+
+  docker-publish:
+    if: github.event_name == 'push'
     strategy:
       matrix:
         # ubuntu-latest leverages larger GH runner pool & completes in ~30s instead of ~3m
@@ -26,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
       - name: generate or hydrate protos
         uses: ./.github/actions/genprotos
 
@@ -48,7 +72,7 @@ jobs:
         with:
           token: ${{ secrets.DEPOT_TOKEN }}
           files: ./docker-bake.hcl
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: true
         env:
           SHA_SHORT: dev-${{ steps.vars.outputs.sha_short }}
           TAG: latest-dev


### PR DESCRIPTION
Remove pull_request_target from the dev Docker workflow so fork PR code no longer runs in a privileged base-repository context. Split PR validation from push publishing: PRs build cache-only with read-only permissions and no GHCR or Depot credentials, while main pushes retain package publishing.