### PR TITLE
Tilt environment: Fix ClickHouse docker image selection

### DIFF
--- a/generate-test-environment.sh
+++ b/generate-test-environment.sh
@@ -26,7 +26,7 @@ if [ -z "$MONGODB_VERSION" ]; then
 fi;
 
 if [ -z "$CLICKHOUSE_VERSION" ]; then
-    CLICKHOUSE_VERSION=$(echo "$VERSIONS" | yq -r '.ch')
+    CLICKHOUSE_VERSION="latest"
 fi;
 
 if [ -z "$POSTGRES_VERSION" ] || [ -z "$MYSQL_VERSION" ] || [ -z "$MONGODB_VERSION" ] || [ -z "$CLICKHOUSE_VERSION" ]; then


### PR DESCRIPTION
After https://github.com/PeerDB-io/peerdb/pull/4478, the last row in flow CI definition for the version matrix was not `latest` anymore but `stable`.

This row is used by the Tilt environment to select the default target version for ClickHouse.  `stable` is not a valid tag hence Tilt environments broke