### PR TITLE
Classify Postgres program-limit-exceeded errors (SQLSTATE class 54)

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -254,6 +254,13 @@ var (
 	ErrorNotifyWalSegmentRemoved = ErrorClass{
 		Class: "NOTIFY_WAL_SEGMENT_REMOVED", action: NotifyUser,
 	}
+	// SQLSTATE class 54 (program limit exceeded): row/statement/column limits,
+	// e.g. an oversized btree index entry on the destination. Retrying can never
+	// succeed; needs internal attention, so give it a dedicated class instead of
+	// letting it drown in OTHER.
+	ErrorNotifyProgramLimitExceeded = ErrorClass{
+		Class: "NOTIFY_PROGRAM_LIMIT_EXCEEDED", action: NotifyTelemetry,
+	}
 	ErrorNotifyClickHouseSupportIsDisabledError = ErrorClass{
 		Class: "NOTIFY_CLICKHOUSE_SUPPORT_IS_DISABLED_ERROR", action: NotifyUser,
 	}
@@ -729,6 +736,14 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 
 		case pgerrcode.OutOfMemory:
 			return ErrorNotifyOOMSource, pgErrorInfo
+
+		case pgerrcode.ProgramLimitExceeded,
+			pgerrcode.StatementTooComplex,
+			pgerrcode.TooManyColumns,
+			pgerrcode.TooManyArguments:
+			// e.g. `index row size 3176 exceeds btree version 4 maximum 2704 for index "..."`
+			// when a destination btree indexes an oversized value
+			return ErrorNotifyProgramLimitExceeded, pgErrorInfo
 
 		case pgerrcode.QueryCanceled:
 			return ErrorNotifyConnectivity, pgErrorInfo

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -439,6 +439,22 @@ func TestPostgresSnapshotDoesNotExistErrorShouldBeInvalidSnapshot(t *testing.T) 
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresProgramLimitExceededErrorShouldBeNotifyTelemetry(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.ProgramLimitExceeded,
+		Message:  `index row size 3176 exceeds btree version 4 maximum 2704 for index "script_outputs_result_idx"`,
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("failed to sync records: failed to copy records into destination table: %w", err))
+	assert.Equal(t, ErrorNotifyProgramLimitExceeded, errorClass, "Unexpected error class")
+	assert.Equal(t, NotifyTelemetry, errorClass.ErrorAction(), "Unexpected error action")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.ProgramLimitExceeded,
+	}, errInfo, "Unexpected error info")
+}
+
 func TestPostgresInvalidValueForSynchronizedStandbySlots(t *testing.T) {
 	err := &pgconn.PgError{
 		Severity: "ERROR",


### PR DESCRIPTION
## What

Adds a dedicated error class `NOTIFY_PROGRAM_LIMIT_EXCEEDED` (action: `notify_telemetry`) for PostgreSQL SQLSTATE class 54 errors: `program_limit_exceeded` (54000), `statement_too_complex` (54001), `too_many_columns` (54011), `too_many_arguments` (54023). Previously these fell through the Postgres error switch to the `OTHER` catch-all.

## Why

A PG→PG mirror hit `index row size 3176 exceeds btree version 4 maximum 2704 for index ...` on the destination during initial load (a btree index on an oversized text value). The sync batch retried every ~2 minutes for ~22 hours — ~1.5k errors — with `errorClass=OTHER`, which internal alerting cannot key on without drowning in unclassified noise, so nobody was alerted until the customer noticed.

Class-54 errors are deterministic: retrying can never succeed (the same oversized tuple fails every time), and the fix requires intervention (e.g. dropping/replacing the offending destination index). A dedicated class lets telemetry alerting route them to the team.

## Testing

Added `TestPostgresProgramLimitExceededErrorShouldBeNotifyTelemetry` with the real error message from the incident; `go test ./alerting/` passes (except two pre-existing tests requiring a live local Postgres).