### PR TITLE
fix(pg): filter by flow name in IsQRepPartitionSynced

### DIFF
--- a/flow/connectors/postgres/qrep_destination.go
+++ b/flow/connectors/postgres/qrep_destination.go
@@ -273,13 +273,13 @@ func (c *PostgresConnector) IsQRepPartitionSynced(ctx context.Context,
 	// setup the query string
 	metadataTableIdentifier := pgx.Identifier{c.metadataSchema, qRepMetadataTableName}
 	queryString := fmt.Sprintf(
-		"SELECT EXISTS(SELECT * FROM %s WHERE partitionID=$1)",
+		"SELECT EXISTS(SELECT * FROM %s WHERE flowJobName=$1 AND partitionID=$2)",
 		metadataTableIdentifier.Sanitize(),
 	)
 
 	// prepare and execute the query
 	var result bool
-	if err := c.conn.QueryRow(ctx, queryString, req.PartitionId).Scan(&result); err != nil {
+	if err := c.conn.QueryRow(ctx, queryString, req.FlowJobName, req.PartitionId).Scan(&result); err != nil {
 		return false, fmt.Errorf("failed to execute query: %w", err)
 	}
 


### PR DESCRIPTION
The Postgres-destination `IsQRepPartitionSynced` check matches the already-synced metadata row by `partitionID` alone, ignoring `flowJobName`. Since MySQL/Mongo initial loads give every table the same constant partition ID ("full-table-partition-id"), once the first table syncs, all other tables in the mirror are wrongly skipped as "already synced" and land empty.

This PR adds a filter for flow name in `IsQRepPartitionSynced`