### PR TITLE
Re-order error classification for MySQLExecuteError

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -1153,17 +1153,6 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
-	if mysqlExecuteError, ok := errors.AsType[*exceptions.MySQLExecuteError](err); ok {
-		errClass := ErrorOther
-		if mysqlExecuteError.Retryable {
-			errClass = ErrorRetryRecoverable
-		}
-		return errClass, ErrorInfo{
-			Source: ErrorSourceMySQL,
-			Code:   "EXECUTE_ERROR",
-		}
-	}
-
 	if _, ok := errors.AsType[*exceptions.MySQLStaleConnectionError](err); ok {
 		return ErrorRetryRecoverable, ErrorInfo{
 			Source: ErrorSourceMySQL,
@@ -1193,6 +1182,19 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		return ErrorUnsupportedDatatype, ErrorInfo{
 			Source: ErrorSourceMySQL,
 			Code:   "UNSUPPORTED_GEOMETRY_LINEAR_RING_NOT_CLOSED",
+		}
+	}
+
+	// mysql execute error is a generic error that can happen when interacting with mysql server;
+	// intentionally checked this after other more specific mysql errors above
+	if mysqlExecuteError, ok := errors.AsType[*exceptions.MySQLExecuteError](err); ok {
+		errClass := ErrorOther
+		if mysqlExecuteError.Retryable {
+			errClass = ErrorRetryRecoverable
+		}
+		return errClass, ErrorInfo{
+			Source: ErrorSourceMySQL,
+			Code:   "EXECUTE_ERROR",
 		}
 	}
 

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1136,6 +1136,14 @@ func TestMySQLGeometryLinearRingNotClosedShouldBeUnsupportedDatatype(t *testing.
 		Source: ErrorSourceMySQL,
 		Code:   "UNSUPPORTED_GEOMETRY_LINEAR_RING_NOT_CLOSED",
 	}, errInfo)
+
+	executeErrWrapper := exceptions.NewMySQLExecuteError(wrapped)
+	errorClass, errInfo = GetErrorClass(t.Context(), executeErrWrapper)
+	assert.Equal(t, ErrorUnsupportedDatatype, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMySQL,
+		Code:   "UNSUPPORTED_GEOMETRY_LINEAR_RING_NOT_CLOSED",
+	}, errInfo)
 }
 
 func TestMySQLGeometryParseErrorUnknownShouldFallThrough(t *testing.T) {


### PR DESCRIPTION
We can get `MySQLGeometryParseError` wrapped inside `MySQLExecuteError`:

```
[qrep] failed to pull records: MySQL execute error: could not convert mysql value for Points: failed to parse MySQL geometry WKB: IllegalArgumentException: Points of LinearRing do not form a closed linestring
```

Reorder the classification logic so `MySQLExecuteError` functions more like a catch-all before other more specific mysql errors. 