### PR TITLE
refactor(mysql): move used_mysql_charsets metric into connector package

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -432,6 +432,11 @@ func (c *MySqlConnector) PullRecords(
 ) error {
 	defer req.RecordStream.Close()
 
+	mysqlMetrics, err := newMetrics(otelManager)
+	if err != nil {
+		return err
+	}
+
 	sourceSchemaAsDestinationColumn, err := internal.PeerDBSourceSchemaAsDestinationColumn(ctx, req.Env)
 	if err != nil {
 		return err
@@ -634,7 +639,7 @@ func (c *MySqlConnector) PullRecords(
 					if colIdx < 0 || colIdx >= len(ev.Table.ColumnType) {
 						continue
 					}
-					enc, err := c.collationEncoding(ctx, collationID, otelManager)
+					enc, err := c.collationEncoding(ctx, collationID, mysqlMetrics)
 					if err != nil {
 						return err
 					}
@@ -644,7 +649,7 @@ func (c *MySqlConnector) PullRecords(
 					setColEncoding(colIdx, enc)
 				}
 				for colIdx, collationID := range ev.Table.EnumSetCollationMap() {
-					enc, err := c.collationEncoding(ctx, collationID, otelManager)
+					enc, err := c.collationEncoding(ctx, collationID, mysqlMetrics)
 					if err != nil {
 						return err
 					}

--- a/flow/connectors/mysql/charset.go
+++ b/flow/connectors/mysql/charset.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/charmap"
 	"golang.org/x/text/encoding/japanese"
@@ -16,8 +14,6 @@ import (
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/encoding/unicode/utf32"
 	"golang.org/x/text/transform"
-
-	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 )
 
 // charsetsNoTranscode lists the MySQL character sets whose stored bytes are
@@ -73,19 +69,10 @@ var mysqlCharsetEncodings = map[string]encoding.Encoding{
 // TABLE_MAP metadata) to the x/text encoding needed to convert that column's
 // bytes to UTF-8.
 func (c *MySqlConnector) collationEncoding(
-	ctx context.Context, collationID uint64, otelManager *otel_metrics.OtelManager,
+	ctx context.Context, collationID uint64, m *metrics,
 ) (encoding.Encoding, error) {
 	if collationID == 0 {
 		return nil, nil
-	}
-
-	recordUsedCharsetMetrics := func(ctx context.Context, charset string, status string) {
-		otelManager.Metrics.UsedMySQLCharsetsCounter.Add(ctx, 1,
-			metric.WithAttributeSet(attribute.NewSet(
-				attribute.String("charset", charset),
-				attribute.String("status", status),
-			)),
-		)
 	}
 
 	charset, err := c.charsetForCollation(ctx, collationID)
@@ -101,15 +88,15 @@ func (c *MySqlConnector) collationEncoding(
 	}
 
 	if _, skip := charsetsNoTranscode[charset]; skip {
-		recordUsedCharsetMetrics(ctx, charset, "not_transcoded")
+		m.recordUsedCharset(ctx, charset, "not_transcoded")
 		return nil, nil
 	}
 	if enc, ok := mysqlCharsetEncodings[charset]; ok {
-		recordUsedCharsetMetrics(ctx, charset, "transcoded")
+		m.recordUsedCharset(ctx, charset, "transcoded")
 		return enc, nil
 	}
 
-	recordUsedCharsetMetrics(ctx, charset, "unsupported")
+	m.recordUsedCharset(ctx, charset, "unsupported")
 	c.warnCharsetOnce(charset, func() {
 		c.logger.Warn("unsupported MySQL character set on CDC path, passing bytes through untranscoded",
 			slog.String("charset", charset), slog.Uint64("collationID", collationID))

--- a/flow/connectors/mysql/metrics.go
+++ b/flow/connectors/mysql/metrics.go
@@ -9,20 +9,14 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 )
 
-// usedMySQLCharsetsName is the base name of the MySQL-only charset usage counter.
 const usedMySQLCharsetsName = "used_mysql_charsets"
 
-// metrics holds MySQL-specific OpenTelemetry instruments. Keeping their
-// definitions in the connector package (rather than the shared otel_metrics
-// package) keeps MySQL-only metric changes scoped to flow/connectors/mysql.
 type metrics struct {
 	usedCharsetsCounter metric.Int64Counter
 }
 
 // newMetrics initializes the MySQL-specific instruments through the shared
-// OtelManager. It must be called once from a single-threaded path (e.g. at the
-// start of PullRecords) because the manager's instrument caches are not
-// concurrency-safe.
+// OtelManager.
 func newMetrics(om *otel_metrics.OtelManager) (*metrics, error) {
 	usedCharsetsCounter, err := om.GetOrInitInt64Counter(
 		otel_metrics.BuildMetricName(usedMySQLCharsetsName),

--- a/flow/connectors/mysql/metrics.go
+++ b/flow/connectors/mysql/metrics.go
@@ -1,0 +1,45 @@
+package connmysql
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
+)
+
+// usedMySQLCharsetsName is the base name of the MySQL-only charset usage counter.
+const usedMySQLCharsetsName = "used_mysql_charsets"
+
+// metrics holds MySQL-specific OpenTelemetry instruments. Keeping their
+// definitions in the connector package (rather than the shared otel_metrics
+// package) keeps MySQL-only metric changes scoped to flow/connectors/mysql.
+type metrics struct {
+	usedCharsetsCounter metric.Int64Counter
+}
+
+// newMetrics initializes the MySQL-specific instruments through the shared
+// OtelManager. It must be called once from a single-threaded path (e.g. at the
+// start of PullRecords) because the manager's instrument caches are not
+// concurrency-safe.
+func newMetrics(om *otel_metrics.OtelManager) (*metrics, error) {
+	usedCharsetsCounter, err := om.GetOrInitInt64Counter(
+		otel_metrics.BuildMetricName(usedMySQLCharsetsName),
+		metric.WithDescription(
+			"Counter of used MySQL charsets, with `charset` label and `status` label indicating unsupported/transcoded/not_transcoded"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &metrics{usedCharsetsCounter: usedCharsetsCounter}, nil
+}
+
+func (m *metrics) recordUsedCharset(ctx context.Context, charset string, status string) {
+	m.usedCharsetsCounter.Add(ctx, 1,
+		metric.WithAttributeSet(attribute.NewSet(
+			attribute.String("charset", charset),
+			attribute.String("status", status),
+		)),
+	)
+}

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
@@ -80,7 +81,6 @@ const (
 	UnchangedToastValuesCounterName      = "unchanged_toast_values"
 	CodeNotificationCounterName          = "code_notification"
 	ServerWalEndLagGaugeName             = "wal_end_lag"
-	UsedMySQLCharsetsName                = "used_mysql_charsets"
 	ColumnTypeChangesName                = "column_type_changes"
 )
 
@@ -136,7 +136,6 @@ type Metrics struct {
 	LogRetentionGauge                metric.Float64Gauge
 	UnchangedToastValuesCounter      metric.Int64Counter
 	ServerWalEndLagGauge             metric.Int64Gauge
-	UsedMySQLCharsetsCounter         metric.Int64Counter
 	ColumnTypeChangesCounter         metric.Int64Counter
 }
 
@@ -177,6 +176,7 @@ type OtelManager struct {
 	Float64GaugesCache map[string]metric.Float64Gauge
 	Int64GaugesCache   map[string]metric.Int64Gauge
 	Int64CountersCache map[string]metric.Int64Counter
+	cacheMu            sync.Mutex
 	Enabled            bool
 }
 
@@ -211,10 +211,13 @@ func (om *OtelManager) Close(ctx context.Context) error {
 func getOrInitMetric[M any, O any](
 	cons func(metric.Meter, string, ...O) (M, error),
 	meter metric.Meter,
+	mu *sync.Mutex,
 	cache map[string]M,
 	name string,
 	opts ...O,
 ) (M, error) {
+	mu.Lock()
+	defer mu.Unlock()
 	gauge, ok := cache[name]
 	if !ok {
 		var err error
@@ -230,16 +233,16 @@ func getOrInitMetric[M any, O any](
 
 func (om *OtelManager) GetOrInitInt64Gauge(name string, opts ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
 	// Once fixed, replace first argument below with metric.Meter.Int64Gauge
-	return getOrInitMetric(ContextAwareInt64Gauge, om.Meter, om.Int64GaugesCache, name, opts...)
+	return getOrInitMetric(ContextAwareInt64Gauge, om.Meter, &om.cacheMu, om.Int64GaugesCache, name, opts...)
 }
 
 func (om *OtelManager) GetOrInitFloat64Gauge(name string, opts ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
 	// Once fixed, replace first argument below with metric.Meter.Float64Gauge
-	return getOrInitMetric(ContextAwareFloat64Gauge, om.Meter, om.Float64GaugesCache, name, opts...)
+	return getOrInitMetric(ContextAwareFloat64Gauge, om.Meter, &om.cacheMu, om.Float64GaugesCache, name, opts...)
 }
 
 func (om *OtelManager) GetOrInitInt64Counter(name string, opts ...metric.Int64CounterOption) (metric.Int64Counter, error) {
-	return getOrInitMetric(NewContextAwareInt64Counter, om.Meter, om.Int64CountersCache, name, opts...)
+	return getOrInitMetric(NewContextAwareInt64Counter, om.Meter, &om.cacheMu, om.Int64CountersCache, name, opts...)
 }
 
 // CodeNotificationCounter is a global counter for emitting notifications for one-off things we want to know about with the least effort.
@@ -573,13 +576,6 @@ func (om *OtelManager) setupMetrics(ctx context.Context) error {
 	if om.Metrics.UnchangedToastValuesCounter, err = om.GetOrInitInt64Counter(BuildMetricName(UnchangedToastValuesCounterName),
 		metric.WithDescription(
 			"Counter of unchanged TOAST values (Postgres only), with `backfilled` indicating whether the original was found in the CDC store"),
-	); err != nil {
-		return err
-	}
-
-	if om.Metrics.UsedMySQLCharsetsCounter, err = om.GetOrInitInt64Counter(BuildMetricName(UsedMySQLCharsetsName),
-		metric.WithDescription(
-			"Counter of used MySQL charsets, with `charset` label and `status` label indicating unsupported/transcoded/not_transcoded"),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What

Moves the MySQL-only `used_mysql_charsets` counter out of the shared `flow/otel_metrics` package and into `flow/connectors/mysql`.

## Why

MySQL-specific metrics currently live in the common `otel_metrics` folder, which means adding/changing one touches a shared path and makes it hard to scope CI test selection by the path where the change happened. Keeping the metric definition in the connector package keeps such changes confined to `flow/connectors/mysql/`.