### PR TITLE
always ping on timeout

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -736,13 +736,9 @@ func PullCdcRecords[Items model.Items](
 		}
 
 		if err != nil && pgconn.Timeout(err) {
-			// If we have hit timeout, either we just need to ping to keep the connection alive
-			// or we are actually hitting `nextRecordDeadline`.
-			if !time.Now().After(nextRecordDeadline) {
-				// The timeout is not hit, hence we just send a ping before moving on to read more messages.
-				if err := p.ReplPing(ctx); err != nil {
-					return fmt.Errorf("ReplPing failed: %w", err)
-				}
+			// On timeout, always send a ping before moving on to read more messages
+			if err := p.ReplPing(ctx); err != nil {
+				return fmt.Errorf("ReplPing failed: %w", err)
 			}
 			// After that, we let the condition checks at the beginging of the loop,
 			// specifically "if we are past the next standby deadline (?)" to


### PR DESCRIPTION
https://github.com/PeerDB-io/peerdb/pull/4324 introduced a new failure scenario:

It can happen when all three criteria hit:
(1) we haven't received a primary keep alive event
(2) we have 0 records processed so far (or we are mid-txn)
(3) we reached sync interval

Current implementation skips the ping when we reach sync interval as it assumes we are closing the batch, but if we have accumulated 0 records so far or we are mid-txn we don't actually plan to terminate the batch, so we should ping regardless of whether we have exceeded nextRecordDeadline or not. 
