### PR TITLE
Renovate simulation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ ancillary.env
 # Ephemeral volumes for docker compose
 volumes/ch_*
 
+# Renovate debug files
+final-updated-packages.txt
+renovate.out
+update-proposals.json

--- a/renovate-simulation.sh
+++ b/renovate-simulation.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This scripts runs Renovate locally to validate renovate.json5 configuration file
+# It generates the folloing files:
+# - `renovate.out` With the raw debug output of the run.
+# - `update-proposals.json` with the list of proposed updates but INCLUDING DISABLED ones
+# - `final-updated-packages.txt` with the list of packages with updates in the resulting PRs (considering disabled/enabled).
+#
+# WARNING: If the script is terminated before restoring the extension source (step 2), make sure you revert
+#          the changes to renovate.json5 manually.
+
+## (1) Check config syntax
+npx --yes --package renovate -- renovate-config-validator renovate.json5 || exit 1
+
+## (2) Temporarily change the renovate.json5 to point to the local extension source
+sed -i 's/local>PeerDB-io/github>PeerDB-io/' renovate.json5
+
+function cleanup {
+  echo "Restoring renovate.json5 to point to the GitHub extension source"
+  sed -i 's/github>PeerDB-io/local>PeerDB-io/' renovate.json5
+}
+trap cleanup EXIT
+
+## (3) Run Renovate locally
+echo "Running Renovate locally..."
+LOG_LEVEL=debug npx renovate --platform=local --require-config=optional --repository-cache=reset > renovate.out
+
+## (4) Extract update proposals
+cat renovate.out | sed '1,/packageFiles with updates/d' | sed 's/"config": {/{/' | sed '/DEBUG/,$d' | jq '.gomod[].deps[]' > update-proposals.json
+
+## (5) Extract final updated packages
+cat renovate.out | grep 'flattened updates found' | tr ',' '\n' > final-updated-packages.txt
+
+echo "List of packages with proposed updates:"
+echo "----------------------------------------"
+cat final-updated-packages.txt

--- a/scripts/renovate-simulation.sh
+++ b/scripts/renovate-simulation.sh
@@ -9,6 +9,13 @@
 # WARNING: If the script is terminated before restoring the extension source (step 2), make sure you revert
 #          the changes to renovate.json5 manually.
 
+if [ -f "renovate.json5" ]; then
+  echo "Found renovate.json5, proceeding..."
+else
+  echo "renovate.json5 not found, please run this script from the root of the repository."
+  exit 1
+fi
+
 ## (1) Check config syntax
 npx --yes --package renovate -- renovate-config-validator renovate.json5 || exit 1
 


### PR DESCRIPTION
This PR adds a script to run Renovate locally in order to validate `renovate.json5` configuration.

:memo: In the future, it can be added as a CI build validation workflow executed only upon changes to `renovate.json5` file.