### PR TITLE
feat(api): add endpoint for pg-pg source and destination row count check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ flow/connectors/postgres/sink_pg.go                     @PeerDB-io/ch-postgres
 flow/model/pg_items.go                                  @PeerDB-io/ch-postgres
 flow/pkg/postgres/dest_validation.go                    @PeerDB-io/ch-postgres
 flow/cmd/reset_sequences.go                             @PeerDB-io/ch-postgres
+flow/cmd/row_counts.go                                  @PeerDB-io/ch-postgres
 
 flow/e2e/pg_schema_dump_test.go                         @PeerDB-io/ch-postgres
 flow/e2e/postgres*.go                                   @PeerDB-io/ch-postgres

--- a/flow/cmd/row_counts.go
+++ b/flow/cmd/row_counts.go
@@ -25,6 +25,11 @@ const (
 	countTimeoutSeconds = 30
 )
 
+// GetMirrorRowCounts returns per-table source and destination row counts for a
+// Postgres-to-Postgres CDC mirror, so the caller can compare the two sides and spot drift.
+// Both peers must be Postgres; query replication (QRep) mirrors are not supported. Tables can
+// be filtered via req.SourceTables. Small tables are counted exactly while large tables use an
+// approximate estimate; a count of -1 signals the value could not be obtained (missing table or timeout).
 func (h *FlowRequestHandler) GetMirrorRowCounts(
 	ctx context.Context,
 	req *protos.RowCountRequest,
@@ -32,22 +37,19 @@ func (h *FlowRequestHandler) GetMirrorRowCounts(
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	// Validate mirror exists and is CDC
 	isCdc, err := h.isCDCFlow(ctx, req.FlowJobName)
 	if err != nil {
 		return nil, NewInternalApiError(fmt.Errorf("unable to check flow type: %w", err))
 	}
 	if !isCdc {
-		return nil, NewInvalidArgumentApiError(fmt.Errorf("row count validation is only supported for CDC mirrors"))
+		return nil, NewInvalidArgumentApiError(fmt.Errorf("row count validation is not supported for query replication mirrors"))
 	}
 
-	// Get flow config to extract table mappings and peer names
 	config, err := h.getFlowConfigFromCatalog(ctx, req.FlowJobName)
 	if err != nil {
 		return nil, NewInternalApiError(fmt.Errorf("unable to get flow config: %w", err))
 	}
 
-	// Verify both peers are Postgres
 	srcType, err := connectors.LoadPeerType(ctx, h.pool, config.SourceName)
 	if err != nil {
 		return nil, NewInternalApiError(fmt.Errorf("unable to load source peer type: %w", err))
@@ -63,7 +65,6 @@ func (h *FlowRequestHandler) GetMirrorRowCounts(
 		return nil, NewInvalidArgumentApiError(fmt.Errorf("destination peer %s is not PostgreSQL", config.DestinationName))
 	}
 
-	// Filter table mappings if source_tables filter is specified
 	tableMappings := config.TableMappings
 	if len(req.SourceTables) > 0 {
 		filterSet := make(map[string]struct{}, len(req.SourceTables))
@@ -83,7 +84,6 @@ func (h *FlowRequestHandler) GetMirrorRowCounts(
 		return &protos.RowCountResponse{TableCounts: nil}, nil
 	}
 
-	// Open connections to source and destination
 	srcConn, srcClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, h.pool, config.SourceName)
 	if err != nil {
 		return nil, NewInternalApiError(fmt.Errorf("failed to connect to source peer: %w", err))
@@ -96,7 +96,6 @@ func (h *FlowRequestHandler) GetMirrorRowCounts(
 	}
 	defer dstClose(ctx)
 
-	// Build result slice
 	results := make([]*protos.TableRowCount, len(tableMappings))
 	for i, tm := range tableMappings {
 		results[i] = &protos.TableRowCount{
@@ -105,8 +104,6 @@ func (h *FlowRequestHandler) GetMirrorRowCounts(
 		}
 	}
 
-	// Query source and destination in parallel,
-	// but serialize queries within each peer since pgx.Conn is not concurrent-safe.
 	g, gCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
@@ -162,7 +159,6 @@ func getTableRowCount(ctx context.Context, conn *pgx.Conn, tableIdentifier strin
 	}
 	qualifiedName := parsed.String()
 
-	// Get table size to decide strategy
 	var tableSizeBytes pgtype.Int8
 	if err := conn.QueryRow(ctx,
 		"SELECT pg_total_relation_size(to_regclass($1))", qualifiedName,

--- a/flow/cmd/row_counts.go
+++ b/flow/cmd/row_counts.go
@@ -1,0 +1,225 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/PeerDB-io/peerdb/flow/connectors"
+	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/pkg/common"
+	"github.com/PeerDB-io/peerdb/flow/shared"
+)
+
+const (
+	// Tables larger than this get approximate counts via reltuples/relpages
+	largeTableThresholdBytes = 10 * 1024 * 1024 * 1024 // 10GB
+	// Per-table statement timeout for COUNT(*)
+	countTimeoutSeconds = 30
+)
+
+func (h *FlowRequestHandler) GetMirrorRowCounts(
+	ctx context.Context,
+	req *protos.RowCountRequest,
+) (*protos.RowCountResponse, APIError) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	// Validate mirror exists and is CDC
+	isCdc, err := h.isCDCFlow(ctx, req.FlowJobName)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("unable to check flow type: %w", err))
+	}
+	if !isCdc {
+		return nil, NewInvalidArgumentApiError(fmt.Errorf("row count validation is only supported for CDC mirrors"))
+	}
+
+	// Get flow config to extract table mappings and peer names
+	config, err := h.getFlowConfigFromCatalog(ctx, req.FlowJobName)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("unable to get flow config: %w", err))
+	}
+
+	// Verify both peers are Postgres
+	srcType, err := connectors.LoadPeerType(ctx, h.pool, config.SourceName)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("unable to load source peer type: %w", err))
+	}
+	dstType, err := connectors.LoadPeerType(ctx, h.pool, config.DestinationName)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("unable to load destination peer type: %w", err))
+	}
+	if srcType != protos.DBType_POSTGRES {
+		return nil, NewInvalidArgumentApiError(fmt.Errorf("source peer %s is not PostgreSQL", config.SourceName))
+	}
+	if dstType != protos.DBType_POSTGRES {
+		return nil, NewInvalidArgumentApiError(fmt.Errorf("destination peer %s is not PostgreSQL", config.DestinationName))
+	}
+
+	// Filter table mappings if source_tables filter is specified
+	tableMappings := config.TableMappings
+	if len(req.SourceTables) > 0 {
+		filterSet := make(map[string]struct{}, len(req.SourceTables))
+		for _, t := range req.SourceTables {
+			filterSet[t] = struct{}{}
+		}
+		filtered := make([]*protos.TableMapping, 0, len(req.SourceTables))
+		for _, tm := range tableMappings {
+			if _, ok := filterSet[tm.SourceTableIdentifier]; ok {
+				filtered = append(filtered, tm)
+			}
+		}
+		tableMappings = filtered
+	}
+
+	if len(tableMappings) == 0 {
+		return &protos.RowCountResponse{TableCounts: nil}, nil
+	}
+
+	// Open connections to source and destination
+	srcConn, srcClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, h.pool, config.SourceName)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("failed to connect to source peer: %w", err))
+	}
+	defer srcClose(ctx)
+
+	dstConn, dstClose, err := connectors.GetByNameAs[*connpostgres.PostgresConnector](ctx, nil, h.pool, config.DestinationName)
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("failed to connect to destination peer: %w", err))
+	}
+	defer dstClose(ctx)
+
+	// Build result slice
+	results := make([]*protos.TableRowCount, len(tableMappings))
+	for i, tm := range tableMappings {
+		results[i] = &protos.TableRowCount{
+			SourceTable:      tm.SourceTableIdentifier,
+			DestinationTable: tm.DestinationTableIdentifier,
+		}
+	}
+
+	// Query source and destination in parallel,
+	// but serialize queries within each peer since pgx.Conn is not concurrent-safe.
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		for i, tm := range tableMappings {
+			if gCtx.Err() != nil {
+				return gCtx.Err()
+			}
+			count, isApprox, err := getTableRowCount(gCtx, srcConn.Conn(), tm.SourceTableIdentifier)
+			if err != nil {
+				slog.WarnContext(gCtx, "failed to get source row count",
+					slog.String("table", tm.SourceTableIdentifier), slog.Any("error", err))
+				results[i].SourceCount = -1
+			} else {
+				results[i].SourceCount = count
+				results[i].SourceIsApproximate = isApprox
+			}
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		for i, tm := range tableMappings {
+			if gCtx.Err() != nil {
+				return gCtx.Err()
+			}
+			count, isApprox, err := getTableRowCount(gCtx, dstConn.Conn(), tm.DestinationTableIdentifier)
+			if err != nil {
+				slog.WarnContext(gCtx, "failed to get destination row count",
+					slog.String("table", tm.DestinationTableIdentifier), slog.Any("error", err))
+				results[i].DestinationCount = -1
+			} else {
+				results[i].DestinationCount = count
+				results[i].DestinationIsApproximate = isApprox
+			}
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("error getting row counts: %w", err))
+	}
+
+	return &protos.RowCountResponse{TableCounts: results}, nil
+}
+
+// getTableRowCount gets the row count for a table. For tables >= 10GB it returns
+// an approximate count using reltuples/relpages. For smaller tables it runs COUNT(*)
+// with a statement timeout. Returns -1 if the count query times out.
+func getTableRowCount(ctx context.Context, conn *pgx.Conn, tableIdentifier string) (int64, bool, error) {
+	parsed, err := common.ParseTableIdentifier(tableIdentifier)
+	if err != nil {
+		return -1, false, fmt.Errorf("failed to parse table identifier %s: %w", tableIdentifier, err)
+	}
+	qualifiedName := parsed.String()
+
+	// Get table size to decide strategy
+	var tableSizeBytes pgtype.Int8
+	if err := conn.QueryRow(ctx,
+		"SELECT pg_total_relation_size(to_regclass($1))", qualifiedName,
+	).Scan(&tableSizeBytes); err != nil {
+		return -1, false, fmt.Errorf("failed to get table size for %s: %w", tableIdentifier, err)
+	}
+	if !tableSizeBytes.Valid {
+		return -1, false, fmt.Errorf("table %s does not exist or size is null", tableIdentifier)
+	}
+
+	if tableSizeBytes.Int64 >= largeTableThresholdBytes {
+		return getApproximateRowCount(ctx, conn, qualifiedName)
+	}
+	return getExactRowCount(ctx, conn, qualifiedName)
+}
+
+// getApproximateRowCount uses the reltuples/relpages density formula (same as the PG planner).
+func getApproximateRowCount(ctx context.Context, conn *pgx.Conn, qualifiedName string) (int64, bool, error) {
+	const estimatedCountQuery = `SELECT
+		CASE
+			WHEN c.reltuples >= 0 AND c.relpages > 0 AND NOT c.relhassubclass
+				THEN (c.reltuples::numeric / c.relpages *
+					(pg_relation_size(c.oid) / current_setting('block_size')::integer))::bigint
+			ELSE -1
+		END
+	FROM pg_class c WHERE c.oid = to_regclass($1)`
+
+	var count pgtype.Int8
+	if err := conn.QueryRow(ctx, estimatedCountQuery, qualifiedName).Scan(&count); err != nil {
+		return -1, true, fmt.Errorf("failed to get approximate count for %s: %w", qualifiedName, err)
+	}
+	if !count.Valid || count.Int64 < 0 {
+		return -1, true, nil
+	}
+	return count.Int64, true, nil
+}
+
+// getExactRowCount runs COUNT(*) with a statement timeout. Returns -1 if timed out.
+func getExactRowCount(ctx context.Context, conn *pgx.Conn, qualifiedName string) (int64, bool, error) {
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return -1, false, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	timeoutMs := countTimeoutSeconds * 1000
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL statement_timeout = '%d'", timeoutMs)); err != nil {
+		return -1, false, fmt.Errorf("failed to set statement timeout: %w", err)
+	}
+
+	var count int64
+	if err := tx.QueryRow(ctx, "SELECT COUNT(*) FROM "+qualifiedName).Scan(&count); err != nil {
+		if shared.IsSQLStateError(err, pgerrcode.QueryCanceled) {
+			return -1, false, nil
+		}
+		return -1, false, fmt.Errorf("failed to count rows in %s: %w", qualifiedName, err)
+	}
+
+	return count, false, nil
+}

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -219,6 +219,21 @@ func (s APITestSuite) waitForFlowDropped(env WorkflowRun, flowJobName string) {
 	})
 }
 
