### PR TITLE
Skip RDS heartbeat GTIDs for MySQL checkpoints

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -101,6 +102,23 @@ func parseSQL(parser *parser.Parser, query []byte) ([]ast.StmtNode, []error, err
 	// TIDB parser errors on null-terminated strings
 	trimmedQuery := shared.UnsafeFastReadOnlyBytesToString(bytes.TrimRight(query, "\x00"))
 	return parser.ParseSQL(trimmedQuery)
+}
+
+func isRDSHeartbeatQuery(schema []byte, query []byte) bool {
+	queryText := strings.ToLower(shared.UnsafeFastReadOnlyBytesToString(query))
+	if !strings.Contains(queryText, "rds_heartbeat") {
+		return false
+	}
+
+	schemaText := strings.ToLower(shared.UnsafeFastReadOnlyBytesToString(schema))
+	if schemaText == "mysql" {
+		return true
+	}
+
+	return strings.Contains(queryText, "mysql.rds_heartbeat") ||
+		strings.Contains(queryText, "`mysql`.`rds_heartbeat") ||
+		strings.Contains(queryText, "`mysql`.rds_heartbeat") ||
+		strings.Contains(queryText, "mysql.`rds_heartbeat")
 }
 
 func (c *MySqlConnector) GetTableSchema(
@@ -460,6 +478,8 @@ func (c *MySqlConnector) PullRecords(
 	var coercionReported bool
 	var updatedOffset string
 	var inTx bool
+	var txOnlyRDSHeartbeat bool
+	var txHasNonRDSHeartbeatEvent bool
 	var recordCount uint32
 
 	// set when a tx is preventing us from respecting the timeout, immediately exit after we see inTx false
@@ -544,18 +564,30 @@ func (c *MySqlConnector) PullRecords(
 		switch ev := event.Event.(type) {
 		case *replication.GTIDEvent:
 			recordCommitLagMetric(ctx, ev.ImmediateCommitTimestamp)
+			txOnlyRDSHeartbeat = false
+			txHasNonRDSHeartbeatEvent = false
 		case *replication.GtidTaggedLogEvent: // MySQL 8.4+ tagged GTIDs
 			recordCommitLagMetric(ctx, ev.ImmediateCommitTimestamp)
+			txOnlyRDSHeartbeat = false
+			txHasNonRDSHeartbeatEvent = false
 		case *replication.XIDEvent:
 			if gset != nil {
 				gset = ev.GSet
-				updatedOffset = gset.String() // accumulated from GTID events above
-				req.RecordStream.UpdateLatestCheckpointText(updatedOffset)
+				if txOnlyRDSHeartbeat && !txHasNonRDSHeartbeatEvent {
+					// RDS blue/green switchovers can expose heartbeat GTIDs that are not readable on green.
+					c.logger.Debug("[mysql] skipping GTID checkpoint update for RDS heartbeat transaction",
+						slog.String("offset", gset.String()))
+				} else {
+					updatedOffset = gset.String() // accumulated from GTID events above
+					req.RecordStream.UpdateLatestCheckpointText(updatedOffset)
+				}
 			} else if event.Header.LogPos > pos.Pos {
 				pos.Pos = event.Header.LogPos
 				updatedOffset = posToOffsetText(pos)
 				req.RecordStream.UpdateLatestCheckpointText(updatedOffset)
 			}
+			txOnlyRDSHeartbeat = false
+			txHasNonRDSHeartbeatEvent = false
 			inTx = false
 		case *replication.RotateEvent:
 			if gset == nil && (event.Header.Timestamp != 0 || string(ev.NextLogName) != pos.Name) {
@@ -579,6 +611,13 @@ func (c *MySqlConnector) PullRecords(
 				updatedOffset = posToOffsetText(pos)
 				req.RecordStream.UpdateLatestCheckpointText(updatedOffset)
 			}
+			if isRDSHeartbeatQuery(ev.Schema, ev.Query) {
+				txOnlyRDSHeartbeat = !txHasNonRDSHeartbeatEvent
+				break
+			}
+			txHasNonRDSHeartbeatEvent = true
+			txOnlyRDSHeartbeat = false
+
 			if mysqlParser == nil {
 				mysqlParser = parser.New()
 			}
@@ -604,6 +643,9 @@ func (c *MySqlConnector) PullRecords(
 				}
 			}
 		case *replication.RowsEvent:
+			txHasNonRDSHeartbeatEvent = true
+			txOnlyRDSHeartbeat = false
+
 			sourceTableName := string(ev.Table.Schema) + "." + string(ev.Table.Table) // TODO this is fragile
 			destinationTableName := req.TableNameMapping[sourceTableName].Name
 			exclusion := req.TableNameMapping[sourceTableName].Exclude

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -110,15 +110,15 @@ func isRDSHeartbeatQuery(schema []byte, query []byte) bool {
 		return false
 	}
 
-	schemaText := strings.ToLower(shared.UnsafeFastReadOnlyBytesToString(schema))
-	if schemaText == "mysql" {
+	if strings.EqualFold(shared.UnsafeFastReadOnlyBytesToString(schema), "mysql") {
 		return true
 	}
 
-	return strings.Contains(queryText, "mysql.rds_heartbeat") ||
-		strings.Contains(queryText, "`mysql`.`rds_heartbeat") ||
-		strings.Contains(queryText, "`mysql`.rds_heartbeat") ||
-		strings.Contains(queryText, "mysql.`rds_heartbeat")
+	return strings.Contains(strings.ReplaceAll(queryText, "`", ""), "mysql.rds_heartbeat")
+}
+
+func shouldSkipGTIDAdvancementForQuery(schema []byte, query []byte) bool {
+	return isRDSHeartbeatQuery(schema, query)
 }
 
 func (c *MySqlConnector) GetTableSchema(
@@ -478,8 +478,8 @@ func (c *MySqlConnector) PullRecords(
 	var coercionReported bool
 	var updatedOffset string
 	var inTx bool
-	var txOnlyRDSHeartbeat bool
-	var txHasNonRDSHeartbeatEvent bool
+	var txOnlySkippableGTIDAdvancementEvents bool
+	var txHasNonSkippableGTIDAdvancementEvent bool
 	var recordCount uint32
 
 	// set when a tx is preventing us from respecting the timeout, immediately exit after we see inTx false
@@ -564,18 +564,18 @@ func (c *MySqlConnector) PullRecords(
 		switch ev := event.Event.(type) {
 		case *replication.GTIDEvent:
 			recordCommitLagMetric(ctx, ev.ImmediateCommitTimestamp)
-			txOnlyRDSHeartbeat = false
-			txHasNonRDSHeartbeatEvent = false
+			txOnlySkippableGTIDAdvancementEvents = false
+			txHasNonSkippableGTIDAdvancementEvent = false
 		case *replication.GtidTaggedLogEvent: // MySQL 8.4+ tagged GTIDs
 			recordCommitLagMetric(ctx, ev.ImmediateCommitTimestamp)
-			txOnlyRDSHeartbeat = false
-			txHasNonRDSHeartbeatEvent = false
+			txOnlySkippableGTIDAdvancementEvents = false
+			txHasNonSkippableGTIDAdvancementEvent = false
 		case *replication.XIDEvent:
 			if gset != nil {
 				gset = ev.GSet
-				if txOnlyRDSHeartbeat && !txHasNonRDSHeartbeatEvent {
+				if txOnlySkippableGTIDAdvancementEvents && !txHasNonSkippableGTIDAdvancementEvent {
 					// RDS blue/green switchovers can expose heartbeat GTIDs that are not readable on green.
-					c.logger.Debug("[mysql] skipping GTID checkpoint update for RDS heartbeat transaction",
+					c.logger.Debug("[mysql] skipping GTID advancement for skippable transaction",
 						slog.String("offset", gset.String()))
 				} else {
 					updatedOffset = gset.String() // accumulated from GTID events above
@@ -586,8 +586,8 @@ func (c *MySqlConnector) PullRecords(
 				updatedOffset = posToOffsetText(pos)
 				req.RecordStream.UpdateLatestCheckpointText(updatedOffset)
 			}
-			txOnlyRDSHeartbeat = false
-			txHasNonRDSHeartbeatEvent = false
+			txOnlySkippableGTIDAdvancementEvents = false
+			txHasNonSkippableGTIDAdvancementEvent = false
 			inTx = false
 		case *replication.RotateEvent:
 			if gset == nil && (event.Header.Timestamp != 0 || string(ev.NextLogName) != pos.Name) {
@@ -611,12 +611,12 @@ func (c *MySqlConnector) PullRecords(
 				updatedOffset = posToOffsetText(pos)
 				req.RecordStream.UpdateLatestCheckpointText(updatedOffset)
 			}
-			if isRDSHeartbeatQuery(ev.Schema, ev.Query) {
-				txOnlyRDSHeartbeat = !txHasNonRDSHeartbeatEvent
+			if shouldSkipGTIDAdvancementForQuery(ev.Schema, ev.Query) {
+				txOnlySkippableGTIDAdvancementEvents = !txHasNonSkippableGTIDAdvancementEvent
 				break
 			}
-			txHasNonRDSHeartbeatEvent = true
-			txOnlyRDSHeartbeat = false
+			txHasNonSkippableGTIDAdvancementEvent = true
+			txOnlySkippableGTIDAdvancementEvents = false
 
 			if mysqlParser == nil {
 				mysqlParser = parser.New()
@@ -643,8 +643,8 @@ func (c *MySqlConnector) PullRecords(
 				}
 			}
 		case *replication.RowsEvent:
-			txHasNonRDSHeartbeatEvent = true
-			txOnlyRDSHeartbeat = false
+			txHasNonSkippableGTIDAdvancementEvent = true
+			txOnlySkippableGTIDAdvancementEvents = false
 
 			sourceTableName := string(ev.Table.Schema) + "." + string(ev.Table.Table) // TODO this is fragile
 			destinationTableName := req.TableNameMapping[sourceTableName].Name

--- a/flow/connectors/mysql/cdc_test.go
+++ b/flow/connectors/mysql/cdc_test.go
@@ -173,6 +173,49 @@ func TestParseSQLParsesTrailingNull(t *testing.T) {
 	}
 }
 
+func TestIsRDSHeartbeatQuery(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		schema []byte
+		query  []byte
+		want   bool
+	}{
+		{
+			name:  "rds heartbeat qualified in query",
+			query: []byte("SET STATEMENT max_statement_time=60 FOR INSERT INTO mysql.rds_heartbeat2(id, value) values (1,1782583487791) ON DUPLICATE KEY UPDATE value = 1782583487791"),
+			want:  true,
+		},
+		{
+			name:   "rds heartbeat with mysql event schema",
+			schema: []byte("mysql"),
+			query:  []byte("INSERT INTO rds_heartbeat2(id, value) VALUES (1, 1782583487791)"),
+			want:   true,
+		},
+		{
+			name:  "rds heartbeat with quoted qualifier",
+			query: []byte("INSERT INTO `mysql`.`rds_heartbeat2` (`id`, `value`) VALUES (1, 1782583487791)"),
+			want:  true,
+		},
+		{
+			name:  "non-heartbeat rds table is not ignored",
+			query: []byte("UPDATE mysql.rds_configuration SET value = 0 WHERE name = 'source delay'"),
+		},
+		{
+			name:   "user table with same suffix is not ignored",
+			schema: []byte("app"),
+			query:  []byte("INSERT INTO rds_heartbeat2(id, value) VALUES (1, 1782583487791)"),
+		},
+		{
+			name:  "ordinary query",
+			query: []byte("ALTER TABLE app.users ADD COLUMN nickname text"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isRDSHeartbeatQuery(tc.schema, tc.query))
+		})
+	}
+}
+
 func TestClassifyOnlineSchemaMigrationTool(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/flow/connectors/mysql/cdc_test.go
+++ b/flow/connectors/mysql/cdc_test.go
@@ -173,7 +173,7 @@ func TestParseSQLParsesTrailingNull(t *testing.T) {
 	}
 }
 
-func TestIsRDSHeartbeatQuery(t *testing.T) {
+func TestShouldSkipGTIDAdvancementForQuery(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		schema []byte
@@ -211,7 +211,7 @@ func TestIsRDSHeartbeatQuery(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, isRDSHeartbeatQuery(tc.schema, tc.query))
+			require.Equal(t, tc.want, shouldSkipGTIDAdvancementForQuery(tc.schema, tc.query))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- detect AWS RDS heartbeat binlog queries such as mysql.rds_heartbeat2
- skip promoting GTID checkpoints for transactions containing only those heartbeat events
- keep normal GTID, row, query, and file/position checkpoint behavior unchanged

## Testing
- GOCACHE=/private/tmp/peerdb-gocache go test ./connectors/mysql -run 'Test(IsRDSHeartbeatQuery|ParseSQLParsesTrailingNull|ParseReplicationOffsetText|ReplicationMechanismInUseFromOffsetText)'