### PR TITLE
fix: handle drop column on clickhouse and remove from schema in clickpipes

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -757,6 +757,37 @@ func (a *FlowableActivity) startNormalize(
 		}
 
 		a.recordDeliveryLag(ctx, config.FlowJobName, res.StartBatchID, res.EndBatchID)
+		// If any destination columns were auto-removed during normalize (user dropped them), persist
+		// the updated schemas to the catalog and warn the user.
+		if len(res.UpdatedSchemaMapping) > 0 {
+			tableNames := make([]string, 0, len(res.UpdatedSchemaMapping))
+			for name := range res.UpdatedSchemaMapping {
+				tableNames = append(tableNames, name)
+			}
+			if updateErr := internal.ReadModifyWriteTableSchemasToCatalog(
+				ctx, a.CatalogPool, logger, config.FlowJobName, tableNames,
+				func(schemas map[string]*protos.TableSchema) (map[string]*protos.TableSchema, error) {
+					result := make(map[string]*protos.TableSchema, len(schemas))
+					for name, schema := range schemas {
+						if updated, ok := res.UpdatedSchemaMapping[name]; ok {
+							result[name] = updated
+						} else {
+							result[name] = schema
+						}
+					}
+					return result, nil
+				},
+			); updateErr != nil {
+				logger.Error("failed to persist auto-refreshed table schemas to catalog",
+					slog.Any("error", updateErr))
+			}
+			for name, schema := range res.UpdatedSchemaMapping {
+				tableNameSchemaMapping[name] = schema
+				a.Alerter.LogFlowWarning(ctx, config.FlowJobName,
+					fmt.Errorf("destination column(s) were dropped from table %s and automatically removed "+
+						"from the mirror schema; future syncs will omit those columns", name))
+			}
+		}
 
 		logger.Info("normalized batches",
 			slog.Int64("startBatchID", res.StartBatchID), slog.Int64("endBatchID", res.EndBatchID), slog.Int64("syncBatchID", batchID))

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -757,36 +758,8 @@ func (a *FlowableActivity) startNormalize(
 		}
 
 		a.recordDeliveryLag(ctx, config.FlowJobName, res.StartBatchID, res.EndBatchID)
