### PR TITLE
Build a MySQL debug image

### DIFF
--- a/.github/workflows/mysql-debug-docker.yml
+++ b/.github/workflows/mysql-debug-docker.yml
@@ -1,0 +1,81 @@
+name: MySQL Debug Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      mysql_version:
+        description: MySQL version tag to build.
+        required: true
+        default: "8.0.46"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/mysql-debug-docker.yml"
+      - "flow/e2e/test_data/mysql-debug/docker-bake.hcl"
+      - "flow/e2e/test_data/mysql-debug/Dockerfile"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/mysql-debug-docker.yml"
+      - "flow/e2e/test_data/mysql-debug/docker-bake.hcl"
+      - "flow/e2e/test_data/mysql-debug/Dockerfile"
+
+env:
+  MYSQL_DEBUG_VERSION: ${{ github.event.inputs.mysql_version || '8.0.46' }}
+
+jobs:
+  docker-build-external:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Build MySQL debug image
+        run: |
+          docker build \
+            --build-arg MYSQL_VERSION="${MYSQL_DEBUG_VERSION}" \
+            --tag peerdb-mysql-debug:e2e \
+            flow/e2e/test_data/mysql-debug
+
+  docker-build:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Short Commit Hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build MySQL debug image
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1
+        with:
+          token: ${{ secrets.DEPOT_TOKEN }}
+          files: ./flow/e2e/test_data/mysql-debug/docker-bake.hcl
+          push: ${{ github.event_name != 'pull_request' }}
+        env:
+          MYSQL_VERSION: ${{ env.MYSQL_DEBUG_VERSION }}
+          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}

--- a/flow/e2e/test_data/mysql-debug/Dockerfile
+++ b/flow/e2e/test_data/mysql-debug/Dockerfile
@@ -1,0 +1,69 @@
+# MySQL debug build for e2e binlog INCIDENT_EVENT testing.
+#
+# The official mysql image ships only the minimal server, which is not compiled WITH_DEBUG and
+# therefore lacks the DBUG facility needed to inject a LOST_EVENTS incident at runtime
+# (SET GLOBAL debug='+d,binlog_inject_incident'). We swap the minimal server for the full server
+# plus mysqld-debug, then route only the final foreground server to mysqld-debug. The stock
+# entrypoint's config checks, datadir initialization, and temporary init server keep using the
+# release binary because the debug binary can trip InnoDB assertions on that path.
+ARG MYSQL_VERSION=8.0.46
+FROM mysql:${MYSQL_VERSION}
+ARG MYSQL_VERSION
+
+LABEL org.opencontainers.image.source="https://github.com/PeerDB-io/peerdb" \
+      org.opencontainers.image.title="PeerDB MySQL Debug" \
+      org.opencontainers.image.description="MySQL ${MYSQL_VERSION} debug image for PeerDB e2e tests"
+
+# Keep the debug/full-server RPMs exactly matched to the server-minimal RPM in the base image.
+# This lets MYSQL_VERSION move without independently hard-coding package versions here.
+#
+# Installing mysql-community-server rewrites /etc/my.cnf with RPM defaults, so preserve the
+# official Docker image config first. It keeps server logs on stderr and includes conf.d.
+RUN set -eux; \
+    mysql_rpm_version="$(rpm -q --qf '%{VERSION}-%{RELEASE}.%{ARCH}' mysql-community-server-minimal)"; \
+    cp /etc/my.cnf /tmp/docker-my.cnf; \
+    printf '%s\n' \
+      '[mysql80-community]' \
+      'name=MySQL 8.0 Community Server' \
+      'baseurl=https://repo.mysql.com/yum/mysql-8.0-community/el/9/$basearch/' \
+      'enabled=1' \
+      'gpgcheck=1' \
+      'gpgkey=https://repo.mysql.com/RPM-GPG-KEY-mysql-2023' \
+      > /etc/yum.repos.d/mysql-community-debug.repo \
+ && microdnf -y remove mysql-community-server-minimal \
+ && microdnf -y --setopt=install_weak_deps=0 install \
+      "mysql-community-client-${mysql_rpm_version}" \
+      "mysql-community-client-plugins-${mysql_rpm_version}" \
+      "mysql-community-common-${mysql_rpm_version}" \
+      "mysql-community-icu-data-files-${mysql_rpm_version}" \
+      "mysql-community-libs-${mysql_rpm_version}" \
+      "mysql-community-server-${mysql_rpm_version}" \
+      "mysql-community-server-debug-${mysql_rpm_version}" \
+ && microdnf clean all \
+ && rm -f /etc/yum.repos.d/mysql-community-debug.repo
+
+# Restore the official Docker config, but keep the RPM socket path. The official image normally
+# uses /var/run/mysqld/mysqld.sock and creates a compatibility symlink in /var/lib/mysql; mysqld-debug
+# asserts while scanning that dangling symlink during final startup.
+RUN set -eux; \
+    cp /tmp/docker-my.cnf /etc/my.cnf; \
+    sed -i 's!socket=/var/run/mysqld/mysqld.sock!socket=/var/lib/mysql/mysql.sock!g' /etc/my.cnf; \
+    rm -f /tmp/docker-my.cnf
+
+# Route entrypoint checks, datadir init, and the temporary init server to the release binary.
+# Only the final foreground server should use mysqld-debug; running debug for init/temp startup
+# trips InnoDB debug assertions before the test can run.
+RUN set -eux; \
+    mv /usr/sbin/mysqld /usr/sbin/mysqld-release; \
+    printf '%s\n' \
+      '#!/bin/bash' \
+      'for arg in "$@"; do' \
+      '  case "$arg" in' \
+      '    --initialize|--initialize-insecure|--daemonize|--verbose|--help|--validate-config)' \
+      '      exec /usr/sbin/mysqld-release "$@"' \
+      '      ;;' \
+      '  esac' \
+      'done' \
+      'exec /usr/sbin/mysqld-debug "$@"' \
+      > /usr/sbin/mysqld; \
+    chmod +x /usr/sbin/mysqld

--- a/flow/e2e/test_data/mysql-debug/docker-bake.hcl
+++ b/flow/e2e/test_data/mysql-debug/docker-bake.hcl
@@ -1,0 +1,32 @@
+variable MYSQL_VERSION {
+  default = "8.0.46"
+}
+
+variable REGISTRY {
+  default = "ghcr.io/peerdb-io"
+}
+
+variable SHA_SHORT {
+  default = "dev"
+}
+
+group "default" {
+  targets = ["mysql-debug"]
+}
+
+target "mysql-debug" {
+  context    = "flow/e2e/test_data/mysql-debug"
+  dockerfile = "Dockerfile"
+  platforms = [
+    "linux/amd64",
+    "linux/arm64",
+  ]
+  args = {
+    MYSQL_VERSION = "${MYSQL_VERSION}"
+  }
+  tags = [
+    "${REGISTRY}/mysql-debug:${MYSQL_VERSION}",
+    "${REGISTRY}/mysql-debug:${MYSQL_VERSION}-${SHA_SHORT}",
+    "${REGISTRY}/mysql-debug:latest",
+  ]
+}


### PR DESCRIPTION
INCIDENT_LOST_EVENTS binlog event (8.0+) can only reliably be triggered by a debug command that's only available in a debug build. There don't seem to be any community images we can use for this, so making one to have an easy way to repro.