### PR TITLE
classify neon transient error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -72,6 +72,7 @@ var (
 	PostgresSpillFileMissingRe         = regexp.MustCompile(`Unable to restore changes for xid \d+`)
 	// e.g. could not rename file "pg_logical/snapshots/25-3370F40.snap.19943.tmp" to "pg_logical/snapshots/25-3370F40.snap"
 	PostgresCouldNotRenameSnapshotRe = regexp.MustCompile(`could not rename file ".*\.snap\..*\.tmp" to ".*\.snap"`)
+	PostgresNeonDonorWalLaggingRe    = regexp.MustCompile(`requested WAL up to [0-9A-F]+/[0-9A-F]+, but current donor \S+ has only up to`)
 	MySqlRdsBinlogFileNotFoundRe     = regexp.MustCompile(`File '/rdsdbdata/log/binlog/mysql-bin-changelog.\d+' not found`)
 	MongoPoolClearedErrorRe          = regexp.MustCompile(`connection pool for .+ was cleared because another operation failed with`)
 )
@@ -610,6 +611,9 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 					return ErrorNotifyConnectivity, pgErrorInfo
 				}
 				if strings.Contains(pgErr.Message, "lost synchronization with server") {
+					return ErrorRetryRecoverable, pgErrorInfo
+				}
+				if PostgresNeonDonorWalLaggingRe.MatchString(pgErr.Message) {
 					return ErrorRetryRecoverable, pgErrorInfo
 				}
 			}

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -179,6 +179,27 @@ func TestNeonProjectQuotaExceededErrorShouldBeConnectivity(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestNeonDonorWalLaggingErrorShouldBeRecoverable(t *testing.T) {
+	// Simulate Neon's walsender failing to read WAL because the donor safekeeper is lagging behind
+	err := &exceptions.PostgresWalError{
+		Msg: &pgproto3.ErrorResponse{
+			Severity: "ERROR",
+			Code:     pgerrcode.InternalError,
+			Message: "[walsender] Failed to read WAL (req_lsn=0/DD7D4000, len=8192): closing remote connection: " +
+				"requested WAL up to 0/DD7D6000, but current donor xxx.aws.neon.tech:6401 has only up to 0/DD7D5FF8",
+			File:    "walsender_hooks.c",
+			Line:    144,
+			Routine: "NeonWALPageRead",
+		},
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("error in WAL: %w", err))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.InternalError,
+	}, errInfo)
+}
+
 func TestPostgresMemoryAllocErrorShouldBeSlotMemalloc(t *testing.T) {
 	// Simulate a Postgres memory allocation error
 	err := &exceptions.PostgresWalError{


### PR DESCRIPTION
Classify a transient Neon error:
```
Postgres WAL error: received error response, message: &{Severity:ERROR SeverityUnlocalized:ERROR Code:XX000 Message:[walsender] Failed to read WAL (req_lsn=0/DD7D4000, len=8192): closing remote connection: requested WAL up to 0/DD7D6000, but current donor safekeeper-6.cell-4.eu-central-1.aws.neon.tech:6401 has only up to 0/DD7D5FF8 Detail: Hint: Position:0 InternalPosition:0 InternalQuery: Where: SchemaName: TableName: ColumnName: DataTypeName: ConstraintName: File:walsender_hooks.c Line:144 Routine:NeonWALPageRead UnknownFields:map[]}
```

Fixes: DBI-907