-		// If any destination columns were auto-removed during normalize (user dropped them), persist
-		// the updated schemas to the catalog and warn the user.
-		if len(res.UpdatedSchemaMapping) > 0 {
-			tableNames := make([]string, 0, len(res.UpdatedSchemaMapping))
-			for name := range res.UpdatedSchemaMapping {
-				tableNames = append(tableNames, name)
-			}
-			if updateErr := internal.ReadModifyWriteTableSchemasToCatalog(
-				ctx, a.CatalogPool, logger, config.FlowJobName, tableNames,
-				func(schemas map[string]*protos.TableSchema) (map[string]*protos.TableSchema, error) {
-					result := make(map[string]*protos.TableSchema, len(schemas))
-					for name, schema := range schemas {
-						if updated, ok := res.UpdatedSchemaMapping[name]; ok {
-							result[name] = updated
-						} else {
-							result[name] = schema
-						}
-					}
-					return result, nil
-				},
-			); updateErr != nil {
-				logger.Error("failed to persist auto-refreshed table schemas to catalog",
-					slog.Any("error", updateErr))
-			}
-			for name, schema := range res.UpdatedSchemaMapping {
-				tableNameSchemaMapping[name] = schema
-				a.Alerter.LogFlowWarning(ctx, config.FlowJobName,
-					fmt.Errorf("destination column(s) were dropped from table %s and automatically removed "+
-						"from the mirror schema; future syncs will omit those columns", name))
-			}
+		if len(res.RemovedColumnsMapping) > 0 {
+			a.applyRemovedColumnsFromNormalize(ctx, logger, config.FlowJobName, res.RemovedColumnsMapping, tableNameSchemaMapping)
 		}
 
 		logger.Info("normalized batches",
@@ -795,6 +768,66 @@ func (a *FlowableActivity) startNormalize(
 		if res.EndBatchID >= batchID {
 			return nil
 		}
+	}
+}
+
+func (a *FlowableActivity) applyRemovedColumnsFromNormalize(
+	ctx context.Context,
+	logger log.Logger,
+	flowJobName string,
+	removedColumnsMapping map[string][]string,
+	tableNameSchemaMapping map[string]*protos.TableSchema,
+) {
+	tableNames := make([]string, 0, len(removedColumnsMapping))
+	for name := range removedColumnsMapping {
+		tableNames = append(tableNames, name)
+	}
+	// Remove only the dropped columns from the schemas read within the transaction to prevent any race condition.
+	updateErr := internal.ReadModifyWriteTableSchemasToCatalog(
+		ctx, a.CatalogPool, logger, flowJobName, tableNames,
+		func(schemas map[string]*protos.TableSchema) (map[string]*protos.TableSchema, error) {
+			result := make(map[string]*protos.TableSchema, len(schemas))
+			for name, schema := range schemas {
+				result[name] = removeColumnsFromSchema(schema, removedColumnsMapping[name])
+			}
+			return result, nil
+		},
+	)
+	if updateErr != nil {
+		logger.Error("failed to persist auto-removed destination columns to catalog",
+			slog.Any("error", updateErr))
+	}
+
+	for name, removed := range removedColumnsMapping {
+		if schema, ok := tableNameSchemaMapping[name]; ok {
+			tableNameSchemaMapping[name] = removeColumnsFromSchema(schema, removed)
+		}
+		if updateErr == nil {
+			a.Alerter.LogFlowWarning(ctx, flowJobName,
+				fmt.Errorf("destination column(s) were dropped from table %s and automatically removed "+
+					"from the mirror schema; future syncs will omit those columns", name))
+		}
+	}
+}
+
+func removeColumnsFromSchema(schema *protos.TableSchema, columns []string) *protos.TableSchema {
+	if len(columns) == 0 {
+		return schema
+	}
+	filteredCols := make([]*protos.FieldDescription, 0, len(schema.Columns))
+	for _, col := range schema.Columns {
+		if !slices.Contains(columns, col.Name) {
+			filteredCols = append(filteredCols, col)
+		}
+	}
+	return &protos.TableSchema{
+		TableIdentifier:       schema.TableIdentifier,
+		PrimaryKeyColumns:     schema.PrimaryKeyColumns,
+		IsReplicaIdentityFull: schema.IsReplicaIdentityFull,
+		System:                schema.System,
+		NullableEnabled:       schema.NullableEnabled,
+		TableOid:              schema.TableOid,
+		Columns:               filteredCols,
 	}
 }
 

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -3,14 +3,17 @@ package connclickhouse
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	ch_proto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	chproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"golang.org/x/sync/errgroup"
@@ -494,10 +497,14 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	type queryInfo struct {
 		table           string
 		query           string
+		generator       *NormalizeQueryGenerator
 		lastNormBatchID int64
 	}
 	queriesCh := make(chan queryInfo)
 	rawTbl := c.GetRawTableName(req.FlowJobName)
+
+	var updatedSchemasMu sync.Mutex
+	updatedSchemas := make(map[string]*protos.TableSchema)
 
 	group, errCtx := errgroup.WithContext(ctx)
 	// create N=PEERDB_CLICKHOUSE_PARALLEL_NORMALIZE goroutines to process requests from queriesCh
@@ -524,6 +531,44 @@ func (c *ClickHouseConnector) NormalizeRecords(
 					slog.Int("parallelWorker", i))
 
 				if err := c.execWithConnection(errCtx, chConn, q.query); err != nil {
+					// If a destination column is missing (user dropped it), try to auto-recover
+					// by refreshing the schema and retrying the INSERT without that column.
+					var chEx *clickhouse.Exception
+					if errors.As(err, &chEx) && ch_proto.Error(chEx.Code) == ch_proto.ErrNoSuchColumnInTable {
+						c.logger.Warn("[clickhouse] missing column in destination, attempting schema refresh and retry",
+							slog.String("table", q.table),
+							slog.Int("parallelWorker", i),
+							slog.Any("error", err))
+						retryQuery, refreshedSchema, refreshErr := c.refreshSchemaAndRebuildQuery(errCtx, q.generator)
+						if refreshErr == nil {
+							retryErr := c.execWithConnection(errCtx, chConn, retryQuery)
+							if retryErr == nil {
+								updatedSchemasMu.Lock()
+								updatedSchemas[q.table] = refreshedSchema
+								updatedSchemasMu.Unlock()
+								c.logger.Warn("[clickhouse] successfully retried normalize after dropping missing destination columns",
+									slog.String("table", q.table),
+									slog.Int("parallelWorker", i))
+								if err := c.SetLastNormalizedBatchIDForTable(errCtx, req.FlowJobName, q.table, endBatchID); err != nil {
+									return fmt.Errorf("error while setting last synced batch id for table %s: %w", q.table, err)
+								}
+								c.logger.Info("executed INSERT command to ClickHouse",
+									slog.String("table", q.table),
+									slog.Int64("endBatchID", endBatchID),
+									slog.Int64("lastNormBatchID", q.lastNormBatchID),
+									slog.Int("parallelWorker", i))
+								continue
+							}
+							c.logger.Error("[clickhouse] retry after schema refresh failed",
+								slog.String("table", q.table),
+								slog.String("query", retryQuery),
+								slog.Any("error", retryErr))
+						} else {
+							c.logger.Error("[clickhouse] failed to refresh schema after missing column error",
+								slog.String("table", q.table),
+								slog.Any("error", refreshErr))
+						}
+					}
 					c.logger.Error("[clickhouse] error while inserting into target clickhouse table",
 						slog.String("table", q.table),
 						slog.Int64("endBatchID", endBatchID),
@@ -603,6 +648,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 			case queriesCh <- queryInfo{
 				table:           tbl,
 				query:           query,
+				generator:       queryGenerator,
 				lastNormBatchID: lastNormBatchIDForTable,
 			}:
 			case <-errCtx.Done():
@@ -625,10 +671,98 @@ func (c *ClickHouseConnector) NormalizeRecords(
 			slog.Int64("batchID", endBatchID), slog.Any("error", err))
 		return model.NormalizeResponse{}, err
 	}
-	return model.NormalizeResponse{
+	resp := model.NormalizeResponse{
 		StartBatchID: lastNormBatchID + 1,
 		EndBatchID:   endBatchID,
-	}, nil
+	}
+	if len(updatedSchemas) > 0 {
+		resp.UpdatedSchemaMapping = updatedSchemas
+	}
+	return resp, nil
+}
+
+// refreshSchemaAndRebuildQuery queries the actual columns present in the destination ClickHouse table,
+// removes any columns from the schema that no longer exist there, and returns a rebuilt normalize query
+// together with the filtered schema. This is used to recover from ErrNoSuchColumnInTable when the user
+// has manually dropped a column from the destination after it was dropped at the source.
+func (c *ClickHouseConnector) refreshSchemaAndRebuildQuery(
+	ctx context.Context,
+	gen *NormalizeQueryGenerator,
+) (string, *protos.TableSchema, error) {
+	colMapping, err := peerdb_clickhouse.GetTableColumnsMapping(ctx, c.logger, c.database, []string{gen.TableName})
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to query destination table columns for schema refresh: %w", err)
+	}
+	actualColSet := make(map[string]struct{}, len(colMapping[gen.TableName]))
+	for _, col := range colMapping[gen.TableName] {
+		actualColSet[col.Name] = struct{}{}
+	}
+
+	currentSchema := gen.tableNameSchemaMapping[gen.TableName]
+
+	// Resolve the table mapping to handle source→destination column name remapping.
+	var tableMapping *protos.TableMapping
+	for _, tm := range gen.tableMappings {
+		if tm.DestinationTableIdentifier == gen.TableName {
+			tableMapping = tm
+			break
+		}
+	}
+
+	var filteredCols []*protos.FieldDescription
+	var removedCols []string
+	for _, col := range currentSchema.Columns {
+		dstColName := col.Name
+		if tableMapping != nil {
+			for _, tm := range tableMapping.Columns {
+				if tm.SourceName == col.Name && tm.DestinationName != "" {
+					dstColName = tm.DestinationName
+					break
+				}
+			}
+		}
+		if _, exists := actualColSet[dstColName]; exists {
+			filteredCols = append(filteredCols, col)
+		} else {
+			removedCols = append(removedCols, dstColName)
+		}
+	}
+
+	if len(removedCols) == 0 {
+		return "", nil, fmt.Errorf(
+			"no user columns were absent from destination table %s despite ErrNoSuchColumnInTable; "+
+				"the missing column may be a PeerDB internal column", gen.TableName)
+	}
+
+	c.logger.Warn("[clickhouse] auto-removing destination-dropped columns from schema",
+		slog.String("table", gen.TableName),
+		slog.Any("removedColumns", removedCols))
+
+	filteredSchema := &protos.TableSchema{
+		TableIdentifier:       currentSchema.TableIdentifier,
+		PrimaryKeyColumns:     currentSchema.PrimaryKeyColumns,
+		IsReplicaIdentityFull: currentSchema.IsReplicaIdentityFull,
+		System:                currentSchema.System,
+		NullableEnabled:       currentSchema.NullableEnabled,
+		TableOid:              currentSchema.TableOid,
+		Columns:               filteredCols,
+	}
+
+	// Build a new query generator with a shallow copy of the schema mapping where
+	// only the affected table's schema is replaced with the filtered one.
+	newMapping := maps.Clone(gen.tableNameSchemaMapping)
+	newMapping[gen.TableName] = filteredSchema
+
+	retryGen := *gen
+	retryGen.tableNameSchemaMapping = newMapping
+	retryGen.Query = ""
+
+	query, err := retryGen.BuildQuery(ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to rebuild normalize query with filtered schema for %s: %w", gen.TableName, err)
+	}
+
+	return query, filteredSchema, nil
 }
 
 func (c *ClickHouseConnector) getDistinctTableNamesInBatch(

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -495,9 +495,9 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	defer periodicLogger()
 
 	type queryInfo struct {
+		generator       *NormalizeQueryGenerator
 		table           string
 		query           string
-		generator       *NormalizeQueryGenerator
 		lastNormBatchID int64
 	}
 	queriesCh := make(chan queryInfo)

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -494,17 +494,11 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	})
 	defer periodicLogger()
 
