### PR TITLE
fix(mysql): use gtid_binlog_pos for MariaDB CDC start position

### DIFF
--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -467,16 +467,6 @@ func (c *MySqlConnector) GetMasterGTIDSet(ctx context.Context) (mysql.GTIDSet, e
 	var query string
 	switch c.Flavor() {
 	case mysql.MariaDBFlavor:
-		// Use gtid_binlog_pos rather than gtid_current_pos. PeerDB acts as a replica that
-		// reads this server's binary log via COM_BINLOG_DUMP, so the start position must be a
-		// GTID that actually exists in that binlog. gtid_current_pos merges gtid_binlog_pos with
-		// gtid_slave_pos, and for a domain last updated by replica threads it returns the
-		// gtid_slave_pos entry, which carries the upstream server's server_id and may not be
-		// present in this server's binlog. Requesting such a GTID makes MariaDB reject the
-		// connection with "requested to start from GTID ..., which is not in the master's binlog
-		// ... slave has diverged". gtid_binlog_pos is by definition the head of the binlog we
-		// stream, so it is always a reachable start point. MariaDB itself recommends against
-		// current_pos for connecting replicas for the same reason. See https://mariadb.com/kb/en/gtid/
 		query = "select @@gtid_binlog_pos"
 	default:
 		query = "select @@GLOBAL.gtid_executed"

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -467,7 +467,17 @@ func (c *MySqlConnector) GetMasterGTIDSet(ctx context.Context) (mysql.GTIDSet, e
 	var query string
 	switch c.Flavor() {
 	case mysql.MariaDBFlavor:
-		query = "select @@gtid_current_pos"
+		// Use gtid_binlog_pos rather than gtid_current_pos. PeerDB acts as a replica that
+		// reads this server's binary log via COM_BINLOG_DUMP, so the start position must be a
+		// GTID that actually exists in that binlog. gtid_current_pos merges gtid_binlog_pos with
+		// gtid_slave_pos, and for a domain last updated by replica threads it returns the
+		// gtid_slave_pos entry, which carries the upstream server's server_id and may not be
+		// present in this server's binlog. Requesting such a GTID makes MariaDB reject the
+		// connection with "requested to start from GTID ..., which is not in the master's binlog
+		// ... slave has diverged". gtid_binlog_pos is by definition the head of the binlog we
+		// stream, so it is always a reachable start point. MariaDB itself recommends against
+		// current_pos for connecting replicas for the same reason. See https://mariadb.com/kb/en/gtid/
+		query = "select @@gtid_binlog_pos"
 	default:
 		query = "select @@GLOBAL.gtid_executed"
 	}


### PR DESCRIPTION
## Problem

Customers on MariaDB CDC hit:

```
ERROR 1236 (HY000): Error: connecting slave requested to start from GTID
0-1026536087-10250614208, which is not in the master's binlog. Since the
master's binlog contains GTIDs with higher sequence numbers, it probably
means that the slave has diverged due to executing extra erroneous transactions
```

## Terminology

- `@@gtid_binlog_pos` is GTID of the last event written to the binary log
- `@@gtid_slave_pos` exists only on replica servers and contains the last replicated GTID. It will write this event to its own binlog ONLY if `log_slave_updates=ON`.
- `@@gtid_current_pos` is the max of `@@gtid_binlog_pos` and `@@gtid_slave_pos`.

## Current behaviour

Now peerdb uses `@@gtid_current_pos` as a starting cdc point. In most cases it's fine. But problems begin if you promote a replica that had `log_slave_updates=OFF` to become a primary (by applying smth like `STOP SLAVE; RESET SLAVE;`). In that case replica's `@@gtid_slave_pos` is not zero and therefore it can be returned as a value of `@@gtid_current_pos` -> which leads to a situation when we try to start replication with GTID which has never been written to that replica binlog.

## Solution

We must always use `@@gtid_binlog_pos`, which is the source of truth for current GTID that exists on the server. For us it doesn't matter whether the server is a replica or primary or has been a replica before. We just need to know what is the current GTID from its own binlog.
