### PR TITLE
DBI-798: Safer check on mirror validation with MySQL sources setting server_id

### DIFF
--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -16,7 +16,6 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
-	mysql_validation "github.com/PeerDB-io/peerdb/flow/pkg/mysql"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
@@ -188,25 +187,6 @@ func (h *FlowRequestHandler) checkSourcePeerReuse(
 		return nil
 	}
 
-	// beyond other PeerDB mirrors (checked below), the pinned server_id must not be already registered
-	// as a replica on the source DB itself.
-	mysqlConn, mysqlClose, err := connectors.GetAs[*connmysql.MySqlConnector](ctx, cfg.Env, peer)
-	if err != nil {
-		return NewInternalApiError(fmt.Errorf("failed to create MySQL connector for source peer %s: %w", cfg.SourceName, err))
-	}
-	defer mysqlClose(ctx)
-
-	if inUse, err := mysql_validation.HasReplicaWithServerId(mysqlConn.Conn(), *mysqlCfg.ServerId); err != nil {
-		return NewInternalApiError(fmt.Errorf("failed to check replicas registered on source peer %s: %w", cfg.SourceName, err))
-	} else if inUse {
-		return NewFailedPreconditionApiError(
-			fmt.Errorf("source peer %q pins server_id=%d, which is already in use by a replica registered on the source database",
-				cfg.SourceName, *mysqlCfg.ServerId),
-			NewMirrorErrorInfo(map[string]string{
-				common.ErrorMetadataOffendingField: "source_name",
-			}))
-	}
-
 	// CDC flows for this source peer other than the mirror being validated.
 	// query_string IS NULL filters out QRep flows, which do
 	// not stream the binlog.
@@ -247,6 +227,25 @@ func (h *FlowRequestHandler) checkSourcePeerReuse(
 	}
 	if err := rows.Err(); err != nil {
 		return NewInternalApiError(fmt.Errorf("failed to iterate flows while checking peer reuse for %s: %w", cfg.SourceName, err))
+	}
+
+	// Beyond other PeerDB mirrors (checked above), the pinned server_id must not be already
+	// registered as a replica on the source DB itself.
+	mysqlConn, mysqlClose, err := connectors.GetAs[*connmysql.MySqlConnector](ctx, cfg.Env, peer)
+	if err != nil {
+		return NewInternalApiError(fmt.Errorf("failed to create MySQL connector for source peer %s: %w", cfg.SourceName, err))
+	}
+	defer mysqlClose(ctx)
+
+	if inUse, err := mysqlConn.HasReplicaWithServerId(ctx, *mysqlCfg.ServerId); err != nil {
+		return NewInternalApiError(fmt.Errorf("failed to check replicas registered on source peer %s: %w", cfg.SourceName, err))
+	} else if inUse {
+		return NewFailedPreconditionApiError(
+			fmt.Errorf("source peer %q pins server_id=%d, which is already in use by a replica registered on the source database",
+				cfg.SourceName, *mysqlCfg.ServerId),
+			NewMirrorErrorInfo(map[string]string{
+				common.ErrorMetadataOffendingField: "source_name",
+			}))
 	}
 
 	return nil

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/PeerDB-io/peerdb/flow/connectors"
-	connmysql "github.com/PeerDB-io/peerdb/flow/connectors/mysql"
 	"github.com/PeerDB-io/peerdb/flow/generated/proto_conversions"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
@@ -133,8 +132,27 @@ func (h *FlowRequestHandler) validateCDCMirrorImpl(
 				NewTablesNotInPublicationErrorInfo(notInPub.Publication),
 				NewTablesNotInPublicationPreconditionFailure(notInPub.Publication, notInPub.Tables))
 		}
