### PR TITLE
fix(clickhouse): preserve legacy soft-delete column casing

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	defaultIsDeletedColName = "_peerdb_is_deleted"
+	legacyIsDeletedColName  = "_PEERDB_IS_DELETED"
 	isDeletedColType        = "UInt8"
 	versionColName          = "_peerdb_version"
 	versionColType          = "UInt64"
@@ -464,6 +465,13 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		return model.NormalizeResponse{}, err
 	}
 
+	destinationColumns, err := peerdb_clickhouse.GetTableColumnsMapping(
+		ctx, c.logger, c.database, destinationTableNames,
+	)
+	if err != nil {
+		return model.NormalizeResponse{}, fmt.Errorf("failed to get destination table columns: %w", err)
+	}
+
 	enablePrimaryUpdate, err := internal.PeerDBEnableClickHousePrimaryUpdate(ctx, req.Env)
 	if err != nil {
 		return model.NormalizeResponse{}, err
@@ -577,6 +585,10 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				continue
 			}
 
+			softDeleteColName := resolveSoftDeleteColumnName(
+				req.SoftDeleteColName,
+				destinationColumns[tbl],
+			)
 			queryGenerator := NewNormalizeQueryGenerator(
 				tbl,
 				req.TableNameSchemaMapping,
@@ -589,7 +601,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				rawTbl,
 				c.chVersion,
 				c.Config.Cluster != "",
-				req.SoftDeleteColName,
+				softDeleteColName,
 				req.Version,
 				req.Flags,
 			)
@@ -633,6 +645,35 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		StartBatchID: lastNormBatchID + 1,
 		EndBatchID:   endBatchID,
 	}, nil