+func (s APITestSuite) waitForDestinationRowCount(env WorkflowRun, dstTable string, expected int64) {
+	s.t.Helper()
+
+	EnvWaitFor(s.t, env, 3*time.Minute, fmt.Sprintf("wait for %d rows in %s", expected, dstTable), func() bool {
+		var count int64
+		if err := s.pg.Conn().QueryRow(
+			s.t.Context(), "SELECT COUNT(*) FROM "+dstTable,
+		).Scan(&count); err != nil {
+			s.t.Log(err)
+			return false
+		}
+		return count == expected
+	})
+}
+
 func testApi[TSource SuiteSource](
 	t *testing.T,
 	setup func(*testing.T, string) (TSource, error),
@@ -3804,4 +3819,147 @@ func (s APITestSuite) TestSnapshotNullPartitionKey() {
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 	EnvWaitForFinished(s.t, env, 3*time.Minute)
 	EnvWaitForCount(env, s.ch, "all 4 rows including nulls should be snapshotted", tableName, "*", 4)
+}
+
+func (s APITestSuite) TestGetMirrorRowCounts() {
+	_, ok := s.source.(*PostgresSource)
+	if !ok {
+		s.t.Skip("row count validation is only supported for PostgreSQL source and destination")
+	}
+
+	srcTable1 := AttachSchema(s, "rowcount_src1")
+	dstTable1 := AttachSchema(s, "rowcount_dst1")
+	srcTable2 := AttachSchema(s, "rowcount_src2")
+	dstTable2 := AttachSchema(s, "rowcount_dst2")
+	srcTable3 := AttachSchema(s, "rowcount_src3")
+	dstTable3 := AttachSchema(s, "rowcount_dst3")
+
+	for _, tbl := range []string{srcTable1, srcTable2, srcTable3} {
+		require.NoError(s.t, s.source.Exec(s.t.Context(),
+			fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", tbl)))
+	}
+	for _, tbl := range []string{dstTable1, dstTable2, dstTable3} {
+		_, err := s.pg.Conn().Exec(s.t.Context(),
+			fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", tbl))
+		require.NoError(s.t, err)
+	}
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s(id, val) SELECT g, 'v'||g FROM generate_series(1,3) g", srcTable1)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s(id, val) SELECT g, 'v'||g FROM generate_series(1,5) g", srcTable2)))
+
+	flowJobName := "get_row_counts_" + s.suffix
+	flowConnConfig := &protos.FlowConnectionConfigs{
+		FlowJobName:     flowJobName,
+		SourceName:      s.source.GeneratePeer(s.t).Name,
+		DestinationName: s.pg.GeneratePeer(s.t).Name,
+		TableMappings: []*protos.TableMapping{
+			{SourceTableIdentifier: srcTable1, DestinationTableIdentifier: dstTable1},
+			{SourceTableIdentifier: srcTable2, DestinationTableIdentifier: dstTable2},
+			{SourceTableIdentifier: srcTable3, DestinationTableIdentifier: dstTable3},
+		},
+		DoInitialSnapshot:  true,
+		System:             protos.TypeSystem_PG,
+		IdleTimeoutSeconds: 15,
+		Version:            shared.InternalVersion_Latest,
+	}
+
+	response, err := s.CreateCDCFlow(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, response)
+
+	tc := NewTemporalClient(s.t)
+	env, err := GetPeerflow(s.t.Context(), s.catalog, tc, flowJobName)
+	require.NoError(s.t, err)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitFor(s.t, env, 3*time.Minute, "wait for initial load to finish", func() bool {
+		return env.GetFlowStatus(s.t) == protos.FlowStatus_STATUS_RUNNING
+	})
+	s.waitForDestinationRowCount(env, dstTable1, 3)
+	s.waitForDestinationRowCount(env, dstTable2, 5)
+	s.waitForDestinationRowCount(env, dstTable3, 0)
+
+	rowCounts, err := s.GetMirrorRowCounts(s.t.Context(), &protos.RowCountRequest{FlowJobName: flowJobName})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, rowCounts)
+	require.Len(s.t, rowCounts.TableCounts, 3)
+
+	bySrc := make(map[string]*protos.TableRowCount, len(rowCounts.TableCounts))
+	for _, tc := range rowCounts.TableCounts {
+		bySrc[tc.SourceTable] = tc
+	}
+	require.Contains(s.t, bySrc, srcTable1)
+	require.Contains(s.t, bySrc, srcTable2)
+	require.Contains(s.t, bySrc, srcTable3)
+
+	require.Equal(s.t, dstTable1, bySrc[srcTable1].DestinationTable)
+	require.Equal(s.t, int64(3), bySrc[srcTable1].SourceCount)
+	require.Equal(s.t, int64(3), bySrc[srcTable1].DestinationCount)
+	require.False(s.t, bySrc[srcTable1].SourceIsApproximate)
+	require.False(s.t, bySrc[srcTable1].DestinationIsApproximate)
+
+	require.Equal(s.t, dstTable2, bySrc[srcTable2].DestinationTable)
+	require.Equal(s.t, int64(5), bySrc[srcTable2].SourceCount)
+	require.Equal(s.t, int64(5), bySrc[srcTable2].DestinationCount)
+
+	require.Equal(s.t, dstTable3, bySrc[srcTable3].DestinationTable)
+	require.Equal(s.t, int64(0), bySrc[srcTable3].SourceCount)
+	require.Equal(s.t, int64(0), bySrc[srcTable3].DestinationCount)
+	require.False(s.t, bySrc[srcTable3].SourceIsApproximate)
+	require.False(s.t, bySrc[srcTable3].DestinationIsApproximate)
+
+	filtered, err := s.GetMirrorRowCounts(s.t.Context(), &protos.RowCountRequest{
+		FlowJobName:  flowJobName,
+		SourceTables: []string{srcTable2},
+	})
+	require.NoError(s.t, err)
+	require.Len(s.t, filtered.TableCounts, 1)
+	require.Equal(s.t, srcTable2, filtered.TableCounts[0].SourceTable)
+	require.Equal(s.t, int64(5), filtered.TableCounts[0].SourceCount)
+	require.Equal(s.t, int64(5), filtered.TableCounts[0].DestinationCount)
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s(id, val) VALUES (4,'v4'),(5,'v5')", srcTable1)))
+	s.waitForDestinationRowCount(env, dstTable1, 5)
+
+	afterCdc, err := s.GetMirrorRowCounts(s.t.Context(), &protos.RowCountRequest{
+		FlowJobName:  flowJobName,
+		SourceTables: []string{srcTable1},
+	})
+	require.NoError(s.t, err)
+	require.Len(s.t, afterCdc.TableCounts, 1)
+	require.Equal(s.t, int64(5), afterCdc.TableCounts[0].SourceCount)
+	require.Equal(s.t, int64(5), afterCdc.TableCounts[0].DestinationCount)
+
+	env.Cancel(s.t.Context())
+	RequireEnvCanceled(s.t, env)
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), "DROP TABLE "+srcTable3))
+
+	missingCounts, err := s.GetMirrorRowCounts(s.t.Context(), &protos.RowCountRequest{
+		FlowJobName:  flowJobName,
+		SourceTables: []string{srcTable3},
+	})
+	require.NoError(s.t, err)
+	require.Len(s.t, missingCounts.TableCounts, 1)
+	require.Equal(s.t, srcTable3, missingCounts.TableCounts[0].SourceTable)
+	require.Equal(s.t, int64(-1), missingCounts.TableCounts[0].SourceCount)
+	require.Equal(s.t, int64(0), missingCounts.TableCounts[0].DestinationCount)
+}
+
+func (s APITestSuite) TestGetMirrorRowCountsNonCDC() {
+	_, ok := s.source.(*PostgresSource)
+	if !ok {
+		s.t.Skip("row count validation is only supported for PostgreSQL source and destination")
+	}
+
+	_, err := s.GetMirrorRowCounts(s.t.Context(), &protos.RowCountRequest{
+		FlowJobName: "nonexistent_flow_" + s.suffix,
+	})
+	require.Error(s.t, err)
+	grpcStatus, ok := status.FromError(err)
+	require.True(s.t, ok)
+	require.Equal(s.t, codes.InvalidArgument, grpcStatus.Code())
+	require.Contains(s.t, grpcStatus.Message(), "not supported for query replication mirrors")
 }

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -159,6 +159,22 @@ message TotalRowsSyncedByMirrorResponse {
   int64 totalCount = 3;
 }
 
