### PR TITLE
Tilt flow: e2e test run using gotestsum outside Tilt

### DIFF
--- a/.github/actions/ingest-test-results/action.yml
+++ b/.github/actions/ingest-test-results/action.yml
@@ -1,0 +1,74 @@
+name: 'Ingest test results'
+description: >-
+  Normalize JUnit test results and ingest them into the CI observability store
+  for analysis. No-op when the o11y target secrets are not configured. Must run
+  from the workspace root (uses .github/scripts/test-results.sh) and requires the
+  `retry` CLI on PATH.
+
+inputs:
+  combination-id:
+    description: >-
+      Identifier for the combination/compatibility this run covers (stored as
+      compatibility_matrix_id). e.g. "pg17-my8-mo7-ch24" or "tilt-TestApiPg".
+    required: true
+  test-results-file:
+    description: Path to the JUnit XML test results file (relative to the workspace root).
+    required: false
+    default: logs/test-results.xml
+  o11y-api-key-id:
+    description: API key id for the o11y ingestion endpoint. Ingestion is skipped when empty.
+    required: false
+    default: ''
+  o11y-api-key-secret:
+    description: API key secret for the o11y ingestion endpoint. Ingestion is skipped when empty.
+    required: false
+    default: ''
+  o11y-query-endpoint:
+    description: Query endpoint the normalized results are POSTed to. Ingestion is skipped when empty.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Ingest tests results for analysis
+      shell: bash
+      env:
+        WORKFLOW_RUN_ID: ${{ github.run_id }}
+        WORKFLOW_RUN_LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WORKFLOW_HEAD_BRANCH: ${{ github.head_ref || github.ref_name }}
+        WORKFLOW_RUN_NUMBER: ${{ github.run_attempt }}
+        COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        SUMMARY_HEADER: "x-clickhouse-summary"
+        COMBINATION_ID: ${{ inputs.combination-id }}
+        TEST_RESULTS_FILE: ${{ inputs.test-results-file }}
+        O11Y_API_KEY_ID: ${{ inputs.o11y-api-key-id }}
+        O11Y_API_KEY_SECRET: ${{ inputs.o11y-api-key-secret }}
+        O11Y_QUERY_ENDPOINT: ${{ inputs.o11y-query-endpoint }}
+      run: |
+        if [ -z "$O11Y_API_KEY_ID" ] \
+          || [ -z "$O11Y_API_KEY_SECRET" ] \
+          || [ -z "$O11Y_QUERY_ENDPOINT" ]; then
+            echo "Secrets not configured; Test results ingestion is disabled."
+            exit 0
+        fi
+        .github/scripts/test-results.sh "$TEST_RESULTS_FILE" > logs/normalized-test-results.ndjson
+        if [ ! -s logs/normalized-test-results.ndjson ]; then
+            echo "Failed to extract test results"
+            exit 1
+        fi
+        # Retry upload with exponential backoff
+        retry --times=5 --delay "1,2,4,8,16,32,64,128" -- \
+        curl --fail-with-body -i -H "Content-Type: application/octet-stream" \
+          --user "$O11Y_API_KEY_ID:$O11Y_API_KEY_SECRET" \
+          "$O11Y_QUERY_ENDPOINT" \
+          --data-binary @logs/normalized-test-results.ndjson \
+          | tee upload.log
+        WRITTEN_ROWS=$(cat upload.log | grep $SUMMARY_HEADER | sed "s/$SUMMARY_HEADER: //" | jq '.written_rows' -r)
+        if [ -z "$WRITTEN_ROWS" ] || [ "$WRITTEN_ROWS" -eq 0 ]; then
+            echo "No results uploaded. Query client logs:"
+            cat upload.log
+            exit 2
+        fi
+        echo "Number of ingested test results: $WRITTEN_ROWS"
+        exit 0

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -664,38 +664,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Ingest tests results for analysis
         if: success() || failure()