+}
+
+func resolveSoftDeleteColumnName(
+	configuredName string,
+	destinationColumns []peerdb_clickhouse.ClickHouseColumn,
+) string {
+	if configuredName == "" {
+		configuredName = defaultIsDeletedColName
+	}
+
+	for _, column := range destinationColumns {
+		if column.Name == configuredName {
+			return column.Name
+		}
+	}
+	if configuredName != defaultIsDeletedColName && configuredName != legacyIsDeletedColName {
+		return configuredName
+	}
+
+	compatibleName := defaultIsDeletedColName
+	if configuredName == defaultIsDeletedColName {
+		compatibleName = legacyIsDeletedColName
+	}
+	for _, column := range destinationColumns {
+		if column.Name == compatibleName {
+			return column.Name
+		}
+	}
+	return configuredName
 }
 
 func (c *ClickHouseConnector) getDistinctTableNamesInBatch(

--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	peerdb_clickhouse "github.com/PeerDB-io/peerdb/flow/pkg/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
@@ -323,6 +324,85 @@ func TestBuildQuery_WithPrimaryUpdate(t *testing.T) {
 	require.Contains(t, query, "JSONExtract(_peerdb_match_data, 'id', 'Int64') AS `id`")
 	require.Contains(t, query, "_peerdb_match_data != ''")
 	require.Contains(t, query, "_peerdb_record_type = 1")
+}
+
+func TestResolveSoftDeleteColumnName(t *testing.T) {
+	columns := []peerdb_clickhouse.ClickHouseColumn{
+		{Name: "_peerdb_is_deleted"},
+		{Name: "_PEERDB_IS_DELETED"},
+	}
+
+	require.Equal(t, "_PEERDB_IS_DELETED", resolveSoftDeleteColumnName("_PEERDB_IS_DELETED", columns))
+	require.Equal(t, "_peerdb_is_deleted", resolveSoftDeleteColumnName("_PEERDB_IS_DELETED", columns[:1]))
+	require.Equal(t, "_PEERDB_IS_DELETED", resolveSoftDeleteColumnName("_peerdb_is_deleted", columns[1:]))
+	require.Equal(t, "_peerdb_is_deleted", resolveSoftDeleteColumnName("", columns[:1]))
+	require.Equal(t, "_PeErDb_Is_DeLeTeD", resolveSoftDeleteColumnName("_PeErDb_Is_DeLeTeD", columns))
+	require.Equal(t, "custom_deleted", resolveSoftDeleteColumnName("custom_deleted", columns))
+	require.Equal(t, "my_deleted", resolveSoftDeleteColumnName(
+		"my_deleted",
+		[]peerdb_clickhouse.ClickHouseColumn{{Name: "MY_deleted"}},
+	))
+}
+
+func TestBuildQuery_UsesDestinationSoftDeleteColumnCase(t *testing.T) {
+	ctx := t.Context()
+	tableName := "my_table"
+	resolvedName := resolveSoftDeleteColumnName(
+		"_PEERDB_IS_DELETED",
+		[]peerdb_clickhouse.ClickHouseColumn{{Name: "_peerdb_is_deleted"}},
+	)
+	g := NewNormalizeQueryGenerator(
+		tableName,
+		map[string]*protos.TableSchema{
+			tableName: {
+				Columns: []*protos.FieldDescription{
+					{Name: "id", Type: string(types.QValueKindInt64)},
+				},
+			},
+		},
+		[]*protos.TableMapping{{
+			SourceTableIdentifier:      "public.my_table",
+			DestinationTableIdentifier: tableName,
+		}},
+		10,
+		5,
+		false,
+		false,
+		map[string]string{},
+		"raw_my_table",
+		nil,
+		false,
+		resolvedName,
+		shared.InternalVersion_Latest,
+		nil,
+	)
+
+	query, err := g.BuildQuery(ctx)
+	require.NoError(t, err)
+	require.Contains(t, query, "AS `_peerdb_is_deleted`")
+	require.Contains(t, query, "(`id`,`_peerdb_is_deleted`,`_peerdb_version`)")
+	require.NotContains(t, query, "`_PEERDB_IS_DELETED`")
+}
+
+func TestProcessTableComparison_WithResolvedSoftDeleteColumnCase(t *testing.T) {
+	connector := &ClickHouseConnector{}
+	destinationColumns := []peerdb_clickhouse.ClickHouseColumn{
+		{Name: "id"},
+		{Name: "_peerdb_is_deleted"},
+		{Name: "_peerdb_version"},
+		{Name: "_peerdb_synced_at"},
+	}
+	softDeleteColName := resolveSoftDeleteColumnName("_PEERDB_IS_DELETED", destinationColumns)
+	err := connector.processTableComparison(
+		"my_table",
+		&protos.TableSchema{
+			Columns: []*protos.FieldDescription{{Name: "id"}},
+		},
+		destinationColumns,
+		[]string{softDeleteColName, "_peerdb_version", "_peerdb_synced_at"},
+		&protos.TableMapping{},
+	)
+	require.NoError(t, err)
 }
 
 func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {

--- a/flow/connectors/clickhouse/validate.go
+++ b/flow/connectors/clickhouse/validate.go
@@ -51,14 +51,9 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 		return nil // no need to validate schema for resync, as we will create or replace the tables
 	}
 
-	peerDBColumns := []string{versionColName}
+	softDeleteColName := defaultIsDeletedColName
 	if cfg.SoftDeleteColName != "" {
-		peerDBColumns = append(peerDBColumns, cfg.SoftDeleteColName)
-	} else {
-		peerDBColumns = append(peerDBColumns, defaultIsDeletedColName)
-	}
-	if cfg.SyncedAtColName != "" {
-		peerDBColumns = append(peerDBColumns, strings.ToLower(cfg.SyncedAtColName))
+		softDeleteColName = cfg.SoftDeleteColName
 	}
 
 	// this is for handling column exclusion, processed schema does that in a step
@@ -135,10 +130,18 @@ func (c *ClickHouseConnector) ValidateMirrorDestination(
 			continue
 		}
 
+		tablePeerDBColumns := []string{
+			versionColName,
+			resolveSoftDeleteColumnName(softDeleteColName, chTableColumnsMapping[dstTableName]),
+		}
+		if cfg.SyncedAtColName != "" {
+			tablePeerDBColumns = append(tablePeerDBColumns, strings.ToLower(cfg.SyncedAtColName))
+		}
+
 		// for resync, we don't need to check the content or structure of the original tables;
 		// they'll anyways get swapped out with the _resync tables which we CREATE OR REPLACE
 		if err := c.processTableComparison(dstTableName, processedMapping[dstTableName],
-			chTableColumnsMapping[dstTableName], peerDBColumns, tableMapping,
+			chTableColumnsMapping[dstTableName], tablePeerDBColumns, tableMapping,
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
### Summary

- resolve the configured soft-delete column against the physical ClickHouse destination schema before normalization
- prefer exact matches, then case-insensitive matches, so both legacy lowercase tables and newer uppercase/custom tables keep working
- apply the same resolution during destination validation

### Root cause

Older PeerDB releases stored the UI default `_PEERDB_IS_DELETED` in mirror config, but ClickHouse table creation and normalization hardcoded the physical column as `_peerdb_is_deleted`. After #4365 began honoring the stored config, upgraded legacy mirrors generated inserts for the uppercase identifier even though their existing tables only had the lowercase column.

### Tests

- `go test ./connectors/clickhouse -skip '^TestCreateRawTableHasTTL$' -count=1`
- `go vet ./connectors/clickhouse`
- `go test -race ./connectors/clickhouse -run 'Test(ResolveSoftDeleteColumnName|BuildQuery_UsesDestinationSoftDeleteColumnCase|ProcessTableComparison_WithResolvedSoftDeleteColumnCase)$' -count=1`

Fixes #4596