### PR TITLE
[DBI-855] MySQL connector: Use binlog event type and meta to determine BINARY(N) actual length and padding

### DIFF
--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -341,6 +341,7 @@ func QValueFromMysqlFieldValue(qkind types.QValueKind, mytype byte, fv mysql.Fie
 // binaryColumnLength returns the declared length N of a fixed-length BINARY(N)
 // `mytype` is the MySQL type for the column
 // `meta` is the metadata for the column type: length for fixed length types.
+// Reimplementation of https://github.com/mysql/mysql-server/blob/845d525d49c8027a4d0cdcc43372c96ba295c857/sql/log_event.cc#L1792-L1805
 func binaryColumnLength(mytype byte, meta uint16) int {
 	if mytype != mysql.MYSQL_TYPE_STRING {
 		return 0

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -338,6 +338,28 @@ func QValueFromMysqlFieldValue(qkind types.QValueKind, mytype byte, fv mysql.Fie
 	}
 }
 
+// binaryColumnLength returns the declared length N of a fixed-length BINARY(N)
+// `mytype` is the MySQL type for the column
+// `meta` is the metadata for the column type: length for fixed length types.
+func binaryColumnLength(mytype byte, meta uint16) int {
+	if mytype != mysql.MYSQL_TYPE_STRING {
+		return 0
+	}
+	if meta < 256 { // no bit-packing, just the length
+		return int(meta)
+	}
+	// bit-packed, for more than 255 bytes:
+	// value = lower_byte(meta) + 2^4 * ((higher_byte(meta)&0x30) XOR 0x30)
+	lowerMetaByte := uint8(meta & 0xFF)
+	higherMetaByte := uint8(meta >> 8)
+	borrowedBitsMask := uint8(0x30)
+	extraBits := higherMetaByte & borrowedBitsMask
+	if extraBits != borrowedBitsMask { // More than 255 bytes
+		return int(lowerMetaByte) | (int((extraBits)^borrowedBitsMask) << 4)
+	}
+	return int(meta & 0xFF)
+}
+
 func QValueFromMysqlRowEvent(
 	ev *replication.TableMapEvent, idx int,
 	enums []string, sets []string,
@@ -497,7 +519,13 @@ func QValueFromMysqlRowEvent(
 	case string:
 		switch qkind {
 		case types.QValueKindBytes:
-			return types.QValueBytes{Val: shared.UnsafeFastStringToReadOnlyBytes(val)}, nil
+			b := shared.UnsafeFastStringToReadOnlyBytes(val)
+			if n := binaryColumnLength(mytype, ev.ColumnMeta[idx]); len(b) < n {
+				padded := make([]byte, n)
+				copy(padded, b)
+				b = padded
+			}
+			return types.QValueBytes{Val: b}, nil
 		case types.QValueKindString:
 			return types.QValueString{Val: val}, nil
 		case types.QValueKindEnum:

--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -341,7 +341,12 @@ func QValueFromMysqlFieldValue(qkind types.QValueKind, mytype byte, fv mysql.Fie
 // binaryColumnLength returns the declared length N of a fixed-length BINARY(N)
 // `mytype` is the MySQL type for the column
 // `meta` is the metadata for the column type: length for fixed length types.
-// Reimplementation of https://github.com/mysql/mysql-server/blob/845d525d49c8027a4d0cdcc43372c96ba295c857/sql/log_event.cc#L1792-L1805
+// Reimplementation of MySQL metadata decoding:
+// - MySQL 8.4: https://github.com/mysql/mysql-server/blob/845d525d49c8027a4d0cdcc43372c96ba295c857/sql/log_event.cc#L1792-L1805
+// - MySQL 5.7: https://github.com/mysql/mysql-server/blob/f7680e98b6bbe3500399fbad465d08a6b75d7a5c/sql/log_event.cc#L2047-L2064
+// - MariaDB 10.6:
+//   https://github.com/MariaDB/server/blob/fcd3f81e08daea471d371d3be051e6feabb06399/sql/rpl_utility_server.cc#L139-L140
+//   https://github.com/MariaDB/server/blob/fcd3f81e08daea471d371d3be051e6feabb06399/sql/sql_type_string.cc#L70-L73
 func binaryColumnLength(mytype byte, meta uint16) int {
 	if mytype != mysql.MYSQL_TYPE_STRING {
 		return 0

--- a/flow/e2e/clickhouse_mysql_test.go
+++ b/flow/e2e/clickhouse_mysql_test.go
@@ -257,7 +257,7 @@ func (s ClickHouseSuite) Test_MySQL_Binary_Trailing_Zeros() {
 	const (
 		snapshotZeroHex = "11111111111111111111111111111100" // ends in 0x00
 		cdcZeroHex      = "21111111111111111111111111111100" // ends in 0x00
-		cdcNonZeroHex   = "31111111111111111111111111111131" // ends in 0x30
+		cdcNonZeroHex   = "31111111111111111111111111111131" // ends in 0x31
 	)
 
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`

--- a/flow/e2e/clickhouse_mysql_test.go
+++ b/flow/e2e/clickhouse_mysql_test.go
@@ -235,12 +235,7 @@ func (s ClickHouseSuite) Test_MySQL_Blobs() {
 //
 // MySQL right-pads BINARY(N) to N bytes with 0x00. Internally this is represented
 // as a binary array of length M=N-number_of_trailing(0x00). When reading from binlog these
-// values need to be adapted ack to N bytes based on the column type
-//
-// This test pins all three values at the full 16 bytes:
-//   - snapshot_zero: trailing 0x00, inserted before snapshot (SELECT path)
-//   - cdc_zero:      trailing 0x00, inserted during CDC (binlog path)
-//   - cdc_nonzero:   non-zero trailing byte, inserted during CDC
+// values need to be adapted back to N bytes based on the column type.
 //
 // See https://github.com/shyiko/mysql-binlog-connector-java/issues/169#issuecomment-301864569
 // for a similar problem in a different project.
@@ -254,23 +249,106 @@ func (s ClickHouseSuite) Test_MySQL_Binary_Trailing_Zeros() {
 	quotedSrcFullName := "\"" + strings.ReplaceAll(srcFullName, ".", "\".\"") + "\""
 	dstTableName := "test_binary_padding_dst"
 
-	const (
-		snapshotZeroHex = "11111111111111111111111111111100" // ends in 0x00
-		cdcZeroHex      = "21111111111111111111111111111100" // ends in 0x00
-		cdcNonZeroHex   = "31111111111111111111111111111131" // ends in 0x31
-	)
+	type binaryCase struct {
+		id             int
+		label          string
+		beforeSnapshot bool
+		// BINARY(16) covers the common short metadata path with a 1-byte row length.
+		b16InsertHex string
+		b16WantHex   string
+		// BINARY(255) covers the upper edge of the same metadata path without switching
+		// to MySQL's 2-byte row length encoding for fixed strings longer than 255 bytes.
+		// MySQL does not allow BINARY(N) with N > 255.
+		b255InsertHex string
+		b255WantHex   string
+	}
+
+	cases := []binaryCase{
+		// SELECT path: correct today, included to prove snapshot and CDC agree.
+		{
+			id:             1,
+			label:          "snapshot_trailing_zero",
+			beforeSnapshot: true,
+			b16InsertHex:   strings.Repeat("11", 15) + "00",
+			b16WantHex:     strings.Repeat("11", 15) + "00",
+			b255InsertHex:  strings.Repeat("11", 254) + "00",
+			b255WantHex:    strings.Repeat("11", 254) + "00",
+		},
+		// CDC path: MySQL packs these shorter than their declared BINARY(N) length.
+		{
+			id:             2,
+			label:          "cdc_trailing_zero",
+			beforeSnapshot: false,
+			b16InsertHex:   "21" + strings.Repeat("11", 14) + "00",
+			b16WantHex:     "21" + strings.Repeat("11", 14) + "00",
+			b255InsertHex:  "21" + strings.Repeat("11", 253) + "00",
+			b255WantHex:    "21" + strings.Repeat("11", 253) + "00",
+		},
+		{
+			id:             3,
+			label:          "cdc_multiple_trailing_zeros",
+			beforeSnapshot: false,
+			b16InsertHex:   "22" + strings.Repeat("11", 11) + strings.Repeat("00", 4),
+			b16WantHex:     "22" + strings.Repeat("11", 11) + strings.Repeat("00", 4),
+			b255InsertHex:  "22" + strings.Repeat("11", 250) + strings.Repeat("00", 4),
+			b255WantHex:    "22" + strings.Repeat("11", 250) + strings.Repeat("00", 4),
+		},
+		{
+			id:             4,
+			label:          "cdc_all_zero",
+			beforeSnapshot: false,
+			b16InsertHex:   strings.Repeat("00", 16),
+			b16WantHex:     strings.Repeat("00", 16),
+			b255InsertHex:  strings.Repeat("00", 255),
+			b255WantHex:    strings.Repeat("00", 255),
+		},
+		{
+			id:             5,
+			label:          "cdc_short_insert",
+			beforeSnapshot: false,
+			b16InsertHex:   "41",
+			b16WantHex:     "41" + strings.Repeat("00", 15),
+			b255InsertHex:  "42",
+			b255WantHex:    "42" + strings.Repeat("00", 254),
+		},
+		// Controls: interior zero bytes and non-zero tails should be preserved without extra padding.
+		{
+			id:             6,
+			label:          "cdc_interior_zero_nonzero_tail",
+			beforeSnapshot: false,
+			b16InsertHex:   "FF00112233445566778899AABBCCDDEE",
+			b16WantHex:     "FF00112233445566778899AABBCCDDEE",
+			b255InsertHex:  "FF00" + strings.Repeat("7F", 252) + "EE",
+			b255WantHex:    "FF00" + strings.Repeat("7F", 252) + "EE",
+		},
+	}
 
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
 			id INT PRIMARY KEY,
 			label TEXT NOT NULL,
-			b BINARY(16) NOT NULL
+			b16 BINARY(16) NOT NULL,
+			b255 BINARY(255) NOT NULL
 		)
 	`, quotedSrcFullName)))
 
-	// snapshot row: initial load reads via SELECT, which returns the full 16 bytes
+	var snapshotCases []binaryCase
+	var cdcCases []binaryCase
+	for _, tc := range cases {
+		if tc.beforeSnapshot {
+			snapshotCases = append(snapshotCases, tc)
+		} else {
+			cdcCases = append(cdcCases, tc)
+		}
+	}
+	snapshotValues := make([]string, 0, len(snapshotCases))
+	for _, tc := range snapshotCases {
+		snapshotValues = append(snapshotValues, fmt.Sprintf(
+			"(%d,'%s',UNHEX('%s'),UNHEX('%s'))",
+			tc.id, tc.label, tc.b16InsertHex, tc.b255InsertHex))
+	}
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
-		`INSERT INTO %s (id,label,b) VALUES (1,'snapshot_zero',UNHEX('%s'))`, quotedSrcFullName, snapshotZeroHex)))
+		`INSERT INTO %s (id,label,b16,b255) VALUES %s`, quotedSrcFullName, strings.Join(snapshotValues, ","))))
 
 	connectionGen := FlowConnectionGenerationConfig{
 		FlowJobName:      s.attachSuffix(srcTableName),
@@ -284,46 +362,66 @@ func (s ClickHouseSuite) Test_MySQL_Binary_Trailing_Zeros() {
 	env := ExecutePeerflow(s.t, tc, flowConnConfig)
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
-	EnvWaitForCount(env, s, "waiting for snapshot row", dstTableName, "id,label,b", 1)
+	EnvWaitForCount(env, s, "waiting for snapshot row", dstTableName, "id,label,b16,b255", len(snapshotCases))
 
-	// CDC rows: read from the binlog, where trailing 0x00 is stripped
+	cdcValues := make([]string, 0, len(cdcCases))
+	for _, tc := range cdcCases {
+		cdcValues = append(cdcValues, fmt.Sprintf(
+			"(%d,'%s',UNHEX('%s'),UNHEX('%s'))",
+			tc.id, tc.label, tc.b16InsertHex, tc.b255InsertHex))
+	}
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
-		`INSERT INTO %s (id,label,b) VALUES (2,'cdc_zero',UNHEX('%s')),(3,'cdc_nonzero',UNHEX('%s'))`,
-		quotedSrcFullName, cdcZeroHex, cdcNonZeroHex)))
+		`INSERT INTO %s (id,label,b16,b255) VALUES %s`, quotedSrcFullName, strings.Join(cdcValues, ","))))
 
