### PR TITLE
DBI-866: Skip maintenance gracefully when catalog KMS key is destroyed

### DIFF
--- a/flow/cmd/maintenance.go
+++ b/flow/cmd/maintenance.go
@@ -51,6 +51,16 @@ type StartMaintenanceResult struct {
 // running the requested maintenance workflow
 func MaintenanceMain(ctx context.Context, args *MaintenanceCLIParams) error {
 	slog.InfoContext(ctx, "Starting Maintenance Mode CLI")
+
+	if _, err := internal.TryGetCatalogPassword(ctx); err != nil {
+		if internal.IsKmsKeyUnavailableErr(err) {
+			slog.WarnContext(ctx, "catalog KMS key is unavailable; service is being deprovisioned, skipping maintenance",
+				slog.Any("error", err))
+			return nil
+		}
+		return fmt.Errorf("failed to verify catalog credentials before maintenance: %w", err)
+	}
+
 	clientOptions := client.Options{
 		HostPort:  args.TemporalHostPort,
 		Namespace: args.TemporalNamespace,

--- a/flow/internal/config.go
+++ b/flow/internal/config.go
@@ -69,6 +69,10 @@ func PeerDBCatalogPassword(ctx context.Context) string {
 	return val
 }
 
+func TryGetCatalogPassword(ctx context.Context) (string, error) {
+	return GetKmsDecryptedEnvString(ctx, "PEERDB_CATALOG_PASSWORD", "")
+}
+
 // PEERDB_CATALOG_DATABASE
 func PeerDBCatalogDatabase() string {
 	return GetEnvString("PEERDB_CATALOG_DATABASE", "")

--- a/flow/internal/env.go
+++ b/flow/internal/env.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -15,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"golang.org/x/exp/constraints"
 )
 
@@ -122,6 +124,33 @@ func decryptWithGcpKms(ctx context.Context, data []byte, keyID string) ([]byte, 
 	}
 
 	return resp.Plaintext, nil
+}
+
+func IsKmsKeyUnavailableErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// AWS: a key pending deletion or disabled surfaces as KMSInvalidStateException.
+	var awsInvalidState *kmstypes.KMSInvalidStateException
+	if errors.As(err, &awsInvalidState) {
+		return true
+	}
+
+	// Fall back to message inspection to stay robust across providers (GCP
+	// returns a FailedPrecondition gRPC error) and error wrapping.
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"destroy_scheduled", // GCP: cryptoKeyVersion is scheduled for destruction
+		"is not enabled",    // GCP: current state is DISABLED/DESTROY_SCHEDULED/DESTROYED
+		"pending deletion",  // AWS: key is pending deletion
+		"is disabled",       // AWS: key is disabled
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 var kmsCache sync.Map


### PR DESCRIPTION
## Problem
During deprovisioning, a maintenance hook Job left over (and retrying) from the provisioning sync can boot after the service's KMS key is `DESTROY_SCHEDULED`. Decrypting `PEERDB_CATALOG_PASSWORD` then panics in `PeerDBCatalogPassword`, and with `restartPolicy: OnFailure` + a high `backoffLimit` the Job crash-loops.

## Change
- `MaintenanceMain` now probes the catalog password up front via a non-panicking `TryGetCatalogPassword`.
- If the failure means the KMS key is gone (`IsKmsKeyUnavailableErr`: GCP `DESTROY_SCHEDULED`/disabled, AWS pending-deletion/disabled), it logs and exits 0 — the service is being torn down, there's no maintenance to run.
- Any other decrypt error is returned, so the Job still retries.

On success the decrypted value is cached, so the later catalog pool init reuses it. No behavior change for healthy keys or KMS-disabled/plaintext environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)