### PR TITLE
Renovate check and simulation CI workflow

### DIFF
--- a/.github/workflows/check-renovate-config.yml
+++ b/.github/workflows/check-renovate-config.yml
@@ -111,6 +111,12 @@ jobs:
               '',
               `Output of \`scripts/renovate-simulation.sh\` for ${context.payload.pull_request.head.sha} ([workflow run](${runUrl})).`,
               '',
+              '#### Proposed updates',
+              '',
+              'Dependency updates in the resulting PRs:',
+              '',
+              proposalsTable,
+              '',
               '#### `final-updated-packages.txt`',
               '',
               'Packages with updates in the resulting PRs (considering disabled/enabled rules):',
@@ -119,11 +125,6 @@ jobs:
               finalPackages,
               '```',
               '',
-              '#### Proposed updates',
-              '',
-              'Dependency updates in the resulting PRs:',
-              '',
-              proposalsTable,
             ].join('\n');
 
             const { owner, repo } = context.repo;

--- a/.github/workflows/check-renovate-config.yml
+++ b/.github/workflows/check-renovate-config.yml
@@ -3,9 +3,10 @@ name: Check renovate config
 # Runs scripts/renovate-simulation.sh on PRs that touch the Renovate setup and
 # fails if the simulation fails or upon incorrect syntax.
 #Posts (and keeps updated) a single PR comment with:
-# - `update-proposals.json`: the list of proposed updates, INCLUDING disabled ones.
 # - `final-updated-packages.txt`: the list of packages with updates in the
 #   resulting PRs (considering disabled/enabled rules).
+# - a table of proposed updates (dependency / from / to) built from
+#   `final-updated-packages-details.json`.
 
 on:
   pull_request:
@@ -54,6 +55,7 @@ jobs:
             renovate.out
             update-proposals.json
             final-updated-packages.txt
+            final-updated-packages-details.json
           retention-days: 30
 
       - name: Post simulation report on the PR
@@ -70,7 +72,38 @@ jobs:
               ? text
               : text.slice(0, max) + `\n… truncated (${text.length - max} characters omitted, full file in the workflow run artifact)`;
             const finalPackages = clip(read('final-updated-packages.txt'), 5000) || '(empty)';
-            const proposals = clip(read('update-proposals.json'), 55000) || '(empty)';
+            // Build a table of proposed updates from the newline-delimited JSON
+            // in final-updated-packages-details.json (one object per line, with
+            // newValue nested under each entry's `updates`).
+            const escapeCell = (value) => String(value ?? '').replace(/\|/g, '\\|');
+            const seen = new Set();
+            const updateRows = read('final-updated-packages-details.json')
+              .split('\n')
+              .filter(Boolean)
+              .flatMap((line) => {
+                let entry;
+                try { entry = JSON.parse(line); } catch { return []; }
+                return (entry.updates || []).map((update) => ({
+                  dependency: entry.depName,
+                  from: entry.currentValue,
+                  to: update.newValue,
+                }));
+              })
+              .filter((row) => {
+                const key = `${row.dependency} :: ${row.from} :: ${row.to}`;
+                if (seen.has(key)) return false;
+                seen.add(key);
+                return true;
+              })
+              .sort((a, b) => a.dependency.localeCompare(b.dependency));
+            const proposalsTable = updateRows.length
+              ? [
+                  '| dependency | from | to |',
+                  '| --- | --- | --- |',
+                  ...updateRows.map((row) =>
+                    `| ${escapeCell(row.dependency)} | ${escapeCell(row.from)} | ${escapeCell(row.to)} |`),
+                ].join('\n')
+              : '(no proposed updates)';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
               marker,
@@ -86,14 +119,11 @@ jobs:
               finalPackages,
               '```',
               '',
-              '<details>',
-              '<summary><code>update-proposals.json</code> — proposed updates, INCLUDING disabled ones</summary>',
+              '#### Proposed updates',
               '',
-              '```json',
-              proposals,
-              '```',
+              'Dependency updates in the resulting PRs:',
               '',
-              '</details>',
+              proposalsTable,
             ].join('\n');
 
             const { owner, repo } = context.repo;