-	type queryInfo struct {
-		generator       *NormalizeQueryGenerator
-		table           string
-		query           string
-		lastNormBatchID int64
-	}
 	queriesCh := make(chan queryInfo)
 	rawTbl := c.GetRawTableName(req.FlowJobName)
 
-	var updatedSchemasMu sync.Mutex
-	updatedSchemas := make(map[string]*protos.TableSchema)
+	var removedColumnsMu sync.Mutex
+	removedColumnsMapping := make(map[string][]string)
 
 	group, errCtx := errgroup.WithContext(ctx)
 	// create N=PEERDB_CLICKHOUSE_PARALLEL_NORMALIZE goroutines to process requests from queriesCh
@@ -530,45 +524,8 @@ func (c *ClickHouseConnector) NormalizeRecords(
 					slog.String("query", q.query),
 					slog.Int("parallelWorker", i))
 
-				if err := c.execWithConnection(errCtx, chConn, q.query); err != nil {
-					// If a destination column is missing (user dropped it), try to auto-recover
-					// by refreshing the schema and retrying the INSERT without that column.
-					var chEx *clickhouse.Exception
-					if errors.As(err, &chEx) && ch_proto.Error(chEx.Code) == ch_proto.ErrNoSuchColumnInTable {
-						c.logger.Warn("[clickhouse] missing column in destination, attempting schema refresh and retry",
-							slog.String("table", q.table),
-							slog.Int("parallelWorker", i),
-							slog.Any("error", err))
-						retryQuery, refreshedSchema, refreshErr := c.refreshSchemaAndRebuildQuery(errCtx, q.generator)
-						if refreshErr == nil {
-							retryErr := c.execWithConnection(errCtx, chConn, retryQuery)
-							if retryErr == nil {
-								updatedSchemasMu.Lock()
-								updatedSchemas[q.table] = refreshedSchema
-								updatedSchemasMu.Unlock()
-								c.logger.Warn("[clickhouse] successfully retried normalize after dropping missing destination columns",
-									slog.String("table", q.table),
-									slog.Int("parallelWorker", i))
-								if err := c.SetLastNormalizedBatchIDForTable(errCtx, req.FlowJobName, q.table, endBatchID); err != nil {
-									return fmt.Errorf("error while setting last synced batch id for table %s: %w", q.table, err)
-								}
-								c.logger.Info("executed INSERT command to ClickHouse",
-									slog.String("table", q.table),
-									slog.Int64("endBatchID", endBatchID),
-									slog.Int64("lastNormBatchID", q.lastNormBatchID),
-									slog.Int("parallelWorker", i))
-								continue
-							}
-							c.logger.Error("[clickhouse] retry after schema refresh failed",
-								slog.String("table", q.table),
-								slog.String("query", retryQuery),
-								slog.Any("error", retryErr))
-						} else {
-							c.logger.Error("[clickhouse] failed to refresh schema after missing column error",
-								slog.String("table", q.table),
-								slog.Any("error", refreshErr))
-						}
-					}
+				removedCols, err := c.execNormalizeQuery(errCtx, chConn, q)
+				if err != nil {
 					c.logger.Error("[clickhouse] error while inserting into target clickhouse table",
 						slog.String("table", q.table),
 						slog.Int64("endBatchID", endBatchID),
@@ -576,6 +533,11 @@ func (c *ClickHouseConnector) NormalizeRecords(
 						slog.Int("parallelWorker", i),
 						slog.Any("error", err))
 					return fmt.Errorf("error while inserting into target clickhouse table %s: %w", q.table, err)
+				}
+				if len(removedCols) > 0 {
+					removedColumnsMu.Lock()
+					removedColumnsMapping[q.table] = removedCols
+					removedColumnsMu.Unlock()
 				}
 
 				c.logger.Info("[clickhouse] set last normalized batch id for table",
@@ -675,20 +637,108 @@ func (c *ClickHouseConnector) NormalizeRecords(
 		StartBatchID: lastNormBatchID + 1,
 		EndBatchID:   endBatchID,
 	}
-	if len(updatedSchemas) > 0 {
-		resp.UpdatedSchemaMapping = updatedSchemas
+	if len(removedColumnsMapping) > 0 {
+		resp.RemovedColumnsMapping = removedColumnsMapping
 	}
 	return resp, nil
 }
 
+// queryInfo describes a normalize INSERT for a single destination table.
+type queryInfo struct {
+	generator       *NormalizeQueryGenerator
+	table           string
+	query           string
+	lastNormBatchID int64
+}
+
+// execNormalizeQuery runs the normalize INSERT; on ErrNoSuchColumnInTable it refreshes the
+// schema against the destination table and retries without the dropped columns. Returns the
+// source names of the columns removed during recovery.
+func (c *ClickHouseConnector) execNormalizeQuery(
+	ctx context.Context,
+	conn clickhouse.Conn,
+	q queryInfo,
+) ([]string, error) {
+	err := c.execWithConnection(ctx, conn, q.query)
+	if err == nil {
+		return nil, nil
+	}
+
+	chEx, ok := errors.AsType[*clickhouse.Exception](err)
+	if !ok || ch_proto.Error(chEx.Code) != ch_proto.ErrNoSuchColumnInTable {
+		return nil, err
+	}
+
+	// A destination column is missing (user dropped it): try to auto-recover by
+	// refreshing the schema and retrying the INSERT without that column.
+	c.logger.Warn("[clickhouse] missing column in destination, attempting schema refresh and retry",
+		slog.String("table", q.table),
+		slog.Any("error", err))
+	retryQuery, removedCols, refreshErr := c.refreshSchemaAndRebuildQuery(ctx, q.generator)
+	if refreshErr != nil {
+		c.logger.Error("[clickhouse] failed to refresh schema after missing column error",
+			slog.String("table", q.table),
+			slog.Any("error", refreshErr))
+		return nil, err
+	}
+	if retryErr := c.execWithConnection(ctx, conn, retryQuery); retryErr != nil {
+		c.logger.Error("[clickhouse] retry after schema refresh failed",
+			slog.String("table", q.table),
+			slog.String("query", retryQuery),
+			slog.Any("error", retryErr))
+		return nil, err
+	}
+	c.logger.Warn("[clickhouse] successfully retried normalize after dropping missing destination columns",
+		slog.String("table", q.table))
+	return removedCols, nil
+}
+
+// filterSchemaColumnsByDestination removes columns from schema whose mapped destination column
+// name (per tableMapping, which may be nil) is absent from actualDestColumns. Returns the
+// filtered schema and the source names of the removed columns (empty if nothing was removed).
+func filterSchemaColumnsByDestination(
+	schema *protos.TableSchema,
+	tableMapping *protos.TableMapping,
+	actualDestColumns map[string]struct{},
+) (*protos.TableSchema, []string) {
+	var filteredCols []*protos.FieldDescription
+	var removedSourceCols []string
+	for _, col := range schema.Columns {
+		dstColName := col.Name
+		if tableMapping != nil {
+			for _, cs := range tableMapping.Columns {
+				if cs.SourceName == col.Name && cs.DestinationName != "" {
+					dstColName = cs.DestinationName
+					break
+				}
+			}
+		}
+		if _, exists := actualDestColumns[dstColName]; exists {
+			filteredCols = append(filteredCols, col)
+		} else {
+			removedSourceCols = append(removedSourceCols, col.Name)
+		}
+	}
+
+	return &protos.TableSchema{
+		TableIdentifier:       schema.TableIdentifier,
+		PrimaryKeyColumns:     schema.PrimaryKeyColumns,
+		IsReplicaIdentityFull: schema.IsReplicaIdentityFull,
+		System:                schema.System,
+		NullableEnabled:       schema.NullableEnabled,
+		TableOid:              schema.TableOid,
+		Columns:               filteredCols,
+	}, removedSourceCols
+}
+
 // refreshSchemaAndRebuildQuery queries the actual columns present in the destination ClickHouse table,
 // removes any columns from the schema that no longer exist there, and returns a rebuilt normalize query
-// together with the filtered schema. This is used to recover from ErrNoSuchColumnInTable when the user
-// has manually dropped a column from the destination after it was dropped at the source.
+// together with the source names of the removed columns. This is used to recover from
+// ErrNoSuchColumnInTable when the user has manually dropped a column from the destination.
 func (c *ClickHouseConnector) refreshSchemaAndRebuildQuery(
 	ctx context.Context,
 	gen *NormalizeQueryGenerator,
-) (string, *protos.TableSchema, error) {
+) (string, []string, error) {
 	colMapping, err := peerdb_clickhouse.GetTableColumnsMapping(ctx, c.logger, c.database, []string{gen.TableName})
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to query destination table columns for schema refresh: %w", err)
@@ -698,8 +748,23 @@ func (c *ClickHouseConnector) refreshSchemaAndRebuildQuery(
 		actualColSet[col.Name] = struct{}{}
 	}
 
-	currentSchema := gen.tableNameSchemaMapping[gen.TableName]
+	query, removedCols, err := rebuildQueryWithDestinationColumns(ctx, gen, actualColSet)
+	if err != nil {
+		return "", nil, err
+	}
 
+	c.logger.Warn("[clickhouse] auto-removing destination-dropped columns from schema",
+		slog.String("table", gen.TableName),
+		slog.Any("removedColumns", removedCols))
+
+	return query, removedCols, nil
+}
+
+func rebuildQueryWithDestinationColumns(
+	ctx context.Context,
+	gen *NormalizeQueryGenerator,
+	actualDestColumns map[string]struct{},
+) (string, []string, error) {
 	// Resolve the table mapping to handle source→destination column name remapping.
 	var tableMapping *protos.TableMapping
 	for _, tm := range gen.tableMappings {
@@ -709,43 +774,13 @@ func (c *ClickHouseConnector) refreshSchemaAndRebuildQuery(
 		}
 	}
 
-	var filteredCols []*protos.FieldDescription
-	var removedCols []string
-	for _, col := range currentSchema.Columns {
-		dstColName := col.Name
-		if tableMapping != nil {
-			for _, tm := range tableMapping.Columns {
-				if tm.SourceName == col.Name && tm.DestinationName != "" {
-					dstColName = tm.DestinationName
-					break
-				}
-			}
-		}
-		if _, exists := actualColSet[dstColName]; exists {
-			filteredCols = append(filteredCols, col)
-		} else {
-			removedCols = append(removedCols, dstColName)
-		}
-	}
+	filteredSchema, removedCols := filterSchemaColumnsByDestination(
+		gen.tableNameSchemaMapping[gen.TableName], tableMapping, actualDestColumns)
 
 	if len(removedCols) == 0 {
 		return "", nil, fmt.Errorf(
 			"no user columns were absent from destination table %s despite ErrNoSuchColumnInTable; "+
 				"the missing column may be a PeerDB internal column", gen.TableName)
-	}
-
-	c.logger.Warn("[clickhouse] auto-removing destination-dropped columns from schema",
-		slog.String("table", gen.TableName),
-		slog.Any("removedColumns", removedCols))
-
-	filteredSchema := &protos.TableSchema{
-		TableIdentifier:       currentSchema.TableIdentifier,
-		PrimaryKeyColumns:     currentSchema.PrimaryKeyColumns,
-		IsReplicaIdentityFull: currentSchema.IsReplicaIdentityFull,
-		System:                currentSchema.System,
-		NullableEnabled:       currentSchema.NullableEnabled,
-		TableOid:              currentSchema.TableOid,
-		Columns:               filteredCols,
 	}
 
 	// Build a new query generator with a shallow copy of the schema mapping where
@@ -762,7 +797,7 @@ func (c *ClickHouseConnector) refreshSchemaAndRebuildQuery(
 		return "", nil, fmt.Errorf("failed to rebuild normalize query with filtered schema for %s: %w", gen.TableName, err)
 	}
 
-	return query, filteredSchema, nil
+	return query, removedCols, nil
 }
 
 func (c *ClickHouseConnector) getDistinctTableNamesInBatch(

--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -517,3 +517,211 @@ func TestGenerateCreateTableSQLForNormalizedTable(t *testing.T) {
 		})
 	}
 }
+
+func Test_FilterSchemaColumnsByDestination(t *testing.T) {
+	makeSchema := func(colNames ...string) *protos.TableSchema {
+		columns := make([]*protos.FieldDescription, 0, len(colNames))
+		for _, name := range colNames {
+			columns = append(columns, &protos.FieldDescription{
+				Name: name,
+				Type: string(types.QValueKindString),
+			})
+		}
+		return &protos.TableSchema{
+			TableIdentifier:   "public.tbl",
+			PrimaryKeyColumns: []string{"id"},
+			NullableEnabled:   true,
+			TableOid:          42,
+			Columns:           columns,
+		}
+	}
+	destColumns := func(colNames ...string) map[string]struct{} {
+		set := make(map[string]struct{}, len(colNames))
+		for _, name := range colNames {
+			set[name] = struct{}{}
+		}
+		return set
+	}
+	columnNames := func(schema *protos.TableSchema) []string {
+		names := make([]string, 0, len(schema.Columns))
+		for _, col := range schema.Columns {
+			names = append(names, col.Name)
+		}
+		return names
+	}
+
+	tests := []struct {
+		name            string
+		schema          *protos.TableSchema
+		tableMapping    *protos.TableMapping
+		actualDestCols  map[string]struct{}
+		expectedKept    []string
+		expectedRemoved []string
+	}{
+		{
+			name:            "single column dropped without rename",
+			schema:          makeSchema("id", "c1", "val"),
+			actualDestCols:  destColumns("id", "c1"),
+			expectedKept:    []string{"id", "c1"},
+			expectedRemoved: []string{"val"},
+		},
+		{
+			name:   "renamed column dropped returns source name",
+			schema: makeSchema("id", "val"),
+			tableMapping: &protos.TableMapping{
+				DestinationTableIdentifier: "tbl_dst",
+				Columns: []*protos.ColumnSetting{
+					{SourceName: "val", DestinationName: "val_dst"},
+				},
+			},
+			actualDestCols:  destColumns("id"),
+			expectedKept:    []string{"id"},
+			expectedRemoved: []string{"val"},
+		},
+		{
+			name:   "renamed column present on destination is kept",
+			schema: makeSchema("id", "val"),
+			tableMapping: &protos.TableMapping{
+				DestinationTableIdentifier: "tbl_dst",
+				Columns: []*protos.ColumnSetting{
+					{SourceName: "val", DestinationName: "val_dst"},
+				},
+			},
+			actualDestCols:  destColumns("id", "val_dst"),
+			expectedKept:    []string{"id", "val"},
+			expectedRemoved: nil,
+		},
+		{
+			name:   "empty destination name falls back to source name",
+			schema: makeSchema("id", "val"),
+			tableMapping: &protos.TableMapping{
+				DestinationTableIdentifier: "tbl_dst",
+				Columns: []*protos.ColumnSetting{
+					{SourceName: "val", DestinationName: ""},
+				},
+			},
+			actualDestCols:  destColumns("id"),
+			expectedKept:    []string{"id"},
+			expectedRemoved: []string{"val"},
+		},
+		{
+			name:            "multiple columns dropped",
+			schema:          makeSchema("id", "c1", "val1", "val2"),
+			actualDestCols:  destColumns("id", "c1"),
+			expectedKept:    []string{"id", "c1"},
+			expectedRemoved: []string{"val1", "val2"},
+		},
+		{
+			name:            "nothing dropped returns empty removed list",
+			schema:          makeSchema("id", "c1", "val"),
+			actualDestCols:  destColumns("id", "c1", "val"),
+			expectedKept:    []string{"id", "c1", "val"},
+			expectedRemoved: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filtered, removed := filterSchemaColumnsByDestination(tc.schema, tc.tableMapping, tc.actualDestCols)
+			require.Equal(t, tc.expectedKept, columnNames(filtered))
+			require.Equal(t, tc.expectedRemoved, removed)
+		})
+	}
+}
+
+func Test_FilterSchemaColumnsByDestination_PreservesSchemaMetadata(t *testing.T) {
+	schema := &protos.TableSchema{
+		TableIdentifier:       "public.tbl",
+		PrimaryKeyColumns:     []string{"id"},
+		IsReplicaIdentityFull: true,
+		System:                protos.TypeSystem_PG,
+		NullableEnabled:       true,
+		TableOid:              42,
+		Columns: []*protos.FieldDescription{
+			{Name: "id", Type: string(types.QValueKindInt64)},
+			{Name: "val", Type: string(types.QValueKindString)},
+		},
+	}
+
+	filtered, removed := filterSchemaColumnsByDestination(schema, nil, map[string]struct{}{"id": {}})
+	require.Equal(t, []string{"val"}, removed)
+	require.Equal(t, schema.TableIdentifier, filtered.TableIdentifier)
+	require.Equal(t, schema.PrimaryKeyColumns, filtered.PrimaryKeyColumns)
+	require.Equal(t, schema.IsReplicaIdentityFull, filtered.IsReplicaIdentityFull)
+	require.Equal(t, schema.System, filtered.System)
+	require.Equal(t, schema.NullableEnabled, filtered.NullableEnabled)
+	require.Equal(t, schema.TableOid, filtered.TableOid)
+}
+
+func Test_RebuildQueryWithDestinationColumns(t *testing.T) {
+	const dstTableName = "tbl_dst"
+
+	newGenerator := func(schema *protos.TableSchema, tableMappings []*protos.TableMapping) *NormalizeQueryGenerator {
+		return NewNormalizeQueryGenerator(
+			dstTableName,
+			map[string]*protos.TableSchema{dstTableName: schema},
+			tableMappings,
+			5, // endBatchID
+			2, // lastNormBatchID
+			false,
+			false,
+			map[string]string{},
+			"raw_tbl",
+			nil,
+			false,
+			"",
+			0,
+			nil,
+		)
+	}
+	schema := &protos.TableSchema{
+		TableIdentifier:   "public.tbl",
+		PrimaryKeyColumns: []string{"id"},
+		Columns: []*protos.FieldDescription{
+			{Name: "id", Type: string(types.QValueKindInt64)},
+			{Name: "c1", Type: string(types.QValueKindInt32)},
+			{Name: "dropped_col", Type: string(types.QValueKindString)},
+		},
+	}
+
+	t.Run("dropped column removed from rebuilt query", func(t *testing.T) {
+		gen := newGenerator(schema, nil)
+		query, removed, err := rebuildQueryWithDestinationColumns(t.Context(), gen, map[string]struct{}{
+			"id": {}, "c1": {},
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"dropped_col"}, removed)
+		require.Contains(t, query, "`id`")
+		require.Contains(t, query, "`c1`")
+		require.NotContains(t, query, "dropped_col")
+
+		// the generator itself must not be mutated: retries build from a copy
+		require.Empty(t, gen.Query)
+		require.Len(t, gen.tableNameSchemaMapping[dstTableName].Columns, 3)
+	})
+
+	t.Run("renamed column returns source name and drops destination name", func(t *testing.T) {
+		gen := newGenerator(schema, []*protos.TableMapping{{
+			SourceTableIdentifier:      "public.tbl",
+			DestinationTableIdentifier: dstTableName,
+			Columns: []*protos.ColumnSetting{
+				{SourceName: "dropped_col", DestinationName: "dropped_col_dst"},
+			},
+		}})
+		query, removed, err := rebuildQueryWithDestinationColumns(t.Context(), gen, map[string]struct{}{
+			"id": {}, "c1": {},
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"dropped_col"}, removed)
+		require.NotContains(t, query, "dropped_col")
+		require.NotContains(t, query, "dropped_col_dst")
+	})
+
+	t.Run("all columns present errors instead of rebuilding", func(t *testing.T) {
+		gen := newGenerator(schema, nil)
+		_, _, err := rebuildQueryWithDestinationColumns(t.Context(), gen, map[string]struct{}{
+			"id": {}, "c1": {}, "dropped_col": {},
+		})
+		require.ErrorContains(t, err, "no user columns were absent from destination table")
+	})
+}

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -3930,6 +3930,14 @@ func (s ClickHouseSuite) Test_Normalize_After_Destination_Column_Drop() {
 }
 
 func (s ClickHouseSuite) Test_Column_Added_Back_After_Destination_Column_Drop() {
+	if mySource, isMysql := s.source.(*MySqlSource); isMysql {
+		cmp, err := mySource.CompareServerVersion(s.t.Context(), mysql_validation.MySQLMinVersionForBinlogRowMetadata)
+		require.NoError(s.t, err)
+		if cmp < 0 {
+			s.t.Skip("source DROP COLUMN requires binlog_row_metadata")
+		}
+	}
+
 	srcTableName := "test_dst_col_readd"
 	srcFullName := s.attachSchemaSuffix(srcTableName)
 	dstTableName := "test_dst_col_readd_dst"

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -3860,3 +3860,230 @@ func (s ClickHouseSuite) Test_Offload_Partition_Ranges() {
 		flowConnConfig.FlowJobName).Scan(&remainingRanges))
 	require.Zero(s.t, remainingRanges)
 }
