### PR TITLE
Make PG `SkipCertVerification` take effect in PG-PG PGdump

### DIFF
--- a/flow/connectors/postgres/pgdump_schema.go
+++ b/flow/connectors/postgres/pgdump_schema.go
@@ -282,7 +282,11 @@ func buildPsqlArgs(config *protos.PostgresConfig) []string {
 
 func appendTLSEnv(ctx context.Context, cmd *exec.Cmd, config *protos.PostgresConfig) {
 	if internal.PGMustUseTlsConnection(config) {
-		cmd.Env = append(cmd.Env, "PGSSLMODE=require")
+		sslMode := "verify-ca"
+		if config.SkipCertVerification {
+			sslMode = "require"
+		}
+		cmd.Env = append(cmd.Env, "PGSSLMODE="+sslMode)
 
 		if config.RootCa != nil && *config.RootCa != "" {
 			// write root CA to a temp file


### PR DESCRIPTION
Default to vreify CA level.

On the one hand, In https://github.com/PeerDB-io/peerdb/pull/4388 aligned PG peers TLS configuration with other connectors, adding an overlapping configuration parameters `disable_tls` and `skip_cert_verification`:

https://github.com/PeerDB-io/peerdb/blob/b31f943463b03aceafff8388710b1bddd8ebdbe9/protos/peers.proto#L131-L132

On the other hand, PG to PG pipes uses direct schema dump to reproduce source entities in target PG. The mentioned change made it use `disable_tls` but it didn't introduce reading `skip_cert_verification`. This was intentional because this changes makes the default more strict for PG schema dump process.

This PR brings "default to verify host" to the PG dump process in an isolated way to be reviewed separately.