--- a/.github/workflows/check-renovate-config.yml
+++ b/.github/workflows/check-renovate-config.yml
@@ -1,0 +1,109 @@
+name: Check renovate config
+
+# Runs scripts/renovate-simulation.sh on PRs that touch the Renovate setup and
+# fails if the simulation fails or upon incorrect syntax.
+#Posts (and keeps updated) a single PR comment with:
+# - `update-proposals.json`: the list of proposed updates, INCLUDING disabled ones.
+# - `final-updated-packages.txt`: the list of packages with updates in the
+#   resulting PRs (considering disabled/enabled rules).
+
+on:
+  pull_request:
+    branches: [main]
+    paths: &renovate_paths
+      - 'renovate.json5'
+      - 'scripts/renovate-simulation.sh'
+      - '.github/workflows/check-renovate-config.yml'
+  pull_request_target:
+    branches: [main]
+    paths: *renovate_paths
+
+permissions:
+  contents: read
+
+jobs:
+  check_renovate_config:
+    # Same fork-handling pattern as flow.yml
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'external-contributor' || null }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+
+      - name: Run Renovate simulation
+        run: ./scripts/renovate-simulation.sh
+        env:
+          # Authenticated github.com lookups to allow
+          # Renovate use `github>PeerDB-io/.github:renovate-config` extension.
+          GITHUB_COM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload simulation output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: renovate-simulation-output
+          path: |
+            renovate.out
+            update-proposals.json
+            final-updated-packages.txt
+          retention-days: 30
+
+      - name: Post simulation report on the PR
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- renovate-simulation-report -->';
+            const read = (path) => {
+              try { return fs.readFileSync(path, 'utf8').trim(); } catch { return ''; }
+            };
+            // Keep the comment under GitHub's 65536-character body limit.
+            const clip = (text, max) => text.length <= max
+              ? text
+              : text.slice(0, max) + `\n… truncated (${text.length - max} characters omitted, full file in the workflow run artifact)`;
+            const finalPackages = clip(read('final-updated-packages.txt'), 5000) || '(empty)';
+            const proposals = clip(read('update-proposals.json'), 55000) || '(empty)';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              '### Renovate simulation report',
+              '',
+              `Output of \`scripts/renovate-simulation.sh\` for ${context.payload.pull_request.head.sha} ([workflow run](${runUrl})).`,
+              '',
+              '#### `final-updated-packages.txt`',
+              '',
+              'Packages with updates in the resulting PRs (considering disabled/enabled rules):',
+              '',
+              '```',
+              finalPackages,
+              '```',
+              '',
+              '<details>',
+              '<summary><code>update-proposals.json</code> — proposed updates, INCLUDING disabled ones</summary>',
+              '',
+              '```json',
+              proposals,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated existing simulation report comment ${existing.id}.`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              core.info('Posted new simulation report comment.');
+            }

--- a/scripts/renovate-simulation.sh
+++ b/scripts/renovate-simulation.sh
@@ -5,7 +5,7 @@
 # - `renovate.out` With the raw debug output of the run.
 # - `update-proposals.json` with the list of proposed updates but INCLUDING DISABLED ones
 # - `final-updated-packages.txt` with the list of packages with updates in the resulting PRs (considering disabled/enabled).
-#
+# - `final-updated-packages-details.json` the final list of proposed changes with details.
 # WARNING: If the script is terminated before restoring the extension source (step 2), make sure you revert
 #          the changes to renovate.json5 manually.
 
@@ -43,6 +43,13 @@ cat renovate.out | sed '1,/packageFiles with updates/d' | sed 's/"config": {/{/'
 
 ## (5) Extract final updated packages
 cat renovate.out | grep 'flattened updates found' | tr ',' '\n' > final-updated-packages.txt
+
+## (6) Combine final updated packages details
+FINAL_UPDATES_FILE="final-updated-packages-details.json"
+cat "" > ${FINAL_UPDATES_FILE}
+for dep in $(cat final-updated-packages.txt | tail -n+2 | sort -u | awk '{print $1}'); do
+  jq --compact-output --arg dep "$dep" '. | select(.depName == $dep)' update-proposals.json >> ${FINAL_UPDATES_FILE}
+done
 
 echo "List of packages with proposed updates:"
 echo "----------------------------------------"

--- a/scripts/renovate-simulation.sh
+++ b/scripts/renovate-simulation.sh
@@ -30,7 +30,13 @@ trap cleanup EXIT
 
 ## (3) Run Renovate locally
 echo "Running Renovate locally..."
-LOG_LEVEL=debug npx renovate --platform=local --require-config=optional --repository-cache=reset > renovate.out
+LOG_LEVEL=debug npx --yes renovate --platform=local --require-config=optional --repository-cache=reset > renovate.out
+renovate_exit=$?
+if [ $renovate_exit -ne 0 ]; then
+  echo "Renovate run failed (exit code $renovate_exit), last lines of renovate.out:"
+  tail -n 100 renovate.out
+  exit $renovate_exit
+fi
 
 ## (4) Extract update proposals
 cat renovate.out | sed '1,/packageFiles with updates/d' | sed 's/"config": {/{/' | sed '/DEBUG/,$d' | jq '.gomod[].deps[]' > update-proposals.json

--- a/scripts/renovate-simulation.sh
+++ b/scripts/renovate-simulation.sh
@@ -42,7 +42,7 @@ fi
 cat renovate.out | sed '1,/packageFiles with updates/d' | sed 's/"config": {/{/' | sed '/DEBUG/,$d' | jq '.gomod[].deps[]' > update-proposals.json
 
 ## (5) Extract final updated packages
-cat renovate.out | grep 'flattened updates found' | tr ',' '\n' > final-updated-packages.txt
+cat renovate.out | grep 'flattened updates found' | tr ',' '\n' | tr ':' '\n' > final-updated-packages.txt
 
 ## (6) Combine final updated packages details
 FINAL_UPDATES_FILE="final-updated-packages-details.json"


### PR DESCRIPTION
Wrap scripts/renovate-simulation.sh syntax check and update simulator script in a GH workflow triggered by PRs changing Renovate configuration.

It:

- Runs  a syntax check
- Runs a simulation of the updates the proposed configuration would generate, posting the results as a PR comment and uploading them and full simulation log as workflow artifacts.

