### PR TITLE
fix: redact Slack auth_token in alert config responses

### DIFF
--- a/flow/cmd/alerts.go
+++ b/flow/cmd/alerts.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -10,6 +12,74 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
+
+// secretFieldsByServiceType lists JSON keys whose values must never be
+// returned to API clients. Keep this in sync with the alert sender configs
+// in flow/alerting.
+var secretFieldsByServiceType = map[string][]string{
+	"slack": {"auth_token"},
+}
+
+// redactServiceConfig returns serviceConfig with all secret fields for the
+// given service type replaced by the empty string. Unknown service types
+// are passed through unchanged.
+func redactServiceConfig(serviceType string, serviceConfig []byte) ([]byte, error) {
+	secretFields, ok := secretFieldsByServiceType[serviceType]
+	if !ok {
+		return serviceConfig, nil
+	}
+	var cfg map[string]json.RawMessage
+	if err := json.Unmarshal(serviceConfig, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal service config for redaction: %w", err)
+	}
+	empty, _ := json.Marshal("")
+	for _, field := range secretFields {
+		if _, present := cfg[field]; present {
+			cfg[field] = empty
+		}
+	}
+	return json.Marshal(cfg)
+}
+
+// mergePreservingSecrets returns submitted with any empty secret fields
+// populated from existing, so that clients can omit a secret to keep its
+// stored value (clients never receive the value, see redactServiceConfig).
+func mergePreservingSecrets(serviceType string, submitted, existing []byte) ([]byte, error) {
+	secretFields, ok := secretFieldsByServiceType[serviceType]
+	if !ok {
+		return submitted, nil
+	}
+	var submittedMap map[string]json.RawMessage
+	if err := json.Unmarshal(submitted, &submittedMap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal submitted service config: %w", err)
+	}
+	var existingMap map[string]json.RawMessage
+	if err := json.Unmarshal(existing, &existingMap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal existing service config: %w", err)
+	}
+	changed := false
+	for _, field := range secretFields {
+		submittedVal, submittedHas := submittedMap[field]
+		if !submittedHas || isEmptyJSONString(submittedVal) {
+			if existingVal, existingHas := existingMap[field]; existingHas {
+				submittedMap[field] = existingVal
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return submitted, nil
+	}
+	return json.Marshal(submittedMap)
+}
+
+func isEmptyJSONString(raw json.RawMessage) bool {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return false
+	}
+	return s == ""
+}
 
 func (h *FlowRequestHandler) GetAlertConfigs(
 	ctx context.Context,
@@ -31,7 +101,11 @@ func (h *FlowRequestHandler) GetAlertConfigs(
 		if err != nil {
 			return nil, NewInternalApiError(fmt.Errorf("failed to decrypt alert config: %w", err))
 		}
-		config.ServiceConfig = string(serviceConfig)
+		redacted, err := redactServiceConfig(config.ServiceType, serviceConfig)
+		if err != nil {
+			return nil, NewInternalApiError(err)
+		}
+		config.ServiceConfig = string(redacted)
 		return config, nil
 	})
 	if err != nil {
@@ -49,7 +123,36 @@ func (h *FlowRequestHandler) PostAlertConfig(
 	if err != nil {
 		return nil, NewInternalApiError(fmt.Errorf("failed to get current enc key: %w", err))
 	}
-	serviceConfig, err := key.Encrypt(shared.UnsafeFastStringToReadOnlyBytes(req.Config.ServiceConfig))
+
+	// On update, fill empty secret fields from the stored config so callers
+	// can omit unchanged secrets (the API never returns them — see
+	// redactServiceConfig).
+	serviceConfigPlaintext := req.Config.ServiceConfig
+	if req.Config.Id != -1 {
+		var existingPayload []byte
+		var existingEncKeyID string
+		err := h.pool.QueryRow(ctx,
+			"SELECT service_config, enc_key_id FROM peerdb_stats.alerting_config WHERE id = $1",
+			req.Config.Id,
+		).Scan(&existingPayload, &existingEncKeyID)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return nil, NewInternalApiError(fmt.Errorf("failed to load existing alert config: %w", err))
+		}
+		if err == nil {
+			existingPlaintext, err := internal.Decrypt(ctx, existingEncKeyID, existingPayload)
+			if err != nil {
+				return nil, NewInternalApiError(fmt.Errorf("failed to decrypt existing alert config: %w", err))
+			}
+			merged, err := mergePreservingSecrets(req.Config.ServiceType,
+				shared.UnsafeFastStringToReadOnlyBytes(req.Config.ServiceConfig), existingPlaintext)
+			if err != nil {
+				return nil, NewInternalApiError(err)
+			}
+			serviceConfigPlaintext = string(merged)
+		}
+	}
+
+	serviceConfig, err := key.Encrypt(shared.UnsafeFastStringToReadOnlyBytes(serviceConfigPlaintext))
 	if err != nil {
 		return nil, NewInternalApiError(fmt.Errorf("failed to encrypt alert config: %w", err))
 	}

--- a/ui/app/alert-config/new.tsx
+++ b/ui/app/alert-config/new.tsx
@@ -15,6 +15,7 @@ import {
   alertConfigType,
   emailConfigType,
   serviceConfigType,
+  serviceTypeEditSchemaMap,
   serviceTypeSchemaMap,
   slackConfigType,
 } from './validation';
@@ -48,7 +49,8 @@ function ConfigLabel(data: { label: string; value: string }) {
 
 function getSlackProps(
   config: slackConfigType,
-  setConfig: Dispatch<SetStateAction<slackConfigType>>
+  setConfig: Dispatch<SetStateAction<slackConfigType>>,
+  forEdit: boolean
 ) {
   return (
     <>
@@ -58,7 +60,12 @@ function getSlackProps(
           key={'auth_token'}
           style={{ height: '2.5rem', marginTop: '0.5rem' }}
           variant='simple'
-          placeholder='Auth Token'
+          type='password'
+          placeholder={
+            forEdit
+              ? 'Leave blank to keep current token'
+              : 'Auth Token'
+          }
           value={config.auth_token}
           onChange={(e) => {
             setConfig((previous) => ({
@@ -136,7 +143,8 @@ function getEmailProps(
 function getServiceFields<T extends serviceConfigType>(
   serviceType: ServiceType,
   config: T,
-  setConfig: Dispatch<SetStateAction<T>>
+  setConfig: Dispatch<SetStateAction<T>>,
+  forEdit: boolean
 ) {
   switch (serviceType) {
     case 'email':
@@ -147,7 +155,8 @@ function getServiceFields<T extends serviceConfigType>(
     case 'slack': {
       return getSlackProps(
         config as slackConfigType,
-        setConfig as Dispatch<SetStateAction<slackConfigType>>
+        setConfig as Dispatch<SetStateAction<slackConfigType>>,
+        forEdit
       );
     }
   }
@@ -175,7 +184,9 @@ export function NewConfig(alertProps: AlertConfigProps) {
       return;
     }
 
-    const serviceSchema = serviceTypeSchemaMap[serviceType];
+    const serviceSchema = alertProps.forEdit
+      ? serviceTypeEditSchemaMap[serviceType]
+      : serviceTypeSchemaMap[serviceType];
     const serviceValidity = serviceSchema.safeParse(config);
     if (!serviceValidity?.success) {
       notifyErr(
@@ -226,7 +237,12 @@ export function NewConfig(alertProps: AlertConfigProps) {
       window.location.reload();
     });
   };
-  const ServiceFields = getServiceFields(serviceType, config, setConfig);
+  const ServiceFields = getServiceFields(
+    serviceType,
+    config,
+    setConfig,
+    alertProps.forEdit ?? false
+  );
   return (
     <div
       style={{

--- a/ui/app/alert-config/page.tsx
+++ b/ui/app/alert-config/page.tsx
@@ -15,6 +15,12 @@ import { tableStyle } from '../peers/[peerName]/style';
 import { fetcher } from '../utils/swr';
 import { AlertConfigProps, NewConfig, ServiceType } from './new';
 
+// Secret JSON keys the backend redacts to "" in alert config responses.
+// Keep in sync with secretFieldsByServiceType in flow/cmd/alerts.go.
+const secretFieldsByServiceType: Record<string, string[]> = {
+  slack: ['auth_token'],
+};
+
 function ServiceIcon({
   serviceType,
   size,
@@ -74,6 +80,16 @@ export default function AlertConfigPage() {
 
   const genConfigJSON = (alertConfig: AlertConfig) => {
     const parsedConfig = JSON.parse(alertConfig.serviceConfig);
+    // Display-only mask for redacted secret fields. The backend returns secrets
+    // as "" (see redactServiceConfig); the edit flow (onEdit) keeps using that
+    // raw "" so the backend keep-existing-secret logic stays intact. We only
+    // dress up the read-only view so an empty value doesn't look unconfigured.
+    for (const field of secretFieldsByServiceType[alertConfig.serviceType] ??
+      []) {
+      if (parsedConfig[field] === '') {
+        parsedConfig[field] = '••••••• (hidden)';
+      }
+    }
     return JSON.stringify(
       { ...parsedConfig, alertForMirrors: alertConfig.alertForMirrors },
       null,

--- a/ui/app/alert-config/validation.ts
+++ b/ui/app/alert-config/validation.ts
@@ -27,6 +27,24 @@ export const slackServiceConfigSchema = z.intersection(
   })
 );
 
+// Edit variant: an empty auth_token means "keep the stored value"; the
+// backend will preserve the existing token. The API never returns the
+// current token to the UI.
+export const slackServiceConfigEditSchema = z.intersection(
+  baseServiceConfigSchema,
+  z.object({
+    auth_token: z
+      .string()
+      .max(256, { message: 'Auth Token is too long' }),
+    channel_ids: z
+      .array(
+        z.string().trim().min(1, { message: 'Channel IDs cannot be empty' })
+      )
+      .min(1, { message: 'At least one channel ID is needed' }),
+    members: z.array(z.string().trim()).optional(),
+  })
+);
+
 export const emailServiceConfigSchema = z.intersection(
   baseServiceConfigSchema,
   z.object({
@@ -66,5 +84,10 @@ export type alertConfigType = z.infer<typeof alertConfigReqSchema>;
 
 export const serviceTypeSchemaMap = {
   slack: slackServiceConfigSchema,
+  email: emailServiceConfigSchema,
+};
+
+export const serviceTypeEditSchemaMap = {
+  slack: slackServiceConfigEditSchema,
   email: emailServiceConfigSchema,
 };

--- a/ui/components/AlertDropdown.tsx
+++ b/ui/components/AlertDropdown.tsx
@@ -22,7 +22,7 @@ export default function AlertDropdown({
 
   return (
     <DropdownMenu.Root>
-      <DropdownMenu.Trigger>
+      <DropdownMenu.Trigger asChild>
         <Button
           aria-controls={open ? 'menu-list-grow' : undefined}
           aria-haspopup='true'


### PR DESCRIPTION
## What

`GetAlertConfigs` returned the decrypted Slack `auth_token` in plaintext, exposing the credential to anyone with UI access.

This PR:
- Redacts secret fields (Slack `auth_token`) on read, so the API never returns the value.
- On update, preserves the stored secret when the client submits an empty value, so the UI can edit other fields without ever seeing the token.
- Renders `auth_token` as a password field with a "leave blank to keep current token" hint and uses a relaxed edit-time validation schema.
- Masks redacted secrets in the read-only config view (`••••••• (hidden)`) so a configured token no longer looks unset.
- Adds `asChild` to the `AlertDropdown` trigger so Radix no longer wraps the `Button` in its own `button`, removing a `<button>` in `<button>` hydration error in the alert config page.

## Example

<img width="777" height="417" alt="Google Chrome 2026-06-05 18 27 15" src="https://github.com/user-attachments/assets/a3003376-a411-4d2a-bcce-3fb2c1458fc3" />


## Why

The Slack auth token is a sensitive credential and should never be exposed to UI clients. See #4345.

Closes #4345