### PR TITLE
feat(snowflake): use maximum VARCHAR length (128 MB) for string columns

### DIFF
--- a/flow/model/qvalue/kind.go
+++ b/flow/model/qvalue/kind.go
@@ -71,7 +71,7 @@ func ToDWHColumnType(
 		} else if val, ok := types.QValueKindToSnowflakeTypeMap[kind]; ok {
 			colType = val
 		} else {
-			colType = "STRING"
+			colType = types.SnowflakeMaxVarchar
 		}
 		if nullableEnabled && !column.Nullable {
 			colType += " NOT NULL"

--- a/flow/shared/types/kind.go
+++ b/flow/shared/types/kind.go
@@ -69,6 +69,13 @@ func (kind QValueKind) IsArray() bool {
 	return strings.HasPrefix(string(kind), "array_")
 }
 
+// SnowflakeMaxVarchar is the maximum VARCHAR length Snowflake allows (128 MB).
+// A bare STRING/VARCHAR declaration defaults to 16 MB, so we specify the max
+// explicitly to avoid silently capping string columns. Snowflake bills storage
+// based on actual data stored and documents no performance difference between
+// max-length and shorter VARCHAR declarations.
+const SnowflakeMaxVarchar = "VARCHAR(134217728)"
+
 var QValueKindToSnowflakeTypeMap = map[QValueKind]string{
 	QValueKindBoolean:     "BOOLEAN",
 	QValueKindInt8:        "INTEGER",
@@ -82,7 +89,7 @@ var QValueKindToSnowflakeTypeMap = map[QValueKind]string{
 	QValueKindFloat32:     "FLOAT",
 	QValueKindFloat64:     "FLOAT",
 	QValueKindQChar:       "CHAR",
-	QValueKindString:      "STRING",
+	QValueKindString:      SnowflakeMaxVarchar,
 	QValueKindEnum:        "STRING",
 	QValueKindUint16Enum:  "INTEGER",
 	QValueKindJSON:        "VARIANT",
@@ -95,7 +102,7 @@ var QValueKindToSnowflakeTypeMap = map[QValueKind]string{
 	QValueKindDate:        "DATE",
 	QValueKindBytes:       "BINARY",
 	QValueKindUUID:        "STRING",
-	QValueKindInvalid:     "STRING",
+	QValueKindInvalid:     SnowflakeMaxVarchar,
 	QValueKindHStore:      "VARIANT",
 	QValueKindGeography:   "GEOGRAPHY",
 	QValueKindGeometry:    "GEOMETRY",


### PR DESCRIPTION

Snowflake's bare `STRING`/`VARCHAR` declaration defaults to **16 MB** even on accounts where the larger-size behavior change bundles are enabled. This silently caps PeerDB-managed string columns (Postgres `text`/`varchar`/`bpchar`) at 16 MB instead of Snowflake's documented maximum of **128 MB** (`VARCHAR(134217728)`).

This PR adds a shared `SnowflakeMaxVarchar` constant and uses it for the generic string kind (`QValueKindString`) and the unknown-kind fallback. The change propagates automatically through `qvalue.ToDWHColumnType` to:

- `generateCreateTableSQLForNormalizedTable` — `CREATE TABLE`
- `ReplayTableSchemaDeltas` — `ALTER TABLE ADD COLUMN`
- `generateMergeStmt` — `CAST(... AS <type>)` in `MERGE`

`QValueKindEnum` (tiny labels) and `QValueKindUUID` (36 chars) intentionally stay as bare `STRING` — they can't exceed 16 MB anyway, so widening them would be noise.

## Security & performance

- **Storage:** None. Snowflake bills based on actual data stored; declared length has no storage impact.
- **Performance:** None. Per the [Snowflake docs on string data types](https://docs.snowflake.com/en/sql-reference/data-types-text#storage-and-performance-considerations):
  > When choosing the maximum length for a VARCHAR column, consider that storing a smaller value (e.g. `'sample text'`) in a column with a larger declared length (e.g. `VARCHAR(16777216)`) has no impact on performance or storage. There is no performance difference between using the full-length `VARCHAR(16777216)` declaration and a smaller length.

  The same guarantee extends to `VARCHAR(134217728)` — declared length is purely a logical ceiling and does not affect compression, micro-partition layout, or query performance.
- **Security:** Purely a column-width ceiling. Snowflake still enforces the 128 MB hard cap.

## Compatibility

The 128 MB ceiling shipped via Snowflake behavior change bundles **BCR-1779 (2024_08)** and **BCR-1942 (2025_03)**. On accounts where those bundles are disabled, `VARCHAR(134217728)` DDL will be rejected. Both bundles are enabled by default on current accounts, so this is safe in practice.

## Test plan

- [x] `flow/shared/types/...` unit tests pass (used my account).
- [x] Snowflake schema-delta e2e suite (`TestSnowflakeSchemaDeltaTestSuite`) runs against a real Snowflake account and passes. Logs confirm string columns are now emitted as `VARCHAR(134217728)` via the `ALTER TABLE ADD COLUMN` path.
- [x] Non-string types (`BOOLEAN`, `VARIANT`, `DATE`, `TIMESTAMP_*`, `NUMERIC`, `FLOAT`, `BINARY`, `TIME`) emit unchanged.
- [x] BCR-1779/BCR-1942 confirmed enabled on the test account (validated with a manual `CREATE TABLE ... VARCHAR(134217728)` smoke test).