### PR TITLE
fix: estimate row counts for postgres partitioned/inherited tables

### DIFF
--- a/flow/connectors/postgres/qrep_partition.go
+++ b/flow/connectors/postgres/qrep_partition.go
@@ -130,17 +130,17 @@ func CTIDBlockPartitioningFunc(ctx context.Context, pp PartitionParams) ([]*prot
 	}
 	switch {
 	case tc.relkind == "p":
-		blocksPerTable, err := getPartitionedTables(ctx, pp.tx, tc.oid)
+		blockStatsPerTable, err := getPartitionedTables(ctx, pp.tx, tc.oid)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get child partitioned tables: %w", err)
 		}
-		return ctidPartitionsForChildTables(pp, blocksPerTable)
+		return ctidPartitionsForChildTables(pp, blockStatsPerTable)
 	case tc.relhassubclass:
-		blocksPerTable, err := getInheritedTables(ctx, pp.tx, tc.oid, tc.qualifiedName)
+		blockStatsPerTable, err := getInheritedTables(ctx, pp.tx, tc.oid, tc.qualifiedName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get child inherited tables: %w", err)
 		}
-		return ctidPartitionsForChildTables(pp, blocksPerTable)
+		return ctidPartitionsForChildTables(pp, blockStatsPerTable)
 	default:
 		return ctidPartitionsForTable(ctx, pp)
 	}
