### PR TITLE
fix(mysql): handle binlog incident event (resync required)

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -1132,6 +1132,13 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
+	if _, ok := errors.AsType[*exceptions.MySQLBinlogIncidentError](err); ok {
+		return ErrorNotifyBinlogInvalid, ErrorInfo{
+			Source: ErrorSourceMySQL,
+			Code:   "BINLOG_INCIDENT",
+		}
+	}
+
 	if mysqlGeometryParseError, ok := errors.AsType[*exceptions.MySQLGeometryParseError](err); ok &&
 		strings.Contains(mysqlGeometryParseError.Error(), mysqlGeometryLinearRingNotClosedError) {
 		return ErrorUnsupportedDatatype, ErrorInfo{

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1202,3 +1202,15 @@ func TestUnwrappedGoogleAPIErrorShouldNotBeBigQuery(t *testing.T) {
 		Code:   "UNKNOWN",
 	}, errInfo)
 }
+
+func TestMySQLBinlogIncidentErrorShouldBeNotifyBinlogInvalid(t *testing.T) {
+	t.Parallel()
+
+	err := exceptions.NewMySQLBinlogIncidentError(1, "LOST_EVENTS")
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("pulling records failed: %w", err))
+	assert.Equal(t, ErrorNotifyBinlogInvalid, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMySQL,
+		Code:   "BINLOG_INCIDENT",
+	}, errInfo)
+}

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -551,6 +552,17 @@ func (c *MySqlConnector) PullRecords(
 				req.RecordStream.UpdateLatestCheckpointText(updatedOffset)
 				c.logger.Info("rotate", slog.String("name", pos.Name), slog.Uint64("pos", uint64(pos.Pos)))
 			}
+		case *replication.GenericEvent:
+			// INCIDENT_EVENT (e.g. LOST_EVENTS) is the source telling us binlog events were
+			// lost from the stream, so our position can no longer be trusted. Fail with a
+			// resync-required error rather than silently skipping the gap. go-mysql decodes
+			// every unhandled event type to GenericEvent, so gate on the header event type.
+			if event.Header.EventType == replication.INCIDENT_EVENT {
+				incident, message := parseIncidentEvent(ev.Data)
+				c.logger.Error("[mysql] received binlog incident event, resync required",
+					slog.Uint64("incident", uint64(incident)), slog.String("message", message))
+				return exceptions.NewMySQLBinlogIncidentError(incident, message)
+			}
 		case *replication.QueryEvent:
 			if !inTx && gset == nil && event.Header.LogPos > pos.Pos {
 				pos.Pos = event.Header.LogPos
@@ -870,6 +882,21 @@ func (c *MySqlConnector) processAlterTableQuery(ctx context.Context, catalogPool
 
 func posToOffsetText(pos mysql.Position) string {
 	return fmt.Sprintf("!f:%s,%x", pos.Name, pos.Pos)
+}
+
+// parseIncidentEvent extracts the incident number and human-readable message from an
+// Incident_log_event body: a little-endian uint16 incident number, a 1-byte message
+// length, then the message. Best-effort: returns what it can if the body is truncated.
+func parseIncidentEvent(data []byte) (uint16, string) {
+	if len(data) < 2 {
+		return 0, ""
+	}
+	incident := binary.LittleEndian.Uint16(data[:2])
+	if len(data) < 3 {
+		return incident, ""
+	}
+	end := min(3+int(data[2]), len(data))
+	return incident, string(data[3:end])
 }
 
 // processTableMapEventSchema compares the TABLE_MAP_EVENT schema against the cached schema

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -553,10 +553,7 @@ func (c *MySqlConnector) PullRecords(
 				c.logger.Info("rotate", slog.String("name", pos.Name), slog.Uint64("pos", uint64(pos.Pos)))
 			}
 		case *replication.GenericEvent:
-			// INCIDENT_EVENT (e.g. LOST_EVENTS) is the source telling us binlog events were
-			// lost from the stream, so our position can no longer be trusted. Fail with a
-			// resync-required error rather than silently skipping the gap. go-mysql decodes
-			// every unhandled event type to GenericEvent, so gate on the header event type.
+			// INCIDENT_EVENT (LOST_EVENTS) - fail and require resync
 			if event.Header.EventType == replication.INCIDENT_EVENT {
 				incident, message := parseIncidentEvent(ev.Data)
 				c.logger.Error("[mysql] received binlog incident event, resync required",
@@ -884,9 +881,8 @@ func posToOffsetText(pos mysql.Position) string {
 	return fmt.Sprintf("!f:%s,%x", pos.Name, pos.Pos)
 }
 
-// parseIncidentEvent extracts the incident number and human-readable message from an
-// Incident_log_event body: a little-endian uint16 incident number, a 1-byte message
-// length, then the message. Best-effort: returns what it can if the body is truncated.
+// parseIncidentEvent extracts the incident number and human-readable message.
+// Best-effort: returns what it can if the body is truncated.
 func parseIncidentEvent(data []byte) (uint16, string) {
 	if len(data) < 2 {
 		return 0, ""

--- a/flow/shared/exceptions/mysql.go
+++ b/flow/shared/exceptions/mysql.go
@@ -138,9 +138,6 @@ func (e *MySQLStaleConnectionError) Error() string {
 		e.Since, e.HeartbeatPeriod)
 }
 
-// MySQLBinlogIncidentError indicates the source emitted an Incident binlog event
-// (e.g. LOST_EVENTS), meaning events are missing from the binlog stream and the CDC
-// position can no longer be trusted. Recovery requires a resync of the mirror.
 type MySQLBinlogIncidentError struct {
 	Message  string
 	Incident uint16

--- a/flow/shared/exceptions/mysql.go
+++ b/flow/shared/exceptions/mysql.go
@@ -137,3 +137,22 @@ func (e *MySQLStaleConnectionError) Error() string {
 	return fmt.Sprintf("MySQL connection is stale: no events received in %v (heartbeat=%v)",
 		e.Since, e.HeartbeatPeriod)
 }
+
+// MySQLBinlogIncidentError indicates the source emitted an Incident binlog event
+// (e.g. LOST_EVENTS), meaning events are missing from the binlog stream and the CDC
+// position can no longer be trusted. Recovery requires a resync of the mirror.
+type MySQLBinlogIncidentError struct {
+	Message  string
+	Incident uint16
+}
+
+func NewMySQLBinlogIncidentError(incident uint16, message string) *MySQLBinlogIncidentError {
+	return &MySQLBinlogIncidentError{Incident: incident, Message: message}
+}
+
+func (e *MySQLBinlogIncidentError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("MySQL binlog incident event received (incident=%d): %s; a resync is required", e.Incident, e.Message)
+	}
+	return fmt.Sprintf("MySQL binlog incident event received (incident=%d); a resync is required", e.Incident)
+}


### PR DESCRIPTION
## Summary

Handle MySQL binlog `INCIDENT_EVENT` (e.g. `LOST_EVENTS`) in the CDC pull loop. When the source emits an incident event, binlog events were lost from the stream and our CDC position can no longer be trusted — so we fail with a resync-required error rather than silently skipping the gap.

- Detect `INCIDENT_EVENT` (decoded by go-mysql as `GenericEvent`, gated on the header event type) in `PullRecords` and return a new `MySQLBinlogIncidentError`.
- Add `parseIncidentEvent` to extract the incident number and message from the event body.
- Classify `MySQLBinlogIncidentError` as `ErrorNotifyBinlogInvalid` / `BINLOG_INCIDENT` in the alerting classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)