### PR TITLE
classification: source column unknown error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -154,6 +154,9 @@ var (
 	ErrorNotifySourceTableMissing = ErrorClass{
 		Class: "NOTIFY_SOURCE_TABLE_MISSING", action: NotifyUser,
 	}
+	ErrorNotifySourceColumnUnknown = ErrorClass{
+		Class: "NOTIFY_SOURCE_COLUMN_UNKNOWN", action: NotifyUser,
+	}
 	ErrorNotifyBadSourceTableReplicaIdentity = ErrorClass{
 		Class: "NOTIFY_BAD_POSTGRES_TABLE_REPLICA_IDENTITY", action: NotifyUser,
 	}
@@ -779,6 +782,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorOther, myErrorInfo
 		case 1146: // ER_NO_SUCH_TABLE
 			return ErrorNotifySourceTableMissing, myErrorInfo
+		case 1054: // ER_BAD_FIELD_ERROR
+			return ErrorNotifySourceColumnUnknown, myErrorInfo
 		case 1943: // ER_DUPLICATE_GTID_DOMAIN (MariaDB)
 			return ErrorNotifyBadGTIDSetup, myErrorInfo
 		case 5, // ERR_OUT_OF_MEMORY

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -955,6 +955,22 @@ func TestMySQLExecuteError(t *testing.T) {
 	}, errInfo)
 }
 
+func TestMySQLUnknownColumnError(t *testing.T) {
+	myErr := &mysql.MyError{
+		Code:    1054,
+		State:   "42S22",
+		Message: "Unknown column '\u2060 id \u2060' in 'field list'",
+	}
+	err := fmt.Errorf("failed to get partitions from source: %w", exceptions.NewMySQLExecuteError(myErr))
+	errorClass, errInfo := GetErrorClass(t.Context(), err)
+	assert.Equal(t, ErrorNotifySourceColumnUnknown, errorClass)
+	assert.Equal(t, NotifyUser, errorClass.ErrorAction())
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMySQL,
+		Code:   "1054",
+	}, errInfo)
+}
+
 func TestClickHouseTooManyPartsWithTableName(t *testing.T) {
 	err := &clickhouse.Exception{
 		Code: int32(chproto.ErrTooManyParts),


### PR DESCRIPTION
If the source schema changes between Setup and Replication, this error can happen because the watermark column derived from catalog, which can store a pk that is stale when comparing to what's in the source db.

I'm not convinced that this is necessarily what happened to this specific issue, as updating primary key name seems like a very rare thing to do. That said, currently I don't have another good theory on how this error was triggered at all and was not able to repro the error when trying to create a table with column name containing the `\u2060` word joiner unicode. 

Fixes: DBI-892