### PR TITLE
classify error as retryable when pipe closed in deadlineCappableConn

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -442,6 +442,13 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		return ErrorOther, errInfo
 	}
 
+	if _, ok := errors.AsType[*exceptions.SSHTunnelClosedError](err); ok {
+		return ErrorRetryRecoverable, ErrorInfo{
+			Source: ErrorSourceSSH,
+			Code:   "TUNNEL_CONNECTION_CLOSED",
+		}
+	}
+
 	// An SSH-tunneled connection that goes bad (e.g. keepalive failure) is wrapped explicitly.
 	if _, ok := errors.AsType[*exceptions.SSHTunnelConnectionError](err); ok {
 		return ErrorNotifyConnectivity, ErrorInfo{

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"syscall"
@@ -85,6 +86,20 @@ func TestSSHTunnelRecoverableDialError(t *testing.T) {
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceSSH,
 		Code:   "TUNNEL_DIAL_ERROR",
+	}, errInfo)
+}
+
+func TestSSHTunnelClosedPipeErrorShouldBeRetryable(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors how deadlineCapableConn wraps net.Pipe teardown errors when an
+	// SSH-tunneled connection is torn down while a query is in flight.
+	err := fmt.Errorf("receive message failed: %w", exceptions.NewSSHTunnelClosedError(io.ErrClosedPipe))
+	errorClass, errInfo := GetErrorClass(t.Context(), err)
+	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceSSH,
+		Code:   "TUNNEL_CONNECTION_CLOSED",
 	}, errInfo)
 }
 

--- a/flow/connectors/utils/deadline_capable_conn.go
+++ b/flow/connectors/utils/deadline_capable_conn.go
@@ -1,9 +1,12 @@
 package utils
 
 import (
+	"errors"
 	"io"
 	"net"
 	"sync"
+
+	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 )
 
 type deadlineCapableConn struct {
@@ -47,6 +50,23 @@ func NewDeadlineCapableConn(sshConn net.Conn) net.Conn {
 	}()
 
 	return dcConn
+}
+
+func (c *deadlineCapableConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	return n, translateErr(err)
+}
+
+func (c *deadlineCapableConn) Write(b []byte) (int, error) {
+	n, err := c.Conn.Write(b)
+	return n, translateErr(err)
+}
+
+func translateErr(err error) error {
+	if errors.Is(err, io.ErrClosedPipe) || errors.Is(err, io.EOF) {
+		return exceptions.NewSSHTunnelClosedError(err)
+	}
+	return err
 }
 
 func (c *deadlineCapableConn) Close() error {

--- a/flow/connectors/utils/deadline_capable_conn_test.go
+++ b/flow/connectors/utils/deadline_capable_conn_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 )
 
 func TestNewDeadlineCapableConn_ReadDeadlineCanBeCleared(t *testing.T) {
@@ -147,7 +149,8 @@ func TestNewDeadlineCapableConn_SSHCloseClosesLocalAndRemote(t *testing.T) {
 
 	select {
 	case err := <-localDone:
-		require.ErrorIs(t, err, io.EOF)
+		var tunnelErr *exceptions.SSHTunnelClosedError
+		require.ErrorAs(t, err, &tunnelErr)
 	case <-time.After(time.Second):
 		t.Fatal("SSH close did not close local side")
 	}
@@ -176,10 +179,10 @@ func TestNewDeadlineCapableConn_RemoteCloseClosesSSHAndLocalSide(t *testing.T) {
 		sshDone <- err
 	}()
 
-	localDonn := make(chan error, 1)
+	localDone := make(chan error, 1)
 	go func() {
 		_, err := conn.Read(make([]byte, 1))
-		localDonn <- err
+		localDone <- err
 	}()
 
 	select {
@@ -196,8 +199,9 @@ func TestNewDeadlineCapableConn_RemoteCloseClosesSSHAndLocalSide(t *testing.T) {
 	}
 
 	select {
-	case err := <-localDonn:
-		require.ErrorIs(t, err, io.EOF)
+	case err := <-localDone:
+		var tunnelErr *exceptions.SSHTunnelClosedError
+		require.ErrorAs(t, err, &tunnelErr)
 	case <-time.After(time.Second):
 		t.Fatal("remote close did not close server side")
 	}

--- a/flow/shared/exceptions/ssh.go
+++ b/flow/shared/exceptions/ssh.go
@@ -60,3 +60,19 @@ func (e *SSHTunnelConnectionError) Error() string {
 func (e *SSHTunnelConnectionError) Unwrap() error {
 	return e.error
 }
+
+type SSHTunnelClosedError struct {
+	error
+}
+
+func NewSSHTunnelClosedError(err error) *SSHTunnelClosedError {
+	return &SSHTunnelClosedError{err}
+}
+
+func (e *SSHTunnelClosedError) Error() string {
+	return "SSH Tunnel Closed: " + e.error.Error()
+}
+
+func (e *SSHTunnelClosedError) Unwrap() error {
+	return e.error
+}


### PR DESCRIPTION
Classify a transient error that can happen with DeadlineCapableConn. In https://github.com/PeerDB-io/peerdb/pull/4380 we introduced an in-memory transport between connector and ssh using net.Pipe() to allow it to respect deadlines. This introduced a scenario where if the ssh tunnel is processing read/write when the pipe is closed, we get an `io.ErrClosedPipe` that ended up unhandled. The error is wrapped in an `SSHTunnelClosedError` to be precise, to avoid blindly handle all `io.ErrClosedPipe` that could hide future unrelated bugs. 

Fixes: DBI-896