### PR TITLE
fix(pg): classify conn closed explicitly as user notify error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -350,12 +350,10 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
-	// Reference:
-	// https://github.dev/jackc/pgx/blob/master/pgconn/pgconn.go#L733-L740
-	if strings.Contains(err.Error(), "conn closed") {
-		return ErrorRetryRecoverable, ErrorInfo{
+	if errors.Is(err, pgconn.ErrConnClosed) {
+		return ErrorNotifyConnectivity, ErrorInfo{
 			Source: ErrorSourceNet,
-			Code:   "UNKNOWN",
+			Code:   "CONN_CLOSED",
 		}
 	}
 
@@ -589,7 +587,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				(strings.HasPrefix(pgErr.Message, "could not stat file ") &&
 					strings.HasSuffix(pgErr.Message, "Stale file handle")) ||
 				// Below error is transient and Aurora Specific
-				(strings.HasPrefix(pgErr.Message, "Internal error encountered during logical decoding")) ||
+				strings.HasPrefix(pgErr.Message, "Internal error encountered during logical decoding") ||
 				//nolint:lll
 				// Handle missing record during logical decoding
 				// https://github.com/postgres/postgres/blob/a0c7b765372d949cec54960dafcaadbc04b3204e/src/backend/access/transam/xlogreader.c#L921

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -78,7 +78,8 @@ func TestSSHTunnelRecoverableDialError(t *testing.T) {
 	err := fmt.Errorf("failed to sync records: %w",
 		fmt.Errorf("failed to get schema for watermark table xxx.xxx: %w",
 			exceptions.NewMySQLExecuteError(exceptions.NewSSHTunnelDialError(
-				errors.New("ssh: unexpected packet in response to channel open: <nil>")))))
+				errors.New("ssh: unexpected packet in response to channel open: <nil>"),
+			))))
 	errorClass, errInfo := GetErrorClass(t.Context(), err)
 	assert.Equal(t, ErrorRetryRecoverable, errorClass)
 	assert.Equal(t, ErrorInfo{
@@ -327,7 +328,8 @@ func TestClickHouseAccessDeniedErrorShouldBeNotifyPermissions(t *testing.T) {
 	}
 	errorClass, errInfo := GetErrorClass(t.Context(),
 		exceptions.NewNormalizationError(fmt.Errorf(
-			"failed to normalize records: failed to copy avro stages to destination: %w", err)))
+			"failed to normalize records: failed to copy avro stages to destination: %w", err,
+		)))
 	assert.Equal(t, ErrorNotifyClickHousePermissionsError, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceClickHouse,
@@ -514,6 +516,30 @@ func TestPostgresReorderbufferSpillFileBadAddressErrorShouldBeRecoverable(t *tes
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresConnClosedErrorShouldBeNotifyConnectivity(t *testing.T) {
+	t.Parallel()
+
+	// Drive real pgx to produce the "conn closed" error rather than hand-building one, so this
+	// guards against a pgx upgrade changing how the sentinel is wrapped (errors.Is must still match).
+	connectionString := internal.GetCatalogConnectionStringFromEnv(t.Context())
+	config, err := pgx.ParseConfig(connectionString)
+	require.NoError(t, err)
+	conn, err := pgx.ConnectConfig(t.Context(), config)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close(t.Context()))
+
+	// Using the connection after it has been closed yields pgconn.ErrConnClosed (wrapped in connLockError).
+	_, err = conn.Exec(t.Context(), "SELECT 1")
+	require.ErrorIs(t, err, pgconn.ErrConnClosed)
+
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed to sync records: %w", err))
+	assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceNet,
+		Code:   "CONN_CLOSED",
+	}, errInfo, "Unexpected error info")
+}
+
 func TestPostgresReorderbufferSpillFileBadFileDescriptorErrorShouldBeRecoverable(t *testing.T) {
 	// Simulate a "could not read from reorderbuffer spill file: Bad file descriptor" error
 	err := &exceptions.PostgresWalError{
@@ -605,7 +631,8 @@ func TestConnectionResetDuringPeerCreateShouldBeConnectivity(t *testing.T) {
 	t.Parallel()
 
 	err := exceptions.NewPeerCreateError(
-		fmt.Errorf("failed to open connection to ClickHouse peer: failed to ping to ClickHouse peer: read: %w", syscall.ECONNRESET))
+		fmt.Errorf("failed to open connection to ClickHouse peer: failed to ping to ClickHouse peer: read: %w", syscall.ECONNRESET),
+	)
 	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed to recreate destination connector: %w", err))
 	assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
@@ -960,7 +987,8 @@ func TestMySQLBinlogEventExceededMaxAllowedPacket(t *testing.T) {
 
 func TestMySQLBinlogChecksumMismatch(t *testing.T) {
 	err := exceptions.NewMySQLExecuteError(
-		fmt.Errorf("failed checksum for WriteRowsEventV2, log pos 12345: %v", replication.ErrChecksumMismatch))
+		fmt.Errorf("failed checksum for WriteRowsEventV2, log pos 12345: %v", replication.ErrChecksumMismatch),
+	)
 	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed in pull records: %w", err))
 	assert.Equal(t, ErrorNotifyBinlogInvalid, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
@@ -971,7 +999,8 @@ func TestMySQLBinlogChecksumMismatch(t *testing.T) {
 
 func TestMySQLExecuteError(t *testing.T) {
 	err := exceptions.NewMySQLExecuteError(
-		tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"})
+		tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"},
+	)
 	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("mysql error: %w", err))
 	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
@@ -980,7 +1009,8 @@ func TestMySQLExecuteError(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 
 	err = exceptions.NewMySQLExecuteError(
-		tls.RecordHeaderError{Msg: "unsupported SSLv2 handshake received"})
+		tls.RecordHeaderError{Msg: "unsupported SSLv2 handshake received"},
+	)
 	errorClass, errInfo = GetErrorClass(t.Context(), fmt.Errorf("mysql error: %w", err))
 	assert.Equal(t, ErrorOther, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
@@ -1081,7 +1111,8 @@ func TestClickHouseLockingAttemptForAlterTimedOutShouldBeRecoverable(t *testing.
 		Message: `Locking attempt for ALTER on "my_database.my_table" has timed out! (120000 ms) Possible deadlock avoided. Client should retry.`,
 	}
 	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf(
-		"failed to push records: failed to sync schema changes: failed to add column case_number for table my_table: %w", err))
+		"failed to push records: failed to sync schema changes: failed to add column case_number for table my_table: %w", err,
+	))
 	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceClickHouse,
@@ -1254,7 +1285,8 @@ func TestGCSTransientErrorsShouldBeRecoverable(t *testing.T) {
 	}
 	err := exceptions.NewGCSError(fmt.Errorf("failed to finalize GCS upload for a.avro: %w", apiErr))
 	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf(
-		"failed to push records: failed to upload to staging: %w", err))
+		"failed to push records: failed to upload to staging: %w", err,
+	))
 	assert.Equal(t, ErrorRetryRecoverable, errorClass)
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceGCS,


### PR DESCRIPTION
classify pg conn closed as notify connectivity error instead of notify telemetry
<img width="1388" height="942" alt="image" src="https://github.com/user-attachments/assets/25795846-f852-4dfb-89e2-729f86b1a61d" />
