### PR TITLE
fix(pg): set idle_session_timeout=0 for pg connections

### DIFF
--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -87,6 +87,7 @@ func newPostgresConnector(
 
 	connConfig.Config.RuntimeParams["timezone"] = "UTC"
 	connConfig.Config.RuntimeParams["idle_in_transaction_session_timeout"] = "0"
+	connConfig.Config.RuntimeParams["idle_session_timeout"] = "0"
 	connConfig.Config.RuntimeParams["statement_timeout"] = "0"
 	connConfig.Config.RuntimeParams["DateStyle"] = "ISO, DMY"
 	// Required for QueryExecModeSimpleProtocol, which is set in some places while querying;

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -67,6 +67,18 @@ func NewPostgresConnector(
 	return newPostgresConnector(ctx, env, pgConfig, protos.DBType_DBTYPE_UNKNOWN)
 }
 
+// setIdleSessionTimeout best-effort disables idle_session_timeout on conn.
+// The GUC only exists on PG14+, so on older supported versions (PG12/13) the
+// server rejects it with SQLSTATE 42704, which we ignore.
+func setIdleSessionTimeout(ctx context.Context, conn *pgx.Conn, logger log.Logger) {
+	if _, err := conn.Exec(ctx, "SET idle_session_timeout = 0"); err != nil {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == pgerrcode.UndefinedObject {
+			return
+		}
+		logger.Warn("failed to set idle_session_timeout", slog.Any("error", err))
+	}
+}
+
 func newPostgresConnector(
 	ctx context.Context, env map[string]string, pgConfig *protos.PostgresConfig, destinationType protos.DBType,
 ) (*PostgresConnector, error) {
@@ -87,7 +99,6 @@ func newPostgresConnector(
 
 	connConfig.Config.RuntimeParams["timezone"] = "UTC"
 	connConfig.Config.RuntimeParams["idle_in_transaction_session_timeout"] = "0"
-	connConfig.Config.RuntimeParams["idle_session_timeout"] = "0"
 	connConfig.Config.RuntimeParams["statement_timeout"] = "0"
 	connConfig.Config.RuntimeParams["DateStyle"] = "ISO, DMY"
 	// Required for QueryExecModeSimpleProtocol, which is set in some places while querying;
@@ -125,6 +136,7 @@ func newPostgresConnector(
 		logger.Error("failed to create connection", slog.Any("error", err))
 		return nil, fmt.Errorf("failed to create connection: %w", err)
 	}
+	setIdleSessionTimeout(ctx, conn, logger)
 
 	metadataSchema := "_peerdb_internal"
 	if pgConfig.MetadataSchema != nil {

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -84,6 +84,7 @@ func (c *PostgresConnector) CreateReplConn(ctx context.Context, env map[string]s
 
 	replConfig.Config.RuntimeParams["timezone"] = "UTC"
 	replConfig.Config.RuntimeParams["idle_in_transaction_session_timeout"] = "0"
+	replConfig.Config.RuntimeParams["idle_session_timeout"] = "0"
 	replConfig.Config.RuntimeParams["statement_timeout"] = "0"
 	replConfig.Config.RuntimeParams["replication"] = "database"
 	replConfig.Config.RuntimeParams["bytea_output"] = "hex"

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -84,7 +84,6 @@ func (c *PostgresConnector) CreateReplConn(ctx context.Context, env map[string]s
 
 	replConfig.Config.RuntimeParams["timezone"] = "UTC"
 	replConfig.Config.RuntimeParams["idle_in_transaction_session_timeout"] = "0"
-	replConfig.Config.RuntimeParams["idle_session_timeout"] = "0"
 	replConfig.Config.RuntimeParams["statement_timeout"] = "0"
 	replConfig.Config.RuntimeParams["replication"] = "database"
 	replConfig.Config.RuntimeParams["bytea_output"] = "hex"
@@ -111,6 +110,7 @@ func (c *PostgresConnector) CreateReplConn(ctx context.Context, env map[string]s
 		internal.LoggerFromCtx(ctx).Error("failed to create replication connection", slog.Any("error", err))
 		return nil, walSenderTimeout{}, fmt.Errorf("failed to create replication connection: %w", err)
 	}
+	setIdleSessionTimeout(ctx, conn, c.logger)
 	return conn, wst, nil
 }
 


### PR DESCRIPTION
we've received a few alerts that were caused by session timeout (can be set to non zero on source db).
example error:
Logical message processing error: failed to get customTypeMapping: FATAL: terminating connection due to idle-session timeout (SQLSTATE 57P05)