### PR TITLE
Remove double-log during resync

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1726,8 +1726,6 @@ func (a *FlowableActivity) updateTableSchemaMappingForResync(
 		}
 	}
 
-	a.Alerter.LogFlowInfo(ctx, flowJobName, "Resync completed for all tables")
-
 	if commitErr := tx.Commit(ctx); commitErr != nil {
 		return a.Alerter.LogFlowError(ctx, flowJobName, fmt.Errorf("failed to commit updating table_schema_mapping: %w", commitErr))
 	}


### PR DESCRIPTION
The function has two callers, one logs `Resync completed for all tables` right after, the other `Resync with soft-delete completed for all tables`