### PR TITLE
qrep: derive pull columns from source instead of catalog schema

### DIFF
--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -410,7 +410,7 @@ func (c *PostgresConnector) GetSelectedColumns(
 	}
 	excludedColumnsSQL := ""
 	if len(excludedColumns) > 0 {
-		excludedColumnsSQL = "AND a.attname NOT IN (" + strings.Join(quotedExcludedColumns, ",") + ")"
+		excludedColumnsSQL = " AND a.attname NOT IN (" + strings.Join(quotedExcludedColumns, ",") + ")"
 	}
 
 	getColumnsSQL := `
@@ -421,7 +421,7 @@ func (c *PostgresConnector) GetSelectedColumns(
 		WHERE n.nspname = $1
 		AND c.relname = $2
 		AND a.attnum > 0
-		AND NOT a.attisdropped ` + excludedColumnsSQL
+		AND NOT a.attisdropped` + excludedColumnsSQL + ` ORDER BY a.attnum`
 
 	rows, err := c.conn.Query(ctx, getColumnsSQL, sourceTable.Namespace, sourceTable.Table)
 	if err != nil {

--- a/flow/connectors/postgres/qrep_source.go
+++ b/flow/connectors/postgres/qrep_source.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -325,14 +324,14 @@ func (c *PostgresConnector) GetMaxValue(
 
 func (c *PostgresConnector) PullQRepRecords(
 	ctx context.Context,
-	catalogPool shared.CatalogPool,
+	_catalogPool shared.CatalogPool,
 	_otelManager *otel_metrics.OtelManager,
 	config *protos.QRepConfig,
 	dstType protos.DBType,
 	partition *protos.QRepPartition,
 	stream *model.QRecordStream,
 ) (int64, int64, error) {
-	return corePullQRepRecords(c, ctx, catalogPool, config, partition, &RecordStreamSink{
+	return corePullQRepRecords(c, ctx, config, partition, &RecordStreamSink{
 		QRecordStream:   stream,
 		DestinationType: dstType,
 	})
@@ -340,45 +339,44 @@ func (c *PostgresConnector) PullQRepRecords(
 
 func (c *PostgresConnector) PullPgQRepRecords(
 	ctx context.Context,
-	catalogPool shared.CatalogPool,
+	_catalogPool shared.CatalogPool,
 	_otelManager *otel_metrics.OtelManager,
 	config *protos.QRepConfig,
 	_dstType protos.DBType,
 	partition *protos.QRepPartition,
 	stream PgCopyWriter,
 ) (int64, int64, error) {
-	return corePullQRepRecords(c, ctx, catalogPool, config, partition, stream)
+	return corePullQRepRecords(c, ctx, config, partition, stream)
 }
 
 func corePullQRepRecords(
 	c *PostgresConnector,
 	ctx context.Context,
-	catalogPool shared.CatalogPool,
 	config *protos.QRepConfig,
 	partition *protos.QRepPartition,
 	sink QRepPullSink,
 ) (int64, int64, error) {
 	partitionIdLog := slog.String(string(shared.PartitionIDKey), partition.PartitionId)
 
-	selectedColumns := "*"
-	if len(config.Exclude) != 0 || len(partition.ChildTableRanges) > 0 {
-		tableSchema, err := internal.LoadTableSchemaFromCatalog(ctx, catalogPool, config.ParentMirrorName, config.DestinationTableIdentifier)
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to load table schema: %w", err)
-		}
-		quotedColumns := make([]string, 0, len(tableSchema.Columns))
-		for _, col := range tableSchema.Columns {
-			if !slices.Contains(config.Exclude, col.Name) {
-				quotedColumns = append(quotedColumns, common.QuoteIdentifier(col.Name))
-			}
-		}
-		selectedColumns = strings.Join(quotedColumns, ",")
-	}
-
 	parsedSrcTable, err := common.ParseTableIdentifier(config.WatermarkTable)
 	if err != nil {
 		c.logger.Error("unable to parse source table", slog.Any("error", err))
 		return 0, 0, fmt.Errorf("unable to parse source table: %w", err)
+	}
+
+	selectedColumns := "*"
+	if len(config.Exclude) != 0 || len(partition.ChildTableRanges) > 0 {
+		// derive columns from the source directly; the catalog schema may be absent
+		// (e.g. resync/table-addition renames the destination) and isn't needed here
+		columns, err := c.GetSelectedColumns(ctx, parsedSrcTable, config.Exclude)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to get selected columns: %w", err)
+		}
+		quotedColumns := make([]string, 0, len(columns))
+		for _, col := range columns {
+			quotedColumns = append(quotedColumns, common.QuoteIdentifier(col))
+		}
+		selectedColumns = strings.Join(quotedColumns, ",")
 	}
 
 	if partition.FullTablePartition {

--- a/flow/connectors/postgres/qrep_source.go
+++ b/flow/connectors/postgres/qrep_source.go
@@ -372,6 +372,9 @@ func corePullQRepRecords(
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to get selected columns: %w", err)
 		}
+		if len(columns) == 0 {
+			return 0, 0, fmt.Errorf("table %s doesn't have queriable columns", parsedSrcTable)
+		}
 		quotedColumns := make([]string, 0, len(columns))
 		for _, col := range columns {
 			quotedColumns = append(quotedColumns, common.QuoteIdentifier(col))

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -126,15 +126,6 @@ func (q *QRepFlowExecution) setupTableSchema(ctx workflow.Context, tableName str
 }
 
 func (q *QRepFlowExecution) setupWatermarkTableOnDestination(ctx workflow.Context) error {
-	// standalone mirrors have no CDC setup_flow to populate table_schema_mapping, so do it
-	// here (regardless of watermark setup); the pull path reads it when Exclude/child ranges are set
-	if q.config.ParentMirrorName == q.config.FlowJobName {
-		if err := q.setupTableSchema(ctx, q.config.WatermarkTable); err != nil {
-			q.logger.Error("failed to fetch schema for watermark table", slog.Any("error", err))
-			return fmt.Errorf("failed to fetch schema for watermark table: %w", err)
-		}
-	}
-
 	if q.config.SetupWatermarkTableOnDestination {
 		q.logger.Info("setting up watermark table on destination for qrep flow")
 
@@ -148,6 +139,12 @@ func (q *QRepFlowExecution) setupWatermarkTableOnDestination(ctx workflow.Contex
 				NonRetryableErrorTypes: nil,
 			},
 		})
+
+		// fetch the schema for the watermark table
+		if err := q.setupTableSchema(ctx, q.config.WatermarkTable); err != nil {
+			q.logger.Error("failed to fetch schema for watermark table", slog.Any("error", err))
+			return fmt.Errorf("failed to fetch schema for watermark table: %w", err)
+		}
 
 		// now setup the normalized tables on the destination peer
 		setupConfig := &protos.SetupNormalizedTableBatchInput{

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -126,6 +126,12 @@ func (q *QRepFlowExecution) setupTableSchema(ctx workflow.Context, tableName str
 }
 
 func (q *QRepFlowExecution) setupWatermarkTableOnDestination(ctx workflow.Context) error {
+	// always populate table_schema_mapping; the pull path reads it when Exclude/child ranges are set
+	if err := q.setupTableSchema(ctx, q.config.WatermarkTable); err != nil {
+		q.logger.Error("failed to fetch schema for watermark table", slog.Any("error", err))
+		return fmt.Errorf("failed to fetch schema for watermark table: %w", err)
+	}
+
 	if q.config.SetupWatermarkTableOnDestination {
 		q.logger.Info("setting up watermark table on destination for qrep flow")
 
@@ -139,12 +145,6 @@ func (q *QRepFlowExecution) setupWatermarkTableOnDestination(ctx workflow.Contex
 				NonRetryableErrorTypes: nil,
 			},
 		})
-
-		// fetch the schema for the watermark table
-		if err := q.setupTableSchema(ctx, q.config.WatermarkTable); err != nil {
-			q.logger.Error("failed to fetch schema for watermark table", slog.Any("error", err))
-			return fmt.Errorf("failed to fetch schema for watermark table: %w", err)
-		}
 
 		// now setup the normalized tables on the destination peer
 		setupConfig := &protos.SetupNormalizedTableBatchInput{

--- a/flow/workflows/qrep_flow.go
+++ b/flow/workflows/qrep_flow.go
@@ -126,10 +126,13 @@ func (q *QRepFlowExecution) setupTableSchema(ctx workflow.Context, tableName str
 }
 
 func (q *QRepFlowExecution) setupWatermarkTableOnDestination(ctx workflow.Context) error {
-	// always populate table_schema_mapping; the pull path reads it when Exclude/child ranges are set
-	if err := q.setupTableSchema(ctx, q.config.WatermarkTable); err != nil {
-		q.logger.Error("failed to fetch schema for watermark table", slog.Any("error", err))
-		return fmt.Errorf("failed to fetch schema for watermark table: %w", err)
+	// standalone mirrors have no CDC setup_flow to populate table_schema_mapping, so do it
+	// here (regardless of watermark setup); the pull path reads it when Exclude/child ranges are set
+	if q.config.ParentMirrorName == q.config.FlowJobName {
+		if err := q.setupTableSchema(ctx, q.config.WatermarkTable); err != nil {
+			q.logger.Error("failed to fetch schema for watermark table", slog.Any("error", err))
+			return fmt.Errorf("failed to fetch schema for watermark table: %w", err)
+		}
 	}
 
 	if q.config.SetupWatermarkTableOnDestination {


### PR DESCRIPTION
## Problem

QRep pulls with excluded columns or child-table range partitions fail with:

```
[qrep] failed to pull records: failed to load table schema: no rows in result set
```

The pull path ([qrep_source.go](flow/connectors/postgres/qrep_source.go)) built the `SELECT` column list by loading the table schema from `table_schema_mapping`, keyed by `(ParentMirrorName, DestinationTableIdentifier)`. When no row exists for that key, `QueryRow().Scan()` returns `pgx.ErrNoRows` ("no rows in result set") and the pull hard-fails.

This has been observed on a CDC mirror. The in-repo setup paths normally populate that row under a matching key, so the exact reason the row was absent for this mirror isn't pinned down (candidates: version skew / older mirror, or attaching to a pre-existing mirror). Regardless, the pull shouldn't depend on the catalog row being present when it can derive the columns directly from the source.

## Fix

Derive the column list **directly from the source** via `GetSelectedColumns` (which reads `pg_attribute`) — the same primitive `getTableSchemaForTable` already uses to build the identical list, so column selection and ordering are unchanged.

This removes the `table_schema_mapping` dependency from the pull path entirely. `catalogPool` is no longer needed by `corePullQRepRecords`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)