-        env:
-          WORKFLOW_RUN_ID: ${{ github.run_id }}
-          WORKFLOW_RUN_LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          WORKFLOW_HEAD_BRANCH: ${{ github.head_ref || github.ref_name }}
-          WORKFLOW_RUN_NUMBER: ${{ github.run_attempt }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          SUMMARY_HEADER: "x-clickhouse-summary"
-          COMBINATION_ID: "pg${{ matrix.db-version.pg }}-my${{ matrix.db-version.mysql }}-mo${{ matrix.db-version.mongo }}-ch${{ matrix.db-version.ch }}"
-        run: |
-          if [ -z "${{ secrets.CI_O11Y_TARGET_API_KEY_ID }}" ] \
-            || [ -z "${{ secrets.CI_O11Y_TARGET_API_KEY_SECRET }}" ] \
-            || [ -z "${{ secrets.CI_O11Y_TARGET_QUERY_ENDPOINT }}" ]; then
-              echo "Secrets not configured; Test results ingestion is disabled."
-              exit 0
-          fi
-          .github/scripts/test-results.sh logs/test-results.xml > logs/normalized-test-results.ndjson
-          if [ ! -s logs/normalized-test-results.ndjson ]; then
-              echo "Failed to extract test results"
-              exit 1
-          fi
-          # Retry upload with exponential backoff
-          retry --times=5 --delay "1,2,4,8,16,32,64,128" -- \
-          curl --fail-with-body -i -H "Content-Type: application/octet-stream" \
-            --user "${{ secrets.CI_O11Y_TARGET_API_KEY_ID }}:${{ secrets.CI_O11Y_TARGET_API_KEY_SECRET }}" \
-            "${{ secrets.CI_O11Y_TARGET_QUERY_ENDPOINT }}" \
-            --data-binary @logs/normalized-test-results.ndjson \
-            | tee upload.log
-          WRITTEN_ROWS=$(cat upload.log | grep $SUMMARY_HEADER | sed "s/$SUMMARY_HEADER: //" | jq '.written_rows' -r)
-          if [ -z "$WRITTEN_ROWS" ] || [ "$WRITTEN_ROWS" -eq 0 ]; then
-              echo "No results uploaded. Query client logs:"
-              cat upload.log
-              exit 2
-          fi
-          echo "Number of ingested test results: $WRITTEN_ROWS"
-          exit 0
+        uses: ./.github/actions/ingest-test-results
+        with:
+          combination-id: "pg${{ matrix.db-version.pg }}-my${{ matrix.db-version.mysql }}-mo${{ matrix.db-version.mongo }}-ch${{ matrix.db-version.ch }}"
+          o11y-api-key-id: ${{ secrets.CI_O11Y_TARGET_API_KEY_ID }}
+          o11y-api-key-secret: ${{ secrets.CI_O11Y_TARGET_API_KEY_SECRET }}
+          o11y-query-endpoint: ${{ secrets.CI_O11Y_TARGET_QUERY_ENDPOINT }}

--- a/.github/workflows/tilt-flow.yml
+++ b/.github/workflows/tilt-flow.yml
@@ -168,11 +168,15 @@ jobs:
             json="$(tilt --port "$TILT_PORT" get uiresource "$res" -o json 2>/dev/null)" || { echo pending; return; }
             upd="$(echo "$json" | jq -r '.status.updateStatus // "none"')"
             run="$(echo "$json" | jq -r '.status.runtimeStatus // "none"')"
-            # A failed build/update or a crashed runtime means this attempt failed.
+            # A failed build/update or a crashed runtime means this attempt
+            # failed -> the caller reloads the resource.
             if [ "$upd" = "error" ] || [ "$run" = "error" ]; then echo error; return; fi
-            # Ready: the update succeeded and the runtime is healthy (or absent,
-            # e.g. proto-gen which has no long-running process).
-            if [ "$upd" = "ok" ] && { [ "$run" = "ok" ] || [ "$run" = "not_applicable" ] || [ "$run" = "none" ]; }; then
+            # Ready: the update succeeded and the runtime is healthy (ok) or the
+            # resource genuinely has no long-running process (not_applicable, e.g.
+            # proto-gen). A missing/empty runtime status (jq's "none" fallback)
+            # means it hasn't come up yet, so fall through to "pending" and keep
+            # probing rather than declaring it ready prematurely.
+            if [ "$upd" = "ok" ] && { [ "$run" = "ok" ] || [ "$run" = "not_applicable" ]; }; then
               echo ready; return
             fi
             echo pending

--- a/.github/workflows/tilt-flow.yml
+++ b/.github/workflows/tilt-flow.yml
@@ -9,12 +9,24 @@ run-name: 'tilt-flow: ${{ inputs.test_matcher }} [services: ${{ inputs.ancillary
 # Coverage and results are saved as a build artifact, and the test results are
 # ingested into the CI observability store (shared with flow.yml).
 #
-# This is a manually dispatched workflow: pick the Go test matcher to run and the
+# This workflow can be triggered manually (workflow_dispatch) or reused by another
+# workflow (workflow_call, e.g. flow.yml): pick the Go test matcher to run and the
 # ancillary services it needs.
+#
+# How a caller would invoke it (a reusable workflow runs as its own job, so it is
+# referenced at jobs.<id>.uses, not as a step):
+#
+#   jobs:
+#     pg-ch-e2e:
+#       uses: ./.github/workflows/tilt-flow.yml
+#       with:
+#         test_matcher: TestGenericCH_PG
+#         ancillary_services: postgres clickhouse
+#       secrets: inherit   # or pass CI_O11Y_TARGET_* explicitly; omit to skip ingestion
 
 on:
   workflow_dispatch:
-    inputs:
+    inputs: &tilt_flow_inputs
       test_matcher:
         description: >-
           Go test matcher passed to `go test -run` (a regex). The tests run on the
@@ -22,7 +34,7 @@ on:
           selects what runs. Examples: "TestGenericCH_PG", "TestMongoClickhouseSuite",
           "^TestPeerFlowE2ETestSuitePG_CH$", "TestApiPg". Leave empty to run everything.
         type: string
-        required: true
+        required: false
         default: TestGenericCH_PG
       ancillary_services:
         description: >-
@@ -31,14 +43,26 @@ on:
           "mysql-gtid clickhouse", "mongodb clickhouse"); connector tests need just
           their DB. Append "toxiproxy openssh" for SSH/chaos tests.
         type: string
