### PR TITLE
mysql: add syncer.EventCacheCount setting

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -241,7 +241,7 @@ func (c *MySqlConnector) SetupReplConn(context.Context, map[string]string) error
 	return nil
 }
 
-func (c *MySqlConnector) startSyncer(ctx context.Context) (*replication.BinlogSyncer, error) {
+func (c *MySqlConnector) startSyncer(ctx context.Context, env map[string]string) (*replication.BinlogSyncer, error) {
 	var tlsConfig *tls.Config
 	if !c.config.DisableTls {
 		var err error
@@ -271,6 +271,10 @@ func (c *MySqlConnector) startSyncer(ctx context.Context) (*replication.BinlogSy
 		config.Password = token
 	}
 
+	eventCacheCount, err := internal.PeerDBMySQLEventCacheCount(ctx, env)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get event cache count: %w", err)
+	}
 	//nolint:gosec
 	return replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
 		ServerID:         rand.Uint32(),
@@ -286,12 +290,14 @@ func (c *MySqlConnector) startSyncer(ctx context.Context) (*replication.BinlogSy
 		ParseTime:        true,
 		TLSConfig:        tlsConfig,
 		HeartbeatPeriod:  c.binlogHeartbeatPeriod,
+		EventCacheCount:  eventCacheCount,
 	}), nil
 }
 
 func (c *MySqlConnector) startStreaming(
 	ctx context.Context,
 	pos string,
+	env map[string]string,
 ) (*replication.BinlogSyncer, *replication.BinlogStreamer, mysql.GTIDSet, mysql.Position, error) {
 	parsedOffset, err := parseReplicationOffsetText(c.Flavor(), pos)
 	if err != nil {
@@ -300,9 +306,9 @@ func (c *MySqlConnector) startStreaming(
 
 	switch parsedOffset.mechanism {
 	case protos.MySqlReplicationMechanism_MYSQL_FILEPOS.String():
-		return c.startCdcStreamingFilePos(ctx, parsedOffset.pos)
+		return c.startCdcStreamingFilePos(ctx, parsedOffset.pos, env)
 	case protos.MySqlReplicationMechanism_MYSQL_GTID.String():
-		return c.startCdcStreamingGtid(ctx, parsedOffset.gset)
+		return c.startCdcStreamingGtid(ctx, parsedOffset.gset, env)
 	default:
 		return nil, nil, nil, mysql.Position{}, fmt.Errorf("empty mysql replication offset")
 	}
@@ -311,8 +317,9 @@ func (c *MySqlConnector) startStreaming(
 func (c *MySqlConnector) startCdcStreamingFilePos(
 	ctx context.Context,
 	pos mysql.Position,
+	env map[string]string,
 ) (*replication.BinlogSyncer, *replication.BinlogStreamer, mysql.GTIDSet, mysql.Position, error) {
-	syncer, err := c.startSyncer(ctx)
+	syncer, err := c.startSyncer(ctx, env)
 	if err != nil {
 		return nil, nil, nil, mysql.Position{}, err
 	}
@@ -327,8 +334,9 @@ func (c *MySqlConnector) startCdcStreamingFilePos(
 func (c *MySqlConnector) startCdcStreamingGtid(
 	ctx context.Context,
 	gset mysql.GTIDSet,
+	env map[string]string,
 ) (*replication.BinlogSyncer, *replication.BinlogStreamer, mysql.GTIDSet, mysql.Position, error) {
-	syncer, err := c.startSyncer(ctx)
+	syncer, err := c.startSyncer(ctx, env)
 	if err != nil {
 		return nil, nil, nil, mysql.Position{}, err
 	}
@@ -389,7 +397,7 @@ func (c *MySqlConnector) PullRecords(
 		return fmt.Errorf("failed to determine if binlog row metadata is supported: %w", err)
 	}
 
-	syncer, mystream, gset, pos, err := c.startStreaming(ctx, req.LastOffset.Text)
+	syncer, mystream, gset, pos, err := c.startStreaming(ctx, req.LastOffset.Text, req.Env)
 	if err != nil {
 		return err
 	}

--- a/flow/connectors/mysql/ssh_keepalive_test.go
+++ b/flow/connectors/mysql/ssh_keepalive_test.go
@@ -316,7 +316,7 @@ func TestMySQLCloseSyncerWithTimeout(t *testing.T) {
 
 	pos, err := connector.GetMasterPos(ctx)
 	require.NoError(t, err)
-	syncer, _, _, _, err := connector.startCdcStreamingFilePos(ctx, pos, map[string]string{}) //nolint:dogsled
+	syncer, _, _, _, err := connector.startCdcStreamingFilePos(ctx, pos, nil) //nolint:dogsled
 	require.NoError(t, err)
 
 	// Let CDC streaming establish before blocking the MySQL server.

--- a/flow/connectors/mysql/ssh_keepalive_test.go
+++ b/flow/connectors/mysql/ssh_keepalive_test.go
@@ -316,7 +316,7 @@ func TestMySQLCloseSyncerWithTimeout(t *testing.T) {
 
 	pos, err := connector.GetMasterPos(ctx)
 	require.NoError(t, err)
-	syncer, _, _, _, err := connector.startCdcStreamingFilePos(ctx, pos) //nolint:dogsled
+	syncer, _, _, _, err := connector.startCdcStreamingFilePos(ctx, pos, map[string]string{}) //nolint:dogsled
 	require.NoError(t, err)
 
 	// Let CDC streaming establish before blocking the MySQL server.

--- a/flow/connectors/mysql/ssh_test.go
+++ b/flow/connectors/mysql/ssh_test.go
@@ -53,7 +53,7 @@ func TestMySQLSyncerClose(t *testing.T) {
 
 	pos, err := connector.GetMasterPos(ctx)
 	require.NoError(t, err)
-	syncer, _, _, _, err := connector.startCdcStreamingFilePos(ctx, pos, map[string]string{}) //nolint:dogsled
+	syncer, _, _, _, err := connector.startCdcStreamingFilePos(ctx, pos, nil) //nolint:dogsled
 	require.NoError(t, err)
 
 	// Let CDC streaming establish before closing the syncer.

--- a/flow/connectors/mysql/ssh_test.go
+++ b/flow/connectors/mysql/ssh_test.go
@@ -53,7 +53,7 @@ func TestMySQLSyncerClose(t *testing.T) {
 
 	pos, err := connector.GetMasterPos(ctx)
 	require.NoError(t, err)
-	syncer, _, _, _, err := connector.startCdcStreamingFilePos(ctx, pos) //nolint:dogsled
+	syncer, _, _, _, err := connector.startCdcStreamingFilePos(ctx, pos, map[string]string{}) //nolint:dogsled
 	require.NoError(t, err)
 
 	// Let CDC streaming establish before closing the syncer.

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -466,7 +466,7 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		DefaultValue:     "10240",
 		ValueType:        protos.DynconfValueType_INT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
-		TargetForSetting: protos.DynconfTarget_MYSQL,
+		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 }
 

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -460,6 +460,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
 		TargetForSetting: protos.DynconfTarget_POSTGRES,
 	},
+	{
+		Name:             "PEERDB_MYSQL_EVENT_CACHE_COUNT",
+		Description:      "Maximum number of events the MySQL Go driver loads in memory at once, useful when pushing large rows",
+		DefaultValue:     "10240",
+		ValueType:        protos.DynconfValueType_INT,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_MYSQL,
+	},
 }
 
 var DynamicIndex = func() map[string]int {
@@ -611,6 +619,10 @@ func PeerDBBigQueryToastMergeChunking(ctx context.Context, env map[string]string
 
 func PeerDBCDCChannelBufferSize(ctx context.Context, env map[string]string) (int, error) {
 	return dynamicConfSigned[int](ctx, env, "PEERDB_CDC_CHANNEL_BUFFER_SIZE")
+}
+
+func PeerDBMySQLEventCacheCount(ctx context.Context, env map[string]string) (int, error) {
+	return dynamicConfSigned[int](ctx, env, "PEERDB_MYSQL_EVENT_CACHE_COUNT")
 }
 
 func PeerDBNormalizeBufferHours(ctx context.Context, env map[string]string) (int64, error) {

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -588,6 +588,7 @@ enum DynconfTarget {
   CLICKHOUSE = 3;
   QUEUES = 4;
   POSTGRES = 5;
+  MYSQL = 6;
 }
 
 message DropFlowActivityInput {

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -588,7 +588,6 @@ enum DynconfTarget {
   CLICKHOUSE = 3;
   QUEUES = 4;
   POSTGRES = 5;
-  MYSQL = 6;
 }
 
 message DropFlowActivityInput {


### PR DESCRIPTION
We saw OOM errors on mysql pipes with large rows
go-mysql has internal events channel where it stores binlog events, that is where this allocation is coming from
It reads packet header that contains info about payload length in bytes and allocates memory for reading next events from the binlog
I think it's expected driver behavior and i'm not sure we should fix smth in that regard
But
There is one thing we could configure additionally to our PEERDB_CDC_CHANNEL_BUFFER_SIZE, we could set EventCacheCount on mysql syncer level.
This way we can cap how many events mysql driver loads in memory. (we can't control events' size though, so if the events themselves are big -> it won't really save us from OOM), by default it equals 10240

mysql go driver simply read packets over network and tries to push events to it's internal channel (which is capped by EventCacheCount):
```
loop:
  data := b.c.ReadPacket()        // blocking socket read
  event := parse(data)
  s.AddEventToStreamer(event)     // blocking channel send → s.ch (cap = EventCacheCount)
```