### PR TITLE
Heartbeat to Temporal more often

### DIFF
--- a/flow/pkg/common/heartbeat.go
+++ b/flow/pkg/common/heartbeat.go
@@ -15,7 +15,7 @@ func HeartbeatRoutine(
 	counter := 0
 	return Interval(
 		ctx,
-		15*time.Second,
+		2*time.Second,
 		func() {
 			counter += 1
 			activity.RecordHeartbeat(ctx, fmt.Sprintf("heartbeat #%d: %s", counter, message()))


### PR DESCRIPTION
Temporal folks said 2-5 second heartbeat intervals are fine, and we're getting faster pause and other cancellation times through that. Not changing heartbeat timeouts.