### PR TITLE
make sure blocking AddRecord also handles keepalive

### DIFF
--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -611,13 +611,36 @@ func PullCdcRecords[Items model.Items](
 	nextRecordDeadline := time.Now().Add(req.IdleTimeout)
 	pkmRequiresResponse := false
 
+	pushToStream := func(rec model.Record[Items]) error {
+		for !records.TryAddRecord(rec) {
+			// if TryAddRecord fails, it implies channel is full due to downstream backpressure;
+			// it will then block in AddRecord, but wake up every messageWaitPeriod to send a
+			// standby status update so that wal_sender_timeout doesn't get triggered.
+			addCtx, cancel := context.WithTimeout(ctx, messageWaitPeriod)
+			err := records.AddRecord(addCtx, rec)
+			cancel()
+			if err == nil {
+				break
+			}
+			if ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+				logger.Info("pushing to stream blocked due to backpressure, sending standby status update")
+				if err := sendStandbyAfterReplLock("backpressure"); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+
 	addRecordWithKey := func(key model.TableWithPkey, rec model.Record[Items]) error {
 		if cdcRecordsStorage != nil {
 			if err := cdcRecordsStorage.Set(key, rec); err != nil {
 				return err
 			}
 		}
-		if err := records.AddRecord(ctx, rec); err != nil {
+		if err := pushToStream(rec); err != nil {
 			return err
 		}
 
@@ -737,8 +760,8 @@ func PullCdcRecords[Items model.Items](
 
 		if err != nil && pgconn.Timeout(err) {
 			// On timeout, always send a ping before moving on to read more messages
-			if err := p.ReplPing(ctx); err != nil {
-				return fmt.Errorf("ReplPing failed: %w", err)
+			if err := sendStandbyAfterReplLock("receive-message"); err != nil {
+				return err
 			}
 			// After that, we let the condition checks at the beginging of the loop,
 			// specifically "if we are past the next standby deadline (?)" to
@@ -911,7 +934,7 @@ func PullCdcRecords[Items model.Items](
 									return err
 								}
 							}
-						} else if err := records.AddRecord(ctx, rec); err != nil {
+						} else if err := pushToStream(rec); err != nil {
 							return err
 						}
 					}

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -111,9 +111,8 @@ func (c *PostgresConnector) runReplConnKeepalive(
 }
 
 // ReplPing sends a standby status update so Postgres doesn't terminate the walsender
-// for inactivity. Called from two places:
-//   - During PullRecords: PullCdcRecords' receive loop, on each messageWaitPeriod timeout.
-//   - Outside PullRecords: runReplConnKeepalive's background ticker, gated by c.pullActive.
+// for inactivity. This is only called from runReplConnKeepalive's background ticker,
+// gated by c.pullActive; while a pull is active, PullCdcRecords handles keepalive.
 func (c *PostgresConnector) ReplPing(ctx context.Context) error {
 	if c.replLock.TryLock() {
 		defer c.replLock.Unlock()

--- a/flow/model/cdc_stream.go
+++ b/flow/model/cdc_stream.go
@@ -59,12 +59,24 @@ func (r *CDCStream[T]) GetLastCheckpoint() CdcCheckpoint {
 	return CdcCheckpoint{ID: r.lastCheckpointID, Text: r.lastCheckpointText}
 }
 
-func (r *CDCStream[T]) AddRecord(ctx context.Context, record Record[T]) error {
+func (r *CDCStream[T]) TryAddRecord(record Record[T]) bool {
 	if !r.needsNormalize {
 		switch record.(type) {
 		case *InsertRecord[T], *UpdateRecord[T], *DeleteRecord[T]:
 			r.needsNormalize = true
 		}
+	}
+	select {
+	case r.records <- record:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *CDCStream[T]) AddRecord(ctx context.Context, record Record[T]) error {
+	if r.TryAddRecord(record) {
+		return nil
 	}
 
 	logger := internal.LoggerFromCtx(ctx)


### PR DESCRIPTION
PullRecords has 2 blocking sites that requires extra keepalive handling:
1. waiting for message to arrive
2. waiting for processed event to be send to the record stream

1 is already handled by https://github.com/PeerDB-io/peerdb/pull/4324, this PR handles 2.

This can happen if there is downstream backpressure while we are trying to add a record into the record stream, the channel itself will block until backpressure is cleared. 

This PR adds an additional keepalive handling when backpressure is detected. 

Note: long-term, i think we still want a single place to handle keepalive, and not having to worry about every blocking callsite inside PullRecord needing to manage it. What's preventing us from doing this today is indeterminism caused by lock contention on the replication connection, making it hard to reason about if keepalive has fired or not. However that fix requires a bigger refactor, so scoping PR to the current approach where PullRecords handle its own keepalives while running. 