### PR TITLE
bug: CDC Date clamping consistent with initial load limits

### DIFF
--- a/flow/connectors/clickhouse/normalize_query.go
+++ b/flow/connectors/clickhouse/normalize_query.go
@@ -86,6 +86,26 @@ func clampDates(dateExpr string) string {
 	return fmt.Sprintf("if(isNull(%s), NULL, %s)", dateExpr, upperAndLowerBounded)
 }
 
+// clampTimestamps bounds a DateTime64(6) SQL expression to PeerDB's supported
+// range, matching the Go-side clamp applied during initial load
+// (processGeneralTime): out-of-range values move to the boundary date with
+// time-of-day preserved. On ClickHouse < 26.7 parseDateTime64BestEffort*
+// already clamps, making this a no-op; on >= 26.7 the parse passes
+// out-of-range values through.
+func clampTimestamps(timestampExpr string) string {
+	minBound := fmt.Sprintf("toDateTime64('%d-01-01 00:00:00',6,'UTC')", qvalue.ClickHouseMinYear)
+	maxBound := fmt.Sprintf("toDateTime64('%d-12-31 23:59:59.999999',6,'UTC')", qvalue.ClickHouseMaxYear)
+	maxDayStart := fmt.Sprintf("toDateTime64('%d-12-31 00:00:00',6,'UTC')", qvalue.ClickHouseMaxYear)
+	// Time-of-day is rebuilt from epoch microseconds instead of calendar
+	// functions which misbehave on out-of-range inputs.
+	timeOfDay := fmt.Sprintf("positiveModulo(toUnixTimestamp64Micro(%s), toInt64(86400000000))", timestampExpr)
+	return fmt.Sprintf("multiIf(isNull(%s), NULL, %s < %s, addMicroseconds(%s, %s), %s > %s, addMicroseconds(%s, %s), %s)",
+		timestampExpr,
+		timestampExpr, minBound, minBound, timeOfDay,
+		timestampExpr, maxBound, maxDayStart, timeOfDay,
+		timestampExpr)
+}
+
 func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error) {
 	selectQuery := strings.Builder{}
 	selectQuery.WriteString("SELECT ")
@@ -194,27 +214,31 @@ func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error
 				}
 			} else {
 				fmt.Fprintf(&projection,
-					"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, %s),6,'UTC') AS %s,",
-					peerdb_clickhouse.QuoteLiteral(colName),
+					"%s AS %s,",
+					clampTimestamps(fmt.Sprintf("parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, %s),6,'UTC')",
+						peerdb_clickhouse.QuoteLiteral(colName))),
 					peerdb_clickhouse.QuoteIdentifier(dstColName),
 				)
 				if t.enablePrimaryUpdate {
 					fmt.Fprintf(&projectionUpdate,
-						"parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, %s),6,'UTC') AS %s,",
-						peerdb_clickhouse.QuoteLiteral(colName),
+						"%s AS %s,",
+						clampTimestamps(fmt.Sprintf("parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, %s),6,'UTC')",
+							peerdb_clickhouse.QuoteLiteral(colName))),
 						peerdb_clickhouse.QuoteIdentifier(dstColName),
 					)
 				}
 			}
 		case "Array(DateTime64(6))", "Nullable(Array(DateTime64(6)))":
 			fmt.Fprintf(&projection,
-				`arrayMap(x -> parseDateTime64BestEffortOrNull(x,6,'UTC'),JSONExtract(_peerdb_data,%s,'Array(String)')) AS %s,`,
+				`arrayMap(x -> %s,JSONExtract(_peerdb_data,%s,'Array(String)')) AS %s,`,
+				clampTimestamps("parseDateTime64BestEffortOrNull(x,6,'UTC')"),
 				peerdb_clickhouse.QuoteLiteral(colName),
 				peerdb_clickhouse.QuoteIdentifier(dstColName),
 			)
 			if t.enablePrimaryUpdate {
 				fmt.Fprintf(&projectionUpdate,
-					`arrayMap(x -> parseDateTime64BestEffortOrNull(x,6,'UTC'),JSONExtract(_peerdb_match_data,%s,'Array(String)')) AS %s,`,
+					`arrayMap(x -> %s,JSONExtract(_peerdb_match_data,%s,'Array(String)')) AS %s,`,
+					clampTimestamps("parseDateTime64BestEffortOrNull(x,6,'UTC')"),
 					peerdb_clickhouse.QuoteLiteral(colName),
 					peerdb_clickhouse.QuoteIdentifier(dstColName),
 				)

--- a/flow/connectors/clickhouse/normalize_query.go
+++ b/flow/connectors/clickhouse/normalize_query.go
@@ -74,6 +74,18 @@ func NewNormalizeQueryGenerator(
 	}
 }
 
