### PR TITLE
fetch disk spill metrics for pg 14/15 as well

### DIFF
--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -326,7 +326,7 @@ func getSlotInfo(
 		NULL::bigint
 	`
 	statsJoin := ""
-	if pgversion >= shared.POSTGRES_16 {
+	if pgversion >= shared.POSTGRES_14 {
 		statsSelect = `
 			EXTRACT(EPOCH FROM psrs.stats_reset)::bigint,
 			psrs.spill_txns,

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -957,7 +957,7 @@ func (c *PostgresConnector) HandleSlotInfo(
 
 	slotMetricGauges.LogicalDecodingWorkMemGauge.Record(ctx, slotInfo.LogicalDecodingWorkMemMb, attributeSet)
 
-	// PG 16+ statistics gauges
+	// pg_stat_replication_slots statistics gauges (PG 14+)
 	if slotInfo.StatsReset != nil {
 		slotMetricGauges.StatsResetGauge.Record(ctx, *slotInfo.StatsReset, attributeSet)
 	}


### PR DESCRIPTION
https://github.com/PeerDB-io/peerdb/pull/3685 gated disk spill related metrics behind pg 16+, but they are available [since pg 14](https://www.postgresql.org/docs/14/monitoring-stats.html#MONITORING-PG-STAT-REPLICATION-SLOTS-VIEW), so make them available for older versions as well. 