### PR TITLE
fix: PG<15 fallback parameters (#4473)

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -82,14 +82,14 @@ const (
 	fallbackUpsertStatementSQL = `WITH src_rank AS (
 		SELECT _peerdb_data,_peerdb_record_type,_peerdb_unchanged_toast_columns,
 		RANK() OVER (PARTITION BY %s ORDER BY _peerdb_timestamp DESC) AS _peerdb_rank
-		FROM %s.%s WHERE _peerdb_batch_id>$1 AND _peerdb_batch_id<=$2 AND _peerdb_destination_table_name=$3
+		FROM %s.%s WHERE _peerdb_batch_id=$1 AND _peerdb_destination_table_name=$2
 	)
 	INSERT INTO %s (%s) SELECT %s FROM src_rank WHERE _peerdb_rank=1 AND _peerdb_record_type!=2
 	ON CONFLICT (%s) DO UPDATE SET %s`
 	fallbackDeleteStatementSQL = `WITH src_rank AS (
 		SELECT _peerdb_data,_peerdb_record_type,_peerdb_unchanged_toast_columns,
 		RANK() OVER (PARTITION BY %s ORDER BY _peerdb_timestamp DESC) AS _peerdb_rank
-		FROM %s.%s WHERE _peerdb_batch_id>$1 AND _peerdb_batch_id<=$2 AND _peerdb_destination_table_name=$3
+		FROM %s.%s WHERE _peerdb_batch_id=$1 AND _peerdb_destination_table_name=$2
 	)
 	%s src_rank WHERE %s AND src_rank._peerdb_rank=1 AND src_rank._peerdb_record_type=2`
 


### PR DESCRIPTION
## Summary

Fixes #4473.

This updates the Postgres <15 fallback normalize statements to use the same per-batch parameters as the PG15+ `MERGE` path:

```sql
_peerdb_batch_id = $1 AND _peerdb_destination_table_name = $2
```