### PR TITLE
hotpath optimization for AddRecord

### DIFF
--- a/flow/model/cdc_stream.go
+++ b/flow/model/cdc_stream.go
@@ -67,6 +67,13 @@ func (r *CDCStream[T]) AddRecord(ctx context.Context, record Record[T]) error {
 		}
 	}
 
+	// hot-path optimization: avoid setting up logger/ticker unless channel is actually full
+	select {
+	case r.records <- record:
+		return nil
+	default:
+	}
+
 	logger := internal.LoggerFromCtx(ctx)
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()


### PR DESCRIPTION
Small optimization in the AddRecord hotpath:

A quick [10s benchmark test](https://github.com/PeerDB-io/peerdb/blob/47539dc086d58d190e4a101010b60bc153d3c288/flow/model/cdc_stream_bench_test.go) shows:


```
BenchmarkAddRecordOld    	 1549653	       767.9 ns/op	    1074 B/op	      23 allocs/op
BenchmarkAddRecordNew    	47112669	        25.49 ns/op	       0 B/op	       0 allocs/op
```
The columns represent number of iterations / average wallclock time per iteration / average bytes of heap memory allocation per iteration / average number of distinct heap allocations per operation, respectively.

This is probably not a bottleneck on CDC throughput today as we are much more likely to be bottlenecked on _processing_ cdc message, but given this code is in the hot path, removing the heap allocation and GC introduced here in the common case is still beneficial. 