-		return nil, NewFailedPreconditionApiError(
-			fmt.Errorf("failed to validate source connector %s: %w", connectionConfigs.SourceName, err))
+		if replicaIdErr, ok := errors.AsType[*common.ReplicaIdentifierInUseError](err); ok {
+			// Beyond other PeerDB mirrors, a replica id must not be already
+			// registered at source.
+			// We only enforce this check if the mirror doesn't already exist as
+			// a resync in that case might happen while the mirror is not paused thus
+			// detecting the same mirror as a conflict.
+			if mirrorExists, err := h.checkIfMirrorNameExists(ctx, connectionConfigs.FlowJobName); err != nil {
+				return nil, NewInternalApiError(
+					fmt.Errorf("failed to check if mirror name exists: %w", err))
+			} else if !mirrorExists {
+				return nil, NewFailedPreconditionApiError(
+					fmt.Errorf("source peer %q pins a replica id = %s, which is already in use by a replica registered on the source database",
+						connectionConfigs.SourceName, replicaIdErr.Id),
+					NewMirrorErrorInfo(map[string]string{
+						common.ErrorMetadataOffendingField: "source_name",
+					}))
+			}
+		} else {
+			return nil, NewFailedPreconditionApiError(
+				fmt.Errorf("failed to validate source connector %s: %w", connectionConfigs.SourceName, err))
+		}
 	}
 
 	dstConn, dstClose, err := connectors.GetByNameAs[connectors.MirrorDestinationValidationConnector](
@@ -227,35 +245,6 @@ func (h *FlowRequestHandler) checkSourcePeerReuse(
 	}
 	if err := rows.Err(); err != nil {
 		return NewInternalApiError(fmt.Errorf("failed to iterate flows while checking peer reuse for %s: %w", cfg.SourceName, err))
-	}
-
-	// beyond other PeerDB mirrors (checked above), the pinned server_id must not be already
-	// registered as a replica on the source DB itself.
-
-	// if this mirror already exists (resync case),
-	// the registered replica may be the mirror's own binlog connection, which is
-	// indistinguishable from a foreign one, so the check must be skipped.
-	if exists, err := h.checkIfMirrorNameExists(ctx, cfg.FlowJobName); err != nil {
-		return NewInternalApiError(fmt.Errorf("failed to check if mirror name exists: %w", err))
-	} else if exists {
-		return nil
-	}
-
-	mysqlConn, mysqlClose, err := connectors.GetAs[*connmysql.MySqlConnector](ctx, cfg.Env, peer)
-	if err != nil {
-		return NewInternalApiError(fmt.Errorf("failed to create MySQL connector for source peer %s: %w", cfg.SourceName, err))
-	}
-	defer mysqlClose(ctx)
-
-	if inUse, err := mysqlConn.HasReplicaWithServerId(ctx, *mysqlCfg.ServerId); err != nil {
-		return NewInternalApiError(fmt.Errorf("failed to check replicas registered on source peer %s: %w", cfg.SourceName, err))
-	} else if inUse {
-		return NewFailedPreconditionApiError(
-			fmt.Errorf("source peer %q pins server_id=%d, which is already in use by a replica registered on the source database",
-				cfg.SourceName, *mysqlCfg.ServerId),
-			NewMirrorErrorInfo(map[string]string{
-				common.ErrorMetadataOffendingField: "source_name",
-			}))
 	}
 
 	return nil

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -11,10 +11,12 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/PeerDB-io/peerdb/flow/connectors"
+	connmysql "github.com/PeerDB-io/peerdb/flow/connectors/mysql"
 	"github.com/PeerDB-io/peerdb/flow/generated/proto_conversions"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
+	mysql_validation "github.com/PeerDB-io/peerdb/flow/pkg/mysql"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
@@ -184,6 +186,25 @@ func (h *FlowRequestHandler) checkSourcePeerReuse(
 	mysqlCfg := peer.GetMysqlConfig()
 	if mysqlCfg == nil || mysqlCfg.ServerId == nil {
 		return nil
+	}
+
+	// beyond other PeerDB mirrors (checked below), the pinned server_id must not be already registered
+	// as a replica on the source DB itself.
+	mysqlConn, mysqlClose, err := connectors.GetAs[*connmysql.MySqlConnector](ctx, cfg.Env, peer)
+	if err != nil {
+		return NewInternalApiError(fmt.Errorf("failed to create MySQL connector for source peer %s: %w", cfg.SourceName, err))
+	}
+	defer mysqlClose(ctx)
+
+	if inUse, err := mysql_validation.HasReplicaWithServerId(mysqlConn.Conn(), *mysqlCfg.ServerId); err != nil {
+		return NewInternalApiError(fmt.Errorf("failed to check replicas registered on source peer %s: %w", cfg.SourceName, err))
+	} else if inUse {
+		return NewFailedPreconditionApiError(
+			fmt.Errorf("source peer %q pins server_id=%d, which is already in use by a replica registered on the source database",
+				cfg.SourceName, *mysqlCfg.ServerId),
+			NewMirrorErrorInfo(map[string]string{
+				common.ErrorMetadataOffendingField: "source_name",
+			}))
 	}
 
 	// CDC flows for this source peer other than the mirror being validated.

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -229,8 +229,18 @@ func (h *FlowRequestHandler) checkSourcePeerReuse(
 		return NewInternalApiError(fmt.Errorf("failed to iterate flows while checking peer reuse for %s: %w", cfg.SourceName, err))
 	}
 
-	// Beyond other PeerDB mirrors (checked above), the pinned server_id must not be already
+	// beyond other PeerDB mirrors (checked above), the pinned server_id must not be already
 	// registered as a replica on the source DB itself.
+
+	// if this mirror already exists (resync case),
+	// the registered replica may be the mirror's own binlog connection, which is
+	// indistinguishable from a foreign one, so the check must be skipped.
+	if exists, err := h.checkIfMirrorNameExists(ctx, cfg.FlowJobName); err != nil {
+		return NewInternalApiError(fmt.Errorf("failed to check if mirror name exists: %w", err))
+	} else if exists {
+		return nil
+	}
+
 	mysqlConn, mysqlClose, err := connectors.GetAs[*connmysql.MySqlConnector](ctx, cfg.Env, peer)
 	if err != nil {
 		return NewInternalApiError(fmt.Errorf("failed to create MySQL connector for source peer %s: %w", cfg.SourceName, err))

--- a/flow/connectors/mysql/validate.go
+++ b/flow/connectors/mysql/validate.go
@@ -138,6 +138,15 @@ func (c *MySqlConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.F
 	return nil
 }
 
+// HasReplicaWithServerId reports whether the source lists a replica registered with serverID.
+func (c *MySqlConnector) HasReplicaWithServerId(ctx context.Context, serverID uint32) (bool, error) {
+	conn, err := c.connect(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to connect: %w", err)
+	}
+	return mysql_validation.HasReplicaWithServerId(conn, serverID)
+}
+
 func (c *MySqlConnector) ValidateCheck(ctx context.Context) error {
 	if c.config.Flavor == protos.MySqlFlavor_MYSQL_UNKNOWN {
 		return fmt.Errorf("flavor is set to unknown")

--- a/flow/connectors/mysql/validate.go
+++ b/flow/connectors/mysql/validate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -135,16 +136,17 @@ func (c *MySqlConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.F
 		return fmt.Errorf("binlog configuration error: %w", err)
 	}
 
-	return nil
-}
-
-// HasReplicaWithServerId reports whether the source lists a replica registered with serverID.
-func (c *MySqlConnector) HasReplicaWithServerId(ctx context.Context, serverID uint32) (bool, error) {
-	conn, err := c.connect(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to connect: %w", err)
+	// NOTE: This error might be recoverable depending on conditions checked by the caller,
+	// this means that it should be last or subsequent failed checks might be ignored in those cases.
+	if c.config.ServerId != nil {
+		if serverIdInUse, err := mysql_validation.HasReplicaWithServerId(conn, *c.config.ServerId); err != nil {
+			return fmt.Errorf("failed to check replicas registered on source peer %s: %w", cfg.SourceName, err)
+		} else if serverIdInUse {
+			return common.NewReplicaIdentifierInUseError(strconv.FormatUint(uint64(*c.config.ServerId), 10))
+		}
 	}
-	return mysql_validation.HasReplicaWithServerId(conn, serverID)
+
+	return nil
 }
 
 func (c *MySqlConnector) ValidateCheck(ctx context.Context) error {

--- a/flow/e2e/mysql_server_id_collisions_test.go
+++ b/flow/e2e/mysql_server_id_collisions_test.go
@@ -1,0 +1,200 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	mysql_validation "github.com/PeerDB-io/peerdb/flow/pkg/mysql"
+)
+
+// createPinnedServerIdPeer creates a MySQL peer that clones the suite source's config while
+// pinning the given server_id.
+func createPinnedServerIdPeer(s APITestSuite, mySource *MySqlSource, name string, serverID uint32) {
+	s.t.Helper()
+	pinnedConfig := proto.CloneOf(mySource.Config)
+	pinnedConfig.ServerId = &serverID
+	_, err := s.CreatePeer(s.t.Context(), &protos.CreatePeerRequest{
+		Peer: &protos.Peer{
+			Name:   name,
+			Type:   protos.DBType_MYSQL,
+			Config: &protos.Peer_MysqlConfig{MysqlConfig: pinnedConfig},
+		},
+	})
+	require.NoError(s.t, err)
+}
+
+// cleanupMirrorAndPeers tears down the mirror and then the given peers via gRPC, even if the test
+// fails, so nothing leaks. t.Context() is already canceled when cleanups run, so it uses a fresh
+// context.
+func cleanupMirrorAndPeers(s APITestSuite, flowJobName string, peerNames ...string) {
+	s.t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		if _, err := s.FlowStateChange(cleanupCtx, &protos.FlowStateChangeRequest{
+			FlowJobName:        flowJobName,
+			RequestedFlowState: protos.FlowStatus_STATUS_TERMINATING,
+		}); err != nil {
+			s.t.Logf("failed to terminate mirror %s: %v", flowJobName, err)
+			return
+		}
+		for {
+			var workflowID string
+			err := s.catalog.QueryRow(
+				cleanupCtx, "select workflow_id from flows where name = $1", flowJobName,
+			).Scan(&workflowID)
+			if errors.Is(err, pgx.ErrNoRows) {
+				break
+			}
+			select {
+			case <-cleanupCtx.Done():
+				s.t.Logf("timed out waiting for mirror %s to be dropped", flowJobName)
+				return
+			case <-time.After(5 * time.Second):
+			}
+		}
+		for _, peerName := range peerNames {
+			if _, err := s.DropPeer(cleanupCtx, &protos.DropPeerRequest{PeerName: peerName}); err != nil {
+				s.t.Logf("failed to drop peer %s: %v", peerName, err)
+			}
+		}
+	})
+}
+
+// waitForReplicaWithServerId waits until the source lists a replica registered with serverID,
+// i.e. a mirror pinning it started streaming the binlog.
+func waitForReplicaWithServerId(s APITestSuite, mySource *MySqlSource, serverID uint32) {
+	s.t.Helper()
+	require.EventuallyWithT(s.t, func(c *assert.CollectT) {
+		// Conn() is non-nil here: the suite source has already executed queries by now.
+		found, err := mysql_validation.HasReplicaWithServerId(mySource.Conn(), serverID)
+		assert.NoError(c, err)
+		assert.True(c, found, "source does not list a replica registered with server_id %d", serverID)
+	}, 3*time.Minute, time.Second)
+}
+
+// TestValidateCDCMirror_ServerIDResync verifies that a running CDC mirror whose MySQL source peer
+// pins a fixed server_id can be resynced. Resync validates the mirror before dropping it, while
+// the mirror's own binlog connection is still registered on the source with the pinned server_id;
+// validation must not mistake that registration for a foreign replica.
+func (s APITestSuite) TestValidateCDCMirror_ServerIDResync() {
+	mySource, ok := s.source.(*MySqlSource)
+	if !ok {
+		s.t.Skip("server_id validation is MySQL-specific")
+	}
+	ctx := s.t.Context()
+
+	tableName := "serverid_resync"
+	require.NoError(s.t, s.source.Exec(ctx,
+		fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", AttachSchema(s, tableName))))
+	require.NoError(s.t, s.source.Exec(ctx,
+		fmt.Sprintf("INSERT INTO %s(id, val) values (1,'first')", AttachSchema(s, tableName))))
+
+	serverID := uint32(4321)
+	peerName := "serverid_resync_" + s.suffix
+	createPinnedServerIdPeer(s, mySource, peerName, serverID)
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      "serverid_resync_" + s.suffix,
+		TableNameMapping: map[string]string{AttachSchema(s, tableName): tableName},
+		Destination:      s.ch.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.SourceName = peerName
+	flowConnConfig.DoInitialSnapshot = true
+
+	createResp, err := s.CreateCDCFlow(ctx, &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, createResp)
+	cleanupMirrorAndPeers(s, flowConnConfig.FlowJobName, peerName)
+
+	// Wait until the mirror streams the binlog: its replica registration with the pinned
+	// server_id must be visible on the source.
+	waitForReplicaWithServerId(s, mySource, serverID)
+
+	// Resync validates the mirror while its own replica registration is still present on the
+	// source; it must not be rejected because of it.
+	_, err = s.FlowStateChange(ctx, &protos.FlowStateChangeRequest{
+		FlowJobName:        flowConnConfig.FlowJobName,
+		RequestedFlowState: protos.FlowStatus_STATUS_RESYNC,
+	})
+	require.NoError(s.t, err)
+}
+
+// TestValidateCDCMirror_ServerIDInUseAcrossPeers verifies that a CDC mirror is rejected when its
+// MySQL source peer pins a server_id that is already registered by another replica on the source
+// database — here, a mirror streaming through a DIFFERENT peer pinning the same server_id. The
+// cross-mirror peer-reuse check cannot relate the two peers, so only the replica registered on
+// the source betrays the collision.
+func (s APITestSuite) TestValidateCDCMirror_ServerIDInUseAcrossPeers() {
+	mySource, ok := s.source.(*MySqlSource)
+	if !ok {
+		s.t.Skip("server_id validation is MySQL-specific")
+	}
+	ctx := s.t.Context()
+
+	tableName := "serverid_crosspeer"
+	require.NoError(s.t, s.source.Exec(ctx,
+		fmt.Sprintf("CREATE TABLE %s(id int primary key, val text)", AttachSchema(s, tableName))))
+	require.NoError(s.t, s.source.Exec(ctx,
+		fmt.Sprintf("INSERT INTO %s(id, val) values (1,'first')", AttachSchema(s, tableName))))
+
+	// Two distinct peers pointing at the same source instance, pinning the same server_id.
+	serverID := uint32(4422)
+	occupantPeer := "serverid_crosspeer_a_" + s.suffix
+	contenderPeer := "serverid_crosspeer_b_" + s.suffix
+	createPinnedServerIdPeer(s, mySource, occupantPeer, serverID)
+	createPinnedServerIdPeer(s, mySource, contenderPeer, serverID)
+
+	// A streaming CDC mirror on the first peer registers a replica with the pinned server_id.
+	existingGen := FlowConnectionGenerationConfig{
+		FlowJobName:      "serverid_crosspeer_existing_" + s.suffix,
+		TableNameMapping: map[string]string{AttachSchema(s, tableName): tableName},
+		Destination:      s.ch.Peer().Name,
+	}
+	existingCfg := existingGen.GenerateFlowConnectionConfigs(s)
+	existingCfg.SourceName = occupantPeer
+	existingCfg.DoInitialSnapshot = true
+	createResp, err := s.CreateCDCFlow(ctx, &protos.CreateCDCFlowRequest{ConnectionConfigs: existingCfg})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, createResp)
+	cleanupMirrorAndPeers(s, existingCfg.FlowJobName, occupantPeer, contenderPeer)
+
+	waitForReplicaWithServerId(s, mySource, serverID)
+
+	// Validating a new mirror on the second peer must fail with the server_id collision. The
+	// mirror's binlog connection is re-registered on each sync batch, so the replica listing can
+	// blink between batches; retry to absorb that.
+	newGen := FlowConnectionGenerationConfig{
+		FlowJobName:      "serverid_crosspeer_new_" + s.suffix,
+		TableNameMapping: map[string]string{AttachSchema(s, tableName): tableName},
+		Destination:      s.ch.Peer().Name,
+	}
+	newCfg := newGen.GenerateFlowConnectionConfigs(s)
+	newCfg.SourceName = contenderPeer
+	newCfg.DoInitialSnapshot = true
+
+	require.EventuallyWithT(s.t, func(c *assert.CollectT) {
+		res, err := s.ValidateCDCMirror(ctx, &protos.CreateCDCFlowRequest{ConnectionConfigs: newCfg})
+		if !assert.Error(c, err) {
+			return
+		}
+		assert.Nil(c, res)
+		st, ok := status.FromError(err)
+		if !assert.True(c, ok, "expected a gRPC status error, got %v", err) {
+			return
+		}
+		assert.Equal(c, codes.FailedPrecondition, st.Code())
+		assert.Contains(c, st.Message(), fmt.Sprintf("pins a replica id = %d", serverID))
+		assert.Contains(c, st.Message(), "already in use by a replica registered on the source database")
+	}, time.Minute, 2*time.Second)
+}

--- a/flow/pkg/common/errors.go
+++ b/flow/pkg/common/errors.go
@@ -49,3 +49,15 @@ func (e *TablesNotInPublicationError) Error() string {
 	}
 	return fmt.Sprintf("tables not in publication %q: %s", e.Publication, strings.Join(parts, ", "))
 }
+
+type ReplicaIdentifierInUseError struct {
+	Id string
+}
+
+func NewReplicaIdentifierInUseError(id string) *ReplicaIdentifierInUseError {
+	return &ReplicaIdentifierInUseError{Id: id}
+}
+
+func (e *ReplicaIdentifierInUseError) Error() string {
+	return fmt.Sprintf("replica identifier %q is already in use by a replica registered on the source database", e.Id)
+}


### PR DESCRIPTION
It adds a check on the utilization of the same `server_id` in the source MySQL server.
This offer an extra layer of protection against collisions with other replication actors. 