### PR TITLE
Include rust builder in renovate, fix script on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ volumes/ch_*
 
 # Renovate debug files
 final-updated-packages.txt
+final-updated-packages-details.json
 renovate.out
 update-proposals.json

--- a/renovate.json5
+++ b/renovate.json5
@@ -47,6 +47,13 @@
       "allowedVersions": "/^8\\.0\\./",
       "automerge": false
     },
+    // Default docker versioning can't parse cargo-chef's compound `latest-rust-<version>-alpine`
+    // tag, so the rust version never rolls forward. Regex versioning captures the embedded version.
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["lukemathwalker/cargo-chef"],
+      "versioning": "regex:^latest-rust-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-alpine$"
+    },
     // Disable updates on generated and dependencies without explicit versions in their life cycles.
     // Disabled updates means that Renovate will not proactively propose changes for these dependencies
     // but its reliance on go MVS might generate update PRs with updates on these if transitively required.

--- a/scripts/renovate-simulation.sh
+++ b/scripts/renovate-simulation.sh
@@ -20,12 +20,12 @@ fi
 npx --yes --package renovate -- renovate-config-validator renovate.json5 || exit 1
 
 ## (2) Temporarily change the renovate.json5 to point to the local extension source
-## Use perl for portable in-place editing (GNU `sed -i` and BSD/macOS `sed -i` are incompatible).
-perl -i -pe 's/local>PeerDB-io/github>PeerDB-io/' renovate.json5
+## Edit via a temp file for portability (GNU `sed -i` and BSD/macOS `sed -i` are incompatible).
+sed 's/local>PeerDB-io/github>PeerDB-io/' renovate.json5 > renovate.json5.tmp && mv renovate.json5.tmp renovate.json5
 
 function cleanup {
   echo "Restoring renovate.json5 to point to the GitHub extension source"
-  perl -i -pe 's/github>PeerDB-io/local>PeerDB-io/' renovate.json5
+  sed 's/github>PeerDB-io/local>PeerDB-io/' renovate.json5 > renovate.json5.tmp && mv renovate.json5.tmp renovate.json5
 }
 trap cleanup EXIT
 

--- a/scripts/renovate-simulation.sh
+++ b/scripts/renovate-simulation.sh
@@ -20,11 +20,12 @@ fi
 npx --yes --package renovate -- renovate-config-validator renovate.json5 || exit 1
 
 ## (2) Temporarily change the renovate.json5 to point to the local extension source
-sed -i 's/local>PeerDB-io/github>PeerDB-io/' renovate.json5
+## Use perl for portable in-place editing (GNU `sed -i` and BSD/macOS `sed -i` are incompatible).
+perl -i -pe 's/local>PeerDB-io/github>PeerDB-io/' renovate.json5
 
 function cleanup {
   echo "Restoring renovate.json5 to point to the GitHub extension source"
-  sed -i 's/github>PeerDB-io/local>PeerDB-io/' renovate.json5
+  perl -i -pe 's/github>PeerDB-io/local>PeerDB-io/' renovate.json5
 }
 trap cleanup EXIT
 
@@ -46,7 +47,7 @@ cat renovate.out | grep 'flattened updates found' | tr ',' '\n' | tr ':' '\n' > 
 
 ## (6) Combine final updated packages details
 FINAL_UPDATES_FILE="final-updated-packages-details.json"
-cat "" > ${FINAL_UPDATES_FILE}
+: > ${FINAL_UPDATES_FILE}
 for dep in $(cat final-updated-packages.txt | tail -n+2 | sort -u | awk '{print $1}'); do
   jq --compact-output --arg dep "$dep" '. | select(.depName == $dep)' update-proposals.json >> ${FINAL_UPDATES_FILE}
 done

--- a/scripts/renovate-simulation.sh
+++ b/scripts/renovate-simulation.sh
@@ -20,12 +20,11 @@ fi
 npx --yes --package renovate -- renovate-config-validator renovate.json5 || exit 1
 
 ## (2) Temporarily change the renovate.json5 to point to the local extension source
-## Edit via a temp file for portability (GNU `sed -i` and BSD/macOS `sed -i` are incompatible).
-sed 's/local>PeerDB-io/github>PeerDB-io/' renovate.json5 > renovate.json5.tmp && mv renovate.json5.tmp renovate.json5
+sed -i.tmp 's/local>PeerDB-io/github>PeerDB-io/' renovate.json5 && rm -f renovate.json5.tmp
 
 function cleanup {
   echo "Restoring renovate.json5 to point to the GitHub extension source"
-  sed 's/github>PeerDB-io/local>PeerDB-io/' renovate.json5 > renovate.json5.tmp && mv renovate.json5.tmp renovate.json5
+  sed -i.tmp 's/github>PeerDB-io/local>PeerDB-io/' renovate.json5 && rm -f renovate.json5.tmp
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
* Rust builder image has a custom naming scheme Renovate doesn't recognize. Not updating the image blocks rust upgrades (#4572)
* sed on mac doesn't support inline replacement so use a temp file for portability
* gitignore one more script output