### PR TITLE
Clean up SSH error classification

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -24,7 +24,6 @@ import (
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology"
 	"go.temporal.io/sdk/temporal"
-	"golang.org/x/crypto/ssh"
 	"google.golang.org/api/googleapi"
 
 	"github.com/PeerDB-io/peerdb/flow/internal"
@@ -437,14 +436,23 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			Source: ErrorSourceSSH,
 			Code:   "TUNNEL_DIAL_ERROR",
 		}
-		if sshDialErr.Retryable {
+		switch {
+		case sshDialErr.Retryable:
 			return ErrorRetryRecoverable, errInfo
+		case errors.Is(sshDialErr, net.ErrClosed) ||
+			strings.HasSuffix(sshDialErr.Error(), "use of closed network connection"):
+			// We force-closed our own tunnel (syncer.Close hung / keepalive failure) and then
+			// dialed on the dead client. Transient and self-heals on reconnect.
+			return ErrorRetryRecoverable, errInfo
+		default:
+			// SSH server rejected the forwarded connection to the source
+			return ErrorNotifyConnectivity, errInfo
 		}
-		return ErrorOther, errInfo
 	}
 
+	// Keepalive failure
 	if _, ok := errors.AsType[*exceptions.SSHTunnelClosedError](err); ok {
-		return ErrorRetryRecoverable, ErrorInfo{
+		return ErrorNotifyConnectivity, ErrorInfo{
 			Source: ErrorSourceSSH,
 			Code:   "TUNNEL_CONNECTION_CLOSED",
 		}
@@ -477,13 +485,6 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		return ErrorNotifyConnectivity, ErrorInfo{
 			Source: ErrorSourceNet,
 			Code:   netErr.Err.Error(),
-		}
-	}
-
-	if sshOpenChanErr, ok := errors.AsType[*ssh.OpenChannelError](err); ok {
-		return ErrorNotifyConnectivity, ErrorInfo{
-			Source: ErrorSourceSSH,
-			Code:   sshOpenChanErr.Reason.String(),
 		}
 	}
 

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -90,14 +90,42 @@ func TestSSHTunnelRecoverableDialError(t *testing.T) {
 	}, errInfo)
 }
 
