### PR TITLE
Optimize encoding maps

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -614,53 +614,18 @@ func (c *MySqlConnector) PullRecords(
 				enumMap := ev.Table.EnumStrValueMap()
 				setMap := ev.Table.SetStrValueMap()
 
-				// build colIdx -> encoding map based on event collation map.
-				// Allocated lazily: tables whose character columns are all utf8/ascii/binary
-				// (the common case) resolve every collation to a nil encoding and never allocate.
-				var colEncodings []encoding.Encoding
+				// Build colIdx -> encoding directly from TABLE_MAP charset metadata.
+				// This mirrors go-mysql's collation traversal without allocating its maps;
+				// when all character columns are utf8/ascii/binary, the slice stays nil.
+				colEncodings, err := c.tableMapColumnEncodings(ctx, ev.Table, enumMap, setMap, otelManager)
+				if err != nil {
+					return err
+				}
 				encFor := func(idx int) encoding.Encoding {
 					if idx >= 0 && idx < len(colEncodings) {
 						return colEncodings[idx]
 					}
 					return nil
-				}
-				setColEncoding := func(colIdx int, enc encoding.Encoding) {
-					if colEncodings == nil {
-						colEncodings = make([]encoding.Encoding, len(ev.Table.ColumnType))
-					}
-					colEncodings[colIdx] = enc
-				}
-				for colIdx, collationID := range ev.Table.CollationMap() {
-					if colIdx < 0 || colIdx >= len(ev.Table.ColumnType) {
-						continue
-					}
-					enc, err := c.collationEncoding(ctx, collationID, otelManager)
-					if err != nil {
-						return err
-					}
-					if enc == nil {
-						continue
-					}
-					setColEncoding(colIdx, enc)
-				}
-				for colIdx, collationID := range ev.Table.EnumSetCollationMap() {
-					enc, err := c.collationEncoding(ctx, collationID, otelManager)
-					if err != nil {
-						return err
-					}
-					if enc == nil {
-						continue
-					}
-					setColEncoding(colIdx, enc)
-					for labels := range slices.Values([][]string{enumMap[colIdx], setMap[colIdx]}) {
-						for i, label := range labels {
-							decoded, err := decodeMySQLString(enc, label)
-							if err != nil {
-								return err
-							}
-							labels[i] = decoded
-						}
-					}
 				}
 
 				// Process TABLE_MAP_EVENT schema to detect new columns

--- a/flow/connectors/mysql/charset.go
+++ b/flow/connectors/mysql/charset.go
@@ -133,25 +133,26 @@ func (c *MySqlConnector) tableMapColumnEncodings(
 	setMap map[int][]string,
 	otelManager *otel_metrics.OtelManager,
 ) ([]encoding.Encoding, error) {
-	var colEncodings []encoding.Encoding
-	if err := c.addTableMapColumnEncodings(
+	colEncodings, err := c.appendTableMapColumnEncodings(
 		ctx, otelManager,
 		tableMap, tableMapCharacterCollation, tableMap.DefaultCharset, tableMap.ColumnCharset,
-		nil, nil, &colEncodings,
-	); err != nil {
+		nil, nil, nil,
+	)
+	if err != nil {
 		return nil, err
 	}
-	if err := c.addTableMapColumnEncodings(
+	colEncodings, err = c.appendTableMapColumnEncodings(
 		ctx, otelManager,
 		tableMap, tableMapEnumSetCollation, tableMap.EnumSetDefaultCharset, tableMap.EnumSetColumnCharset,
-		enumMap, setMap, &colEncodings,
-	); err != nil {
+		enumMap, setMap, colEncodings,
+	)
+	if err != nil {
 		return nil, err
 	}
 	return colEncodings, nil
 }
 
-func (c *MySqlConnector) addTableMapColumnEncodings(
+func (c *MySqlConnector) appendTableMapColumnEncodings(
 	ctx context.Context,
 	otelManager *otel_metrics.OtelManager,
 	tableMap *replication.TableMapEvent,
@@ -160,11 +161,11 @@ func (c *MySqlConnector) addTableMapColumnEncodings(
 	columnCharset []uint64,
 	enumMap map[int][]string,
 	setMap map[int][]string,
-	colEncodings *[]encoding.Encoding,
-) error {
+	colEncodings []encoding.Encoding,
+) ([]encoding.Encoding, error) {
 	if len(defaultCharset) != 0 {
 		if len(defaultCharset)%2 == 0 {
-			return fmt.Errorf("malformed TABLE_MAP default charset metadata: expected odd item count, got %d", len(defaultCharset))
+			return nil, fmt.Errorf("malformed TABLE_MAP default charset metadata: expected odd item count, got %d", len(defaultCharset))
 		}
 
 		defaultCollation := defaultCharset[0]
@@ -175,14 +176,16 @@ func (c *MySqlConnector) addTableMapColumnEncodings(
 			}
 
 			collationID := tableMapDefaultCollation(defaultCharset, collationPos, defaultCollation)
-			if err := c.addTableMapColumnEncoding(
+			var err error
+			colEncodings, err = c.appendTableMapColumnEncoding(
 				ctx, otelManager, tableMap, collationType, colIdx, collationID, enumMap, setMap, colEncodings,
-			); err != nil {
-				return err
+			)
+			if err != nil {
+				return nil, err
 			}
 			collationPos++
 		}
-		return nil
+		return colEncodings, nil
 	}
 
 	if len(columnCharset) != 0 {
@@ -192,22 +195,24 @@ func (c *MySqlConnector) addTableMapColumnEncodings(
 				continue
 			}
 			if collationPos >= len(columnCharset) {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"malformed TABLE_MAP column charset metadata: got %d collations, missing collation for column %d",
 					len(columnCharset), colIdx,
 				)
 			}
 
-			if err := c.addTableMapColumnEncoding(
+			var err error
+			colEncodings, err = c.appendTableMapColumnEncoding(
 				ctx, otelManager, tableMap, collationType, colIdx, columnCharset[collationPos],
 				enumMap, setMap, colEncodings,
-			); err != nil {
-				return err
+			)
+			if err != nil {
+				return nil, err
 			}
 			collationPos++
 		}
 	}
-	return nil
+	return colEncodings, nil
 }
 
 func tableMapDefaultCollation(defaultCharset []uint64, collationPos int, defaultCollation uint64) uint64 {
@@ -234,7 +239,7 @@ func tableMapIncludesCollation(
 	}
 }
 
-func (c *MySqlConnector) addTableMapColumnEncoding(
+func (c *MySqlConnector) appendTableMapColumnEncoding(
 	ctx context.Context,
 	otelManager *otel_metrics.OtelManager,
 	tableMap *replication.TableMapEvent,
@@ -243,30 +248,30 @@ func (c *MySqlConnector) addTableMapColumnEncoding(
 	collationID uint64,
 	enumMap map[int][]string,
 	setMap map[int][]string,
-	colEncodings *[]encoding.Encoding,
-) error {
+	colEncodings []encoding.Encoding,
+) ([]encoding.Encoding, error) {
 	enc, err := c.collationEncoding(ctx, collationID, otelManager)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if enc == nil {
-		return nil
+		return colEncodings, nil
 	}
 
-	if *colEncodings == nil {
-		*colEncodings = make([]encoding.Encoding, len(tableMap.ColumnType))
+	if colEncodings == nil {
+		colEncodings = make([]encoding.Encoding, len(tableMap.ColumnType))
 	}
-	(*colEncodings)[colIdx] = enc
+	colEncodings[colIdx] = enc
 
 	if collationType == tableMapEnumSetCollation {
 		if err := decodeMySQLStrings(enc, enumMap[colIdx]); err != nil {
-			return err
+			return nil, err
 		}
 		if err := decodeMySQLStrings(enc, setMap[colIdx]); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return colEncodings, nil
 }
 
 func (c *MySqlConnector) charsetForCollation(ctx context.Context, collationID uint64) (string, error) {

--- a/flow/connectors/mysql/charset.go
+++ b/flow/connectors/mysql/charset.go
@@ -169,7 +169,7 @@ func (c *MySqlConnector) addTableMapColumnEncodings(
 
 		defaultCollation := defaultCharset[0]
 		collationPos := 0
-		for colIdx := 0; colIdx < int(tableMap.ColumnCount); colIdx++ {
+		for colIdx := range int(tableMap.ColumnCount) {
 			if !tableMapIncludesCollation(tableMap, collationType, colIdx) {
 				continue
 			}
@@ -187,7 +187,7 @@ func (c *MySqlConnector) addTableMapColumnEncodings(
 
 	if len(columnCharset) != 0 {
 		collationPos := 0
-		for colIdx := 0; colIdx < int(tableMap.ColumnCount); colIdx++ {
+		for colIdx := range int(tableMap.ColumnCount) {
 			if !tableMapIncludesCollation(tableMap, collationType, colIdx) {
 				continue
 			}

--- a/flow/connectors/mysql/charset.go
+++ b/flow/connectors/mysql/charset.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/go-mysql-org/go-mysql/replication"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/text/encoding"
@@ -69,6 +70,13 @@ var mysqlCharsetEncodings = map[string]encoding.Encoding{
 	"utf32":   utf32.UTF32(utf32.BigEndian, utf32.IgnoreBOM),
 }
 
+type tableMapCollationType uint8
+
+const (
+	tableMapCharacterCollation tableMapCollationType = iota
+	tableMapEnumSetCollation
+)
+
 // collationEncoding resolves a MySQL collation id (as carried in binlog
 // TABLE_MAP metadata) to the x/text encoding needed to convert that column's
 // bytes to UTF-8.
@@ -116,6 +124,149 @@ func (c *MySqlConnector) collationEncoding(
 	})
 
 	return nil, nil
+}
+
+func (c *MySqlConnector) tableMapColumnEncodings(
+	ctx context.Context,
+	tableMap *replication.TableMapEvent,
+	enumMap map[int][]string,
+	setMap map[int][]string,
+	otelManager *otel_metrics.OtelManager,
+) ([]encoding.Encoding, error) {
+	var colEncodings []encoding.Encoding
+	if err := c.addTableMapColumnEncodings(
+		ctx, otelManager,
+		tableMap, tableMapCharacterCollation, tableMap.DefaultCharset, tableMap.ColumnCharset,
+		nil, nil, &colEncodings,
+	); err != nil {
+		return nil, err
+	}
+	if err := c.addTableMapColumnEncodings(
+		ctx, otelManager,
+		tableMap, tableMapEnumSetCollation, tableMap.EnumSetDefaultCharset, tableMap.EnumSetColumnCharset,
+		enumMap, setMap, &colEncodings,
+	); err != nil {
+		return nil, err
+	}
+	return colEncodings, nil
+}
+
+func (c *MySqlConnector) addTableMapColumnEncodings(
+	ctx context.Context,
+	otelManager *otel_metrics.OtelManager,
+	tableMap *replication.TableMapEvent,
+	collationType tableMapCollationType,
+	defaultCharset []uint64,
+	columnCharset []uint64,
+	enumMap map[int][]string,
+	setMap map[int][]string,
+	colEncodings *[]encoding.Encoding,
+) error {
+	if len(defaultCharset) != 0 {
+		if len(defaultCharset)%2 == 0 {
+			return fmt.Errorf("malformed TABLE_MAP default charset metadata: expected odd item count, got %d", len(defaultCharset))
+		}
+
+		defaultCollation := defaultCharset[0]
+		collationPos := 0
+		for colIdx := 0; colIdx < int(tableMap.ColumnCount); colIdx++ {
+			if !tableMapIncludesCollation(tableMap, collationType, colIdx) {
+				continue
+			}
+
+			collationID := tableMapDefaultCollation(defaultCharset, collationPos, defaultCollation)
+			if err := c.addTableMapColumnEncoding(
+				ctx, otelManager, tableMap, collationType, colIdx, collationID, enumMap, setMap, colEncodings,
+			); err != nil {
+				return err
+			}
+			collationPos++
+		}
+		return nil
+	}
+
+	if len(columnCharset) != 0 {
+		collationPos := 0
+		for colIdx := 0; colIdx < int(tableMap.ColumnCount); colIdx++ {
+			if !tableMapIncludesCollation(tableMap, collationType, colIdx) {
+				continue
+			}
+			if collationPos >= len(columnCharset) {
+				return fmt.Errorf(
+					"malformed TABLE_MAP column charset metadata: got %d collations, missing collation for column %d",
+					len(columnCharset), colIdx,
+				)
+			}
+
+			if err := c.addTableMapColumnEncoding(
+				ctx, otelManager, tableMap, collationType, colIdx, columnCharset[collationPos],
+				enumMap, setMap, colEncodings,
+			); err != nil {
+				return err
+			}
+			collationPos++
+		}
+	}
+	return nil
+}
+
+func tableMapDefaultCollation(defaultCharset []uint64, collationPos int, defaultCollation uint64) uint64 {
+	for idx := 1; idx+1 < len(defaultCharset); idx += 2 {
+		if defaultCharset[idx] == uint64(collationPos) {
+			return defaultCharset[idx+1]
+		}
+	}
+	return defaultCollation
+}
+
+func tableMapIncludesCollation(
+	tableMap *replication.TableMapEvent,
+	collationType tableMapCollationType,
+	colIdx int,
+) bool {
+	switch collationType {
+	case tableMapCharacterCollation:
+		return tableMap.IsCharacterColumn(colIdx)
+	case tableMapEnumSetCollation:
+		return tableMap.IsEnumOrSetColumn(colIdx)
+	default:
+		return false
+	}
+}
+
+func (c *MySqlConnector) addTableMapColumnEncoding(
+	ctx context.Context,
+	otelManager *otel_metrics.OtelManager,
+	tableMap *replication.TableMapEvent,
+	collationType tableMapCollationType,
+	colIdx int,
+	collationID uint64,
+	enumMap map[int][]string,
+	setMap map[int][]string,
+	colEncodings *[]encoding.Encoding,
+) error {
+	enc, err := c.collationEncoding(ctx, collationID, otelManager)
+	if err != nil {
+		return err
+	}
+	if enc == nil {
+		return nil
+	}
+
+	if *colEncodings == nil {
+		*colEncodings = make([]encoding.Encoding, len(tableMap.ColumnType))
+	}
+	(*colEncodings)[colIdx] = enc
+
+	if collationType == tableMapEnumSetCollation {
+		if err := decodeMySQLStrings(enc, enumMap[colIdx]); err != nil {
+			return err
+		}
+		if err := decodeMySQLStrings(enc, setMap[colIdx]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *MySqlConnector) charsetForCollation(ctx context.Context, collationID uint64) (string, error) {
@@ -180,4 +331,15 @@ func decodeMySQLString(enc encoding.Encoding, s string) (string, error) {
 		return "", fmt.Errorf("failed to transcode column string to UTF-8: %w", err)
 	}
 	return out, nil
+}
+
+func decodeMySQLStrings(enc encoding.Encoding, values []string) error {
+	for idx, value := range values {
+		decoded, err := decodeMySQLString(enc, value)
+		if err != nil {
+			return err
+		}
+		values[idx] = decoded
+	}
+	return nil
 }

--- a/flow/e2e/clickhouse_mysql_test.go
+++ b/flow/e2e/clickhouse_mysql_test.go
@@ -618,14 +618,17 @@ func (s ClickHouseSuite) Test_MySQL_Charset_Consistency() {
 		CREATE TABLE IF NOT EXISTS %s (
 			id SERIAL PRIMARY KEY,
 			latin1_col VARCHAR(50) CHARACTER SET latin1 NOT NULL,
-			gbk_col VARCHAR(50) CHARACTER SET gbk NOT NULL
+			gbk_col VARCHAR(50) CHARACTER SET gbk NOT NULL,
+			latin1_enum ENUM('café', 'plain') CHARACTER SET latin1 NOT NULL,
+			gbk_set SET('你好', '再见') CHARACTER SET gbk NOT NULL
 		)
 	`, quotedSrcFullName)))
 
 	// Insert before snapshot. The source connection runs SET NAMES utf8mb4, so the server
 	// transcodes these UTF-8 literals down into the columns' latin1/gbk storage encodings.
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
-		`INSERT INTO %s (latin1_col, gbk_col) VALUES ('café', '你好')`, quotedSrcFullName)))
+		`INSERT INTO %s (latin1_col, gbk_col, latin1_enum, gbk_set) VALUES ('café', '你好', 'café', '你好,再见')`,
+		quotedSrcFullName)))
 
 	connectionGen := FlowConnectionGenerationConfig{
 		FlowJobName:      s.attachSuffix(srcTableName),
@@ -639,15 +642,16 @@ func (s ClickHouseSuite) Test_MySQL_Charset_Consistency() {
 	env := ExecutePeerflow(s.t, tc, flowConnConfig)
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
-	EnvWaitForCount(env, s, "waiting on snapshot", dstTableName, "id,latin1_col,gbk_col", 1)
+	EnvWaitForCount(env, s, "waiting on snapshot", dstTableName, "id,latin1_col,gbk_col,latin1_enum,gbk_set", 1)
 
 	// Same values via CDC (binlog path).
 	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
-		`INSERT INTO %s (latin1_col, gbk_col) VALUES ('café', '你好')`, quotedSrcFullName)))
+		`INSERT INTO %s (latin1_col, gbk_col, latin1_enum, gbk_set) VALUES ('café', '你好', 'café', '你好,再见')`,
+		quotedSrcFullName)))
 
-	EnvWaitForCount(env, s, "waiting on cdc", dstTableName, "id,latin1_col,gbk_col", 2)
+	EnvWaitForCount(env, s, "waiting on cdc", dstTableName, "id,latin1_col,gbk_col,latin1_enum,gbk_set", 2)
 
-	rows, err := s.GetRows(dstTableName, "id,latin1_col,gbk_col")
+	rows, err := s.GetRows(dstTableName, "id,latin1_col,gbk_col,latin1_enum,gbk_set")
 	require.NoError(s.t, err)
 	require.Len(s.t, rows.Records, 2)
 
@@ -656,8 +660,14 @@ func (s ClickHouseSuite) Test_MySQL_Charset_Consistency() {
 		"snapshot and CDC latin1 values should be consistent")
 	require.Equal(s.t, rows.Records[0][2].Value(), rows.Records[1][2].Value(),
 		"snapshot and CDC gbk values should be consistent")
+	require.Equal(s.t, rows.Records[0][3].Value(), rows.Records[1][3].Value(),
+		"snapshot and CDC latin1 enum values should be consistent")
+	require.Equal(s.t, rows.Records[0][4].Value(), rows.Records[1][4].Value(),
+		"snapshot and CDC gbk set values should be consistent")
 	require.Equal(s.t, "café", rows.Records[1][1].Value())
 	require.Equal(s.t, "你好", rows.Records[1][2].Value())
+	require.Equal(s.t, "café", rows.Records[1][3].Value())
+	require.Equal(s.t, "你好,再见", rows.Records[1][4].Value())
 
 	env.Cancel(s.t.Context())
 	RequireEnvCanceled(s.t, env)


### PR DESCRIPTION
Follow-up to #4436

Optimize building two extra maps per event on go-mysql side when re-encoding won't be needed (common case)