+
+func (s ClickHouseSuite) Test_Normalize_After_Destination_Column_Drop() {
+	srcTableName := "test_dst_col_drop"
+	srcFullName := s.attachSchemaSuffix(srcTableName)
+	dstTableName := "test_dst_col_drop_dst"
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id SERIAL PRIMARY KEY,
+			c1 INT NOT NULL,
+			val TEXT NOT NULL
+		)`, srcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1, val) VALUES (1, 'first')", srcFullName)))
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("ch_dst_col_drop"),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+
+	tc := NewTemporalClient(s.t)
+	env := ExecutePeerflow(s.t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,c1,val")
+
+	// user drops a column directly on the destination table
+	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	require.NoError(s.t, err)
+	if s.cluster {
+		require.NoError(s.t, ch.Exec(s.t.Context(),
+			fmt.Sprintf("ALTER TABLE `%s_shard` ON CLUSTER cicluster DROP COLUMN `val`", dstTableName)))
+		require.NoError(s.t, ch.Exec(s.t.Context(),
+			fmt.Sprintf("ALTER TABLE `%s` ON CLUSTER cicluster DROP COLUMN `val`", dstTableName)))
+	} else {
+		require.NoError(s.t, ch.Exec(s.t.Context(),
+			fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `val`", dstTableName)))
+	}
+	require.NoError(s.t, ch.Close())
+
+	// normalize should hit ErrNoSuchColumnInTable, auto-remove the column from the schema and retry
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1, val) VALUES (2, 'second')", srcFullName)))
+	EnvWaitForEqualTablesWithNames(env, s, "normalize after destination column drop", srcTableName, dstTableName, "id,c1")
+
+	EnvWaitFor(s.t, env, time.Minute, "catalog schema updated to drop column", func() bool {
+		schema, err := internal.LoadTableSchemaFromCatalog(s.t.Context(), s.catalog, flowConnConfig.FlowJobName, dstTableName)
+		if err != nil {
+			return false
+		}
+		return !slices.ContainsFunc(schema.Columns, func(col *protos.FieldDescription) bool {
+			return col.Name == "val"
+		})
+	})
+
+	// subsequent syncs should normalize with the updated schema, omitting the dropped column
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1, val) VALUES (3, 'third')", srcFullName)))
+	EnvWaitForEqualTablesWithNames(env, s, "normalize with updated schema", srcTableName, dstTableName, "id,c1")
+
+	env.Cancel(s.t.Context())
+	RequireEnvCanceled(s.t, env)
+
+	dropEnv := ExecuteDropFlow(s.t.Context(), tc, flowConnConfig, 0)
+	EnvWaitForFinished(s.t, dropEnv, 3*time.Minute)
+}
+
+func (s ClickHouseSuite) Test_Column_Added_Back_After_Destination_Column_Drop() {
+	srcTableName := "test_dst_col_readd"
+	srcFullName := s.attachSchemaSuffix(srcTableName)
+	dstTableName := "test_dst_col_readd_dst"
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id SERIAL PRIMARY KEY,
+			c1 INT NOT NULL,
+			val TEXT
+		)`, srcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1, val) VALUES (1, 'first')", srcFullName)))
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("ch_dst_col_readd"),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	flowConnConfig.Env = map[string]string{"PEERDB_NULLABLE": "true"}
+
+	tc := NewTemporalClient(s.t)
+	env := ExecutePeerflow(s.t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,c1,val")
+
+	// user drops a column directly on the destination table
+	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	require.NoError(s.t, err)
+	if s.cluster {
+		require.NoError(s.t, ch.Exec(s.t.Context(),
+			fmt.Sprintf("ALTER TABLE `%s_shard` ON CLUSTER cicluster DROP COLUMN `val`", dstTableName)))
+		require.NoError(s.t, ch.Exec(s.t.Context(),
+			fmt.Sprintf("ALTER TABLE `%s` ON CLUSTER cicluster DROP COLUMN `val`", dstTableName)))
+	} else {
+		require.NoError(s.t, ch.Exec(s.t.Context(),
+			fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `val`", dstTableName)))
+	}
+	require.NoError(s.t, ch.Close())
+
+	// normalize hits ErrNoSuchColumnInTable and auto-removes the column from the schema
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1, val) VALUES (2, 'second')", srcFullName)))
+	EnvWaitForEqualTablesWithNames(env, s, "normalize after destination column drop", srcTableName, dstTableName, "id,c1")
+	EnvWaitFor(s.t, env, time.Minute, "catalog schema updated to drop column", func() bool {
+		schema, err := internal.LoadTableSchemaFromCatalog(s.t.Context(), s.catalog, flowConnConfig.FlowJobName, dstTableName)
+		if err != nil {
+			return false
+		}
+		return !slices.ContainsFunc(schema.Columns, func(col *protos.FieldDescription) bool {
+			return col.Name == "val"
+		})
+	})
+
+	// drop the column on the source too; DML after the DDL updates the cached relation message
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("ALTER TABLE %s DROP COLUMN val", srcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1) VALUES (3)", srcFullName)))
+	EnvWaitForEqualTablesWithNames(env, s, "normalize after source column drop", srcTableName, dstTableName, "id,c1")
+
+	// re-add the column on the source: the schema delta should add it back to the
+	// catalog schema and recreate it on the destination
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("ALTER TABLE %s ADD COLUMN val TEXT", srcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1, val) VALUES (4, 'fourth')", srcFullName)))
+
+	EnvWaitFor(s.t, env, time.Minute, "catalog schema updated to re-add column", func() bool {
+		schema, err := internal.LoadTableSchemaFromCatalog(s.t.Context(), s.catalog, flowConnConfig.FlowJobName, dstTableName)
+		if err != nil {
+			return false
+		}
+		return slices.ContainsFunc(schema.Columns, func(col *protos.FieldDescription) bool {
+			return col.Name == "val"
+		})
+	})
+	EnvWaitForEqualTablesWithNames(env, s, "normalize after column re-added", srcTableName, dstTableName, "id,c1,val")
+
+	env.Cancel(s.t.Context())
+	RequireEnvCanceled(s.t, env)
+
+	dropEnv := ExecuteDropFlow(s.t.Context(), tc, flowConnConfig, 0)
+	EnvWaitForFinished(s.t, dropEnv, 3*time.Minute)
+}
+
+func (s ClickHouseSuite) Test_Normalize_After_Destination_Two_Column_Drop() {
+	srcTableName := "test_dst_two_col_drop"
+	srcFullName := s.attachSchemaSuffix(srcTableName)
+	dstTableName := "test_dst_two_col_drop_dst"
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id SERIAL PRIMARY KEY,
+			c1 INT NOT NULL,
+			val1 TEXT NOT NULL,
+			val2 TEXT NOT NULL
+		)`, srcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1, val1, val2) VALUES (1, 'first', 'uno')", srcFullName)))
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("ch_dst_two_col_drop"),
+		TableNameMapping: map[string]string{srcFullName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+
+	tc := NewTemporalClient(s.t)
+	env := ExecutePeerflow(s.t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitForEqualTablesWithNames(env, s, "waiting on initial", srcTableName, dstTableName, "id,c1,val1,val2")
+
+	// user drops two columns directly on the destination table
+	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	require.NoError(s.t, err)
+	for _, col := range []string{"val1", "val2"} {
+		if s.cluster {
+			require.NoError(s.t, ch.Exec(s.t.Context(),
+				fmt.Sprintf("ALTER TABLE `%s_shard` ON CLUSTER cicluster DROP COLUMN `%s`", dstTableName, col)))
+			require.NoError(s.t, ch.Exec(s.t.Context(),
+				fmt.Sprintf("ALTER TABLE `%s` ON CLUSTER cicluster DROP COLUMN `%s`", dstTableName, col)))
+		} else {
+			require.NoError(s.t, ch.Exec(s.t.Context(),
+				fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `%s`", dstTableName, col)))
+		}
+	}
+	require.NoError(s.t, ch.Close())
+
+	// normalize should hit ErrNoSuchColumnInTable, auto-remove both columns from the schema and retry
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1, val1, val2) VALUES (2, 'second', 'dos')", srcFullName)))
+	EnvWaitForEqualTablesWithNames(env, s, "normalize after destination two column drop", srcTableName, dstTableName, "id,c1")
+
+	EnvWaitFor(s.t, env, time.Minute, "catalog schema updated to drop both columns", func() bool {
+		schema, err := internal.LoadTableSchemaFromCatalog(s.t.Context(), s.catalog, flowConnConfig.FlowJobName, dstTableName)
+		if err != nil {
+			return false
+		}
+		return !slices.ContainsFunc(schema.Columns, func(col *protos.FieldDescription) bool {
+			return col.Name == "val1" || col.Name == "val2"
+		})
+	})
+
+	// subsequent syncs should normalize with the updated schema, omitting both dropped columns
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (c1, val1, val2) VALUES (3, 'third', 'tres')", srcFullName)))
+	EnvWaitForEqualTablesWithNames(env, s, "normalize with updated schema", srcTableName, dstTableName, "id,c1")
+
+	env.Cancel(s.t.Context())
+	RequireEnvCanceled(s.t, env)
+
+	dropEnv := ExecuteDropFlow(s.t.Context(), tc, flowConnConfig, 0)
+	EnvWaitForFinished(s.t, dropEnv, 3*time.Minute)
+}

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -188,6 +188,9 @@ type SyncResponse struct {
 type NormalizeResponse struct {
 	StartBatchID int64
 	EndBatchID   int64
+	// Non-nil when columns that were dropped from the destination were auto-removed from the in-memory schema.
+	// The caller should persist these updated schemas to the catalog.
+	UpdatedSchemaMapping map[string]*protos.TableSchema
 }
 
 type RelationMessageMapping map[uint32]*pglogrepl.RelationMessage

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -186,11 +186,11 @@ type SyncResponse struct {
 }
 
 type NormalizeResponse struct {
-	StartBatchID int64
-	EndBatchID   int64
 	// Non-nil when columns that were dropped from the destination were auto-removed from the in-memory schema.
 	// The caller should persist these updated schemas to the catalog.
 	UpdatedSchemaMapping map[string]*protos.TableSchema
+	StartBatchID         int64
+	EndBatchID           int64
 }
 
 type RelationMessageMapping map[uint32]*pglogrepl.RelationMessage

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -186,11 +186,12 @@ type SyncResponse struct {
 }
 
 type NormalizeResponse struct {
-	// Non-nil when columns that were dropped from the destination were auto-removed from the in-memory schema.
-	// The caller should persist these updated schemas to the catalog.
-	UpdatedSchemaMapping map[string]*protos.TableSchema
-	StartBatchID         int64
-	EndBatchID           int64
+	// Keyed by destination table name; values are SOURCE column names that were auto-removed
+	// during normalize because the user dropped the corresponding destination columns.
+	// The caller should remove these columns from the catalog schemas.
+	RemovedColumnsMapping map[string][]string
+	StartBatchID          int64
+	EndBatchID            int64
 }
 
 type RelationMessageMapping map[uint32]*pglogrepl.RelationMessage


### PR DESCRIPTION
### Problem
When customer removes a column from table in Clickhouse, Normalize fails due to SQL query error mentioning unknown column.

In order to deal with this, we had to change the source schema for the table to remove that column.

This PR aims to make this easier by identifying if the column is deleted and retrying and updating the schema.

We check the errors in Normalization step and match if its occurring from a missing column, if it is we refresh the schema and retry normalization and also update the schema.