### PR TITLE
fix(mysql): gofumpt formatting in cdc.go

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -719,7 +719,8 @@ func (c *MySqlConnector) PullRecords(
 				case ddlKindAlterTable:
 					if err := c.processAlterTableQuery(
 						ctx, catalogPool, otelManager, req, alterStmt,
-						string(ev.Schema), binlogRowMetadataSupported, req.InternalVersion); err != nil {
+						string(ev.Schema), binlogRowMetadataSupported, req.InternalVersion,
+					); err != nil {
 						return fmt.Errorf("failed to process ALTER TABLE query: %w", err)
 					}
 				case ddlKindRenameTable:
@@ -1253,10 +1254,12 @@ func parseIncidentEvent(data []byte) (uint16, string) {
 }
 
 func (c *MySqlConnector) recordColumnTypeChange(ctx context.Context, otelManager *otel_metrics.OtelManager,
-	table, column string, from, to types.QValueKind, eventType string) {
+	table, column string, from, to types.QValueKind, eventType string,
+) {
 	key := fmt.Sprintf("%s.%s.%s.%s", table, column, from, to)
 	if _, ok := c.warnedTypeChanges.LoadOrStore(key, struct{}{}); !ok {
-		c.logger.Warn("column type change detected, not propagating",
+		c.logger.Warn(
+			"column type change detected, not propagating",
 			slog.String("table", table),
 			slog.String("column", column),
 			slog.Any("from", from),


### PR DESCRIPTION
## Problem

`gofumpt` (via golangci-lint) is failing on `main` for `flow/connectors/mysql/cdc.go`. The multi-line function signatures/calls introduced by recent commits don't have their closing `)` on their own line, which gofumpt requires. This blocks unrelated PRs since CI checks the PR merged with its base.

## Fix

Run `gofumpt -w` on `flow/connectors/mysql/cdc.go`. Purely formatting — no behavior change:
- `processAlterTableQuery` call: closing `)` moved to its own line
- `recordColumnTypeChange` signature: closing `)` moved to its own line
- `logger.Warn` call: first arg moved onto its own line

`gofumpt -l` now reports clean and `go build ./connectors/mysql/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)