+// clampDates bounds a Date32 SQL expression to PeerDB's supported range,
+// matching the Go-side clamp applied during initial load (processGeneralTime).
+// On ClickHouse < 26.7 parseDateTime64BestEffort* already clamps, making this
+// a no-op; on >= 26.7 the parse passes out-of-range values through.
+func clampDates(dateExpr string) string {
+	lowerBounded := fmt.Sprintf("greatest(toDate32('%d-01-01'), %s)", qvalue.ClickHouseMinYear, dateExpr)
+	upperAndLowerBounded := fmt.Sprintf("least(toDate32('%d-12-31'), %s)", qvalue.ClickHouseMaxYear, lowerBounded)
+	// isNull guard is required: greatest/least ignore NULL arguments on
+	// current ClickHouse, which would otherwise turn NULL dates into the bound.
+	return fmt.Sprintf("if(isNull(%s), NULL, %s)", dateExpr, upperAndLowerBounded)
+}
+
 func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error) {
 	selectQuery := strings.Builder{}
 	selectQuery.WriteString("SELECT ")
@@ -151,14 +163,16 @@ func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error
 			}
 		case "Date32", "Nullable(Date32)":
 			fmt.Fprintf(&projection,
-				"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, %s),6,'UTC')) AS %s,",
-				peerdb_clickhouse.QuoteLiteral(colName),
+				"%s AS %s,",
+				clampDates(fmt.Sprintf("toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_data, %s),6,'UTC'))",
+					peerdb_clickhouse.QuoteLiteral(colName))),
 				peerdb_clickhouse.QuoteIdentifier(dstColName),
 			)
 			if t.enablePrimaryUpdate {
 				fmt.Fprintf(&projectionUpdate,
-					"toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, %s),6,'UTC')) AS %s,",
-					peerdb_clickhouse.QuoteLiteral(colName),
+					"%s AS %s,",
+					clampDates(fmt.Sprintf("toDate32(parseDateTime64BestEffortOrNull(JSONExtractString(_peerdb_match_data, %s),6,'UTC'))",
+						peerdb_clickhouse.QuoteLiteral(colName))),
 					peerdb_clickhouse.QuoteIdentifier(dstColName),
 				)
 			}

--- a/flow/connectors/clickhouse/normalize_query.go
+++ b/flow/connectors/clickhouse/normalize_query.go
@@ -86,6 +86,12 @@ func clampDates(dateExpr string) string {
 	return fmt.Sprintf("if(isNull(%s), NULL, %s)", dateExpr, upperAndLowerBounded)
 }
 
+var (
+	minBound    = fmt.Sprintf("toDateTime64('%d-01-01 00:00:00',6,'UTC')", qvalue.ClickHouseMinYear)
+	maxBound    = fmt.Sprintf("toDateTime64('%d-12-31 23:59:59.999999',6,'UTC')", qvalue.ClickHouseMaxYear)
+	maxDayStart = fmt.Sprintf("toDateTime64('%d-12-31 00:00:00',6,'UTC')", qvalue.ClickHouseMaxYear)
+)
+
 // clampTimestamps bounds a DateTime64(6) SQL expression to PeerDB's supported
 // range, matching the Go-side clamp applied during initial load
 // (processGeneralTime): out-of-range values move to the boundary date with
@@ -93,9 +99,6 @@ func clampDates(dateExpr string) string {
 // already clamps, making this a no-op; on >= 26.7 the parse passes
 // out-of-range values through.
 func clampTimestamps(timestampExpr string) string {
-	minBound := fmt.Sprintf("toDateTime64('%d-01-01 00:00:00',6,'UTC')", qvalue.ClickHouseMinYear)
-	maxBound := fmt.Sprintf("toDateTime64('%d-12-31 23:59:59.999999',6,'UTC')", qvalue.ClickHouseMaxYear)
-	maxDayStart := fmt.Sprintf("toDateTime64('%d-12-31 00:00:00',6,'UTC')", qvalue.ClickHouseMaxYear)
 	// Time-of-day is rebuilt from epoch microseconds instead of calendar
 	// functions which misbehave on out-of-range inputs.
 	timeOfDay := fmt.Sprintf("positiveModulo(toUnixTimestamp64Micro(%s), toInt64(86400000000))", timestampExpr)

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -372,8 +372,8 @@ func (c *QValueAvroConverter) processGoTime(t time.Duration, so sizeOpt) (any, i
 }
 
 const (
-	clickHouseMinYear = 1900
-	clickHouseMaxYear = 2299
+	ClickHouseMinYear = 1900
+	ClickHouseMaxYear = 2299
 )
 
 func (c *QValueAvroConverter) processGeneralTime(t time.Time, format string, isDate bool, so sizeOpt) (any, int64) {
@@ -390,10 +390,10 @@ func (c *QValueAvroConverter) processGeneralTime(t time.Time, format string, isD
 			}
 		}
 	case protos.DBType_CLICKHOUSE:
-		if year := t.Year(); year < clickHouseMinYear {
-			t = time.Date(clickHouseMinYear, time.January, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
-		} else if year > clickHouseMaxYear {
-			t = time.Date(clickHouseMaxYear, time.December, 31, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
+		if year := t.Year(); year < ClickHouseMinYear {
+			t = time.Date(ClickHouseMinYear, time.January, 1, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
+		} else if year > ClickHouseMaxYear {
+			t = time.Date(ClickHouseMaxYear, time.December, 31, t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
 		}
 	case protos.DBType_SNOWFLAKE:
 		// Snowflake has issues with avro timestamp types, returning as string form

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -372,6 +372,11 @@ func (c *QValueAvroConverter) processGoTime(t time.Duration, so sizeOpt) (any, i
 }
 
 const (
+	// TODO:
+	// This limits match the current ClickHouse stable version ranges.
+	// These are being expended with https://github.com/ClickHouse/ClickHouse/issues/65380
+	// Follow-up to update these limits or make them dynamic in function of the target ClickHouse dp
+	// capabilities.
 	ClickHouseMinYear = 1900
 	ClickHouseMaxYear = 2299
 )


### PR DESCRIPTION
In https://github.com/PeerDB-io/peerdb/pull/4534/ we added logic to proactively clamp dates to CH Date32 limits at the time.

However, the scope of that change didn't include CDC. CDC normalization was therefore constrained by ClickHouse's `parseDateTime64BestEffortOrNull` limits.

These limits changed with with https://github.com/clickHouse/clickhouse/pull/107907 leaving initial loads and cdc supported date ranges inconsistent with each other.

This PR aligns CDC to use the same limits as initial load.

From now this is a constant to `[1900-01-01,  2299-12-31]` but  might want to follow up with a piece of functionality probing destination CH valid ranges to make the most of the target CH version capabilities.