-        required: true
+        required: false
         default: postgres clickhouse
+  # Reuse the exact same inputs when invoked from another workflow. The o11y
+  # secrets are optional: a caller can pass them explicitly or via
+  # `secrets: inherit`; when absent, test-results ingestion is skipped.
+  workflow_call:
+    inputs: *tilt_flow_inputs
+    secrets:
+      CI_O11Y_TARGET_API_KEY_ID:
+        required: false
+      CI_O11Y_TARGET_API_KEY_SECRET:
+        required: false
+      CI_O11Y_TARGET_QUERY_ENDPOINT:
+        required: false
 
 permissions:
   contents: read
 
 concurrency:
-  group: tilt-flow-${{ github.ref }}-${{ github.event.inputs.test_matcher }}
+  group: tilt-flow-${{ github.ref }}-${{ inputs.test_matcher }}
   cancel-in-progress: true
 
 env:
@@ -239,7 +263,7 @@ jobs:
       # ----------------------------------------------------------------------
       - name: Start requested ancillary services
         env:
-          ANCILLARY_SERVICES: ${{ github.event.inputs.ancillary_services }}
+          ANCILLARY_SERVICES: ${{ inputs.ancillary_services }}
         run: |
           set -euo pipefail
           if [ -z "${ANCILLARY_SERVICES// /}" ]; then
