### PR TITLE
Validate PARTITION BY expression with fake virtual table and Dynamic type for all columns

### DIFF
--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -25,6 +25,7 @@ import (
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
 	"github.com/PeerDB-io/peerdb/flow/e2eshared"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
 	"github.com/PeerDB-io/peerdb/flow/pkg/clickhouse"
@@ -670,6 +671,39 @@ func (s ClickHouseSuite) Test_WeirdTable_Question() {
 
 func (s ClickHouseSuite) Test_WeirdTable_Dash() {
 	s.WeirdTable("table-group%a%b%c")
+}
+
+func (s ClickHouseSuite) Test_ValidatePartitionByExpression() {
+	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	require.NoError(s.t, err)
+	defer ch.Close()
+
+	logger := internal.LoggerFromCtx(s.t.Context())
+	const targetTable = "replicated_events"
+	columnNames := []string{"id", "val"}
+
+	for _, tc := range []struct {
+		name       string
+		expression string
+		wantErr    bool
+	}{
+		{name: "invalid_syntax_rejected", expression: "INVALID EXPRESSION", wantErr: true},
+		{name: "missing_column_rejected", expression: "i_am_not_a_column % 2", wantErr: true},
+		{name: "aggregate_expression_rejected", expression: "MAX(id)", wantErr: true},
+		{name: "valid_expression_passes", expression: "id % 2", wantErr: false},
+		{name: "empty_expression_passes", expression: "", wantErr: false},
+	} {
+		s.t.Run(tc.name, func(t *testing.T) {
+			err := clickhouse.ValidatePartitionByExpression(
+				s.t.Context(), logger, ch, tc.expression, targetTable, columnNames, nil)
+			if tc.wantErr {
+				require.ErrorContains(t, err,
+					fmt.Sprintf("invalid partition expression (%s) for table %s", tc.expression, targetTable))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 // large NUMERICs (precision >76) are mapped to String on CH, test

--- a/flow/pkg/clickhouse/validation.go
+++ b/flow/pkg/clickhouse/validation.go
@@ -323,3 +323,60 @@ func ValidateClusterShardingKey(cluster, shardingKey, sourceTable string, hasPri
 		sourceTable,
 	)
 }
+
+// ValidatePartitionByExpression validates the "PARTITION BY <expr>" expression of a table mapping.
+//
+// NOTE: it currently spot-checks the expression without type validation, for simplicity.
+// The expression runs against a "fake table": a subquery exposing every replicable column
+// of the mapping, all typed Dynamic, as in the following example:
+//
+//	SELECT (toYYYYMM(t))
+//	FROM (
+//	    SELECT CAST(NULL, 'Dynamic') AS `id`,
+//	           CAST(NULL, 'Dynamic') AS `t`
+//	)
+//	LIMIT 0
+//
+// This catches references to unknown or excluded columns and syntax errors while staying
+// type-agnostic — a sweet spot between no validation and a full validation requiring type
+// awareness, which adds several layers of complexity. Type misuse and DDL-only rules
+// (deterministic expressions, nullable keys) still surface at destination-table creation.
+func ValidatePartitionByExpression(
+	ctx context.Context,
+	logger log.Logger,
+	conn clickhouse.Conn,
+	expression string,
+	targetTable string,
+	columnNames []string,
+	excludedColumns []string,
+) error {
+	if expression == "" {
+		// Nothing to validate
+		return nil
+	}
+
+	// If the validation query fails to execute in CH, we deem the expression invalid
+	rows, err := Query(ctx, logger, conn, buildPartitionByValidationQuery(expression, columnNames, excludedColumns))
+	if err != nil {
+		return fmt.Errorf("invalid partition expression (%s) for table %s: %w", expression, targetTable, err)
+	}
+	rows.Close()
+	return nil
+}
+
+// buildPartitionByValidationQuery renders the type-agnostic probe query: the mapping's
+// replicable columns as Dynamic placeholders. PeerDB's metadata columns (_peerdb_*) are
+// deliberately not exposed, so expressions may only reference replicated source columns.
+func buildPartitionByValidationQuery(expression string, columnNames, excludedColumns []string) string {
+	excludedSet := make(map[string]struct{}, len(excludedColumns))
+	for _, col := range excludedColumns {
+		excludedSet[col] = struct{}{}
+	}
+	placeholders := make([]string, 0, len(columnNames))
+	for _, column := range columnNames {
+		if _, excluded := excludedSet[column]; !excluded {
+			placeholders = append(placeholders, "CAST(NULL, 'Dynamic') AS "+QuoteIdentifier(column))
+		}
+	}
+	return fmt.Sprintf("SELECT (%s) FROM (SELECT %s) LIMIT 0", expression, strings.Join(placeholders, ", "))
+}

--- a/flow/pkg/clickhouse/validation_test.go
+++ b/flow/pkg/clickhouse/validation_test.go
@@ -214,3 +214,19 @@ func TestValidateClusterShardingKey(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildPartitionByValidationQuery(t *testing.T) {
+	t.Run("columns as dynamic placeholders", func(t *testing.T) {
+		query := buildPartitionByValidationQuery("toYYYYMM(t)", []string{"id", "t"}, nil)
+		require.Equal(t,
+			"SELECT (toYYYYMM(t)) FROM (SELECT "+
+				"CAST(NULL, 'Dynamic') AS `id`, "+
+				"CAST(NULL, 'Dynamic') AS `t`) LIMIT 0",
+			query)
+	})
+
+	t.Run("excluded columns are omitted", func(t *testing.T) {
+		query := buildPartitionByValidationQuery("id % 2", []string{"id", "secret"}, []string{"secret"})
+		require.Equal(t, "SELECT (id % 2) FROM (SELECT CAST(NULL, 'Dynamic') AS `id`) LIMIT 0", query)
+	})
+}


### PR DESCRIPTION
This PR adds a helper method to spot check ClickHouse expressions used in `PARTITION BY <expr>`. 

It provides a quick check without adding too much complexity trading off type validation in the columns used by `expr` beyond the consistency of infered types. 

Part of https://linear.app/clickhouse/issue/DBI-758