### PR TITLE
MongoDB connector: Add `skip_cert_verification` parameter to Peer Configuration

### DIFF
--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -106,15 +106,16 @@ func NewMongoConnector(ctx context.Context, config *protos.MongoConfig) (*MongoC
 	}
 
 	clientOptions, err := peerdb_mongo.BuildClientOptions(peerdb_mongo.ClientConfig{
-		Uri:                 config.Uri,
-		Username:            config.Username,
-		Password:            config.Password,
-		ReadPreference:      protoReadPrefToString[config.ReadPreference],
-		DisableTls:          config.DisableTls,
-		RootCa:              config.GetRootCa(),
-		TlsHost:             config.TlsHost,
-		CreateTlsConfigFunc: common.CreateTlsConfigFromRootCAString,
-		Dialer:              &meteredDialer,
+		Uri:                  config.Uri,
+		Username:             config.Username,
+		Password:             config.Password,
+		ReadPreference:       protoReadPrefToString[config.ReadPreference],
+		DisableTls:           config.DisableTls,
+		SkipCertVerification: config.SkipCertVerification,
+		RootCa:               config.GetRootCa(),
+		TlsHost:              config.TlsHost,
+		CreateTlsConfigFunc:  common.CreateTlsConfigFromRootCAString,
+		Dialer:               &meteredDialer,
 	})
 	if err != nil {
 		return nil, err

--- a/flow/pkg/mongo/client_options.go
+++ b/flow/pkg/mongo/client_options.go
@@ -19,15 +19,16 @@ const (
 )
 
 type ClientConfig struct {
-	Uri                 string
-	Username            string
-	Password            string
-	ReadPreference      string
-	DisableTls          bool
-	RootCa              string
-	TlsHost             string
-	CreateTlsConfigFunc func(minVersion uint16, rootCAs string, host string, tlsHost string, skipCertVerification bool) (*tls.Config, error)
-	Dialer              options.ContextDialer
+	Uri                  string
+	Username             string
+	Password             string
+	ReadPreference       string
+	DisableTls           bool
+	SkipCertVerification bool
+	RootCa               string
+	TlsHost              string
+	CreateTlsConfigFunc  func(minVersion uint16, rootCAs string, host string, tlsHost string, skipCertVerification bool) (*tls.Config, error)
+	Dialer               options.ContextDialer
 }
 
 func BuildClientOptions(config ClientConfig) (*options.ClientOptions, error) {
@@ -72,8 +73,9 @@ func BuildClientOptions(config ClientConfig) (*options.ClientOptions, error) {
 	} else if connStr.SSLSet && !connStr.SSL {
 		// user set tls=false in URI param — honor it
 	} else {
-		// apply TLS config — honor tlsInsecure from URI params if set
-		skipCertVerification := connStr.SSLInsecureSet && connStr.SSLInsecure
+		// apply TLS config
+		skipCertVerification := config.SkipCertVerification || // explicit deactivation from config
+			connStr.SSLInsecureSet && connStr.SSLInsecure // honor tlsInsecure from URI params if set
 		tlsConfig, err := config.CreateTlsConfigFunc(tls.VersionTLS12, config.RootCa, "", config.TlsHost, skipCertVerification)
 		if err != nil {
 			return nil, err

--- a/nexus/analyzer/src/lib.rs
+++ b/nexus/analyzer/src/lib.rs
@@ -719,6 +719,10 @@ fn parse_db_options(db_type: DbType, with_options: &[SqlOption]) -> anyhow::Resu
                     .get("disable_tls")
                     .map(|s| s.parse::<bool>().unwrap_or_default())
                     .unwrap_or_default(),
+                skip_cert_verification: opts
+                    .get("skip_cert_verification")
+                    .map(|s| s.parse::<bool>().unwrap_or_default())
+                    .unwrap_or_default(),
                 root_ca: opts.get("root_ca").map(|s| s.to_string()),
                 tls_host: opts
                     .get("tls_host")

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -82,6 +82,7 @@ message MongoConfig {
   optional string root_ca = 6 [(peerdb_redacted) = true];
   ReadPreference read_preference = 7;
   optional SSHConfig ssh_config = 8;
+  bool skip_cert_verification = 9;
 }
 
 message AwsAuthStaticCredentialsConfig {

--- a/ui/app/peers/create/[peerType]/helpers/mo.ts
+++ b/ui/app/peers/create/[peerType]/helpers/mo.ts
@@ -34,6 +34,15 @@ export const mongoSetting: PeerSetting[] = [
     tips: 'If you are using a non-TLS connection, check this box.',
   },
   {
+    label: 'Skip Certificate Verification?',
+    field: 'skipCertVerification',
+    stateHandler: (value, setter) =>
+      setter((curr) => ({ ...curr, skipCertVerification: value as boolean })),
+    type: 'switch',
+    optional: true,
+    tips: 'Skip TLS certificate verification (insecure, use with caution).',
+  },
+  {
     label: 'TLS Host',
     field: 'tlsHost',
     stateHandler: (value, setter) =>
@@ -65,6 +74,7 @@ export const blankMongoSetting: MongoConfig = {
   username: '',
   password: '',
   disableTls: false,
+  skipCertVerification: false,
   tlsHost: '',
   readPreference: 0,
 };

--- a/ui/app/peers/create/[peerType]/schema.ts
+++ b/ui/app/peers/create/[peerType]/schema.ts
@@ -703,6 +703,7 @@ export const mongoSchema = z.object({
   username: z.string({ error: () => 'Username must be a string' }),
   password: z.string({ error: () => 'Password must be a string' }),
   disableTls: z.boolean().optional(),
+  skipCertVerification: z.boolean().optional(),
   rootCa: z
     .string({ error: () => 'Root CA must be a string' })
     .optional()


### PR DESCRIPTION
This Pull Request adds `skip_cert_verification` parameter to MongoDB peer configuration.

This flag allows disabling host verification at client side thus aligning the connector with Postgres' and MySQL's.