### PR TITLE
WIP: perf(cdc-graph): bound cdc_batches scan and add composite index

### DIFF
--- a/nexus/catalog/migrations/V55__cdc_batches_flow_name_start_time_index.sql
+++ b/nexus/catalog/migrations/V55__cdc_batches_flow_name_start_time_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_cdc_batches_flow_name_start_time ON peerdb_stats.cdc_batches (flow_name, start_time);


### PR DESCRIPTION
## Problem

The `CDCGraph` query range-joins `generate_series` ticks against `peerdb_stats.cdc_batches`:

```sql
LEFT JOIN peerdb_stats.cdc_batches
  ON start_time >= tm AND start_time < tm + $1::INTERVAL
  AND flow_name = $4
```

There's **no global lower bound on `start_time`** — the only constraint on which rows are touched comes from the per-bucket join condition. The existing indexes (`HASH(flow_name)` and `btree(start_time)`) can't be combined in a single scan, so a likely plan pulls **every batch for the flow across all history** via the hash index and then joins it down to ~30 buckets. For a long-running mirror that means millions of rows scanned to render a small graph.

## Changes

1. **Query rewrite** ([flow/cmd/mirror_status.go](flow/cmd/mirror_status.go)) — pull the flow's batches for the window into a bounded CTE (single scan) via an explicit `start_time >= lower_bound.lb` filter, then keep the same range join over that small set. Semantics are unchanged, including calendar-correct `month` stepping from `generate_series`.

2. **Composite index** (`V55`) — `(flow_name, start_time)` so the bounded scan becomes a single tight index range scan. The existing `idx_cdc_batches_flow_name` HASH index is now redundant and could be dropped in a follow-up (left in place here to keep this change low-risk).

## Notes

- Output shape and values are identical to the previous query; only the access path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)