### PR TITLE
CI: Monitor CI stages times with actions-timeline action

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -142,6 +142,9 @@ jobs:
           DOCKER_MODS: linuxserver/mods:openssh-server-ssh-tunnel
 
     steps:
+      - uses: Kesin11/actions-timeline@v3.1.1
+        with:
+          expand-composite-actions: true
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
Introduces https://github.com/marketplace/actions/actions-timeline action to our CI build thus allowing for analysis of CI stages performance. 