+message RowCountRequest {
+  string flow_job_name = 1;
+  repeated string source_tables = 2; // optional filter; if empty, all tables
+}
+
+message TableRowCount {
+  string source_table = 1;
+  string destination_table = 2;
+  int64 source_count = 3;  // -1 means timed out
+  int64 destination_count = 4;  // -1 means timed out
+  bool source_is_approximate = 5;
+  bool destination_is_approximate = 6;
+}
+
+message RowCountResponse { repeated TableRowCount table_counts = 1; }
+
 message PeerSchemasResponse { repeated string schemas = 1; }
 
 message PeerPublicationsResponse { repeated string publication_names = 1; }
@@ -832,6 +848,13 @@ service FlowService {
   rpc ResetMirrorSequences(ResetMirrorSequencesRequest) returns (ResetMirrorSequencesResponse) {
     option (google.api.http) = {
       post : "/v1/mirrors/sequences/reset",
+      body : "*"
+    };
+  }
+
+  rpc GetMirrorRowCounts(RowCountRequest) returns (RowCountResponse) {
+    option (google.api.http) = {
+      post : "/v1/mirrors/row_counts",
       body : "*"
     };
   }


### PR DESCRIPTION
## Why
This is useful for validating mirror correctness after initial load and zero-lag CDC for PG - PG mirrors.

## What
- Adds new proto definitions for a route
- New handler in flow-api for mirror row count check, scoped to PG to PG mirrors.
- Adds api test for this new route

## What the endpoint does
User can pick a selection of tables to validate counts for.
Counts for source and destination obtained via two goroutines.
- For tables greater than 10GB -- gets an approximate row count as counts can take a long time
- For tables lesser than 10GB -- gets exact count
Count times capped to 30 seconds for each table. Response structure denotes what the counts are and whether they're approximate

- [x] Functionally tested