-	EnvWaitForCount(env, s, "waiting for cdc rows", dstTableName, "id,label,b", 3)
+	EnvWaitForCount(env, s, "waiting for cdc rows", dstTableName, "id,label,b16,b255", len(cases))
 
-	rows, err := s.GetRows(dstTableName, "id,label,b")
+	rows, err := s.GetRows(dstTableName, "id,label,b16,b255")
 	require.NoError(s.t, err)
-	require.Len(s.t, rows.Records, 3, "expected 3 rows")
+	require.Len(s.t, rows.Records, len(cases), "expected all binary padding test rows")
 
-	byLabel := make(map[string][]byte, len(rows.Records))
+	byLabel := make(map[string]map[string][]byte, len(rows.Records))
 	for _, row := range rows.Records {
 		label, ok := row[1].Value().(string)
 		require.True(s.t, ok, "label should be a string")
-		switch v := row[2].Value().(type) {
-		case string:
-			byLabel[label] = []byte(v)
-		case []byte:
-			byLabel[label] = v
-		default:
-			require.Failf(s.t, "unexpected type for BINARY(16) column", "label=%s type=%T", label, row[2].Value())
+		byLabel[label] = make(map[string][]byte, 2)
+		for _, col := range []struct {
+			name string
+			idx  int
+		}{
+			{name: "b16", idx: 2},
+			{name: "b255", idx: 3},
+		} {
+			switch v := row[col.idx].Value().(type) {
+			case string:
+				byLabel[label][col.name] = []byte(v)
+			case []byte:
+				byLabel[label][col.name] = v
+			default:
+				require.Failf(s.t, "unexpected type for binary column",
+					"label=%s column=%s type=%T", label, col.name, row[col.idx].Value())
+			}
 		}
 	}
 
-	expect := func(label, srcHex string) {
-		want, decErr := hex.DecodeString(srcHex)
-		require.NoError(s.t, decErr)
-		got, ok := byLabel[label]
-		require.Truef(s.t, ok, "missing row %q in destination", label)
-		require.Equalf(s.t, want, got,
-			"BINARY(16) %q: MySQL stores 16 bytes (%s) but ClickHouse has %d bytes (%s)",
-			label, srcHex, len(got), strings.ToUpper(hex.EncodeToString(got)))
+	for _, tc := range cases {
+		for _, col := range []struct {
+			name    string
+			wantHex string
+		}{
+			{name: "b16", wantHex: tc.b16WantHex},
+			{name: "b255", wantHex: tc.b255WantHex},
+		} {
+			want, decErr := hex.DecodeString(col.wantHex)
+			require.NoError(s.t, decErr)
+			gotByCol, ok := byLabel[tc.label]
+			require.Truef(s.t, ok, "missing row %q in destination", tc.label)
+			got, ok := gotByCol[col.name]
+			require.Truef(s.t, ok, "missing column %q for row %q in destination", col.name, tc.label)
+			require.Equalf(s.t, want, got,
+				"%s %q: MySQL stores %d bytes (%s) but ClickHouse has %d bytes (%s)",
+				col.name, tc.label, len(want), col.wantHex, len(got), strings.ToUpper(hex.EncodeToString(got)))
+		}
 	}
-
-	expect("snapshot_zero", snapshotZeroHex) // SELECT path: correct today
-	expect("cdc_zero", cdcZeroHex)           // binlog path, trailing 0x00: reproduces the truncation
-	expect("cdc_nonzero", cdcNonZeroHex)     // binlog path, non-zero trailing byte: unaffected
 
 	env.Cancel(s.t.Context())
 	RequireEnvCanceled(s.t, env)

--- a/flow/e2e/clickhouse_mysql_test.go
+++ b/flow/e2e/clickhouse_mysql_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strconv"
@@ -224,6 +225,105 @@ func (s ClickHouseSuite) Test_MySQL_Blobs() {
 		'tinytext','mediumtext','longtext','char','varchar','{"a":2}')`, quotedSrcFullName)))
 
 	EnvWaitForEqualTablesWithNames(env, s, "waiting on cdc", srcTableName, dstTableName, "id,k,tb,mb,lb,bi,vb,tt,mt,lt,ch,vc,js")
+
+	env.Cancel(s.t.Context())
+	RequireEnvCanceled(s.t, env)
+}
+
+// Test_MySQL_Binary_Trailing_Zeros reproduces trailing-0x00 truncation of fixed-length
+// BINARY(N) columns over CDC.
+//
+// MySQL right-pads BINARY(N) to N bytes with 0x00. Internally this is represented
+// as a binary array of length M=N-number_of_trailing(0x00). When reading from binlog these
+// values need to be adapted ack to N bytes based on the column type
+//
+// This test pins all three values at the full 16 bytes:
+//   - snapshot_zero: trailing 0x00, inserted before snapshot (SELECT path)
+//   - cdc_zero:      trailing 0x00, inserted during CDC (binlog path)
+//   - cdc_nonzero:   non-zero trailing byte, inserted during CDC
+//
+// See https://github.com/shyiko/mysql-binlog-connector-java/issues/169#issuecomment-301864569
+// for a similar problem in a different project.
+func (s ClickHouseSuite) Test_MySQL_Binary_Trailing_Zeros() {
+	if _, ok := s.source.(*MySqlSource); !ok {
+		s.t.Skip("only applies to mysql")
+	}
+
+	srcTableName := "test_binary_padding"
+	srcFullName := s.attachSchemaSuffix(srcTableName)
+	quotedSrcFullName := "\"" + strings.ReplaceAll(srcFullName, ".", "\".\"") + "\""
+	dstTableName := "test_binary_padding_dst"
+
+	const (
+		snapshotZeroHex = "11111111111111111111111111111100" // ends in 0x00
+		cdcZeroHex      = "21111111111111111111111111111100" // ends in 0x00
+		cdcNonZeroHex   = "31111111111111111111111111111131" // ends in 0x30
+	)
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id INT PRIMARY KEY,
+			label TEXT NOT NULL,
+			b BINARY(16) NOT NULL
+		)
+	`, quotedSrcFullName)))
+
+	// snapshot row: initial load reads via SELECT, which returns the full 16 bytes
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
+		`INSERT INTO %s (id,label,b) VALUES (1,'snapshot_zero',UNHEX('%s'))`, quotedSrcFullName, snapshotZeroHex)))
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix(srcTableName),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+
+	tc := NewTemporalClient(s.t)
+	env := ExecutePeerflow(s.t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	EnvWaitForCount(env, s, "waiting for snapshot row", dstTableName, "id,label,b", 1)
+
+	// CDC rows: read from the binlog, where trailing 0x00 is stripped
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
+		`INSERT INTO %s (id,label,b) VALUES (2,'cdc_zero',UNHEX('%s')),(3,'cdc_nonzero',UNHEX('%s'))`,
+		quotedSrcFullName, cdcZeroHex, cdcNonZeroHex)))
+
+	EnvWaitForCount(env, s, "waiting for cdc rows", dstTableName, "id,label,b", 3)
+
+	rows, err := s.GetRows(dstTableName, "id,label,b")
+	require.NoError(s.t, err)
+	require.Len(s.t, rows.Records, 3, "expected 3 rows")
+
+	byLabel := make(map[string][]byte, len(rows.Records))
+	for _, row := range rows.Records {
+		label, ok := row[1].Value().(string)
+		require.True(s.t, ok, "label should be a string")
+		switch v := row[2].Value().(type) {
+		case string:
+			byLabel[label] = []byte(v)
+		case []byte:
+			byLabel[label] = v
+		default:
+			require.Failf(s.t, "unexpected type for BINARY(16) column", "label=%s type=%T", label, row[2].Value())
+		}
+	}
+
+	expect := func(label, srcHex string) {
+		want, decErr := hex.DecodeString(srcHex)
+		require.NoError(s.t, decErr)
+		got, ok := byLabel[label]
+		require.Truef(s.t, ok, "missing row %q in destination", label)
+		require.Equalf(s.t, want, got,
+			"BINARY(16) %q: MySQL stores 16 bytes (%s) but ClickHouse has %d bytes (%s)",
+			label, srcHex, len(got), strings.ToUpper(hex.EncodeToString(got)))
+	}
+
+	expect("snapshot_zero", snapshotZeroHex) // SELECT path: correct today
+	expect("cdc_zero", cdcZeroHex)           // binlog path, trailing 0x00: reproduces the truncation
+	expect("cdc_nonzero", cdcNonZeroHex)     // binlog path, non-zero trailing byte: unaffected
 
 	env.Cancel(s.t.Context())
 	RequireEnvCanceled(s.t, env)


### PR DESCRIPTION
MySQL BINARY(N) values are right-padded, from https://dev.mysql.com/doc/refman/5.7/en/binary-varbinary.html

> When BINARY values are stored, they are right-padded with the pad value to the specified length. The pad value is 0x00 (the zero byte). Values are right-padded with 0x00 for inserts, and no trailing bytes are removed for retrievals. All bytes are significant in comparisons, including ORDER BY and DISTINCT operations. 0x00 and space differ in comparisons, with 0x00 sorting before space.

In MySQL binlog, these values are:
- zero-right-trimmed: stored without the right side zeros.
- with the length  of the zero-right-trimmed binary.

When querying the data, MySQL uses the record type and metadata to restore the original length but, when reading events from binlog directly, 

Closes: DBI-855
Related to: https://github.com/ClickHouse/support-escalation/issues/8013

References:

- Similar issue in different project: https://github.com/shyiko/mysql-binlog-connector-java/issues/169#issuecomment-301864569
- https://dev.mysql.com/doc/refman/5.7/en/binary-varbinary.html