### PR TITLE
handle clickhouse znode error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -967,6 +967,10 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		case chproto.ErrUnknownDatabase,
 			chproto.ErrAuthenticationFailed:
 			return ErrorNotifyConnectivity, chErrorInfo
+		case chproto.ErrUnexpectedZookeeperError:
+			if strings.Contains(chException.Message, "ZNODEEXISTS") {
+				return ErrorRetryRecoverable, chErrorInfo
+			}
 		case chproto.ErrKeeperException:
 			if chException.Message == "Session expired" || strings.HasPrefix(chException.Message, "Coordination error: Connection loss") {
 				return ErrorRetryRecoverable, chErrorInfo

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -270,6 +270,20 @@ func TestClickHouseAccessEntityNotFoundErrorShouldBeRecoverable(t *testing.T) {
 	}
 }
 
+func TestClickHouseUnexpectedZookeeperZnodeExistsErrorShouldBeRecoverable(t *testing.T) {
+	err := &clickhouse.Exception{
+		Code:    int32(chproto.ErrUnexpectedZookeeperError),
+		Message: "Got unexpected ZooKeeper error ZNODEEXISTS (at index 10) for part all_0_0_1",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		exceptions.NewClickHouseQRepSyncError(fmt.Errorf("failed to sync records: QRepSync Error: %w", err), "", ""))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceClickHouse,
+		Code:   strconv.Itoa(int(chproto.ErrUnexpectedZookeeperError)),
+	}, errInfo)
+}
+
 func TestClickHouseAccessDeniedErrorShouldBeNotifyPermissions(t *testing.T) {
 	err := &clickhouse.Exception{
 		Code:    int32(chproto.ErrAccessDenied),


### PR DESCRIPTION
Classify transient error:
`Got unexpected ZooKeeper error ZNODEEXISTS (at index 10) for part all_0_0_1`

Fixes: DBI-889