@@ -290,7 +314,7 @@ jobs:
       - name: Run tests
         working-directory: ./flow
         env:
-          TEST_MATCHER: ${{ github.event.inputs.test_matcher }}
+          TEST_MATCHER: ${{ inputs.test_matcher }}
         run: |
           # Disable errexit so we can capture gotestsum's exit code and still emit
           # coverage for the artifact upload; keep nounset.
@@ -371,7 +395,7 @@ jobs:
         if: success() || failure()
         uses: ./.github/actions/ingest-test-results
         with:
-          combination-id: "tilt-${{ github.event.inputs.test_matcher }}"
+          combination-id: "tilt-${{ inputs.test_matcher }}"
           o11y-api-key-id: ${{ secrets.CI_O11Y_TARGET_API_KEY_ID }}
           o11y-api-key-secret: ${{ secrets.CI_O11Y_TARGET_API_KEY_SECRET }}
           o11y-query-endpoint: ${{ secrets.CI_O11Y_TARGET_QUERY_ENDPOINT }}

--- a/.github/workflows/tilt-flow.yml
+++ b/.github/workflows/tilt-flow.yml
@@ -5,8 +5,9 @@ run-name: 'tilt-flow: ${{ inputs.test_matcher }} [services: ${{ inputs.ancillary
 # runner, it brings the whole stack up through Tilt (repo_root/Tiltfile). Tilt
 # drives docker-compose-dev.yml (core PeerDB services) and
 # ancillary-docker-compose.yml (test databases + infra). The tests themselves run
-# on the host via gotestsum (selected by a Go test matcher) against that stack,
-# and coverage + results are uploaded to Codecov, mirroring flow.yml.
+# on the host via gotestsum (selected by a Go test matcher) against that stack.
+# Coverage and results are saved as a build artifact, and the test results are
+# ingested into the CI observability store (shared with flow.yml).
 #
 # This is a manually dispatched workflow: pick the Go test matcher to run and the
 # ancillary services it needs.
@@ -90,7 +91,9 @@ jobs:
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list
           sudo apt-get update
-          sudo apt-get install -y libgeos-dev
+          # libgeos-dev: geometry support; retry: used by the test-results
+          # ingestion composite action's upload backoff.
+          sudo apt-get install -y libgeos-dev retry
           # pg_dump must be >= the server major version; install v18 so it
           # can dump PG 16, 17, and 18 (backward compatible).
           sudo apt-get install -y postgresql-client-18
@@ -290,7 +293,7 @@ jobs:
           TEST_MATCHER: ${{ github.event.inputs.test_matcher }}
         run: |
           # Disable errexit so we can capture gotestsum's exit code and still emit
-          # coverage for the Codecov upload; keep nounset.
+          # coverage for the artifact upload; keep nounset.
           set +e -u
 
           # Write coverage OUTSIDE the flow/ tree. `tilt up` keeps live-watching
@@ -313,7 +316,7 @@ jobs:
             -args -test.gocoverdir="$coverdir"
           rc=$?
 
-          # Emit coverage even on test failure so the Codecov step always has data.
+          # Emit coverage even on test failure so the uploaded artifact always has data.
           go tool covdata textfmt -i="$coverdir" -o ../coverage.out || true
           exit "$rc"
 
@@ -364,16 +367,11 @@ jobs:
             coverage.out
           retention-days: 30
 
-      - name: Upload test results to Codecov
+      - name: Ingest tests results for analysis
         if: success() || failure()
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        uses: ./.github/actions/ingest-test-results
         with:
-          report_type: test_results
-          files: logs/test-results.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload coverage reports to Codecov
-        if: success() || failure()
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          combination-id: "tilt-${{ github.event.inputs.test_matcher }}"
+          o11y-api-key-id: ${{ secrets.CI_O11Y_TARGET_API_KEY_ID }}
+          o11y-api-key-secret: ${{ secrets.CI_O11Y_TARGET_API_KEY_SECRET }}
+          o11y-query-endpoint: ${{ secrets.CI_O11Y_TARGET_QUERY_ENDPOINT }}

