### PR TITLE
fix: emit Slack alert members as <@USERID> mentions

### DIFF
--- a/flow/alerting/slack_alert_sender.go
+++ b/flow/alerting/slack_alert_sender.go
@@ -43,21 +43,26 @@ func newSlackAlertSender(config *slackAlertConfig) *SlackAlertSender {
 	}
 }
 
+func formatCCMembers(members []string) string {
+	if len(members) == 0 {
+		return "cc: <!channel>"
+	}
+	var b strings.Builder
+	b.WriteString("cc:")
+	for _, member := range members {
+		b.WriteString(" <@")
+		b.WriteString(member)
+		b.WriteString(">")
+	}
+	return b.String()
+}
+
 func (s *SlackAlertSender) sendAlert(ctx context.Context, alertTitle string, alertMessage string) error {
+	ccMembersPart := formatCCMembers(s.members)
 	for _, channelID := range s.channelIDs {
-		var ccMembersPart strings.Builder
-		if len(s.members) == 0 {
-			ccMembersPart.WriteString("cc: <!channel>")
-		} else {
-			ccMembersPart.WriteString("cc:")
-			for _, member := range s.members {
-				ccMembersPart.WriteString(" @")
-				ccMembersPart.WriteString(member)
-			}
-		}
 		_, _, _, err := s.client.SendMessageContext(ctx, channelID, slack.MsgOptionBlocks(
 			slack.NewHeaderBlock(slack.NewTextBlockObject("plain_text", ":rotating_light:Alert:rotating_light:: "+alertTitle, true, false)),
-			slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", alertMessage+"\n"+ccMembersPart.String(), false, false), nil, nil),
+			slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", alertMessage+"\n"+ccMembersPart, false, false), nil, nil),
 		))
 		if err != nil {
 			return fmt.Errorf("failed to send message to Slack channel %s: %w", channelID, err)

--- a/flow/alerting/slack_alert_sender_test.go
+++ b/flow/alerting/slack_alert_sender_test.go
@@ -1,0 +1,44 @@
+package alerting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatCCMembers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		members []string
+		want    string
+	}{
+		{
+			name:    "empty members pings whole channel",
+			members: nil,
+			want:    "cc: <!channel>",
+		},
+		{
+			name:    "empty slice pings whole channel",
+			members: []string{},
+			want:    "cc: <!channel>",
+		},
+		{
+			name:    "single member wrapped in Slack mention syntax",
+			members: []string{"U01ABC234"},
+			want:    "cc: <@U01ABC234>",
+		},
+		{
+			name:    "multiple members each wrapped and space-separated",
+			members: []string{"U01ABC234", "U05XYZ999"},
+			want:    "cc: <@U01ABC234> <@U05XYZ999>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, formatCCMembers(tt.members))
+		})
+	}
+}

--- a/flow/alerting/slack_alert_sender_test.go
+++ b/flow/alerting/slack_alert_sender_test.go
@@ -9,6 +9,7 @@ import (
 func TestFormatCCMembers(t *testing.T) {
 	t.Parallel()
 
+	//nolint:govet // it's a test, no need for fieldalignment
 	tests := []struct {
 		name    string
 		members []string

--- a/ui/app/alert-config/new.tsx
+++ b/ui/app/alert-config/new.tsx
@@ -87,8 +87,8 @@ function getSlackProps(
       <div>
         <p>Members</p>
         <Label as='label' style={{ fontSize: 14 }}>
-          Slack usernames to tag in the channel for these alerts. If left empty,
-          pings the whole channel
+          Slack user IDs (e.g. U01ABC234) to tag in the channel for these
+          alerts. If left empty, pings the whole channel
         </Label>
         <TextField
           key={'members'}


### PR DESCRIPTION
## Problem

Slack alert cc lines were built with `@<name>` syntax, which Slack renders as **plain text** and never turns into an actual mention — so the tagged users were never notified.

## Fix

- Wrap each member in Slack's mrkdwn mention syntax `<@USERID>` so the cc line produces real, clickable mentions.
- Keep the `<!channel>` fallback when no members are configured.
- Update the alert-config UI hint to clarify the field expects Slack **user IDs** (e.g. `U01ABC234`), not display names.
- Extract the cc-line construction into `formatCCMembers`, covered by a table-driven unit test.

## Example

### Before:
<img width="599" height="107" alt="image" src="https://github.com/user-attachments/assets/b6146e7e-9cca-42e0-8482-358cb270b9fe" />

### After:
<img width="639" height="104" alt="image" src="https://github.com/user-attachments/assets/37ab3981-e73b-49c0-82a7-fcfa73f830bd" />


## Testing

- `go test ./alerting/ -run TestFormatCCMembers` — passes (empty / single / multiple members, `<!channel>` fallback).
- End-to-end verified against a live Slack workspace using the local dev stack: triggered an alert and confirmed the cc line renders as a real highlighted `@mention` (previously plain text).

Close https://github.com/PeerDB-io/peerdb/issues/4353