### PR TITLE
use exact count when estimates fail

### DIFF
--- a/flow/connectors/postgres/qrep_partition.go
+++ b/flow/connectors/postgres/qrep_partition.go
@@ -486,12 +486,12 @@ func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPar
 		); err != nil {
 			return 0, fmt.Errorf("failed to query for estimated row count: %w", err)
 		}
+
 		pp.logger.Info("estimated row count",
 			slog.String("query", estimatedCountTemplate),
 			slog.String("watermarkTable", pp.watermarkTable),
 			slog.Bool("relhassubclass", relhassubclass),
-			slog.String("formula", fmt.Sprintf("%v / %d * (%d / %d)",
-				reltuples, relpages, relationSize, blockSize)))
+			slog.String("formula", fmt.Sprintf("%v / %d * (%d / %d)", reltuples, relpages, relationSize, blockSize)))
 
 		if v, err := estimatedCount.Int64Value(); err != nil {
 			pp.logger.Warn("estimated row count outside int64 range, falling back to precise count",

--- a/flow/connectors/postgres/qrep_partition.go
+++ b/flow/connectors/postgres/qrep_partition.go
@@ -470,7 +470,9 @@ func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPar
 	if pp.lastRangeEnd == nil {
 		pp.logger.Info("fetch estimated row count", slog.String("query", estimatedCountTemplate))
 		if err := pp.tx.QueryRow(ctx, estimatedCountTemplate, pp.watermarkTable).Scan(&totalRows); err != nil {
-			return 0, fmt.Errorf("failed to query for estimated row count: %w", err)
+			pp.logger.Warn("failed to query estimated row count, falling back to precise count",
+				slog.Any("error", err),
+				slog.String("watermarkTable", pp.watermarkTable))
 		}
 	} else {
 		whereClause = fmt.Sprintf("WHERE %s > $1", pp.watermarkColumn)

--- a/flow/connectors/postgres/qrep_partition.go
+++ b/flow/connectors/postgres/qrep_partition.go
@@ -456,50 +456,55 @@ func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPar
 	// For inherited/partitioned tables pg_relation_size, reltuples, and relpages
 	// only reflect the parent table, so we return 0 and fall back to precise count query.
 	const estimatedCountTemplate = `SELECT CASE
-		WHEN c.relhassubclass THEN 0
-		WHEN c.reltuples >= 0 AND c.relpages > 0 THEN
-			(c.reltuples / c.relpages * (pg_relation_size(c.oid) / current_setting('block_size')::integer))::bigint
-		ELSE c.reltuples::bigint
+			WHEN c.reltuples >= 0 AND c.relpages > 0 AND NOT c.relhassubclass
+			    THEN c.reltuples::numeric / c.relpages * (pg_relation_size(c.oid) / current_setting('block_size')::integer)
+			ELSE 0::numeric
 		END
 		FROM pg_class c WHERE c.oid = to_regclass($1)`
 
-	var totalRows pgtype.Int8
+	var totalRows int64
 	var whereClause string
 	var queryArgs []any
 
 	if pp.lastRangeEnd == nil {
 		pp.logger.Info("fetch estimated row count", slog.String("query", estimatedCountTemplate))
-		if err := pp.tx.QueryRow(ctx, estimatedCountTemplate, pp.watermarkTable).Scan(&totalRows); err != nil {
-			pp.logger.Warn("failed to query estimated row count, falling back to precise count",
+		var n pgtype.Numeric
+		if err := pp.tx.QueryRow(ctx, estimatedCountTemplate, pp.watermarkTable).Scan(&n); err != nil {
+			return 0, fmt.Errorf("failed to query for estimated row count: %w", err)
+		} else if v, err := n.Int64Value(); err != nil {
+			pp.logger.Warn("estimated row count outside int64 range, falling back to precise count",
 				slog.Any("error", err),
 				slog.String("watermarkTable", pp.watermarkTable))
+		} else if v.Valid {
+			totalRows = v.Int64
 		}
 	} else {
 		whereClause = fmt.Sprintf("WHERE %s > $1", pp.watermarkColumn)
 		queryArgs = []any{pp.lastRangeEnd}
 	}
 
-	// reltuples is -1 if the table has never been analyzed
-	// reltuples is 0 if:
-	//   - table is new and stats is stale; or
+	// estimated rows is <= 0 if:
+	//   - table has never been analyzed; or
+	//   - row count outside int64 range; or
 	//   - table is inherited/partitioned (see query above); or
 	//   - polling-based flows (estimated row count is skipped)
 	// In all cases, fall back to precise count query
-	if totalRows.Int64 <= 0 {
+	if totalRows <= 0 {
 		countQuery := fmt.Sprintf(preciseCountTemplate, pp.watermarkTable, whereClause)
 		pp.logger.Info("fetch row count", slog.String("query", countQuery))
 		if err := pp.tx.QueryRow(ctx, countQuery, queryArgs...).Scan(&totalRows); err != nil {
 			return 0, fmt.Errorf("failed to query for precise row count: %w", err)
 		}
 	}
-	if totalRows.Int64 <= 0 {
+
+	if totalRows <= 0 {
 		pp.logger.Warn("no records to replicate, returning")
 		return 0, nil
 	}
 
-	adjustedPartitions := shared.AdjustNumPartitions(totalRows.Int64, numRowsPerPartition)
+	adjustedPartitions := shared.AdjustNumPartitions(totalRows, numRowsPerPartition)
 	pp.logger.Info("[postgres] partition details",
-		slog.Int64("totalRows", totalRows.Int64),
+		slog.Int64("totalRows", totalRows),
 		slog.Int64("desiredNumRowsPerPartition", numRowsPerPartition),
 		slog.Int64("adjustedNumPartitions", adjustedPartitions.AdjustedNumPartitions),
 		slog.Int64("adjustedNumRowsPerPartition", adjustedPartitions.AdjustedNumRowsPerPartition))

--- a/flow/connectors/postgres/qrep_partition.go
+++ b/flow/connectors/postgres/qrep_partition.go
@@ -455,11 +455,19 @@ func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPar
 	// see https://www.citusdata.com/blog/2016/10/12/count-performance/#dup_counts_estimated_full).
 	// For inherited/partitioned tables pg_relation_size, reltuples, and relpages
 	// only reflect the parent table, so we return 0 and fall back to precise count query.
-	const estimatedCountTemplate = `SELECT CASE
-			WHEN c.reltuples >= 0 AND c.relpages > 0 AND NOT c.relhassubclass
-			    THEN c.reltuples::numeric / c.relpages * (pg_relation_size(c.oid) / current_setting('block_size')::integer)
-			ELSE 0::numeric
-		END
+	const estimatedCountTemplate = `SELECT
+    		-- for logging/debugging purpose
+			c.reltuples,
+			c.relpages,
+			c.relhassubclass,
+			pg_relation_size(c.oid),
+			current_setting('block_size')::integer,
+			-- row estimation formula
+			CASE
+				WHEN c.reltuples >= 0 AND c.relpages > 0 AND NOT c.relhassubclass
+				    THEN c.reltuples::numeric / c.relpages * (pg_relation_size(c.oid) / current_setting('block_size')::integer)
+				ELSE 0::numeric
+			END
 		FROM pg_class c WHERE c.oid = to_regclass($1)`
 
 	var totalRows int64
@@ -467,11 +475,25 @@ func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPar
 	var queryArgs []any
 
 	if pp.lastRangeEnd == nil {
-		pp.logger.Info("fetch estimated row count", slog.String("query", estimatedCountTemplate))
-		var n pgtype.Numeric
-		if err := pp.tx.QueryRow(ctx, estimatedCountTemplate, pp.watermarkTable).Scan(&n); err != nil {
+		var reltuples float32
+		var relpages int32
+		var relhassubclass bool
+		var relationSize int64
+		var blockSize int32
+		var estimatedCount pgtype.Numeric
+		if err := pp.tx.QueryRow(ctx, estimatedCountTemplate, pp.watermarkTable).Scan(
+			&reltuples, &relpages, &relhassubclass, &relationSize, &blockSize, &estimatedCount,
+		); err != nil {
 			return 0, fmt.Errorf("failed to query for estimated row count: %w", err)
-		} else if v, err := n.Int64Value(); err != nil {
+		}
+		pp.logger.Info("estimated row count",
+			slog.String("query", estimatedCountTemplate),
+			slog.String("watermarkTable", pp.watermarkTable),
+			slog.Bool("relhassubclass", relhassubclass),
+			slog.String("formula", fmt.Sprintf("%v / %d * (%d / %d)",
+				reltuples, relpages, relationSize, blockSize)))
+
+		if v, err := estimatedCount.Int64Value(); err != nil {
 			pp.logger.Warn("estimated row count outside int64 range, falling back to precise count",
 				slog.Any("error", err),
 				slog.String("watermarkTable", pp.watermarkTable))


### PR DESCRIPTION
Encountered a scenario where the query count estimate led to `ERROR: bigint out of range (SQLSTATE 22003)`; and the while the exact row count for the table is very low.

The query is:

```
SELECT CASE
WHEN c.relhassubclass THEN 0
WHEN c.reltuples >= 0 AND c.relpages > 0 THEN
	(c.reltuples / c.relpages * (pg_relation_size(c.oid) / current_setting('block_size')::integer))::bigint
ELSE c.reltuples::bigint
END
FROM pg_class c WHERE c.oid = to_regclass($1)
```

When stats are not populated due to a relatively new table, reltuples could be 0 or -1, and in both cases the result would not overflow.  Given the actual row count is small, the most likely scenario seem to be table bloat with dead rows that led to both reltuples and pg_relation_size to be very high. 

When we hit this error, we can conservatively fall back to actual table count. 

Fixes: DBI-766