--- a/.github/workflows/tilt-flow.yml
+++ b/.github/workflows/tilt-flow.yml
@@ -309,6 +309,12 @@ jobs:
           go tool covdata textfmt -i=coverage -o ../coverage.out || true
           exit "$rc"
 
+      - name: Report Tilt environment status on test failure
+        if: failure()
+        run: |
+          echo "Tilt environment status:"
+          tilt --port=10352 get uiresource -o json
+
       - name: Upload logs and test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/tilt-flow.yml
+++ b/.github/workflows/tilt-flow.yml
@@ -317,11 +317,37 @@ jobs:
           go tool covdata textfmt -i="$coverdir" -o ../coverage.out || true
           exit "$rc"
 
-      - name: Report Tilt environment status on test failure
+      - name: Capture Tilt state and service logs on failure
         if: failure()
         run: |
-          echo "Tilt environment status:"
-          tilt --port=10352 get uiresource -o json
+          set +e -u
+          mkdir -p logs
+
+          # Full resource state -> step log + artifact (queryable with jq).
+          echo "===== Tilt resource state ====="
+          tilt --port "$TILT_PORT" get uiresource -o json | tee logs/tilt-resources.json
+
+          # Highlight non-test resources that weren't healthy at failure time.
+          echo "===== Non-test resources not in updateStatus=ok ====="
+          jq '.items[]
+                | select((.metadata.name | startswith("e2e_")) or (.metadata.name | startswith("connector_")) | not)
+                | select(.status.updateStatus != "ok" and .status.updateStatus != "none")
+                | {name: .metadata.name, updateStatus: .status.updateStatus, runtimeStatus: .status.runtimeStatus}' \
+             logs/tilt-resources.json 2>/dev/null || true
+
+          # Capture per-service logs for the snapshot path (snapshot-worker writes
+          # to MinIO/S3, ClickHouse loads from it) so server-side failures like a
+          # stuck initial snapshot are visible in the uploaded artifact. The Tilt
+          # test launchers run go test on the host, so the worker logs are the only
+          # window into why a mirror hangs in STATUS_SNAPSHOT.
+          for svc in flow-snapshot-worker flow-worker flow-api peerdb catalog minio \
+                     clickhouse postgres postgres2 mongodb mysql-gtid mysql-pos mariadb \
+                     provision-clickhouse provision-postgres setup-clickhouse-peer setup-postgres-peer; do
+            if tilt --port "$TILT_PORT" get uiresource "$svc" >/dev/null 2>&1; then
+              echo "Capturing logs for $svc -> logs/tilt-$svc.log"
+              tilt --port "$TILT_PORT" logs "$svc" > "logs/tilt-$svc.log" 2>&1 || true
+            fi
+          done
 
       - name: Upload logs and test results
         if: always()

--- a/.github/workflows/tilt-flow.yml
+++ b/.github/workflows/tilt-flow.yml
@@ -292,7 +292,15 @@ jobs:
           # Disable errexit so we can capture gotestsum's exit code and still emit
           # coverage for the Codecov upload; keep nounset.
           set +e -u
-          mkdir -p coverage ../logs
+
+          # Write coverage OUTSIDE the flow/ tree. `tilt up` keeps live-watching
+          # flow/ for the whole job (the flow images use docker_build only=['flow/']),
+          # so writing coverage into flow/coverage during the run would trigger Tilt
+          # to rebuild flow-worker/flow-api/flow-snapshot-worker mid-test, knocking
+          # them back to in_progress. $RUNNER_TEMP is outside the repo, so it's never
+          # watched.
+          coverdir="$RUNNER_TEMP/gocoverdir"
+          mkdir -p "$coverdir" ../logs
 
           # Only scope by -run when a matcher was provided (empty => run everything).
           run_args=()