-func TestSSHTunnelClosedPipeErrorShouldBeRetryable(t *testing.T) {
+func TestSSHTunnelDialConnectFailedShouldBeConnectivity(t *testing.T) {
+	t.Parallel()
+
+	// The SSH bastion rejected the forwarded connection to the source (DNS / refused / timeout).
+	err := fmt.Errorf("failed to create connection: %w",
+		exceptions.NewSSHTunnelDialError(errors.New("ssh: rejected: connect failed (Name or service not known)")))
+	errorClass, errInfo := GetErrorClass(t.Context(), err)
+	assert.Equal(t, ErrorNotifyConnectivity, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceSSH,
+		Code:   "TUNNEL_DIAL_ERROR",
+	}, errInfo)
+}
+
+func TestSSHTunnelDialClosedConnShouldBeRetryable(t *testing.T) {
+	t.Parallel()
+
+	// We force-closed our own tunnel (syncer.Close hung / keepalive failure), then dialed on the dead client.
+	err := fmt.Errorf("connection to source down: %w",
+		exceptions.NewSSHTunnelDialError(&net.OpError{Op: "dial", Err: net.ErrClosed}))
+	errorClass, errInfo := GetErrorClass(t.Context(), err)
+	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceSSH,
+		Code:   "TUNNEL_DIAL_ERROR",
+	}, errInfo)
+}
+
+func TestSSHTunnelClosedPipeErrorShouldBeConnectivity(t *testing.T) {
 	t.Parallel()
 
 	// Mirrors how deadlineCapableConn wraps net.Pipe teardown errors when an
 	// SSH-tunneled connection is torn down while a query is in flight.
 	err := fmt.Errorf("receive message failed: %w", exceptions.NewSSHTunnelClosedError(io.ErrClosedPipe))
 	errorClass, errInfo := GetErrorClass(t.Context(), err)
-	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorNotifyConnectivity, errorClass)
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceSSH,
 		Code:   "TUNNEL_CONNECTION_CLOSED",

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -102,7 +102,7 @@ func NewMongoConnector(ctx context.Context, config *protos.MongoConfig) (*MongoC
 	mc.ssh = sshTunnel
 
 	var meteredDialer utils.MeteredDialer
-	if sshTunnel != nil && sshTunnel.Client != nil {
+	if sshTunnel.IsActive() {
 		meteredDialer = utils.NewMeteredDialer(&mc.totalBytesRead, &mc.deltaBytesRead, sshTunnel.DialContext)
 	} else {
 		meteredDialer = utils.NewMeteredDialer(&mc.totalBytesRead, &mc.deltaBytesRead, (&net.Dialer{Timeout: time.Minute}).DialContext)

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -88,8 +88,8 @@ func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlC
 			case <-ssh.GetKeepaliveChan(ctx):
 				c.logger.Info("SSH keepalive failed, closing connection")
 				ctx = context.Background()
-				// close the SSH client so that BinlogSyncer notices too
-				if err := ssh.Client.Close(); err != nil {
+				// close the SSH tunnel so that BinlogSyncer notices too
+				if err := ssh.Close(); err != nil {
 					c.logger.Error("Failed to close SSH client", slog.Any("error", err))
 				}
 				if conn := c.conn.Swap(nil); conn != nil {
@@ -171,7 +171,7 @@ func (c *MySqlConnector) ConnectionActive(ctx context.Context) error {
 
 func (c *MySqlConnector) Dialer() client.Dialer {
 	var meteredDialer utils.MeteredDialer
-	if c.ssh != nil && c.ssh.Client != nil {
+	if c.ssh.IsActive() {
 		meteredDialer = utils.NewMeteredDialer(&c.totalBytesRead, &c.deltaBytesRead, c.ssh.DialContext)
 	} else {
 		meteredDialer = utils.NewMeteredDialer(&c.totalBytesRead, &c.deltaBytesRead, (&net.Dialer{Timeout: time.Minute}).DialContext)

--- a/flow/connectors/postgres/ssh_wrapped_conn.go
+++ b/flow/connectors/postgres/ssh_wrapped_conn.go
@@ -19,7 +19,7 @@ func NewPostgresConnFromConfig(
 	rdsAuth *utils.RDSAuth,
 	tunnel *utils.SSHTunnel,
 ) (*pgx.Conn, error) {
-	if tunnel != nil && tunnel.Client != nil {
+	if tunnel.IsActive() {
 		connConfig.DialFunc = tunnel.DialContext
 		// DNS lookup seems to happen before connection is established which can be an issue if given host
 		// can only be resolved on the SSH host https://github.com/jackc/pgx/issues/1724

--- a/flow/connectors/utils/ssh.go
+++ b/flow/connectors/utils/ssh.go
@@ -20,7 +20,7 @@ import (
 const SSHKeepaliveInterval = 15 * time.Second
 
 type SSHTunnel struct {
-	*ssh.Client
+	client        *ssh.Client
 	logger        *slog.Logger
 	keepaliveChan atomic.Pointer[chan struct{}]
 	badTunnel     atomic.Bool
@@ -93,7 +93,7 @@ func NewSSHTunnel(
 		}
 
 		return &SSHTunnel{
-			Client: client,
+			client: client,
 			logger: internal.SlogLoggerFromCtx(ctx),
 		}, nil
 	}
@@ -107,8 +107,12 @@ func (tunnel *SSHTunnel) IsBad() bool {
 	return tunnel != nil && tunnel.badTunnel.Load()
 }
 
+func (tunnel *SSHTunnel) IsActive() bool {
+	return tunnel != nil && tunnel.client != nil
+}
+
 func (tunnel *SSHTunnel) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	conn, err := tunnel.Client.DialContext(ctx, network, address)
+	conn, err := tunnel.client.DialContext(ctx, network, address)
 	if err != nil {
 		return nil, exceptions.NewSSHTunnelDialError(err)
 	}
@@ -116,12 +120,12 @@ func (tunnel *SSHTunnel) DialContext(ctx context.Context, network, address strin
 }
 
 func (tunnel *SSHTunnel) Close() error {
-	if tunnel != nil && tunnel.Client != nil {
+	if tunnel != nil && tunnel.client != nil {
 		if keepaliveChan := tunnel.keepaliveChan.Swap(nil); keepaliveChan != nil {
 			close(*keepaliveChan)
 		}
 		tunnel.badTunnel.Store(true)
-		return tunnel.Client.Close()
+		return tunnel.client.Close()
 	}
 	return nil
 }
@@ -155,7 +159,7 @@ func (tunnel *SSHTunnel) runKeepaliveLoop(
 			}
 			go func() {
 				requestSent.Store(true)
-				_, _, err := tunnel.Client.SendRequest("keepalive@openssh.com", true, nil)
+				_, _, err := tunnel.client.SendRequest("keepalive@openssh.com", true, nil)
 				requestSent.Store(false)
 				if err != nil {
 					keepaliveErr = err
@@ -185,7 +189,7 @@ func (tunnel *SSHTunnel) runKeepaliveLoop(
 }
 
 func (tunnel *SSHTunnel) StartKeepalive(ctx context.Context, onFailure func()) {
-	if tunnel == nil || tunnel.Client == nil || tunnel.badTunnel.Load() {
+	if tunnel == nil || tunnel.client == nil || tunnel.badTunnel.Load() {
 		return
 	}
 	if tunnel.keepaliveChan.Load() != nil {
@@ -201,7 +205,7 @@ func (tunnel *SSHTunnel) StartKeepalive(ctx context.Context, onFailure func()) {
 // returns a channel that is closed if the SSH keepalive fails,
 // or nil if no SSH tunnel is configured
 func (tunnel *SSHTunnel) GetKeepaliveChan(ctx context.Context) <-chan struct{} {
-	if tunnel == nil || tunnel.Client == nil || tunnel.badTunnel.Load() {
+	if tunnel == nil || tunnel.client == nil || tunnel.badTunnel.Load() {
 		// nil channel would be of no consequence in a select
 		// UNLESS it's the only branch in a select, in which case it would block forever
 		return nil

--- a/flow/connectors/utils/ssh_test.go
+++ b/flow/connectors/utils/ssh_test.go
@@ -19,11 +19,11 @@ func TestSSHTunnel_GetKeepaliveChan_NilCases(t *testing.T) {
 	require.Nil(t, tunnel.GetKeepaliveChan(context.Background()), "Nil tunnel should return nil channel")
 
 	// Nil client
-	tunnel = &SSHTunnel{Client: nil}
+	tunnel = &SSHTunnel{}
 	require.Nil(t, tunnel.GetKeepaliveChan(context.Background()), "Tunnel with nil client should return nil channel")
 
 	// Bad tunnel
-	tunnel = &SSHTunnel{Client: nil}
+	tunnel = &SSHTunnel{}
 	tunnel.badTunnel.Store(true)
 	require.Nil(t, tunnel.GetKeepaliveChan(context.Background()), "Bad tunnel should return nil channel")
 }
@@ -36,11 +36,11 @@ func TestSSHTunnel_StartKeepalive_NilCases(t *testing.T) {
 	tunnel.StartKeepalive(context.Background(), onFailure)
 	require.False(t, called, "Nil tunnel should not call onFailure")
 
-	tunnel = &SSHTunnel{Client: nil}
+	tunnel = &SSHTunnel{}
 	tunnel.StartKeepalive(context.Background(), onFailure)
 	require.False(t, called, "Tunnel with nil client should not call onFailure")
 
-	tunnel = &SSHTunnel{Client: nil}
+	tunnel = &SSHTunnel{}
 	tunnel.badTunnel.Store(true)
 	tunnel.StartKeepalive(context.Background(), onFailure)
 	require.False(t, called, "Bad tunnel should not call onFailure")
@@ -52,7 +52,7 @@ func TestSSHTunnel_Close_NilCases(t *testing.T) {
 	require.NoError(t, tunnel.Close(), "Closing nil tunnel should not error")
 
 	// Nil client
-	tunnel = &SSHTunnel{Client: nil}
+	tunnel = &SSHTunnel{}
 	err := tunnel.Close()
 	require.NoError(t, err, "Closing tunnel with nil client should not error")
 


### PR DESCRIPTION
Resolves DBI-927

* SSH errors are notify connectivity by default
* Except for the cases where we shot ourselves in the foot somehow by closing the connection and using it, those are RECOVERABLE as they're expected to only occur once
* Remove the old raw ssh.OpenChannelError branch which was notify connectivity but got wrapped into our exceptions and handled above; make the client a field so the client isn't called directly without error wrapping