### PR TITLE
LogFlowError on mysql ConnectionActive failure

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -149,7 +149,7 @@ func pullAndSyncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDC
 	}
 
 	if err := srcConn.ConnectionActive(ctx); err != nil {
-		return nil, fmt.Errorf("connection to source down: %w", err)
+		return nil, a.Alerter.LogFlowError(ctx, flowName, fmt.Errorf("connection to source down: %w", err))
 	}
 
 	batchSize := options.BatchSize


### PR DESCRIPTION
Avoids stuck mirror being silent in error logs