@@ -302,11 +310,11 @@ jobs:
 
           gotestsum --format standard-quiet --no-color --junitfile ../logs/test-results.xml -- \
             -cover -coverpkg github.com/PeerDB-io/peerdb/flow/... -p 32 ./... "${run_args[@]}" -timeout 1200s \
-            -args -test.gocoverdir="$PWD/coverage"
+            -args -test.gocoverdir="$coverdir"
           rc=$?
 
           # Emit coverage even on test failure so the Codecov step always has data.
-          go tool covdata textfmt -i=coverage -o ../coverage.out || true
+          go tool covdata textfmt -i="$coverdir" -o ../coverage.out || true
           exit "$rc"
 
       - name: Report Tilt environment status on test failure

--- a/.github/workflows/tilt-flow.yml
+++ b/.github/workflows/tilt-flow.yml
@@ -335,18 +335,23 @@ jobs:
                 | {name: .metadata.name, updateStatus: .status.updateStatus, runtimeStatus: .status.runtimeStatus}' \
              logs/tilt-resources.json 2>/dev/null || true
 
-          # Capture per-service logs for the snapshot path (snapshot-worker writes
-          # to MinIO/S3, ClickHouse loads from it) so server-side failures like a
-          # stuck initial snapshot are visible in the uploaded artifact. The Tilt
-          # test launchers run go test on the host, so the worker logs are the only
-          # window into why a mirror hangs in STATUS_SNAPSHOT.
-          for svc in flow-snapshot-worker flow-worker flow-api peerdb catalog minio \
-                     clickhouse postgres postgres2 mongodb mysql-gtid mysql-pos mariadb \
-                     provision-clickhouse provision-postgres setup-clickhouse-peer setup-postgres-peer; do
-            if tilt --port "$TILT_PORT" get uiresource "$svc" >/dev/null 2>&1; then
-              echo "Capturing logs for $svc -> logs/tilt-$svc.log"
-              tilt --port "$TILT_PORT" logs "$svc" > "logs/tilt-$svc.log" 2>&1 || true
-            fi
+          # Capture container logs for the snapshot path (snapshot-worker writes to
+          # MinIO/S3, ClickHouse loads from it) so server-side failures like a stuck
+          # initial snapshot are visible in the artifact. The mirror runs in the
+          # flow-worker/flow-snapshot-worker containers, so these are the only window
+          # into why it hangs in STATUS_SNAPSHOT.
+          #
+          # NOTE: `tilt logs` is unavailable here — in this headless `tilt up --stream`
+          # run Tilt serves the apiserver (so `tilt get/enable/trigger/wait` work) but
+          # not the web-UI websocket `tilt logs` needs ("websocket: bad handshake").
+          # Tilt drives docker-compose, so read the logs straight from Docker instead.
+          echo "===== Containers ====="
+          docker ps -a --format '{{.Names}}\t{{.Status}}' | tee logs/docker-ps.txt
+          echo "===== Capturing docker container logs ====="
+          docker ps -a --format '{{.Names}}' | while read -r c; do
+            [ -n "$c" ] || continue
+            echo "  $c -> logs/docker-$c.log"
+            docker logs --timestamps "$c" > "logs/docker-$c.log" 2>&1 || true
           done
 
       - name: Upload logs and test results

--- a/.github/workflows/tilt-flow.yml
+++ b/.github/workflows/tilt-flow.yml
@@ -1,26 +1,28 @@
 name: tilt-flow
+run-name: 'tilt-flow: ${{ inputs.test_matcher }} [services: ${{ inputs.ancillary_services }}]'
 
 # Like flow.yml, but instead of provisioning every service from scratch on the
 # runner, it brings the whole stack up through Tilt (repo_root/Tiltfile). Tilt
 # drives docker-compose-dev.yml (core PeerDB services) and
