### PR TITLE
API Client automatic tagging: Use develops identity with right permissions

### DIFF
--- a/.github/workflows/flow-api-client-tag.yml
+++ b/.github/workflows/flow-api-client-tag.yml
@@ -95,8 +95,8 @@ jobs:
             exit 1
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "DevOps Bot"
+          git config --global user.email "peerdb-oss-devops-bot@clickhouse.com"
 
           target="$(git rev-parse refs/remotes/origin/flow-api-client)"
           echo "Tagging flow-api-client tip ${target} as ${tag}"

--- a/.github/workflows/flow-api-client-tag.yml
+++ b/.github/workflows/flow-api-client-tag.yml
@@ -36,6 +36,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Test DEVOPS_BOT_GITHUB_TOKEN can post PR comments (temporary)
+        shell: bash
+        env:
+          #GITHUB_TOKEN: ${{ secrets.DEVOPS_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh pr comment https://github.com/PeerDB-io/peerdb/pull/4560 --body "test message"
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Fetch flow-api-client branch and existing tags

--- a/.github/workflows/flow-api-client-tag.yml
+++ b/.github/workflows/flow-api-client-tag.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Create and push tag
         shell: bash
         env:
+          GITHUB_TOKEN: ${{ secrets.DEVOPS_BOT_GITHUB_TOKEN }}
           INPUT_VERSION: ${{ inputs.version }}
           RESOLVED_VERSION: ${{ steps.resolve.outputs.version }}
         run: |


### PR DESCRIPTION
Follows on https://github.com/PeerDB-io/peerdb/pull/4532 by adding the right GITHUB_TOKEN to the flow so it's able to push tags.