### PR TITLE
fix(clickhouse): drop orphaned shard table after mirror resync exchange

### DIFF
--- a/flow/connectors/clickhouse/cdc.go
+++ b/flow/connectors/clickhouse/cdc.go
@@ -331,6 +331,18 @@ func (c *ClickHouseConnector) RenameTables(
 		}
 
 		if originalTableExists {
+			// Before swapping, resolve the shard table that the original Distributed table currently points to.
+			// After the EXCHANGE the Distributed table is dropped, leaving that shard orphaned unless we drop it explicitly.
+			var originalShardTable string
+			if c.Config.Cluster != "" {
+				originalShardTable, err = c.getDistributedShardTable(ctx, renameRequest.NewName)
+				if err != nil {
+					c.logger.Warn("could not resolve shard table for original distributed table, old shard may be left behind",
+						slog.String("table", renameRequest.NewName), slog.Any("error", err))
+					originalShardTable = ""
+				}
+			}
+
 			// target table exists, so we can attempt to swap. In most cases, we will have Atomic engine,
 			// which supports a special query to exchange two tables, allowing dependent (materialized) views and dictionaries on these tables
 			c.logger.Info("attempting atomic exchange",
@@ -343,6 +355,15 @@ func (c *ClickHouseConnector) RenameTables(
 					fmt.Sprintf(dropTableSQLWithCHSetting, peerdb_clickhouse.QuoteIdentifier(renameRequest.CurrentName), onCluster),
 				); err != nil {
 					return nil, fmt.Errorf("unable to drop exchanged table %s: %w", renameRequest.CurrentName, err)
+				}
+				// Drop the original shard table that is now orphaned after the Distributed table was exchanged and dropped.
+				if originalShardTable != "" {
+					if err := c.execWithLogging(ctx,
+						fmt.Sprintf(dropTableSQLWithCHSetting, peerdb_clickhouse.QuoteIdentifier(originalShardTable), onCluster),
+					); err != nil {
+						return nil, fmt.Errorf("unable to drop orphaned shard table %s: %w", originalShardTable, err)
+					}
+					c.logger.Info("dropped orphaned shard table after resync exchange", slog.String("shardTable", originalShardTable))
 				}
 			} else if ex, ok := err.(*clickhouse.Exception); !ok || chproto.Error(ex.Code) != chproto.ErrNotImplemented {
 				// move on to the fallback code if unimplemented, in all other error codes / types return,

--- a/flow/connectors/mongo/qrep.go
+++ b/flow/connectors/mongo/qrep.go
@@ -73,7 +73,7 @@ func (c *MongoConnector) GetQRepPartitions(
 		return fullTablePartition, nil
 	}
 
-	return c.minMaxPartitions(ctx, collection, adjustedPartitions.AdjustedNumPartitions)
+	return c.buildPartitions(ctx, collection, adjustedPartitions.AdjustedNumPartitions)
 }
 
 func (c *MongoConnector) GetDefaultPartitionKeyForTables(
@@ -232,6 +232,26 @@ func toRangeFilter(watermarkColumn string, partitionRange *protos.PartitionRange
 			bson.E{Key: watermarkColumn, Value: bson.D{
 				bson.E{Key: "$gte", Value: startObjectID},
 				bson.E{Key: "$lte", Value: endObjectID},
+			}},
+		}, nil
+	case *protos.PartitionRange_IntRange:
+		// Numeric _id: inclusive range. PartitionHelper builds non-overlapping
+		// [start, end] integer ranges. Mongo compares int32/int64 numerically, so
+		// int64 bounds match int32-typed _ids.
+		return bson.D{
+			bson.E{Key: watermarkColumn, Value: bson.D{
+				bson.E{Key: "$gte", Value: r.IntRange.Start},
+				bson.E{Key: "$lte", Value: r.IntRange.End},
+			}},
+		}, nil
+	case *protos.PartitionRange_StringRange:
+		// String _id: half-open [start, end) range. computeStringBoundaries makes
+		// ranges contiguous and sets the final end just past the real max, so $lt
+		// gives exact coverage with no gaps or overlap.
+		return bson.D{
+			bson.E{Key: watermarkColumn, Value: bson.D{
+				bson.E{Key: "$gte", Value: r.StringRange.Start},
+				bson.E{Key: "$lt", Value: r.StringRange.End},
 			}},
 		}, nil
 	default:

--- a/flow/connectors/mongo/qrep_partition.go
+++ b/flow/connectors/mongo/qrep_partition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"slices"
 
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -16,37 +17,95 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
-// minMaxPartitions creates partitions by querying only the min and max _id
-// from the collection (leveraging the default _id index), then uniformly
-// dividing the ObjectID range using integer arithmetic on the full 12-byte
-// value. Since the first 4-byte timestamp is the most significant component,
-// this naturally partitions by time while also provides best-effort handling
-// of edge cases where records are all inserted in the same second.
-func (c *MongoConnector) minMaxPartitions(
-	ctx context.Context,
-	collection *mongo.Collection,
-	numPartitions int64,
-) ([]*protos.QRepPartition, error) {
-	fullTablePartition := []*protos.QRepPartition{{
+// stringPartitionUpperSentinel is appended to the collection's max string _id to
+// form the exclusive upper bound of the final string partition. It is the highest
+// valid Unicode code point, so `max + sentinel` sorts strictly after `max` (and
+// after every real _id, since `max` is the maximum). This lets every string
+// partition use uniform half-open [start, end) ($gte/$lt) semantics while still
+// capturing the maximum document in the last partition.
+const stringPartitionUpperSentinel = "\U0010FFFF"
+
+const (
+	// stringSampleOversample draws more samples than partitions so quantile
+	// boundaries are well distributed even with clustered keys.
+	stringSampleOversample = 20
+	// stringSampleMaxSize caps sampling cost on very large collections.
+	stringSampleMaxSize = 100000
+)
+
+// fullTablePartitions returns the single-partition full-table fallback used when a
+// collection cannot be partitioned (unsupported/mixed _id type, empty collection,
+// or degenerate min/max range).
+func fullTablePartitions() []*protos.QRepPartition {
+	return []*protos.QRepPartition{{
 		PartitionId:        utils.FullTablePartitionID,
 		Range:              nil,
 		FullTablePartition: true,
 	}}
+}
 
-	minID, maxID, found, err := findMinMaxObjectIDs(ctx, collection, c.config.ReadPreference)
+// buildPartitions reads the collection's min and max _id (cheap, leverages the
+// default _id index) and dispatches to a type-specific partitioner:
+//   - ObjectID  -> uniform division of the 12-byte ObjectID keyspace
+//   - Int32/64  -> uniform division of the numeric range (reuses PartitionHelper)
+//   - String    -> sampling-based quantile boundaries
+//
+// Mixed-type _id (min and max differ in type), Double, or any other type fall back
+// to a full-table partition. The change stream resume token is captured before this
+// runs, so any writes during partitioning are replayed by CDC.
+func (c *MongoConnector) buildPartitions(
+	ctx context.Context,
+	collection *mongo.Collection,
+	numPartitions int64,
+) ([]*protos.QRepPartition, error) {
+	minRaw, err := findBoundaryID(ctx, collection, Lower, c.config.ReadPreference)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to find min _id: %w", err)
 	}
-	if !found {
-		c.logger.Info("[mongo] no valid min/max ObjectIDs found, falling back to full table partition")
-		return fullTablePartition, nil
+	if minRaw.IsZero() {
+		c.logger.Info("[mongo] no documents found, falling back to full table partition")
+		return fullTablePartitions(), nil
 	}
+	maxRaw, err := findBoundaryID(ctx, collection, Upper, c.config.ReadPreference)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find max _id: %w", err)
+	}
+	if maxRaw.IsZero() {
+		c.logger.Info("[mongo] no documents found, falling back to full table partition")
+		return fullTablePartitions(), nil
+	}
+
+	switch {
+	case minRaw.Type == bson.TypeObjectID && maxRaw.Type == bson.TypeObjectID:
+		return c.objectIDPartitions(minRaw.ObjectID(), maxRaw.ObjectID(), numPartitions)
+	case isNumericIDType(minRaw.Type) && isNumericIDType(maxRaw.Type):
+		minVal, _ := rawValueToInt64(minRaw)
+		maxVal, _ := rawValueToInt64(maxRaw)
+		return c.numericPartitions(minVal, maxVal, numPartitions)
+	case minRaw.Type == bson.TypeString && maxRaw.Type == bson.TypeString:
+		return c.stringPartitions(ctx, collection, minRaw.StringValue(), maxRaw.StringValue(), numPartitions)
+	default:
+		c.logger.Info("[mongo] _id type not supported for partitioning (or mixed types), falling back to full table partition",
+			slog.String("minType", minRaw.Type.String()),
+			slog.String("maxType", maxRaw.Type.String()))
+		return fullTablePartitions(), nil
+	}
+}
+
+// objectIDPartitions divides the ObjectID keyspace uniformly using integer
+// arithmetic on the full 12-byte value. Since the leading 4-byte timestamp is the
+// most significant component, this naturally partitions by insertion time.
+func (c *MongoConnector) objectIDPartitions(
+	minID bson.ObjectID,
+	maxID bson.ObjectID,
+	numPartitions int64,
+) ([]*protos.QRepPartition, error) {
 	minInt := new(big.Int).SetBytes(minID[:])
 	maxInt := new(big.Int).SetBytes(maxID[:])
 	intRange := new(big.Int).Sub(maxInt, minInt)
 	if intRange.Sign() <= 0 {
 		c.logger.Info("[mongo] min/max ObjectID range is non-positive, falling back to full table partition")
-		return fullTablePartition, nil
+		return fullTablePartitions(), nil
 	}
 
 	c.logger.Info("[mongo] using min/max ObjectID partitioning",
@@ -88,6 +147,182 @@ func (c *MongoConnector) minMaxPartitions(
 	return partitions, nil
 }
 
+// numericPartitions divides a numeric (int32/int64) _id range uniformly, reusing
+// the shared PartitionHelper which builds non-overlapping IntPartitionRange
+// partitions with tested +1 boundary semantics covering [min, max] inclusive.
+func (c *MongoConnector) numericPartitions(
+	minVal int64,
+	maxVal int64,
+	numPartitions int64,
+) ([]*protos.QRepPartition, error) {
+	if maxVal <= minVal {
+		c.logger.Info("[mongo] numeric min/max range is non-positive, falling back to full table partition")
+		return fullTablePartitions(), nil
+	}
+
+	c.logger.Info("[mongo] using numeric _id partitioning",
+		slog.Int64("minID", minVal),
+		slog.Int64("maxID", maxVal),
+		slog.Int64("numPartitions", numPartitions))
+
+	helper := utils.NewPartitionHelper(c.logger)
+	if err := helper.AddPartitionsWithRange(minVal, maxVal, numPartitions); err != nil {
+		return nil, fmt.Errorf("failed to build numeric partitions: %w", err)
+	}
+	return helper.GetPartitions(), nil
+}
+
+// stringPartitions builds partitions for a string _id collection. Because string
+// keys (e.g. package names) are not uniformly distributed, uniform division of the
+// keyspace would be badly skewed; instead we sample the collection and pick quantile
+// boundaries so each partition holds a roughly equal share of documents.
+func (c *MongoConnector) stringPartitions(
+	ctx context.Context,
+	collection *mongo.Collection,
+	minVal string,
+	maxVal string,
+	numPartitions int64,
+) ([]*protos.QRepPartition, error) {
+	if minVal >= maxVal {
+		c.logger.Info("[mongo] string min/max range is non-positive, falling back to full table partition")
+		return fullTablePartitions(), nil
+	}
+
+	samples, err := c.sampleStringIDs(ctx, collection, numPartitions)
+	if err != nil {
+		return nil, err
+	}
+
+	ranges := computeStringBoundaries(minVal, maxVal, samples, numPartitions)
+	if len(ranges) < 2 {
+		c.logger.Info("[mongo] insufficient string boundaries from sampling, falling back to full table partition",
+			slog.Int("sampleCount", len(samples)))
+		return fullTablePartitions(), nil
+	}
+
+	c.logger.Info("[mongo] using sampled string _id partitioning",
+		slog.String("minID", minVal),
+		slog.String("maxID", maxVal),
+		slog.Int("numPartitions", len(ranges)),
+		slog.Int("sampleCount", len(samples)))
+
+	partitions := make([]*protos.QRepPartition, 0, len(ranges))
+	for _, rng := range ranges {
+		partitions = append(partitions, &protos.QRepPartition{
+			PartitionId: uuid.NewString(),
+			Range: &protos.PartitionRange{
+				Range: &protos.PartitionRange_StringRange{
+					StringRange: &protos.StringPartitionRange{
+						Start: rng[0],
+						End:   rng[1],
+					},
+				},
+			},
+			FullTablePartition: false,
+		})
+	}
+	return partitions, nil
+}
+
+// sampleStringIDs draws a random sample of string _id values. $sample with a size
+// below ~5% of the collection uses WiredTiger's random cursor, so this is cheap even
+// on large collections; it honours the configured read preference (run on a
+// secondary to avoid loading the primary).
+func (c *MongoConnector) sampleStringIDs(
+	ctx context.Context,
+	collection *mongo.Collection,
+	numPartitions int64,
+) ([]string, error) {
+	sampleSize := numPartitions * stringSampleOversample
+	if sampleSize > stringSampleMaxSize {
+		sampleSize = stringSampleMaxSize
+	}
+
+	aggCmd := bson.D{
+		{Key: "aggregate", Value: collection.Name()},
+		{Key: "pipeline", Value: bson.A{
+			bson.D{{Key: "$sample", Value: bson.D{{Key: "size", Value: int32(sampleSize)}}}},
+			bson.D{{Key: "$project", Value: bson.D{{Key: DefaultDocumentKeyColumnName, Value: 1}}}},
+		}},
+		{Key: "cursor", Value: bson.D{}},
+	}
+
+	cursor, err := collection.Database().RunCommandCursor(ctx, aggCmd,
+		options.RunCmd().SetReadPreference(protoToReadPref[c.config.ReadPreference]))
+	if err != nil {
+		return nil, fmt.Errorf("failed to sample _id values: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	samples := make([]string, 0, sampleSize)
+	for cursor.Next(ctx) {
+		rv := cursor.Current.Lookup(DefaultDocumentKeyColumnName)
+		if rv.Type == bson.TypeString {
+			samples = append(samples, rv.StringValue())
+		}
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("cursor error while sampling _id values: %w", err)
+	}
+	return samples, nil
+}
+
+// computeStringBoundaries turns a random sample of string _ids plus the real
+// min/max into a contiguous set of half-open [start, end) ranges. Interior
+// boundaries are quantiles of the (deduplicated, sorted) sample; the first range
+// starts at the real min and the last range ends just past the real max (via the
+// sentinel) so coverage of [min, max] is exact with no gaps or overlap.
+//
+// It is pure (no I/O) to keep the boundary math unit-testable. Returns fewer ranges
+// than numPartitions when the sample yields too few distinct interior boundaries.
+func computeStringBoundaries(minVal string, maxVal string, samples []string, numPartitions int64) [][2]string {
+	// Keep unique sampled values strictly inside (min, max).
+	seen := make(map[string]struct{}, len(samples))
+	interior := make([]string, 0, len(samples))
+	for _, s := range samples {
+		if s <= minVal || s >= maxVal {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		interior = append(interior, s)
+	}
+	slices.Sort(interior)
+
+	// Pick up to numPartitions-1 evenly spaced interior boundaries (quantiles).
+	desiredBoundaries := numPartitions - 1
+	var picked []string
+	if int64(len(interior)) <= desiredBoundaries {
+		picked = interior
+	} else {
+		picked = make([]string, 0, desiredBoundaries)
+		for i := int64(1); i <= desiredBoundaries; i++ {
+			idx := i * int64(len(interior)) / numPartitions
+			if idx >= int64(len(interior)) {
+				idx = int64(len(interior)) - 1
+			}
+			picked = append(picked, interior[idx])
+		}
+		picked = slices.Compact(picked) // drop consecutive duplicate quantiles
+	}
+
+	// Build contiguous half-open ranges: [min, p0), [p0, p1), ..., [pLast, max+sentinel).
+	starts := append([]string{minVal}, picked...)
+	ranges := make([][2]string, len(starts))
+	for i := range starts {
+		var end string
+		if i+1 < len(starts) {
+			end = starts[i+1]
+		} else {
+			end = maxVal + stringPartitionUpperSentinel
+		}
+		ranges[i] = [2]string{starts[i], end}
+	}
+	return ranges
+}
+
 // bigIntToObjectID converts a big.Int back to a 12-byte ObjectID.
 func bigIntToObjectID(n *big.Int) (bson.ObjectID, error) {
 	var oid bson.ObjectID
@@ -98,33 +333,19 @@ func bigIntToObjectID(n *big.Int) (bson.ObjectID, error) {
 	return oid, nil
 }
 
-// findMinMaxObjectIDs returns the min and max object IDs from the collection.
-// The two boundary queries are not wrapped in a snapshot session: a concurrent
-// insert between them may shift the true min/max, but this is safe because the
-// change stream resume token is captured before either query runs. Any writes
-// that occur during or after partitioning will be replayed by the change stream.
-func findMinMaxObjectIDs(
-	ctx context.Context,
-	collection *mongo.Collection,
-	readPreference protos.ReadPreference,
-) (bson.ObjectID, bson.ObjectID, bool, error) {
-	minRaw, err := findBoundaryID(ctx, collection, Lower, readPreference)
-	if err != nil {
-		return bson.ObjectID{}, bson.ObjectID{}, false, fmt.Errorf("failed to find min _id: %w", err)
-	}
-	if minRaw.Type != bson.TypeObjectID {
-		return bson.ObjectID{}, bson.ObjectID{}, false, nil
-	}
+func isNumericIDType(t bson.Type) bool {
+	return t == bson.TypeInt32 || t == bson.TypeInt64
+}
 
-	maxRaw, err := findBoundaryID(ctx, collection, Upper, readPreference)
-	if err != nil {
-		return bson.ObjectID{}, bson.ObjectID{}, false, fmt.Errorf("failed to find max _id: %w", err)
+func rawValueToInt64(rv bson.RawValue) (int64, bool) {
+	switch rv.Type {
+	case bson.TypeInt32:
+		return int64(rv.Int32()), true
+	case bson.TypeInt64:
+		return rv.Int64(), true
+	default:
+		return 0, false
 	}
-	if maxRaw.Type != bson.TypeObjectID {
-		return bson.ObjectID{}, bson.ObjectID{}, false, nil
-	}
-
-	return minRaw.ObjectID(), maxRaw.ObjectID(), true, nil
 }
 
 type Boundary int

--- a/flow/connectors/mongo/qrep_partition_test.go
+++ b/flow/connectors/mongo/qrep_partition_test.go
@@ -1,0 +1,170 @@
+package connmongo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+)
+
+// rawValueOf marshals a single-field document and returns the _id RawValue, so we
+// can exercise the BSON type-detection helpers with real driver values.
+func rawValueOf(t *testing.T, id any) bson.RawValue {
+	t.Helper()
+	raw, err := bson.Marshal(bson.D{{Key: DefaultDocumentKeyColumnName, Value: id}})
+	require.NoError(t, err)
+	return bson.Raw(raw).Lookup(DefaultDocumentKeyColumnName)
+}
+
+func TestRawValueToInt64(t *testing.T) {
+	v, ok := rawValueToInt64(rawValueOf(t, int32(281704574)))
+	require.True(t, ok)
+	require.Equal(t, int64(281704574), v)
+
+	v, ok = rawValueToInt64(rawValueOf(t, int64(9000000000)))
+	require.True(t, ok)
+	require.Equal(t, int64(9000000000), v)
+
+	_, ok = rawValueToInt64(rawValueOf(t, "flipboard.app"))
+	require.False(t, ok)
+
+	_, ok = rawValueToInt64(rawValueOf(t, 3.14))
+	require.False(t, ok)
+}
+
+func TestIsNumericIDType(t *testing.T) {
+	require.True(t, isNumericIDType(rawValueOf(t, int32(1)).Type))
+	require.True(t, isNumericIDType(rawValueOf(t, int64(1)).Type))
+	require.False(t, isNumericIDType(rawValueOf(t, "x").Type))
+	require.False(t, isNumericIDType(rawValueOf(t, 1.5).Type))
+	oid, _ := bson.ObjectIDFromHex("507f1f77bcf86cd799439011")
+	require.False(t, isNumericIDType(rawValueOf(t, oid).Type))
+}
+
+// assertContiguous verifies the ranges form a gap-free, non-overlapping cover of
+// [min, max+sentinel): first start == min, last end == max+sentinel, and each
+// range's end equals the next range's start.
+func assertContiguous(t *testing.T, ranges [][2]string, minVal, maxVal string) {
+	t.Helper()
+	require.NotEmpty(t, ranges)
+	require.Equal(t, minVal, ranges[0][0], "first partition must start at min")
+	require.Equal(t, maxVal+stringPartitionUpperSentinel, ranges[len(ranges)-1][1], "last partition must end just past max")
+	for i := range ranges {
+		require.Less(t, ranges[i][0], ranges[i][1], "range start must be < end")
+		if i+1 < len(ranges) {
+			require.Equal(t, ranges[i][1], ranges[i+1][0], "ranges must be contiguous")
+		}
+	}
+}
+
+func TestComputeStringBoundaries(t *testing.T) {
+	t.Run("even distribution", func(t *testing.T) {
+		samples := []string{"b", "c", "d", "e", "f", "g", "h", "i"}
+		ranges := computeStringBoundaries("a", "z", samples, 4)
+		require.Len(t, ranges, 4)
+		assertContiguous(t, ranges, "a", "z")
+	})
+
+	t.Run("clustered samples still contiguous", func(t *testing.T) {
+		samples := []string{"com.a", "com.b", "com.c", "com.d", "com.e", "com.f"}
+		ranges := computeStringBoundaries("com.a", "org.z", samples, 3)
+		require.LessOrEqual(t, len(ranges), 3)
+		assertContiguous(t, ranges, "com.a", "org.z")
+	})
+
+	t.Run("fewer distinct samples than partitions", func(t *testing.T) {
+		ranges := computeStringBoundaries("a", "z", []string{"m"}, 4)
+		require.Len(t, ranges, 2) // one interior boundary -> two partitions
+		assertContiguous(t, ranges, "a", "z")
+		require.Equal(t, [2]string{"a", "m"}, ranges[0])
+	})
+
+	t.Run("duplicate samples deduplicated", func(t *testing.T) {
+		samples := []string{"m", "m", "m", "m"}
+		ranges := computeStringBoundaries("a", "z", samples, 4)
+		require.Len(t, ranges, 2)
+		assertContiguous(t, ranges, "a", "z")
+	})
+
+	t.Run("samples outside (min,max) ignored", func(t *testing.T) {
+		// "a" == min and "z" == max must be dropped; only "m" is a valid interior boundary
+		samples := []string{"a", "z", "m", "0", "zzzz"}
+		ranges := computeStringBoundaries("a", "z", samples, 4)
+		require.Len(t, ranges, 2)
+		assertContiguous(t, ranges, "a", "z")
+		require.Equal(t, [2]string{"a", "m"}, ranges[0])
+	})
+
+	t.Run("no usable samples yields single range", func(t *testing.T) {
+		ranges := computeStringBoundaries("a", "z", nil, 4)
+		require.Len(t, ranges, 1) // caller treats <2 as full-table fallback
+		assertContiguous(t, ranges, "a", "z")
+	})
+
+	t.Run("many samples produce requested partition count", func(t *testing.T) {
+		samples := make([]string, 0, 100)
+		for i := 'b'; i < 'b'+20; i++ {
+			for j := 'a'; j < 'a'+5; j++ {
+				samples = append(samples, string([]rune{i, j}))
+			}
+		}
+		ranges := computeStringBoundaries("aa", "zz", samples, 8)
+		require.Len(t, ranges, 8)
+		assertContiguous(t, ranges, "aa", "zz")
+	})
+}
+
+func intPartition(start, end int64) *protos.PartitionRange {
+	return &protos.PartitionRange{Range: &protos.PartitionRange_IntRange{
+		IntRange: &protos.IntPartitionRange{Start: start, End: end},
+	}}
+}
+
+func stringPartition(start, end string) *protos.PartitionRange {
+	return &protos.PartitionRange{Range: &protos.PartitionRange_StringRange{
+		StringRange: &protos.StringPartitionRange{Start: start, End: end},
+	}}
+}
+
+func TestToRangeFilter(t *testing.T) {
+	t.Run("int range is inclusive on both ends", func(t *testing.T) {
+		filter, err := toRangeFilter(DefaultDocumentKeyColumnName, intPartition(10, 20))
+		require.NoError(t, err)
+		require.Equal(t, bson.D{
+			bson.E{Key: DefaultDocumentKeyColumnName, Value: bson.D{
+				bson.E{Key: "$gte", Value: int64(10)},
+				bson.E{Key: "$lte", Value: int64(20)},
+			}},
+		}, filter)
+	})
+
+	t.Run("string range is half-open", func(t *testing.T) {
+		filter, err := toRangeFilter(DefaultDocumentKeyColumnName, stringPartition("com.a", "com.m"))
+		require.NoError(t, err)
+		require.Equal(t, bson.D{
+			bson.E{Key: DefaultDocumentKeyColumnName, Value: bson.D{
+				bson.E{Key: "$gte", Value: "com.a"},
+				bson.E{Key: "$lt", Value: "com.m"},
+			}},
+		}, filter)
+	})
+
+	t.Run("object id range still supported", func(t *testing.T) {
+		r := &protos.PartitionRange{Range: &protos.PartitionRange_ObjectIdRange{
+			ObjectIdRange: &protos.ObjectIdPartitionRange{
+				Start: "507f1f77bcf86cd799439011",
+				End:   "507f1f77bcf86cd7994390ff",
+			},
+		}}
+		_, err := toRangeFilter(DefaultDocumentKeyColumnName, r)
+		require.NoError(t, err)
+	})
+
+	t.Run("unsupported range type errors", func(t *testing.T) {
+		r := &protos.PartitionRange{Range: &protos.PartitionRange_NullRange{NullRange: &protos.NullPartitionRange{}}}
+		_, err := toRangeFilter(DefaultDocumentKeyColumnName, r)
+		require.Error(t, err)
+	})
+}

--- a/flow/connectors/utils/monitoring/monitoring.go
+++ b/flow/connectors/utils/monitoring/monitoring.go
@@ -362,6 +362,8 @@ func addPartitionToQRepRun(ctx context.Context, tx pgx.Tx, flowJobName string,
 			rangeEnd = new(rangeEndValue.(string))
 		case *protos.PartitionRange_ObjectIdRange:
 			rangeStart, rangeEnd = &x.ObjectIdRange.Start, &x.ObjectIdRange.End
+		case *protos.PartitionRange_StringRange:
+			rangeStart, rangeEnd = &x.StringRange.Start, &x.StringRange.End
 		case *protos.PartitionRange_NullRange:
 			// leave rangeStart and rangeEnd as nil
 		default:

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -324,6 +324,11 @@ message ObjectIdPartitionRange {
   string end = 2;
 }
 
+message StringPartitionRange {
+  string start = 1;
+  string end = 2;
+}
+
 message PartitionRange {
   // can be a timestamp range or an integer range
   oneof range {
@@ -333,6 +338,7 @@ message PartitionRange {
     UIntPartitionRange uint_range = 4;
     ObjectIdPartitionRange object_id_range = 5;
     NullPartitionRange null_range = 6;
+    StringPartitionRange string_range = 7;
   }
 }
 


### PR DESCRIPTION
## Problem

After a mirror resync on a clustered ClickHouse destination, the old local shard table (e.g. `itunes_apps_shard`) is left behind as an orphan.

During resync, `RenameTables` does:
1. `EXCHANGE TABLES itunes_apps AND itunes_apps_resync` — swaps the two Distributed tables
2. `DROP TABLE itunes_apps_resync` — drops the now-old Distributed shell

But this only handles the Distributed layer. The local shard that the original `itunes_apps` pointed to (`itunes_apps_shard`) has no Distributed table referencing it anymore and is never dropped, leaving it as dead storage.

## Fix

Before the `EXCHANGE`, resolve the shard table name from the original Distributed table's `engine_full` definition using the existing `getDistributedShardTable` helper. After the exchange and Distributed drop succeed, explicitly drop that shard table.

If the shard lookup fails (e.g. non-Distributed engine, single-node deployment), we log a warning and continue — the swap itself is not blocked.

## Test plan

- [ ] Run a mirror resync on a clustered ClickHouse destination
- [ ] Confirm `itunes_apps_shard` (or equivalent old shard) is gone after resync completes
- [ ] Confirm `itunes_apps` Distributed table still points to the new timestamped shard and data is intact