-# ancillary-docker-compose.yml (test databases + infra), and exposes the
-# e2e_*/connector_* test launchers as Tilt resources we can trigger on demand.
+# ancillary-docker-compose.yml (test databases + infra). The tests themselves run
+# on the host via gotestsum (selected by a Go test matcher) against that stack,
+# and coverage + results are uploaded to Codecov, mirroring flow.yml.
 #
-# This is a manually dispatched workflow: pick a single test resource to run and
-# the ancillary services it needs.
+# This is a manually dispatched workflow: pick the Go test matcher to run and the
+# ancillary services it needs.
 
 on:
   workflow_dispatch:
     inputs:
-      test_resources:
+      test_matcher:
         description: >-
-          Space-separated list of test resources to run (Tilt e2e_* or connector_*
-          resources). They run in parallel (the launchers are allow_parallel).
-          Examples: "e2e_postgres", "e2e_postgres connector_postgres",
-          "e2e_mysql-gtid e2e_mysql-pos e2e_mariadb".
+          Go test matcher passed to `go test -run` (a regex). The tests run on the
+          host against the Tilt-provided stack, over ./... so the matcher alone
+          selects what runs. Examples: "TestGenericCH_PG", "TestMongoClickhouseSuite",
+          "^TestPeerFlowE2ETestSuitePG_CH$", "TestApiPg". Leave empty to run everything.
         type: string
         required: true
-        default: e2e_postgres
+        default: TestGenericCH_PG
       ancillary_services:
         description: >-
           Space-separated ancillary Tilt resources to start before the test.
@@ -35,7 +37,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: tilt-flow-${{ github.ref }}-${{ github.event.inputs.test_resources }}
+  group: tilt-flow-${{ github.ref }}-${{ github.event.inputs.test_matcher }}
   cancel-in-progress: true
 
 env:
@@ -268,83 +270,61 @@ jobs:
           done
           echo "All requested ancillary services are up and running."
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       # ----------------------------------------------------------------------
-      # Last step: invoke the requested test resource(s) and report their result.
-      # The launchers are allow_parallel, so all are triggered up front and then
-      # polled to completion concurrently.
+      # Run the tests on the host against the Tilt-provided stack, selected by
+      # the Go test matcher. Unlike flow.yml we do NOT start temporal/peer-flow
+      # here — those run as containers managed by Tilt — but the gotestsum +
+      # coverage invocation otherwise mirrors flow.yml's "run tests" step. The
+      # tests auto-load connection settings from the project-root .env.
       # ----------------------------------------------------------------------
-      - name: Run requested test resources
+      - name: Run tests
+        working-directory: ./flow
         env:
-          TEST_RESOURCES: ${{ github.event.inputs.test_resources }}
+          TEST_MATCHER: ${{ github.event.inputs.test_matcher }}
         run: |
-          set -uo pipefail
-          if [ -z "${TEST_RESOURCES// /}" ]; then
-            echo "::error::No test resources specified."
-            exit 1
+          # Disable errexit so we can capture gotestsum's exit code and still emit
+          # coverage for the Codecov upload; keep nounset.
+          set +e -u
+          mkdir -p coverage ../logs
+
+          # Only scope by -run when a matcher was provided (empty => run everything).
+          run_args=()
+          if [ -n "${TEST_MATCHER// /}" ]; then
+            run_args=(-run "$TEST_MATCHER")
           fi
 
-          echo "Enabling and triggering test resources: $TEST_RESOURCES"
-          # enable accepts multiple resources...
-          tilt --port "$TILT_PORT" enable $TEST_RESOURCES
-          # ...but each must be triggered individually to start.
-          for t in $TEST_RESOURCES; do
-            echo "Triggering $t"
-            tilt --port "$TILT_PORT" trigger "$t"
-          done
+          gotestsum --format standard-quiet --no-color --junitfile ../logs/test-results.xml -- \
+            -cover -coverpkg github.com/PeerDB-io/peerdb/flow/... -p 32 ./... "${run_args[@]}" -timeout 1200s \
+            -args -test.gocoverdir="$PWD/coverage"
+          rc=$?
 
