### PR TITLE
DBI-782: PG Connector TLS settings unification

### DIFF
--- a/flow/connectors/postgres/pgdump_schema.go
+++ b/flow/connectors/postgres/pgdump_schema.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 // pg_dump from newer Postgres versions emits statements that older
@@ -280,7 +281,7 @@ func buildPsqlArgs(config *protos.PostgresConfig) []string {
 }
 
 func appendTLSEnv(ctx context.Context, cmd *exec.Cmd, config *protos.PostgresConfig) {
-	if config.RequireTls {
+	if internal.PGMustUseTlsConnection(config) {
 		cmd.Env = append(cmd.Env, "PGSSLMODE=require")
 
 		if config.RootCa != nil && *config.RootCa != "" {

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -146,7 +146,10 @@ func ParseConfig(connectionString string, pgConfig *protos.PostgresConfig) (*pgx
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse connection string: %w", err)
 	}
-	if pgConfig.RequireTls || pgConfig.RootCa != nil {
+
+	shouldUseTls := internal.PGMustUseTlsConnection(pgConfig)
+
+	if shouldUseTls || pgConfig.RootCa != nil {
 		tlsConfig, err := common.CreateTlsConfig(tls.VersionTLS12, pgConfig.RootCa, connConfig.Host, pgConfig.TlsHost, false)
 		if err != nil {
 			return nil, err

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -150,7 +150,7 @@ func ParseConfig(connectionString string, pgConfig *protos.PostgresConfig) (*pgx
 	shouldUseTls := internal.PGMustUseTlsConnection(pgConfig)
 
 	if shouldUseTls || pgConfig.RootCa != nil {
-		tlsConfig, err := common.CreateTlsConfig(tls.VersionTLS12, pgConfig.RootCa, connConfig.Host, pgConfig.TlsHost, false)
+		tlsConfig, err := common.CreateTlsConfig(tls.VersionTLS12, pgConfig.RootCa, connConfig.Host, pgConfig.TlsHost, pgConfig.SkipCertVerification)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -150,7 +150,8 @@ func ParseConfig(connectionString string, pgConfig *protos.PostgresConfig) (*pgx
 	shouldUseTls := internal.PGMustUseTlsConnection(pgConfig)
 
 	if shouldUseTls || pgConfig.RootCa != nil {
-		tlsConfig, err := common.CreateTlsConfig(tls.VersionTLS12, pgConfig.RootCa, connConfig.Host, pgConfig.TlsHost, pgConfig.SkipCertVerification)
+		tlsConfig, err := common.CreateTlsConfig(
+			tls.VersionTLS12, pgConfig.RootCa, connConfig.Host, pgConfig.TlsHost, pgConfig.SkipCertVerification)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/internal/postgres.go
+++ b/flow/internal/postgres.go
@@ -15,6 +15,15 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
+// This function determines when PG should use TLS connections in function of the peer configuration.
+// The logic is as follows:
+// 1. If TLS is explicitly required by the user (RequireTls=true), then we use TLS.
+// 2. If TLS is not explicitly required, but DisableTls is explicitly set to false, then we also use TLS.
+// 3. Otherwise, we do not use TLS.
+func PGMustUseTlsConnection(pgConfig *protos.PostgresConfig) bool {
+	return pgConfig.RequireTls || (pgConfig.DisableTls != nil && !*pgConfig.DisableTls)
+}
+
 func GetPGConnectionString(pgConfig *protos.PostgresConfig, flowName string) string {
 	// strip path and query params that may be present in the host
 	host, _, _ := strings.Cut(pgConfig.Host, "/")
@@ -40,8 +49,11 @@ func GetPGConnectionString(pgConfig *protos.PostgresConfig, flowName string) str
 	q := u.Query()
 	q.Set("application_name", applicationName)
 	q.Set("client_encoding", "UTF8")
-	if pgConfig.RequireTls {
+	if PGMustUseTlsConnection(pgConfig) {
 		q.Set("sslmode", "require")
+		// When require or more strict modes are set, the PostgreSQL client library will use the TLS
+		// configuration provided by the user.
+		// Other modes such as "verify-ca" or "verify-full" might be relaxed by this configuration.
 	}
 
 	u.RawQuery = q.Encode()

--- a/flow/internal/postgres_test.go
+++ b/flow/internal/postgres_test.go
@@ -10,6 +10,70 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 )
 
+func TestPGMustUseTlsConnection(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		disableTls *bool
+		name       string
+		requireTls bool
+		expected   bool
+	}{
+		{
+			// Legacy API: disable_tls missing, no TLS required.
+			name:       "require=false disable=missing",
+			requireTls: false,
+			disableTls: nil,
+			expected:   false,
+		},
+		{
+			// New API using DisableTLS: disable_tls explicitly false => use TLS.
+			name:       "require=false disable=false",
+			requireTls: false,
+			disableTls: boolPtr(false),
+			expected:   true,
+		},
+		{
+			// New API using DisableTLS: disable_tls explicitly true => no TLS.
+			name:       "require=false disable=true",
+			requireTls: false,
+			disableTls: boolPtr(true),
+			expected:   false,
+		},
+		{
+			// RequireTls dominates regardless of disable_tls being missing.
+			name:       "require=true disable=missing",
+			requireTls: true,
+			disableTls: nil,
+			expected:   true,
+		},
+		{
+			// Should not be seen in practice, RequireTls dominates.
+			name:       "require=true disable=false",
+			requireTls: true,
+			disableTls: boolPtr(false),
+			expected:   true,
+		},
+		{
+			// Should not be seen in practice, RequireTls dominates.
+			name:       "require=true disable=true",
+			requireTls: true,
+			disableTls: boolPtr(true),
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &protos.PostgresConfig{
+				RequireTls: tt.requireTls,
+				DisableTls: tt.disableTls,
+			}
+			assert.Equal(t, tt.expected, PGMustUseTlsConnection(config))
+		})
+	}
+}
+
 func TestGetPGConnectionString(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/flow/shared/telemetry/activity_logging.go
+++ b/flow/shared/telemetry/activity_logging.go
@@ -395,7 +395,7 @@ func LogPeerInfo(ctx context.Context, peer *protos.Peer, version string, variant
 	switch config := peer.Config.(type) {
 	case *protos.Peer_PostgresConfig:
 		info.Host = config.PostgresConfig.Host
-		info.DisableTLS = !config.PostgresConfig.RequireTls
+		info.DisableTLS = !internal.PGMustUseTlsConnection(config.PostgresConfig)
 		info.TLSHost = config.PostgresConfig.TlsHost
 		info.SshHost = config.PostgresConfig.SshConfig.GetHost()
 		info.DatabaseName = config.PostgresConfig.Database

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -777,6 +777,13 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .get("require_tls")
                     .map(|s| s.parse::<bool>().unwrap_or_default())
                     .unwrap_or_default(),
+                disable_tls: opts
+                    .get("disable_tls")
+                    .map(|s| s.parse::<bool>().unwrap_or_default()),
+                skip_cert_verification: opts
+                    .get("skip_cert_verification")
+                    .map(|s| s.parse::<bool>().unwrap_or_default())
+                    .unwrap_or_default(),
                 auth_type: PostgresAuthType::PostgresPassword.into(),
                 aws_auth: None,
             };

--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -177,6 +177,8 @@ impl CatalogConfig<'_> {
             root_ca: None,
             tls_host: String::new(),
             require_tls: false,
+            disable_tls: None,
+            skip_cert_verification: false,
             auth_type: PostgresAuthType::PostgresPassword.into(),
             aws_auth: None,
         }

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -128,6 +128,7 @@ message PostgresConfig {
   bool require_tls = 10;
   PostgresAuthType auth_type = 11;
   optional AwsAuthenticationConfig aws_auth = 12;
+  optional bool disable_tls = 13;
 }
 
 message EventHubConfig {

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -129,6 +129,7 @@ message PostgresConfig {
   PostgresAuthType auth_type = 11;
   optional AwsAuthenticationConfig aws_auth = 12;
   optional bool disable_tls = 13;
+  bool skip_cert_verification = 14;
 }
 
 message EventHubConfig {

--- a/ui/app/peers/create/[peerType]/helpers/pg.ts
+++ b/ui/app/peers/create/[peerType]/helpers/pg.ts
@@ -61,6 +61,14 @@ export const postgresSetting: PeerSetting[] = [
     optional: true,
   },
   {
+    label: 'Skip Certificate Verification?',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, skipCertVerification: value as boolean })),
+    type: 'switch',
+    tips: 'Skip TLS certificate verification (insecure, use with caution).',
+    optional: true,
+  },
+  {
     label: 'Root Certificate',
     stateHandler: (value, setter) => {
       if (!value) {
@@ -202,6 +210,7 @@ export const blankPostgresSetting: PostgresConfig = {
   password: '',
   database: '',
   requireTls: false,
+  skipCertVerification: false,
   authType: PostgresAuthType.POSTGRES_PASSWORD,
   awsAuth: {
     region: '',


### PR DESCRIPTION
This Pull Request aligns PG connector TLS configuration parameters with other connectors that use `DisableTLS`.
To keep backward compatibility, this new config parameter is optional and is always overridden by the existing`RequireTLS`.

Additionally, it adds `SkipCertVerification`  (default `false` in accordance to the current hard-coded behaviour) thus allowing for encrypted connection to unverified hosts. 

Closes: DBI-782