@@ -227,11 +227,11 @@ func ctidPartitionsForTable(ctx context.Context, pp PartitionParams) ([]*protos.
 //   - partition 3: [T3:0-9]
 func ctidPartitionsForChildTables(
 	pp PartitionParams,
-	blocksPerTable map[string]int64,
+	blockStatsPerTable map[string]tableBlockStats,
 ) ([]*protos.QRepPartition, error) {
 	var totalBlocks int64
-	for _, blocks := range blocksPerTable {
-		totalBlocks += blocks
+	for _, blockStats := range blockStatsPerTable {
+		totalBlocks += blockStats.blockCount
 	}
 	if totalBlocks == 0 {
 		pp.logger.Warn("zero non-empty child tables found")
@@ -240,10 +240,10 @@ func ctidPartitionsForChildTables(
 
 	pp.logger.Info("child tables detected",
 		slog.String("table", pp.watermarkTable),
-		slog.Int("numChildTables", len(blocksPerTable)),
+		slog.Int("numChildTables", len(blockStatsPerTable)),
 		slog.Int64("totalBlocks", totalBlocks))
 
-	sortedTables := slices.Sorted(maps.Keys(blocksPerTable))
+	sortedTables := slices.Sorted(maps.Keys(blockStatsPerTable))
 	blocksPerPartition := max(int64(1), shared.DivCeil(totalBlocks, pp.numPartitions))
 
 	var partitions []*protos.QRepPartition
@@ -255,7 +255,7 @@ func ctidPartitionsForChildTables(
 
 		for remaining > 0 && childIdx < len(sortedTables) {
 			tableName := sortedTables[childIdx]
-			blocks := blocksPerTable[tableName]
+			blocks := blockStatsPerTable[tableName].blockCount
 			remainingBlocks := blocks - blockOffset
 			consume := min(remaining, remainingBlocks)
 
@@ -330,13 +330,21 @@ func classifyTable(ctx context.Context, tx pgx.Tx, table string) (tableClassific
 	return classification, nil
 }
 
-// getPartitionedTables returns a map of partitioned child table names to their block counts,
+// tableBlockStats defines block-related stats of a relation as returned from the pg_class system catalog
+// table.
+type tableBlockStats struct {
+	blockDensity float64
+	blockCount   int64
+}
+
+// getPartitionedTables returns a map of partitioned child table names to their block stats,
 // recursively handle multi-level partitioned tables.
 // Uses OID-based join to avoid to_regclass which lowercases unquoted mixed-case identifiers.
-func getPartitionedTables(ctx context.Context, tx pgx.Tx, parentOID uint32) (map[string]int64, error) {
+func getPartitionedTables(ctx context.Context, tx pgx.Tx, parentOID uint32) (map[string]tableBlockStats, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT c.oid, format('%s.%s', n.nspname, c.relname), c.relkind::text,
-			(pg_relation_size(c.oid) / current_setting('block_size')::int)::bigint
+			(pg_relation_size(c.oid) / current_setting('block_size')::int)::bigint,
+			(CASE WHEN c.relpages > 0 THEN c.reltuples::float / c.relpages ELSE 0 END)::float
 		FROM pg_inherits i
 		JOIN pg_class c ON i.inhrelid = c.oid
 		JOIN pg_namespace n ON c.relnamespace = n.oid
@@ -349,15 +357,16 @@ func getPartitionedTables(ctx context.Context, tx pgx.Tx, parentOID uint32) (map
 	defer rows.Close()
 
 	type tableInfo struct {
-		name   string
-		kind   string
-		blocks int64
-		oid    uint32
+		name    string
+		kind    string
+		blocks  int64
+		density float64
+		oid     uint32
 	}
 	var tableInfos []tableInfo
 	for rows.Next() {
 		var info tableInfo
-		if err := rows.Scan(&info.oid, &info.name, &info.kind, &info.blocks); err != nil {
+		if err := rows.Scan(&info.oid, &info.name, &info.kind, &info.blocks, &info.density); err != nil {
 			return nil, fmt.Errorf("failed to scan child table: %w", err)
 		}
 		tableInfos = append(tableInfos, info)
@@ -366,40 +375,50 @@ func getPartitionedTables(ctx context.Context, tx pgx.Tx, parentOID uint32) (map
 		return nil, err
 	}
 
-	blocksPerPartitionedTable := make(map[string]int64)
+	blockStatsPerPartitionedTable := make(map[string]tableBlockStats)
 	for _, info := range tableInfos {
 		if info.kind == "p" {
 			leaveTables, err := getPartitionedTables(ctx, tx, info.oid)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get partitions of %s: %w", info.name, err)
 			}
-			maps.Copy(blocksPerPartitionedTable, leaveTables)
+			maps.Copy(blockStatsPerPartitionedTable, leaveTables)
 		} else if info.blocks > 0 { // skips empty table
-			blocksPerPartitionedTable[info.name] = info.blocks
+			blockStatsPerPartitionedTable[info.name] = tableBlockStats{
+				blockDensity: info.density,
+				blockCount:   info.blocks,
+			}
 		}
 	}
-	return blocksPerPartitionedTable, nil
+	return blockStatsPerPartitionedTable, nil
 }
 
-// getInheritedTables returns a map of table names to their block counts for an inherited
+// getInheritedTables returns a map of table names to their block stats for an inherited
 // table hierarchy. Unlike partitioned tables, the parent itself stores data and is included.
 // Uses OID-based join to avoid to_regclass which lowercases unquoted mixed-case identifiers.
-func getInheritedTables(ctx context.Context, tx pgx.Tx, parentOID uint32, parentName string) (map[string]int64, error) {
-	blocksPerTable := make(map[string]int64)
+func getInheritedTables(ctx context.Context, tx pgx.Tx, parentOID uint32, parentName string) (map[string]tableBlockStats, error) {
+	blocksPerTable := make(map[string]tableBlockStats)
 
 	var numBlocks int64
-	if err := tx.QueryRow(ctx,
-		"SELECT (pg_relation_size($1) / current_setting('block_size')::int)::bigint",
-		parentOID).Scan(&numBlocks); err != nil {
+	var blockDensity float64
+	if err := tx.QueryRow(ctx, `
+			SELECT (pg_relation_size($1) / current_setting('block_size')::int)::bigint,
+				(CASE WHEN c.relpages > 0 THEN c.reltuples::float / c.relpages ELSE 0 END)::float
+			FROM pg_class c WHERE c.oid = $1
+		`, parentOID).Scan(&numBlocks, &blockDensity); err != nil {
 		return nil, fmt.Errorf("failed to get block count for %s: %w", parentName, err)
 	}
 	if numBlocks > 0 {
-		blocksPerTable[parentName] = numBlocks
+		blocksPerTable[parentName] = tableBlockStats{
+			blockCount:   numBlocks,
+			blockDensity: blockDensity,
+		}
 	}
 
 	rows, err := tx.Query(ctx, `
 		SELECT c.oid, format('%s.%s', n.nspname, c.relname), c.relhassubclass,
-			(pg_relation_size(c.oid) / current_setting('block_size')::int)::bigint
+			(pg_relation_size(c.oid) / current_setting('block_size')::int)::bigint,
+			(CASE WHEN c.relpages > 0 THEN c.reltuples::float / c.relpages ELSE 0 END)::float
 		FROM pg_inherits i
 		JOIN pg_class c ON i.inhrelid = c.oid
 		JOIN pg_namespace n ON c.relnamespace = n.oid
@@ -415,12 +434,13 @@ func getInheritedTables(ctx context.Context, tx pgx.Tx, parentOID uint32, parent
 		name        string
 		blocks      int64
 		oid         uint32
+		density     float64
 		hasSubclass bool
 	}
 	var children []tableInfo
 	for rows.Next() {
 		var info tableInfo
-		if err := rows.Scan(&info.oid, &info.name, &info.hasSubclass, &info.blocks); err != nil {
+		if err := rows.Scan(&info.oid, &info.name, &info.hasSubclass, &info.blocks, &info.density); err != nil {
 			return nil, fmt.Errorf("failed to scan child table: %w", err)
 		}
 		children = append(children, info)
@@ -431,7 +451,10 @@ func getInheritedTables(ctx context.Context, tx pgx.Tx, parentOID uint32, parent
 
 	for _, child := range children {
 		if child.blocks > 0 {
-			blocksPerTable[child.name] = child.blocks
+			blocksPerTable[child.name] = tableBlockStats{
+				blockCount:   child.blocks,
+				blockDensity: child.density,
+			}
 		}
 		if child.hasSubclass {
 			childTables, err := getInheritedTables(ctx, tx, child.oid, child.name)
@@ -445,16 +468,10 @@ func getInheritedTables(ctx context.Context, tx pgx.Tx, parentOID uint32, parent
 	return blocksPerTable, nil
 }
 
-// ComputeNumPartitions computes the number of partitions given desired number of rows
-// per partition, with automatic adjustment to respect the maximum partition limit.
-// TODO: use estimated row count for partitioned/inherited tables as well
-func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPartition int64) (int64, error) {
-	const preciseCountTemplate = "SELECT COUNT(*) FROM %s %s"
+func estimatedNumRowsForTable(ctx context.Context, pp PartitionParams) (int64, error) {
 	// Use reltuples/relpages density multiplied by the current on-disk page count
 	// for a more accurate estimate than just reltuples (this is what the planner uses,
 	// see https://www.citusdata.com/blog/2016/10/12/count-performance/#dup_counts_estimated_full).
-	// For inherited/partitioned tables pg_relation_size, reltuples, and relpages
-	// only reflect the parent table, so we return 0 and fall back to precise count query.
 	const estimatedCountTemplate = `SELECT
     		-- for logging/debugging purpose
 			c.reltuples,
@@ -471,34 +488,78 @@ func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPar
 		FROM pg_class c WHERE c.oid = to_regclass($1)`
 
 	var totalRows int64
+	var reltuples float32
+	var relpages int32
+	var relhassubclass bool
+	var relationSize int64
+	var blockSize int32
+	var estimatedCount pgtype.Numeric
+	if err := pp.tx.QueryRow(ctx, estimatedCountTemplate, pp.watermarkTable).Scan(
+		&reltuples, &relpages, &relhassubclass, &relationSize, &blockSize, &estimatedCount,
+	); err != nil {
+		return 0, fmt.Errorf("failed to query for estimated row count: %w", err)
+	}
+
+	pp.logger.Info("estimated row count",
+		slog.String("query", estimatedCountTemplate),
+		slog.String("watermarkTable", pp.watermarkTable),
+		slog.Bool("relhassubclass", relhassubclass),
+		slog.String("formula", fmt.Sprintf("%v / %d * (%d / %d)", reltuples, relpages, relationSize, blockSize)))
+
+	if v, err := estimatedCount.Int64Value(); err != nil {
+		pp.logger.Warn("estimated row count outside int64 range, falling back to precise count",
+			slog.Any("error", err),
+			slog.String("watermarkTable", pp.watermarkTable))
+	} else if v.Valid {
+		totalRows = v.Int64
+	}
+	return totalRows, nil
+}
+
+// ComputeNumPartitions computes the number of partitions given desired number of rows
+// per partition, with automatic adjustment to respect the maximum partition limit.
+func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPartition int64) (int64, error) {
+	const preciseCountTemplate = "SELECT COUNT(*) FROM %s %s"
+
+	var totalRows int64
 	var whereClause string
 	var queryArgs []any
 
 	if pp.lastRangeEnd == nil {
-		var reltuples float32
-		var relpages int32
-		var relhassubclass bool
-		var relationSize int64
-		var blockSize int32
-		var estimatedCount pgtype.Numeric
-		if err := pp.tx.QueryRow(ctx, estimatedCountTemplate, pp.watermarkTable).Scan(
-			&reltuples, &relpages, &relhassubclass, &relationSize, &blockSize, &estimatedCount,
-		); err != nil {
-			return 0, fmt.Errorf("failed to query for estimated row count: %w", err)
+		// Classify the table as inherited, partitioned, or neither. If there are inherited tables or partitions,
+		// we need to sum estimated row counts across all inherited tables or partitions.
+		tc, err := classifyTable(ctx, pp.tx, pp.watermarkTable)
+		if err != nil {
+			return 0, err
 		}
-
-		pp.logger.Info("estimated row count",
-			slog.String("query", estimatedCountTemplate),
-			slog.String("watermarkTable", pp.watermarkTable),
-			slog.Bool("relhassubclass", relhassubclass),
-			slog.String("formula", fmt.Sprintf("%v / %d * (%d / %d)", reltuples, relpages, relationSize, blockSize)))
-
-		if v, err := estimatedCount.Int64Value(); err != nil {
-			pp.logger.Warn("estimated row count outside int64 range, falling back to precise count",
-				slog.Any("error", err),
-				slog.String("watermarkTable", pp.watermarkTable))
-		} else if v.Valid {
-			totalRows = v.Int64
+		switch {
+		case tc.relkind == "p": // Partitioned table
+			blockStatsPerTable, err := getPartitionedTables(ctx, pp.tx, tc.oid)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get child partitioned tables: %w", err)
+			}
+			for _, blockStats := range blockStatsPerTable {
+				totalRows += int64(blockStats.blockDensity * float64(blockStats.blockCount))
+			}
+			pp.logger.Info("estimated row count for partitioned table",
+				slog.String("watermarkTable", pp.watermarkTable),
+				slog.Int("numPartitions", len(blockStatsPerTable)))
+		case tc.relhassubclass:
+			blockStatsPerTable, err := getInheritedTables(ctx, pp.tx, tc.oid, tc.qualifiedName)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get child inherited tables: %w", err)
+			}
+			for _, blockStats := range blockStatsPerTable {
+				totalRows += int64(blockStats.blockDensity * float64(blockStats.blockCount))
+			}
+			pp.logger.Info("estimated row count for inherited table",
+				slog.String("watermarkTable", pp.watermarkTable),
+				slog.Int("numSubclasses", len(blockStatsPerTable)))
+		default:
+			var err error
+			if totalRows, err = estimatedNumRowsForTable(ctx, pp); err != nil {
+				return 0, err
+			}
 		}
 	} else {
 		whereClause = fmt.Sprintf("WHERE %s > $1", pp.watermarkColumn)
@@ -508,7 +569,6 @@ func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPar
 	// estimated rows is <= 0 if:
 	//   - table has never been analyzed; or
 	//   - row count outside int64 range; or
-	//   - table is inherited/partitioned (see query above); or
 	//   - polling-based flows (estimated row count is skipped)
 	// In all cases, fall back to precise count query
 	if totalRows <= 0 {

--- a/flow/connectors/postgres/qrep_partition_test.go
+++ b/flow/connectors/postgres/qrep_partition_test.go
@@ -570,10 +570,10 @@ func TestCtidPartitionsForChildTablesOffsetNumberBounds(t *testing.T) {
 		numPartitions: 8,
 		logger:        log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testOffsetBounds"))),
 	}
-	leafBlocks := map[string]int64{
-		"public.t1": 100,
-		"public.t2": 45,
-		"public.t3": 10,
+	leafBlocks := map[string]tableBlockStats{
+		"public.t1": tableBlockStats{blockCount: 100},
+		"public.t2": tableBlockStats{blockCount: 45},
+		"public.t3": tableBlockStats{blockCount: 10},
 	}
 	// blocksPerPartition = DivCeil(155, 8) = 20
 	partitions, err := ctidPartitionsForChildTables(pp, leafBlocks)
@@ -777,6 +777,160 @@ func TestCTIDPartitioningOnEmptyInheritedTable(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	require.Empty(t, partitions)
+}
+
+// analyzeTables runs ANALYZE on each table so that pg_class.reltuples/relpages are
+// populated; without this the density-based row estimate is 0 and ComputeNumPartitions
+// falls back to a precise COUNT(*) instead of exercising the estimation path.
+func analyzeTables(t *testing.T, conn *pgx.Conn, tables []string) {
+	t.Helper()
+	for _, tbl := range tables {
+		if _, err := conn.Exec(t.Context(), "ANALYZE "+tbl); err != nil {
+			t.Fatalf("Failed to ANALYZE %s: %v", tbl, err)
+		}
+	}
+}
+
+// TestComputeNumPartitionsForPartitionedTable verifies that ComputeNumPartitions sums the
+// estimated row counts of the leaf partitions (the partitioned parent itself stores no rows).
+func TestComputeNumPartitionsForPartitionedTable(t *testing.T) {
+	t.Parallel()
+	schemaName, conn, _ := setupTestSchema(t)
+
+	parentTable := schemaName + ".partitioned_est"
+	_, err := conn.Exec(t.Context(), fmt.Sprintf(`
+		CREATE TABLE %s (
+			id SERIAL,
+			partition_key INT NOT NULL,
+			value TEXT,
+			PRIMARY KEY (partition_key, id)
+		) PARTITION BY RANGE (partition_key)
+	`, parentTable))
+	require.NoError(t, err)
+
+	numChildTables := 5
+	rowsPerChild := 90
+	totalRows := numChildTables * rowsPerChild
+	tablesToAnalyze := []string{parentTable}
+	for i := range numChildTables {
+		child := fmt.Sprintf("%s.child_est_%d", schemaName, i)
+		lo := i * rowsPerChild
+		hi := (i + 1) * rowsPerChild
+		_, err = conn.Exec(t.Context(), fmt.Sprintf(
+			`CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (%d) TO (%d)`,
+			child, parentTable, lo, hi))
+		require.NoError(t, err)
+		tablesToAnalyze = append(tablesToAnalyze, child)
+	}
+	for i := range numChildTables {
+		for j := range rowsPerChild {
+			_, err = conn.Exec(t.Context(), fmt.Sprintf(
+				`INSERT INTO %s (partition_key, value) VALUES ($1, $2)`, parentTable),
+				i*rowsPerChild+j, fmt.Sprintf("val_%d_%d", i, j))
+			require.NoError(t, err)
+		}
+	}
+	analyzeTables(t, conn, tablesToAnalyze)
+
+	logger := log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testComputePartitioned")))
+	tx, err := conn.BeginTx(t.Context(), pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback(t.Context()) })
+
+	// Directly verify the summed estimate covers only the leaf partitions and is close to
+	// the actual row count.
+	tc, err := classifyTable(t.Context(), tx, parentTable)
+	require.NoError(t, err)
+	require.Equal(t, "p", tc.relkind)
+	blockStats, err := getPartitionedTables(t.Context(), tx, tc.oid)
+	require.NoError(t, err)
+	require.Len(t, blockStats, numChildTables)
+	var estimated int64
+	for _, bs := range blockStats {
+		estimated += int64(bs.blockDensity * float64(bs.blockCount))
+	}
+	require.InDelta(t, totalRows, estimated, float64(totalRows)*0.1,
+		"estimated rows %d should be within 10%% of actual %d", estimated, totalRows)
+
+	// ...and the user-facing partition computation uses that estimate rather than COUNT(*).
+	pp := PartitionParams{
+		tx:              tx,
+		watermarkTable:  parentTable,
+		watermarkColumn: `"partition_key"`,
+		logger:          logger,
+	}
+	rowsPerPartition := int64(100)
+	numPartitions, err := ComputeNumPartitions(t.Context(), pp, rowsPerPartition)
+	require.NoError(t, err)
+	require.Equal(t, shared.DivCeil(int64(totalRows), rowsPerPartition), numPartitions)
+}
+
+// TestComputeNumPartitionsForInheritedTable verifies that ComputeNumPartitions sums the
+// estimated row counts across the whole inheritance hierarchy, including the parent, which
+// (unlike a partitioned parent) stores its own rows.
+func TestComputeNumPartitionsForInheritedTable(t *testing.T) {
+	t.Parallel()
+	schemaName, conn, _ := setupTestSchema(t)
+
+	parentTable := schemaName + ".parent_est"
+	_, err := conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s (id SERIAL PRIMARY KEY, value TEXT)`, parentTable))
+	require.NoError(t, err)
+
+	numChildren := 4
+	rowsPerTable := 90
+	// Parent stores its own rows in the inheritance case, so it counts toward the total.
+	totalRows := (numChildren + 1) * rowsPerTable
+	tablesToAnalyze := []string{parentTable}
+	children := make([]string, numChildren)
+	for i := range numChildren {
+		children[i] = fmt.Sprintf("%s.child_inh_est_%d", schemaName, i)
+		_, err = conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s () INHERITS (%s)`, children[i], parentTable))
+		require.NoError(t, err)
+		tablesToAnalyze = append(tablesToAnalyze, children[i])
+	}
+	for j := range rowsPerTable {
+		_, err = conn.Exec(t.Context(), fmt.Sprintf(`INSERT INTO %s (value) VALUES ($1)`, parentTable), fmt.Sprintf("parent_%d", j))
+		require.NoError(t, err)
+	}
+	for i, child := range children {
+		for j := range rowsPerTable {
+			_, err = conn.Exec(t.Context(), fmt.Sprintf(`INSERT INTO %s (value) VALUES ($1)`, child), fmt.Sprintf("child_%d_%d", i, j))
+			require.NoError(t, err)
+		}
+	}
+	analyzeTables(t, conn, tablesToAnalyze)
+
+	logger := log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testComputeInherited")))
+	tx, err := conn.BeginTx(t.Context(), pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback(t.Context()) })
+
+	// Directly verify the summed estimate covers the parent plus every child and is close to
+	// the actual row count.
+	tc, err := classifyTable(t.Context(), tx, parentTable)
+	require.NoError(t, err)
+	require.True(t, tc.relhassubclass)
+	blockStats, err := getInheritedTables(t.Context(), tx, tc.oid, tc.qualifiedName)
+	require.NoError(t, err)
+	require.Len(t, blockStats, numChildren+1)
+	var estimated int64
+	for _, bs := range blockStats {
+		estimated += int64(bs.blockDensity * float64(bs.blockCount))
+	}
+	require.InDelta(t, totalRows, estimated, float64(totalRows)*0.1,
+		"estimated rows %d should be within 10%% of actual %d", estimated, totalRows)
+
+	// ...and the user-facing partition computation uses that estimate rather than COUNT(*).
+	pp := PartitionParams{
+		tx:              tx,
+		watermarkTable:  parentTable,
+		watermarkColumn: `"id"`,
+		logger:          logger,
+	}
+	rowsPerPartition := int64(100)
+	numPartitions, err := ComputeNumPartitions(t.Context(), pp, rowsPerPartition)
+	require.NoError(t, err)
+	require.Equal(t, shared.DivCeil(int64(totalRows), rowsPerPartition), numPartitions)
 }
 
 // returns the number of rows inserted


### PR DESCRIPTION
Previously, Postgres tables that other tables inherit from, or that have manually-added partitions, did not go through the estimated row count logic when determining the number of partitions for snapshotting. Instead, we ran a precise COUNT(*) which was an expensive operation.

This change updates the estimation logic to walk through the tree of partitions and children tables and sum up estimated rows across all of them, instead of falling through to the COUNT(*) query.