-          # Each launcher is a one-shot local_resource: poll its update status
-          # until it succeeds (ok) or fails (error). Anything else means it is
-          # still queued/running. Track each resource's outcome; report a per-test
-          # log dump as soon as it finishes, then a summary at the end.
-          TIMEOUT=1800
-          pending="$TEST_RESOURCES"
-          failed=""
-          deadline=$((SECONDS + TIMEOUT))
-          while [ -n "${pending// /}" ] && [ "$SECONDS" -lt "$deadline" ]; do
-            still_pending=""
-            for t in $pending; do
-              update_status="$(tilt --port "$TILT_PORT" get uiresource "$t" -o json 2>/dev/null | jq -r '.status.updateStatus // "unknown"')"
-              case "$update_status" in
-                ok)
-                  echo "Test '$t' succeeded."
-                  echo "----- logs for '$t' -----"
-                  tilt --port "$TILT_PORT" logs "$t" || true
-                  ;;
-                error)
-                  echo "::error::Test '$t' failed."
-                  echo "----- logs for '$t' -----"
-                  tilt --port "$TILT_PORT" logs "$t" || true
-                  failed="$failed $t"
-                  ;;
-                *)
-                  still_pending="$still_pending $t"
-                  ;;
-              esac
-            done
-            pending="$still_pending"
-            [ -n "${pending// /}" ] && sleep 5
-          done
+          # Emit coverage even on test failure so the Codecov step always has data.
+          go tool covdata textfmt -i=coverage -o ../coverage.out || true
+          exit "$rc"
 
-          # Anything still pending hit the overall timeout.
-          if [ -n "${pending// /}" ]; then
-            for t in $pending; do
-              echo "::error::Test '$t' did not finish within ${TIMEOUT}s."
-              echo "----- logs for '$t' (timed out) -----"
-              tilt --port "$TILT_PORT" logs "$t" || true
-              failed="$failed $t"
-            done
-          fi
+      - name: Upload logs and test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tilt-flow-logs
+          path: |
+            logs/
+            coverage.out
+          retention-days: 30
 
-          echo "===== Summary ====="
-          for t in $TEST_RESOURCES; do
-            case " $failed " in
-              *" $t "*) echo "  $t: FAILED" ;;
-              *) echo "  $t: PASSED" ;;
-            esac
-          done
+      - name: Upload test results to Codecov
+        if: success() || failure()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        with:
+          report_type: test_results
+          files: logs/test-results.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
-          if [ -n "${failed// /}" ]; then
-            echo "::error::One or more test resources failed:$failed"
-            exit 1
-          fi
-          echo "All requested test resources passed."
+      - name: Upload coverage reports to Codecov
+        if: success() || failure()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -170,6 +170,8 @@ services:
       - *flow-snapshot-worker-debug-port
     environment:
       <<: [*catalog-config, *flow-worker-env, *minio-config]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       temporal-admin-tools:
         condition: service_healthy


### PR DESCRIPTION
Follows https://github.com/PeerDB-io/peerdb/pull/4474,

With these changes, Tilt environment on CI is fully functional. We also move to use e2e invocation directly with `gotestsum`. 

Additionally, internal test results ingestion is moved to an action and shared between traditional flow.yml based and Tilt based CI. 

Finally, this workflow is set-up so it can be invoked from other workflows as follow:

```yaml
jobs:
  pg-ch-e2e:
    uses: ./.github/workflows/tilt-flow.yml
    with:
      test_matcher: TestGenericCH_PG
      ancillary_services: postgres clickhouse
    secrets: inherit
```