### PR TITLE
PG -> BigQuery JSON passthrough

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -145,7 +145,13 @@ func pullAndSyncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDC
 
 	tblNameMapping := make(map[string]model.NameAndExclude, len(options.TableMappings))
 	for _, v := range options.TableMappings {
-		tblNameMapping[v.SourceTableIdentifier] = model.NewNameAndExclude(v.DestinationTableIdentifier, v.Exclude)
+		tblNameMapping[v.SourceTableIdentifier] = model.NewNameAndExclude(
+			v.DestinationTableIdentifier, v.Exclude, v.JsonPassthroughColumns)
+	}
+
+	destinationType, err := connectors.LoadPeerType(ctx, a.CatalogPool, config.DestinationName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load destination peer type: %w", err)
 	}
 
 	if err := srcConn.ConnectionActive(ctx); err != nil {
@@ -244,6 +250,7 @@ func pullAndSyncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDC
 			MaxBatchSize:                batchSize,
 			IdleTimeout:                 idleTimeout,
 			TableNameSchemaMapping:      tableNameSchemaMapping,
+			DestinationType:             destinationType,
 			OverridePublicationName:     config.PublicationName,
 			OverrideReplicationSlotName: config.ReplicationSlotName,
 			RecordStream:                recordBatchPull,

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -26,6 +26,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 	"github.com/PeerDB-io/peerdb/flow/shared"
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
 const (
@@ -691,6 +692,15 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 				return false, fmt.Errorf("failed to delete table %s: %w", tableIdentifier, deleteErr)
 			}
 		} else {
+			if err := validateCDCJSONPassthroughColumns(
+				tableIdentifier,
+				jsonPassthroughColumnsForDestination(config.TableMappings, tableIdentifier),
+				tableSchema,
+				existingMetadata.Schema,
+			); err != nil {
+				return false, err
+			}
+
 			// table exists, go to next table
 			c.logger.Info("[bigquery] table already exists, skipping",
 				slog.String("table", tableIdentifier),
@@ -767,6 +777,69 @@ func (c *BigQueryConnector) SetupNormalizedTable(
 
 	datasetTablesSet[datasetTable] = struct{}{}
 	return false, nil
+}
+
+func jsonPassthroughColumnsForDestination(
+	tableMappings []*protos.TableMapping,
+	tableIdentifier string,
+) []string {
+	for _, tableMapping := range tableMappings {
+		if tableMapping.DestinationTableIdentifier == tableIdentifier {
+			return tableMapping.JsonPassthroughColumns
+		}
+	}
+	return nil
+}
+
+func validateCDCJSONPassthroughColumns(
+	tableIdentifier string,
+	jsonPassthroughColumns []string,
+	tableSchema *protos.TableSchema,
+	dstSchema bigquery.Schema,
+) error {
+	if len(jsonPassthroughColumns) == 0 {
+		return nil
+	}
+	if tableSchema == nil {
+		return fmt.Errorf("json passthrough configured for table %s but table schema was not found", tableIdentifier)
+	}
+
+	sourceTypes := make(map[string]types.QValueKind, len(tableSchema.Columns))
+	for _, field := range tableSchema.Columns {
+		sourceTypes[field.Name] = types.QValueKind(field.Type)
+	}
+	destinationTypes := make(map[string]bigquery.FieldType, len(dstSchema))
+	for _, field := range dstSchema {
+		destinationTypes[field.Name] = field.Type
+	}
+
+	for _, columnName := range jsonPassthroughColumns {
+		sourceType, ok := sourceTypes[columnName]
+		if !ok {
+			return fmt.Errorf("json passthrough column %s.%s was not found in table schema",
+				tableIdentifier, columnName)
+		}
+		switch sourceType {
+		case types.QValueKindJSON, types.QValueKindJSONB:
+		case types.QValueKindArrayJSON, types.QValueKindArrayJSONB:
+			return fmt.Errorf("json passthrough column %s.%s has unsupported JSON array source type %s",
+				tableIdentifier, columnName, sourceType)
+		default:
+			return fmt.Errorf("json passthrough column %s.%s has non-JSON source type %s",
+				tableIdentifier, columnName, sourceType)
+		}
+
+		destinationType, ok := destinationTypes[columnName]
+		if !ok {
+			return fmt.Errorf("json passthrough column %s.%s was not found in BigQuery destination schema",
+				tableIdentifier, columnName)
+		}
+		if destinationType != bigquery.JSONFieldType {
+			return fmt.Errorf("json passthrough column %s.%s has non-JSON BigQuery destination type %s",
+				tableIdentifier, columnName, destinationType)
+		}
+	}
+	return nil
 }
 
 func (c *BigQueryConnector) SyncFlowCleanup(ctx context.Context, jobName string) error {

--- a/flow/connectors/bigquery/json_passthrough_test.go
+++ b/flow/connectors/bigquery/json_passthrough_test.go
@@ -1,0 +1,185 @@
+package connbigquery
+
+import (
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
+)
+
+func testQRecordSchema(columnName string, kind types.QValueKind) types.QRecordSchema {
+	return types.QRecordSchema{
+		Fields: []types.QField{{Name: columnName, Type: kind}},
+	}
+}
+
+func testProtoTableSchema(columnName string, kind types.QValueKind) *protos.TableSchema {
+	return &protos.TableSchema{
+		Columns: []*protos.FieldDescription{{Name: columnName, Type: string(kind)}},
+	}
+}
+
+func testBigQuerySchema(columnName string, fieldType bigquery.FieldType) bigquery.Schema {
+	return bigquery.Schema{
+		&bigquery.FieldSchema{Name: columnName, Type: fieldType},
+	}
+}
+
+func TestValidateQRepJSONPassthroughColumns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		columns   []string
+		srcSchema types.QRecordSchema
+		dstSchema bigquery.Schema
+		wantErr   string
+	}{
+		{
+			name:      "allows scalar json",
+			columns:   []string{"payload"},
+			srcSchema: testQRecordSchema("payload", types.QValueKindJSON),
+			dstSchema: testBigQuerySchema("payload", bigquery.JSONFieldType),
+		},
+		{
+			name:      "allows scalar jsonb",
+			columns:   []string{"payload"},
+			srcSchema: testQRecordSchema("payload", types.QValueKindJSONB),
+			dstSchema: testBigQuerySchema("payload", bigquery.JSONFieldType),
+		},
+		{
+			name:      "ignores empty config",
+			srcSchema: testQRecordSchema("payload", types.QValueKindString),
+			dstSchema: testBigQuerySchema("payload", bigquery.StringFieldType),
+		},
+		{
+			name:      "rejects source json array",
+			columns:   []string{"payload"},
+			srcSchema: testQRecordSchema("payload", types.QValueKindArrayJSON),
+			dstSchema: testBigQuerySchema("payload", bigquery.JSONFieldType),
+			wantErr:   "unsupported JSON array source type",
+		},
+		{
+			name:      "rejects non JSON source",
+			columns:   []string{"payload"},
+			srcSchema: testQRecordSchema("payload", types.QValueKindString),
+			dstSchema: testBigQuerySchema("payload", bigquery.JSONFieldType),
+			wantErr:   "non-JSON source type",
+		},
+		{
+			name:      "rejects missing source column",
+			columns:   []string{"payload"},
+			srcSchema: testQRecordSchema("other_payload", types.QValueKindJSON),
+			dstSchema: testBigQuerySchema("payload", bigquery.JSONFieldType),
+			wantErr:   "was not found in source schema",
+		},
+		{
+			name:      "rejects missing destination column",
+			columns:   []string{"payload"},
+			srcSchema: testQRecordSchema("payload", types.QValueKindJSON),
+			dstSchema: testBigQuerySchema("other_payload", bigquery.JSONFieldType),
+			wantErr:   "was not found in BigQuery destination schema",
+		},
+		{
+			name:      "rejects non JSON destination",
+			columns:   []string{"payload"},
+			srcSchema: testQRecordSchema("payload", types.QValueKindJSON),
+			dstSchema: testBigQuerySchema("payload", bigquery.StringFieldType),
+			wantErr:   "non-JSON BigQuery destination type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateQRepJSONPassthroughColumns(tt.columns, tt.srcSchema, tt.dstSchema)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCDCJSONPassthroughColumns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		columns     []string
+		tableSchema *protos.TableSchema
+		dstSchema   bigquery.Schema
+		wantErr     string
+	}{
+		{
+			name:        "allows scalar json with BigQuery JSON destination",
+			columns:     []string{"payload"},
+			tableSchema: testProtoTableSchema("payload", types.QValueKindJSON),
+			dstSchema:   testBigQuerySchema("payload", bigquery.JSONFieldType),
+		},
+		{
+			name:        "allows scalar jsonb with BigQuery JSON destination",
+			columns:     []string{"payload"},
+			tableSchema: testProtoTableSchema("payload", types.QValueKindJSONB),
+			dstSchema:   testBigQuerySchema("payload", bigquery.JSONFieldType),
+		},
+		{
+			name:        "ignores empty config",
+			tableSchema: testProtoTableSchema("payload", types.QValueKindString),
+			dstSchema:   testBigQuerySchema("payload", bigquery.StringFieldType),
+		},
+		{
+			name:        "rejects missing table schema",
+			columns:     []string{"payload"},
+			tableSchema: nil,
+			dstSchema:   testBigQuerySchema("payload", bigquery.JSONFieldType),
+			wantErr:     "table schema was not found",
+		},
+		{
+			name:        "rejects source json array",
+			columns:     []string{"payload"},
+			tableSchema: testProtoTableSchema("payload", types.QValueKindArrayJSON),
+			dstSchema:   testBigQuerySchema("payload", bigquery.JSONFieldType),
+			wantErr:     "unsupported JSON array source type",
+		},
+		{
+			name:        "rejects non JSON source",
+			columns:     []string{"payload"},
+			tableSchema: testProtoTableSchema("payload", types.QValueKindString),
+			dstSchema:   testBigQuerySchema("payload", bigquery.JSONFieldType),
+			wantErr:     "non-JSON source type",
+		},
+		{
+			name:        "rejects missing destination column",
+			columns:     []string{"payload"},
+			tableSchema: testProtoTableSchema("payload", types.QValueKindJSON),
+			dstSchema:   testBigQuerySchema("other_payload", bigquery.JSONFieldType),
+			wantErr:     "was not found in BigQuery destination schema",
+		},
+		{
+			name:        "rejects non JSON destination",
+			columns:     []string{"payload"},
+			tableSchema: testProtoTableSchema("payload", types.QValueKindJSON),
+			dstSchema:   testBigQuerySchema("payload", bigquery.StringFieldType),
+			wantErr:     "non-JSON BigQuery destination type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateCDCJSONPassthroughColumns("dataset.events", tt.columns, tt.tableSchema, tt.dstSchema)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/flow/connectors/bigquery/qrep.go
+++ b/flow/connectors/bigquery/qrep.go
@@ -33,6 +33,10 @@ func (c *BigQueryConnector) SyncQRepRecords(
 		return 0, nil, err
 	}
 
+	if err := validateQRepJSONPassthroughColumns(config.JsonPassthroughColumns, srcSchema, tblMetadata.Schema); err != nil {
+		return 0, nil, err
+	}
+
 	c.logger.Info(fmt.Sprintf("QRep sync function called and partition existence checked for"+
 		" partition %s of destination table %s",
 		partition.PartitionId, destTable))
@@ -96,6 +100,50 @@ func (c *BigQueryConnector) replayTableSchemaDeltasQRep(
 		return nil, fmt.Errorf("failed to get metadata of table %s: %w", destDatasetTable, err)
 	}
 	return dstTableMetadata, nil
+}
+
+func validateQRepJSONPassthroughColumns(
+	jsonPassthroughColumns []string,
+	srcSchema types.QRecordSchema,
+	dstSchema bigquery.Schema,
+) error {
+	if len(jsonPassthroughColumns) == 0 {
+		return nil
+	}
+
+	sourceTypes := make(map[string]types.QValueKind, len(srcSchema.Fields))
+	for _, field := range srcSchema.Fields {
+		sourceTypes[field.Name] = field.Type
+	}
+	destinationTypes := make(map[string]bigquery.FieldType, len(dstSchema))
+	for _, field := range dstSchema {
+		destinationTypes[field.Name] = field.Type
+	}
+
+	for _, columnName := range jsonPassthroughColumns {
+		sourceType, ok := sourceTypes[columnName]
+		if !ok {
+			return fmt.Errorf("json passthrough column %s was not found in source schema", columnName)
+		}
+		switch sourceType {
+		case types.QValueKindJSON, types.QValueKindJSONB:
+		case types.QValueKindArrayJSON, types.QValueKindArrayJSONB:
+			return fmt.Errorf("json passthrough column %s has unsupported JSON array source type %s",
+				columnName, sourceType)
+		default:
+			return fmt.Errorf("json passthrough column %s has non-JSON source type %s", columnName, sourceType)
+		}
+
+		destinationType, ok := destinationTypes[columnName]
+		if !ok {
+			return fmt.Errorf("json passthrough column %s was not found in BigQuery destination schema", columnName)
+		}
+		if destinationType != bigquery.JSONFieldType {
+			return fmt.Errorf("json passthrough column %s has non-JSON BigQuery destination type %s",
+				columnName, destinationType)
+		}
+	}
+	return nil
 }
 
 func (c *BigQueryConnector) SetupQRepMetadataTables(ctx context.Context, config *protos.QRepConfig) error {

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -111,6 +111,14 @@ func (c *PostgresConnector) NewPostgresCDCSource(ctx context.Context, cdcConfig 
 		}
 	}
 
+	if err := validateCDCJSONPassthroughConfig(
+		cdcConfig.DestinationType,
+		cdcConfig.TableNameMapping,
+		cdcConfig.TableNameSchemaMapping,
+	); err != nil {
+		return nil, err
+	}
+
 	var schemaNameForRelID map[uint32]string
 	if cdcConfig.SourceSchemaAsDestinationColumn {
 		schemaNameForRelID = make(map[uint32]string, len(cdcConfig.TableNameSchemaMapping))
@@ -319,6 +327,31 @@ func validateJSONPassthroughTableSchema(tableSchema *protos.TableSchema, tableNa
 
 	return fmt.Errorf("json passthrough column %s.%s configured but destination column was not found",
 		tableName, columnName)
+}
+
+func validateCDCJSONPassthroughConfig(
+	destinationType protos.DBType,
+	tableNameMapping map[string]model.NameAndExclude,
+	tableNameSchemaMapping map[string]*protos.TableSchema,
+) error {
+	for sourceTableName, nameAndExclude := range tableNameMapping {
+		if len(nameAndExclude.JSONPassthroughColumns) == 0 {
+			continue
+		}
+		if destinationType != protos.DBType_BIGQUERY {
+			return fmt.Errorf("json passthrough columns configured for source table %s with non-BigQuery destination %s",
+				sourceTableName, destinationType)
+		}
+
+		for columnName := range nameAndExclude.JSONPassthroughColumns {
+			if err := validateJSONPassthroughTableSchema(
+				tableNameSchemaMapping[nameAndExclude.Name], nameAndExclude.Name, columnName,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (p *PostgresCDCSource) shouldPassthroughJSONColumn(

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -63,6 +63,7 @@ type PostgresCDCSource struct {
 	hushWarnUnhandledMessageType             map[pglogrepl.MessageType]struct{}
 	hushWarnUnknownTableDetected             map[uint32]struct{}
 	jsonApi                                  jsoniter.API
+	destinationType                          protos.DBType
 	flowJobName                              string
 	handleInheritanceForNonPartitionedTables bool
 	originMetadataAsDestinationColumn        bool
@@ -82,6 +83,7 @@ type PostgresCDCConfig struct {
 	HandleInheritanceForNonPartitionedTables bool
 	SourceSchemaAsDestinationColumn          bool
 	OriginMetaAsDestinationColumn            bool
+	DestinationType                          protos.DBType
 	InternalVersion                          uint32
 }
 
@@ -134,6 +136,7 @@ func (c *PostgresConnector) NewPostgresCDCSource(ctx context.Context, cdcConfig 
 		hushWarnUnhandledMessageType:             make(map[pglogrepl.MessageType]struct{}),
 		hushWarnUnknownTableDetected:             make(map[uint32]struct{}),
 		jsonApi:                                  jsonApi,
+		destinationType:                          cdcConfig.DestinationType,
 		flowJobName:                              cdcConfig.FlowJobName,
 		handleInheritanceForNonPartitionedTables: cdcConfig.HandleInheritanceForNonPartitionedTables,
 		originMetadataAsDestinationColumn:        cdcConfig.OriginMetaAsDestinationColumn,
@@ -202,6 +205,7 @@ type replProcessor[Items model.Items] interface {
 		tuple *pglogrepl.TupleDataColumn,
 		col *pglogrepl.RelationMessageColumn,
 		customTypeMapping map[uint32]pkg_pg.CustomDataType,
+		jsonPassthrough bool,
 	) error
 
 	AddStringColumn(items Items, name string, value string)
@@ -219,6 +223,7 @@ func (pgProcessor) Process(
 	tuple *pglogrepl.TupleDataColumn,
 	col *pglogrepl.RelationMessageColumn,
 	customTypeMapping map[uint32]pkg_pg.CustomDataType,
+	_ bool,
 ) error {
 	switch tuple.DataType {
 	case 'n': // null
@@ -254,6 +259,7 @@ func (qProcessor) Process(
 	tuple *pglogrepl.TupleDataColumn,
 	col *pglogrepl.RelationMessageColumn,
 	customTypeMapping map[uint32]pkg_pg.CustomDataType,
+	jsonPassthrough bool,
 ) error {
 	switch tuple.DataType {
 	case 'n': // null
@@ -262,6 +268,7 @@ func (qProcessor) Process(
 		// bytea also appears here as a hex
 		data, err := p.decodeColumnData(
 			tuple.Data, col.DataType, col.TypeModifier, pgtype.TextFormatCode, customTypeMapping, p.internalVersion,
+			jsonPassthrough,
 		)
 		if err != nil {
 			p.logger.Error("error decoding text column data", slog.Any("error", err),
@@ -272,6 +279,7 @@ func (qProcessor) Process(
 	case 'b': // binary
 		data, err := p.decodeColumnData(
 			tuple.Data, col.DataType, col.TypeModifier, pgtype.BinaryFormatCode, customTypeMapping, p.internalVersion,
+			jsonPassthrough,
 		)
 		if err != nil {
 			return fmt.Errorf("error decoding binary data for column %s: %w", col.Name, err)
@@ -285,6 +293,62 @@ func (qProcessor) Process(
 
 func (qProcessor) AddStringColumn(items model.RecordItems, name string, value string) {
 	items.AddColumn(name, types.QValueString{Val: value})
+}
+
+func validateJSONPassthroughTableSchema(tableSchema *protos.TableSchema, tableName string, columnName string) error {
+	if tableSchema == nil {
+		return fmt.Errorf("json passthrough column %s.%s configured but destination table schema was not found",
+			tableName, columnName)
+	}
+
+	for _, column := range tableSchema.Columns {
+		if column.Name != columnName {
+			continue
+		}
+		switch types.QValueKind(column.Type) {
+		case types.QValueKindJSON, types.QValueKindJSONB:
+			return nil
+		case types.QValueKindArrayJSON, types.QValueKindArrayJSONB:
+			return fmt.Errorf("json passthrough column %s.%s has unsupported JSON array type %s",
+				tableName, columnName, column.Type)
+		default:
+			return fmt.Errorf("json passthrough column %s.%s maps to non-JSON destination type %s",
+				tableName, columnName, column.Type)
+		}
+	}
+
+	return fmt.Errorf("json passthrough column %s.%s configured but destination column was not found",
+		tableName, columnName)
+}
+
+func (p *PostgresCDCSource) shouldPassthroughJSONColumn(
+	nameAndExclude model.NameAndExclude,
+	col *pglogrepl.RelationMessageColumn,
+) (bool, error) {
+	if _, ok := nameAndExclude.JSONPassthroughColumns[col.Name]; !ok {
+		return false, nil
+	}
+	if p.destinationType != protos.DBType_BIGQUERY {
+		return false, fmt.Errorf("json passthrough column %s.%s configured for non-BigQuery destination %s",
+			nameAndExclude.Name, col.Name, p.destinationType)
+	}
+
+	switch col.DataType {
+	case pgtype.JSONOID, pgtype.JSONBOID:
+	case pgtype.JSONArrayOID, pgtype.JSONBArrayOID:
+		return false, fmt.Errorf("json passthrough column %s.%s has unsupported Postgres JSON array type OID %d",
+			nameAndExclude.Name, col.Name, col.DataType)
+	default:
+		return false, fmt.Errorf("json passthrough column %s.%s has non-JSON Postgres type OID %d",
+			nameAndExclude.Name, col.Name, col.DataType)
+	}
+
+	if err := validateJSONPassthroughTableSchema(
+		p.tableNameSchemaMapping[nameAndExclude.Name], nameAndExclude.Name, col.Name,
+	); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func processTuple[Items model.Items](
@@ -319,12 +383,16 @@ func processTuple[Items model.Items](
 		if _, ok := nameAndExclude.Exclude[rcol.Name]; ok {
 			continue
 		}
+		jsonPassthrough, err := p.shouldPassthroughJSONColumn(nameAndExclude, rcol)
+		if err != nil {
+			return none, nil, err
+		}
 		if tcol.DataType == 'u' {
 			if unchangedToastColumns == nil {
 				unchangedToastColumns = make(map[string]struct{})
 			}
 			unchangedToastColumns[rcol.Name] = struct{}{}
-		} else if err := processor.Process(items, p, tcol, rcol, customTypeMapping); err != nil {
+		} else if err := processor.Process(items, p, tcol, rcol, customTypeMapping, jsonPassthrough); err != nil {
 			return none, nil, err
 		}
 	}
@@ -342,6 +410,7 @@ func processTuple[Items model.Items](
 
 func (p *PostgresCDCSource) decodeColumnData(
 	data []byte, dataType uint32, typmod int32, formatCode int16, customTypeMapping map[uint32]pkg_pg.CustomDataType, version uint32,
+	jsonPassthrough bool,
 ) (types.QValue, error) {
 	var parsedData any
 	var err error
@@ -354,6 +423,9 @@ func (p *PostgresCDCSource) decodeColumnData(
 			return nil, fmt.Errorf("failed to scan json: %w", err)
 		}
 		if text.Valid {
+			if jsonPassthrough {
+				return types.QValueJSON{Val: text.String}, nil
+			}
 			if err := p.jsonApi.UnmarshalFromString(text.String, &parsedData); err != nil {
 				p.logger.Error("[pg_cdc] failed to unmarshal json", slog.Any("error", err))
 				return nil, fmt.Errorf("failed to unmarshal json: %w", err)

--- a/flow/connectors/postgres/cdc_test.go
+++ b/flow/connectors/postgres/cdc_test.go
@@ -4,17 +4,29 @@ import (
 	"testing"
 
 	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
 func newTestCDCSource(t *testing.T) *PostgresCDCSource {
 	t.Helper()
 	return &PostgresCDCSource{
-		PostgresConnector: &PostgresConnector{},
+		PostgresConnector: &PostgresConnector{typeMap: pgtype.NewMap()},
+		jsonApi:           createExtendedJSONUnmarshaler(),
 		otelManager:       &otel_metrics.OtelManager{},
+	}
+}
+
+func cdcTestTableSchema(columnName string, kind types.QValueKind) *protos.TableSchema {
+	return &protos.TableSchema{
+		Columns: []*protos.FieldDescription{
+			{Name: columnName, Type: string(kind)},
+		},
 	}
 }
 
@@ -35,4 +47,175 @@ func TestProcessMessageInvalidMessage(t *testing.T) {
 	require.Nil(t, rec)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error parsing logical message (msgType=\"S\", walStart=0/1)")
+}
+
+func TestCDCDecodeJSONPassthroughPreservesRawNestedJSON(t *testing.T) {
+	t.Parallel()
+
+	p := newTestCDCSource(t)
+	rawJSON := `{"items":[{"n":1000000000000000000000000000000000000000}],"deep":{"array":[1,2,{"ok":true}]}}`
+
+	qvalue, err := p.decodeColumnData(
+		[]byte(rawJSON),
+		pgtype.JSONOID,
+		-1,
+		pgtype.TextFormatCode,
+		nil,
+		0,
+		true,
+	)
+
+	require.NoError(t, err)
+	jsonValue, ok := qvalue.(types.QValueJSON)
+	require.True(t, ok)
+	require.Equal(t, rawJSON, jsonValue.Val)
+	require.False(t, jsonValue.IsArray)
+}
+
+func TestValidateCDCJSONPassthroughConfig(t *testing.T) {
+	t.Parallel()
+
+	tableMapping := map[string]model.NameAndExclude{
+		"public.events": model.NewNameAndExclude("dataset.events", nil, []string{"payload"}),
+	}
+
+	tests := []struct {
+		name          string
+		destination   protos.DBType
+		schemaMapping map[string]*protos.TableSchema
+		wantErr       string
+	}{
+		{
+			name:        "allows scalar json",
+			destination: protos.DBType_BIGQUERY,
+			schemaMapping: map[string]*protos.TableSchema{
+				"dataset.events": cdcTestTableSchema("payload", types.QValueKindJSON),
+			},
+		},
+		{
+			name:        "allows scalar jsonb",
+			destination: protos.DBType_BIGQUERY,
+			schemaMapping: map[string]*protos.TableSchema{
+				"dataset.events": cdcTestTableSchema("payload", types.QValueKindJSONB),
+			},
+		},
+		{
+			name:        "rejects non BigQuery destination",
+			destination: protos.DBType_POSTGRES,
+			schemaMapping: map[string]*protos.TableSchema{
+				"dataset.events": cdcTestTableSchema("payload", types.QValueKindJSON),
+			},
+			wantErr: "non-BigQuery destination",
+		},
+		{
+			name:        "rejects json array schema",
+			destination: protos.DBType_BIGQUERY,
+			schemaMapping: map[string]*protos.TableSchema{
+				"dataset.events": cdcTestTableSchema("payload", types.QValueKindArrayJSON),
+			},
+			wantErr: "unsupported JSON array type",
+		},
+		{
+			name:        "rejects non JSON schema",
+			destination: protos.DBType_BIGQUERY,
+			schemaMapping: map[string]*protos.TableSchema{
+				"dataset.events": cdcTestTableSchema("payload", types.QValueKindString),
+			},
+			wantErr: "maps to non-JSON destination type",
+		},
+		{
+			name:        "rejects missing column",
+			destination: protos.DBType_BIGQUERY,
+			schemaMapping: map[string]*protos.TableSchema{
+				"dataset.events": cdcTestTableSchema("other_payload", types.QValueKindJSON),
+			},
+			wantErr: "destination column was not found",
+		},
+		{
+			name:          "rejects missing table schema",
+			destination:   protos.DBType_BIGQUERY,
+			schemaMapping: map[string]*protos.TableSchema{},
+			wantErr:       "destination table schema was not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateCDCJSONPassthroughConfig(tt.destination, tableMapping, tt.schemaMapping)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestShouldPassthroughJSONColumnOIDValidation(t *testing.T) {
+	t.Parallel()
+
+	nameAndExclude := model.NewNameAndExclude("dataset.events", nil, []string{"payload"})
+
+	tests := []struct {
+		name            string
+		columnName      string
+		oid             uint32
+		wantPassthrough bool
+		wantErr         string
+	}{
+		{
+			name:            "allows json",
+			columnName:      "payload",
+			oid:             pgtype.JSONOID,
+			wantPassthrough: true,
+		},
+		{
+			name:            "allows jsonb",
+			columnName:      "payload",
+			oid:             pgtype.JSONBOID,
+			wantPassthrough: true,
+		},
+		{
+			name:       "rejects json array",
+			columnName: "payload",
+			oid:        pgtype.JSONArrayOID,
+			wantErr:    "unsupported Postgres JSON array type OID",
+		},
+		{
+			name:       "rejects non JSON",
+			columnName: "payload",
+			oid:        pgtype.Int4OID,
+			wantErr:    "non-JSON Postgres type OID",
+		},
+		{
+			name:       "ignores columns outside allowlist",
+			columnName: "other_payload",
+			oid:        pgtype.Int4OID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := newTestCDCSource(t)
+			p.destinationType = protos.DBType_BIGQUERY
+			p.tableNameSchemaMapping = map[string]*protos.TableSchema{
+				"dataset.events": cdcTestTableSchema("payload", types.QValueKindJSON),
+			}
+
+			passthrough, err := p.shouldPassthroughJSONColumn(nameAndExclude, &pglogrepl.RelationMessageColumn{
+				Name:     tt.columnName,
+				DataType: tt.oid,
+			})
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantPassthrough, passthrough)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -330,6 +330,7 @@ func pullCore[Items model.Items](
 		HandleInheritanceForNonPartitionedTables: handleInheritanceForNonPartitionedTables,
 		SourceSchemaAsDestinationColumn:          sourceSchemaAsDestinationColumn,
 		OriginMetaAsDestinationColumn:            originMetaAsDestinationColumn,
+		DestinationType:                          req.DestinationType,
 		InternalVersion:                          req.InternalVersion,
 	})
 	if err != nil {

--- a/flow/connectors/postgres/qrep_query_executor.go
+++ b/flow/connectors/postgres/qrep_query_executor.go
@@ -286,10 +286,15 @@ func (qe *QRepQueryExecutor) processRowsStream(
 	stream *model.QRecordStream,
 	rows pgx.Rows,
 	fieldDescriptions []pgconn.FieldDescription,
+	jsonPassthroughColumns map[string]struct{},
 ) (int64, int64, error) {
 	var numRows int64
 	var numBytes int64
 	const logPerRows = 50000
+
+	if err := validateQRepJSONPassthroughFields(dstType, jsonPassthroughColumns, fieldDescriptions); err != nil {
+		return 0, 0, err
+	}
 
 	jsonApi := createExtendedJSONUnmarshaler()
 	schema, err := stream.Schema()
@@ -309,7 +314,7 @@ func (qe *QRepQueryExecutor) processRowsStream(
 			return numRows, numBytes, err
 		}
 
-		record, err := qe.mapRowToQRecord(rows, dstType, nullableFields, fieldDescriptions, jsonApi)
+		record, err := qe.mapRowToQRecord(rows, dstType, nullableFields, fieldDescriptions, jsonApi, jsonPassthroughColumns)
 		if err != nil {
 			qe.logger.Error("[pg_query_executor] failed to map row to QRecord", slog.Any("error", err))
 			return numRows, numBytes, fmt.Errorf("failed to map row to QRecord: %w", err)
@@ -350,6 +355,7 @@ func (qe *QRepQueryExecutor) processFetchedRows(
 	fetchSize int,
 	dstType protos.DBType,
 	stream *model.QRecordStream,
+	jsonPassthroughColumns map[string]struct{},
 ) (int64, int64, error) {
 	qe.logger.Info("[pg_query_executor] fetching from cursor", slog.String("cursor", cursorName))
 
@@ -362,7 +368,8 @@ func (qe *QRepQueryExecutor) processFetchedRows(
 	defer rows.Close()
 
 	fieldDescriptions := rows.FieldDescriptions()
-	numRows, numBytes, err := qe.processRowsStream(ctx, cursorName, dstType, stream, rows, fieldDescriptions)
+	numRows, numBytes, err := qe.processRowsStream(
+		ctx, cursorName, dstType, stream, rows, fieldDescriptions, jsonPassthroughColumns)
 	if err != nil {
 		qe.logger.Error("[pg_query_executor] failed to process rows", slog.Any("error", err))
 		return numRows, numBytes, fmt.Errorf("failed to process rows: %w", err)
@@ -501,12 +508,62 @@ func (qe *QRepQueryExecutor) ExecuteQueryIntoSinkGettingCurrentSnapshotXmin(
 	return totalRecords, totalBytes, currentSnapshotXmin.Int64, err
 }
 
+func shouldPassthroughJSONColumn(
+	dstType protos.DBType,
+	columnName string,
+	jsonPassthroughColumns map[string]struct{},
+) bool {
+	if dstType != protos.DBType_BIGQUERY {
+		return false
+	}
+	_, ok := jsonPassthroughColumns[columnName]
+	return ok
+}
+
+func validateQRepJSONPassthroughFields(
+	dstType protos.DBType,
+	jsonPassthroughColumns map[string]struct{},
+	fds []pgconn.FieldDescription,
+) error {
+	if len(jsonPassthroughColumns) == 0 {
+		return nil
+	}
+	if dstType != protos.DBType_BIGQUERY {
+		return fmt.Errorf("json passthrough columns configured for non-BigQuery destination %s", dstType)
+	}
+
+	foundColumns := make(map[string]struct{}, len(jsonPassthroughColumns))
+	for _, fd := range fds {
+		if _, ok := jsonPassthroughColumns[fd.Name]; !ok {
+			continue
+		}
+		foundColumns[fd.Name] = struct{}{}
+		switch fd.DataTypeOID {
+		case pgtype.JSONOID, pgtype.JSONBOID:
+		case pgtype.JSONArrayOID, pgtype.JSONBArrayOID:
+			return fmt.Errorf("json passthrough column %s has unsupported Postgres JSON array type OID %d",
+				fd.Name, fd.DataTypeOID)
+		default:
+			return fmt.Errorf("json passthrough column %s has non-JSON Postgres type OID %d",
+				fd.Name, fd.DataTypeOID)
+		}
+	}
+
+	for column := range jsonPassthroughColumns {
+		if _, ok := foundColumns[column]; !ok {
+			return fmt.Errorf("json passthrough column %s was not found in Postgres query result", column)
+		}
+	}
+	return nil
+}
+
 func (qe *QRepQueryExecutor) mapRowToQRecord(
 	row pgx.Rows,
 	dstType protos.DBType,
 	nullableFields map[string]struct{},
 	fds []pgconn.FieldDescription,
 	jsonApi jsoniter.API,
+	jsonPassthroughColumns map[string]struct{},
 ) ([]types.QValue, error) {
 	rawValues := row.RawValues()
 	values := make([]any, len(fds))
@@ -521,6 +578,17 @@ func (qe *QRepQueryExecutor) mapRowToQRecord(
 		// Special handling for JSON types
 		switch fd.DataTypeOID {
 		case pgtype.JSONOID, pgtype.JSONBOID:
+			if shouldPassthroughJSONColumn(dstType, fd.Name, jsonPassthroughColumns) {
+				var text pgtype.Text
+				if err := qe.conn.TypeMap().Scan(fd.DataTypeOID, fd.Format, buf, &text); err != nil {
+					qe.logger.Error("[pg_query_executor] failed to scan json passthrough", slog.Any("error", err))
+					return nil, fmt.Errorf("failed to scan json passthrough: %w", err)
+				}
+				if text.Valid {
+					values[i] = types.QValueJSON{Val: text.String}
+				}
+				continue
+			}
 			if err := jsonApi.Unmarshal(buf, &values[i]); err != nil {
 				qe.logger.Error("[pg_query_executor] failed to unmarshal json", slog.Any("error", err))
 				return nil, fmt.Errorf("failed to unmarshal json: %w", err)

--- a/flow/connectors/postgres/qrep_query_executor_test.go
+++ b/flow/connectors/postgres/qrep_query_executor_test.go
@@ -8,12 +8,16 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 	"github.com/PeerDB-io/peerdb/flow/shared"
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
 func setupDB(t *testing.T, testName string) (*PostgresConnector, string) {
@@ -40,6 +44,109 @@ func teardownDB(t *testing.T, conn *pgx.Conn, schemaName string) {
 	_, err := conn.Exec(t.Context(),
 		fmt.Sprintf("DROP SCHEMA %s CASCADE", common.QuoteIdentifier(schemaName)))
 	require.NoError(t, err, "error while dropping schema")
+}
+
+func TestValidateQRepJSONPassthroughFields(t *testing.T) {
+	t.Parallel()
+
+	allowlist := map[string]struct{}{"payload": {}}
+
+	tests := []struct {
+		name        string
+		destination protos.DBType
+		columns     map[string]struct{}
+		fields      []pgconn.FieldDescription
+		wantErr     string
+	}{
+		{
+			name:        "allows scalar json",
+			destination: protos.DBType_BIGQUERY,
+			columns:     allowlist,
+			fields:      []pgconn.FieldDescription{{Name: "payload", DataTypeOID: pgtype.JSONOID}},
+		},
+		{
+			name:        "allows scalar jsonb",
+			destination: protos.DBType_BIGQUERY,
+			columns:     allowlist,
+			fields:      []pgconn.FieldDescription{{Name: "payload", DataTypeOID: pgtype.JSONBOID}},
+		},
+		{
+			name:        "ignores empty config for non BigQuery",
+			destination: protos.DBType_POSTGRES,
+			fields:      []pgconn.FieldDescription{{Name: "payload", DataTypeOID: pgtype.JSONOID}},
+		},
+		{
+			name:        "rejects non BigQuery destination",
+			destination: protos.DBType_POSTGRES,
+			columns:     allowlist,
+			fields:      []pgconn.FieldDescription{{Name: "payload", DataTypeOID: pgtype.JSONOID}},
+			wantErr:     "non-BigQuery destination",
+		},
+		{
+			name:        "rejects json array",
+			destination: protos.DBType_BIGQUERY,
+			columns:     allowlist,
+			fields:      []pgconn.FieldDescription{{Name: "payload", DataTypeOID: pgtype.JSONArrayOID}},
+			wantErr:     "unsupported Postgres JSON array type OID",
+		},
+		{
+			name:        "rejects jsonb array",
+			destination: protos.DBType_BIGQUERY,
+			columns:     allowlist,
+			fields:      []pgconn.FieldDescription{{Name: "payload", DataTypeOID: pgtype.JSONBArrayOID}},
+			wantErr:     "unsupported Postgres JSON array type OID",
+		},
+		{
+			name:        "rejects non JSON",
+			destination: protos.DBType_BIGQUERY,
+			columns:     allowlist,
+			fields:      []pgconn.FieldDescription{{Name: "payload", DataTypeOID: pgtype.TextOID}},
+			wantErr:     "non-JSON Postgres type OID",
+		},
+		{
+			name:        "rejects missing output column",
+			destination: protos.DBType_BIGQUERY,
+			columns:     allowlist,
+			fields:      []pgconn.FieldDescription{{Name: "other_payload", DataTypeOID: pgtype.JSONOID}},
+			wantErr:     "was not found in Postgres query result",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateQRepJSONPassthroughFields(tt.destination, tt.columns, tt.fields)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseFieldFromPostgresOIDPreservesQValueJSONPassthrough(t *testing.T) {
+	t.Parallel()
+
+	rawJSON := `{"items":[{"n":1000000000000000000000000000000000000000}],"deep":{"array":[1,2,{"ok":true}]}}`
+	connector := &PostgresConnector{typeMap: pgtype.NewMap()}
+
+	qvalue, err := connector.parseFieldFromPostgresOID(
+		pgtype.JSONOID,
+		-1,
+		true,
+		protos.DBType_BIGQUERY,
+		types.QValueJSON{Val: rawJSON},
+		nil,
+		0,
+	)
+
+	require.NoError(t, err)
+	jsonValue, ok := qvalue.(types.QValueJSON)
+	require.True(t, ok)
+	require.Equal(t, rawJSON, jsonValue.Val)
+	require.False(t, jsonValue.IsArray)
 }
 
 func TestExecuteAndProcessQuery(t *testing.T) {

--- a/flow/connectors/postgres/qrep_source.go
+++ b/flow/connectors/postgres/qrep_source.go
@@ -333,8 +333,9 @@ func (c *PostgresConnector) PullQRepRecords(
 	stream *model.QRecordStream,
 ) (int64, int64, error) {
 	return corePullQRepRecords(c, ctx, catalogPool, config, partition, &RecordStreamSink{
-		QRecordStream:   stream,
-		DestinationType: dstType,
+		QRecordStream:          stream,
+		DestinationType:        dstType,
+		JSONPassthroughColumns: newColumnSet(config.JsonPassthroughColumns),
 	})
 }
 
@@ -545,8 +546,9 @@ func (c *PostgresConnector) PullXminRecordStream(
 	stream *model.QRecordStream,
 ) (int64, int64, int64, error) {
 	return pullXminRecordStream(c, ctx, config, partition, RecordStreamSink{
-		QRecordStream:   stream,
-		DestinationType: dstType,
+		QRecordStream:          stream,
+		DestinationType:        dstType,
+		JSONPassthroughColumns: newColumnSet(config.JsonPassthroughColumns),
 	})
 }
 

--- a/flow/connectors/postgres/qvalue_convert.go
+++ b/flow/connectors/postgres/qvalue_convert.go
@@ -485,6 +485,9 @@ func (c *PostgresConnector) parseFieldFromPostgresOID(
 		boolVal := value.(bool)
 		return types.QValueBoolean{Val: boolVal}, nil
 	case types.QValueKindJSON, types.QValueKindJSONB:
+		if jsonVal, ok := value.(types.QValueJSON); ok {
+			return jsonVal, nil
+		}
 		tmp, err := parseJSON(value, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse JSON: %w", err)

--- a/flow/connectors/postgres/sink_q.go
+++ b/flow/connectors/postgres/sink_q.go
@@ -19,7 +19,19 @@ import (
 
 type RecordStreamSink struct {
 	*model.QRecordStream
-	DestinationType protos.DBType
+	DestinationType        protos.DBType
+	JSONPassthroughColumns map[string]struct{}
+}
+
+func newColumnSet(columns []string) map[string]struct{} {
+	if len(columns) == 0 {
+		return nil
+	}
+	columnSet := make(map[string]struct{}, len(columns))
+	for _, column := range columns {
+		columnSet[column] = struct{}{}
+	}
+	return columnSet
 }
 
 func (stream RecordStreamSink) ExecuteQueryWithTx(
@@ -78,7 +90,7 @@ func (stream RecordStreamSink) ExecuteQueryWithTx(
 	var totalNumBytes int64
 	for {
 		numRows, numBytes, err := qe.processFetchedRows(ctx, query, tx, cursorName, shared.QRepFetchSize,
-			stream.DestinationType, stream.QRecordStream)
+			stream.DestinationType, stream.QRecordStream, stream.JSONPassthroughColumns)
 		if err != nil {
 			qe.logger.Error("[pg_query_executor] failed to process fetched rows", slog.Any("error", err))
 			return totalNumRows, totalNumBytes, err

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -14,19 +14,32 @@ import (
 )
 
 type NameAndExclude struct {
-	Exclude map[string]struct{}
-	Name    string
+	Exclude                map[string]struct{}
+	JSONPassthroughColumns map[string]struct{}
+	Name                   string
 }
 
-func NewNameAndExclude(name string, exclude []string) NameAndExclude {
-	var exset map[string]struct{}
-	if len(exclude) != 0 {
-		exset = make(map[string]struct{}, len(exclude))
-		for _, col := range exclude {
-			exset[col] = struct{}{}
-		}
+func newStringSet(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
 	}
-	return NameAndExclude{Name: name, Exclude: exset}
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
+}
+
+func NewNameAndExclude(name string, exclude []string, jsonPassthroughColumns ...[]string) NameAndExclude {
+	var passthroughColumns []string
+	if len(jsonPassthroughColumns) != 0 {
+		passthroughColumns = jsonPassthroughColumns[0]
+	}
+	return NameAndExclude{
+		Exclude:                newStringSet(exclude),
+		JSONPassthroughColumns: newStringSet(passthroughColumns),
+		Name:                   name,
+	}
 }
 
 type RecordTypeCounts struct {
@@ -76,6 +89,8 @@ type PullRecordsRequest[T Items] struct {
 	TableNameMapping map[string]NameAndExclude
 	// tablename to schema mapping
 	TableNameSchemaMapping map[string]*protos.TableSchema
+	// DestinationType is the destination peer type for destination-specific source decoding.
+	DestinationType protos.DBType
 	// overrides dynamic configuration
 	Env map[string]string
 	// override publication name

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -41,6 +41,7 @@ message TableMapping {
   string sharding_key = 7;
   string policy_name = 8;
   string partition_by_expr = 9;
+  repeated string json_passthrough_columns = 10;
 }
 
 message SetupInput {
@@ -427,6 +428,8 @@ message QRepConfig {
   repeated string flags = 31; // internal
   // if true, then a separate null partition will be created for rows with null values in the watermark column
   bool add_null_partition = 32; // internal
+
+  repeated string json_passthrough_columns = 33;
 }
 
 message ChildTableRange {

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -194,6 +194,7 @@ export function reformattedTableMapping(
       shardingKey: row.shardingKey,
       policyName: row.policyName,
       partitionByExpr: row.partitionByExpr,
+      jsonPassthroughColumns: [],
     }));
 }
 
@@ -231,6 +232,7 @@ export function changesToTablesMapping(
           shardingKey: row.shardingKey,
           policyName: row.policyName,
           partitionByExpr: row.partitionByExpr,
+          jsonPassthroughColumns: [],
         }) as TableMapping
     );
   return mapping;

--- a/ui/app/mirrors/create/helpers/common.ts
+++ b/ui/app/mirrors/create/helpers/common.ts
@@ -88,6 +88,7 @@ export const blankQRepSetting: QRepConfig = {
   parentMirrorName: '',
   exclude: [],
   columns: [],
+  jsonPassthroughColumns: [],
   sourceType: DBType.DBTYPE_UNKNOWN,
   flags: [],
 };


### PR DESCRIPTION
# PG -> BigQuery JSON Passthrough

## Summary

This adds explicit per-column JSON passthrough for Postgres source to BigQuery destination, covering both CDC and QRep.

For allowlisted scalar Postgres `json` / `jsonb` columns, PeerDB keeps the raw JSON text in `types.QValueJSON` instead of eagerly decoding the full document and marshaling it back to a JSON string before Avro staging.

BigQuery behavior is intentionally unchanged: staging still carries JSON as a string and the destination insert/merge path still uses:

```sql
PARSE_JSON(<json_string>, wide_number_mode => 'round')
```

So BigQuery remains the parser/validator of record for this path. The optimization removes duplicated source-side JSON work that is not needed when the destination is BigQuery.

## Why

Today, PG -> BigQuery JSON columns pay for a full JSON materialization pass before writing Avro, even though BigQuery will parse the same JSON string again.

```mermaid
flowchart LR
  pg["Postgres json/jsonb column"]
  scan["Scan value to text"]
  unmarshal["jsoniter unmarshal<br/>relaxed-number handling"]
  remarshal["Marshal back to JSON string<br/>QValueJSON"]
  avro["Avro staging as STRING"]
  bqstage["BigQuery staging table"]
  parse["PARSE_JSON with wide_number_mode round"]
  dst["BigQuery JSON column"]

  pg --> scan --> unmarshal --> remarshal --> avro --> bqstage --> parse --> dst
```

With passthrough enabled, PeerDB skips the redundant source-side decode/remarshal and preserves the raw JSON text until BigQuery parses it.

```mermaid
flowchart LR
  pg["Postgres json/jsonb column"]
  scan["Scan value to text"]
  qvalue["QValueJSON raw text"]
  avro["Avro staging as STRING"]
  bqstage["BigQuery staging table"]
  parse["PARSE_JSON with wide_number_mode round"]
  dst["BigQuery JSON column"]

  pg --> scan --> qvalue --> avro --> bqstage --> parse --> dst
```

Nested arrays inside a JSON document do not need special detection. The feature validates only the Postgres column/result type. A scalar `jsonb` value may have an array root or deeply nested arrays; it is still a scalar `jsonb` column and is safe for passthrough. Postgres `json[]` / `jsonb[]` columns are rejected.

## Public Interface

CDC table mapping:

```json
{
  "source_table_identifier": "public.events",
  "destination_table_identifier": "dataset.events",
  "json_passthrough_columns": ["payload"]
}
```

QRep config:

```json
{
  "qrep_config": {
    "destination_table_identifier": "dataset.events",
    "query": "SELECT id, raw_payload::jsonb AS payload FROM public.events WHERE updated_at BETWEEN {{.start}} AND {{.end}}",
    "json_passthrough_columns": ["payload"]
  }
}
```

For QRep, names are SQL output names, including aliases.

## Benchmark

The benchmark used a public-safe synthetic schema informed by a production content table, without reusing production field names or values.

Synthetic row shape:

- 41 total columns
- 6 scalar JSONB content columns
- JSON document roots are arrays, matching the important shape pressure while still being scalar Postgres JSONB columns
- Two payload profiles:
  - `sample_like_6_json_columns`: 3,016 JSON bytes per row
  - `large_content_6_json_columns`: 73,600 JSON bytes per row

Machine:

- macOS 26.5.1, Darwin 25.5.0, arm64
- Apple M3 Pro
- 11 logical CPUs
- 36 GiB RAM
- Go 1.26.1

### Isolated JSON Preparation

This isolates the duplicated JSON work removed by passthrough.

| Profile | Before | After | Speedup | CPU saved | Allocations |
| --- | ---: | ---: | ---: | ---: | ---: |
| sample-like, 3 KB JSON/row | 43.5 us/row | 0.885 us/row | 49.2x | 98.0% | 1104 -> 18 allocs/row |
| large-content, 74 KB JSON/row | 658 us/row | 16.0 us/row | 41.1x | 97.6% | 15283 -> 18 allocs/row |

### Full Synthetic Row Preparation

This includes a 41-column synthetic Avro-compatible row conversion on both sides; only the JSON preparation differs.

| Profile | Before | After | Speedup | CPU saved | Allocations |
| --- | ---: | ---: | ---: | ---: | ---: |
| sample-like, 3 KB JSON/row | 47.3 us/row | 3.80 us/row | 12.5x | 92.0% | 1200 -> 114 allocs/row |
| large-content, 74 KB JSON/row | 683 us/row | 18.8 us/row | 36.4x | 97.3% | 15379 -> 114 allocs/row |

Projected CPU savings from the full synthetic row benchmark:

| Profile | Rows | Before | After | CPU Saved |
| --- | ---: | ---: | ---: | ---: |
| sample-like | 1M | 47.3s | 3.8s | 43.5s |
| sample-like | 10M | 7.9m | 38.0s | 7.3m |
| large-content | 1M | 11.4m | 18.8s | 11.1m |
| large-content | 10M | 1.90h | 3.1m | 1.84h |

These are CPU-time estimates from a single benchmark process. End-to-end wall-clock savings depend on worker parallelism, source fetch cost, Avro write cost, network, and BigQuery load/merge time. The removed work is still real CPU and allocation pressure on PeerDB workers.

## Safety

```mermaid
flowchart TD
  cfg["json_passthrough_columns configured"]
  bq{"Destination is BigQuery?"}
  pgtype{"Postgres type is scalar json/jsonb?"}
  bqtype{"BigQuery destination column is JSON?"}
  pass["Passthrough raw JSON text"]
  reject["Fail with clear error"]

  cfg --> bq
  bq -- no --> reject
  bq -- yes --> pgtype
  pgtype -- "JSON array column or non-JSON" --> reject
  pgtype -- scalar json/jsonb --> bqtype
  bqtype -- no --> reject
  bqtype -- yes --> pass
```

Validation behavior:

- Opt-in only.
- PG -> BigQuery only.
- Scalar Postgres `json` / `jsonb` only.
- Postgres `json[]` / `jsonb[]` columns are rejected.
- Non-JSON source columns are rejected.
- Existing BigQuery destination columns must be `JSON`.
- Non-BigQuery destinations retain existing relaxed-number JSON normalization.

## Tests

Added coverage for:

- CDC scalar `json` / `jsonb` passthrough validation.
- CDC raw nested JSON preservation.
- QRep scalar `json` / `jsonb` output-column validation.
- Rejection of Postgres JSON array columns and non-JSON source columns.
- Rejection of non-JSON BigQuery destination columns.
- Existing BigQuery `PARSE_JSON(..., wide_number_mode=>'round')` transform behavior.

Targeted checks run:

```sh
GOCACHE=/private/tmp/go-build-peerdb go test ./connectors/postgres -run 'Test(CDCDecodeJSONPassthroughPreservesRawNestedJSON|ValidateCDCJSONPassthroughConfig|ShouldPassthroughJSONColumnOIDValidation|ValidateQRepJSONPassthroughFields|ParseFieldFromPostgresOIDPreservesQValueJSONPassthrough)$'

GOCACHE=/private/tmp/go-build-peerdb go test ./connectors/bigquery -run 'Test(ValidateQRepJSONPassthroughColumns|ValidateCDCJSONPassthroughColumns|AvroTransform)$'

GOCACHE=/private/tmp/go-build-peerdb go test ./connectors/postgres ./connectors/bigquery -run '^$'
```

Full local Postgres connector tests require local Postgres/Toxiproxy/SSH services and were not used for this benchmark.
