### PR TITLE
.github: Fix deprecated workflow

### DIFF
--- a/.github/workflows/deprecated-connector.yml
+++ b/.github/workflows/deprecated-connector.yml
@@ -11,7 +11,7 @@ name: Deprecated connector
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, labeled, synchronize, reopened]
   pull_request:
     types: [labeled]
   issues:


### PR DESCRIPTION
Adds the labeled types to pull_reqest_target for PR originating from forks