### PR TITLE
fix: estimate row counts for postgres partitioned/inherited tables

### DIFF
--- a/flow/connectors/postgres/qrep_partition.go
+++ b/flow/connectors/postgres/qrep_partition.go
@@ -130,17 +130,18 @@ func CTIDBlockPartitioningFunc(ctx context.Context, pp PartitionParams) ([]*prot
 	}
 	switch {
 	case tc.relkind == "p":
-		blocksPerTable, err := getPartitionedTables(ctx, pp.tx, tc.oid)
+		blockStatsPerTable, err := getPartitionedTables(ctx, pp.tx, tc.oid)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get child partitioned tables: %w", err)
 		}
-		return ctidPartitionsForChildTables(pp, blocksPerTable)
+		return ctidPartitionsForChildTables(pp, blockStatsPerTable)
 	case tc.relhassubclass:
-		blocksPerTable, err := getInheritedTables(ctx, pp.tx, tc.oid, tc.qualifiedName)
+		visited := make(map[uint32]struct{})
+		blockStatsPerTable, err := getInheritedTables(ctx, pp.tx, tc.oid, tc.qualifiedName, visited)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get child inherited tables: %w", err)
 		}
-		return ctidPartitionsForChildTables(pp, blocksPerTable)
+		return ctidPartitionsForChildTables(pp, blockStatsPerTable)
 	default:
 		return ctidPartitionsForTable(ctx, pp)
 	}
@@ -227,11 +228,11 @@ func ctidPartitionsForTable(ctx context.Context, pp PartitionParams) ([]*protos.
 //   - partition 3: [T3:0-9]
 func ctidPartitionsForChildTables(
 	pp PartitionParams,
-	blocksPerTable map[string]int64,
+	blockStatsPerTable map[string]tableBlockStats,
 ) ([]*protos.QRepPartition, error) {
 	var totalBlocks int64
-	for _, blocks := range blocksPerTable {
-		totalBlocks += blocks
+	for _, blockStats := range blockStatsPerTable {
+		totalBlocks += blockStats.blockCount
 	}
 	if totalBlocks == 0 {
 		pp.logger.Warn("zero non-empty child tables found")
@@ -240,10 +241,10 @@ func ctidPartitionsForChildTables(
 
 	pp.logger.Info("child tables detected",
 		slog.String("table", pp.watermarkTable),
-		slog.Int("numChildTables", len(blocksPerTable)),
+		slog.Int("numChildTables", len(blockStatsPerTable)),
 		slog.Int64("totalBlocks", totalBlocks))
 
-	sortedTables := slices.Sorted(maps.Keys(blocksPerTable))
+	sortedTables := slices.Sorted(maps.Keys(blockStatsPerTable))
 	blocksPerPartition := max(int64(1), shared.DivCeil(totalBlocks, pp.numPartitions))
 
 	var partitions []*protos.QRepPartition
@@ -255,7 +256,7 @@ func ctidPartitionsForChildTables(
 
 		for remaining > 0 && childIdx < len(sortedTables) {
 			tableName := sortedTables[childIdx]
-			blocks := blocksPerTable[tableName]
+			blocks := blockStatsPerTable[tableName].blockCount
 			remainingBlocks := blocks - blockOffset
 			consume := min(remaining, remainingBlocks)
 
@@ -330,13 +331,21 @@ func classifyTable(ctx context.Context, tx pgx.Tx, table string) (tableClassific
 	return classification, nil
 }
 
-// getPartitionedTables returns a map of partitioned child table names to their block counts,
+// tableBlockStats defines block-related stats of a relation as returned from the pg_class system catalog
+// table.
+type tableBlockStats struct {
+	blockDensity float64
+	blockCount   int64
+}
+
+// getPartitionedTables returns a map of partitioned child table names to their block stats,
 // recursively handle multi-level partitioned tables.
 // Uses OID-based join to avoid to_regclass which lowercases unquoted mixed-case identifiers.
-func getPartitionedTables(ctx context.Context, tx pgx.Tx, parentOID uint32) (map[string]int64, error) {
+func getPartitionedTables(ctx context.Context, tx pgx.Tx, parentOID uint32) (map[string]tableBlockStats, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT c.oid, format('%s.%s', n.nspname, c.relname), c.relkind::text,
-			(pg_relation_size(c.oid) / current_setting('block_size')::int)::bigint
+			(pg_relation_size(c.oid) / current_setting('block_size')::int)::bigint,
+			(CASE WHEN c.relpages > 0 THEN c.reltuples::float / c.relpages ELSE 0 END)::float
 		FROM pg_inherits i
 		JOIN pg_class c ON i.inhrelid = c.oid
 		JOIN pg_namespace n ON c.relnamespace = n.oid
@@ -349,15 +358,16 @@ func getPartitionedTables(ctx context.Context, tx pgx.Tx, parentOID uint32) (map
 	defer rows.Close()
 
 	type tableInfo struct {
-		name   string
-		kind   string
-		blocks int64
-		oid    uint32
+		name    string
+		kind    string
+		blocks  int64
+		density float64
+		oid     uint32
 	}
 	var tableInfos []tableInfo
 	for rows.Next() {
 		var info tableInfo
-		if err := rows.Scan(&info.oid, &info.name, &info.kind, &info.blocks); err != nil {
+		if err := rows.Scan(&info.oid, &info.name, &info.kind, &info.blocks, &info.density); err != nil {
 			return nil, fmt.Errorf("failed to scan child table: %w", err)
 		}
 		tableInfos = append(tableInfos, info)
@@ -366,40 +376,57 @@ func getPartitionedTables(ctx context.Context, tx pgx.Tx, parentOID uint32) (map
 		return nil, err
 	}
 
-	blocksPerPartitionedTable := make(map[string]int64)
+	blockStatsPerPartitionedTable := make(map[string]tableBlockStats)
 	for _, info := range tableInfos {
 		if info.kind == "p" {
 			leaveTables, err := getPartitionedTables(ctx, tx, info.oid)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get partitions of %s: %w", info.name, err)
 			}
-			maps.Copy(blocksPerPartitionedTable, leaveTables)
+			maps.Copy(blockStatsPerPartitionedTable, leaveTables)
 		} else if info.blocks > 0 { // skips empty table
-			blocksPerPartitionedTable[info.name] = info.blocks
+			blockStatsPerPartitionedTable[info.name] = tableBlockStats{
+				blockDensity: info.density,
+				blockCount:   info.blocks,
+			}
 		}
 	}
-	return blocksPerPartitionedTable, nil
+	return blockStatsPerPartitionedTable, nil
 }
 
-// getInheritedTables returns a map of table names to their block counts for an inherited
+// getInheritedTables returns a map of table names to their block stats for an inherited
 // table hierarchy. Unlike partitioned tables, the parent itself stores data and is included.
 // Uses OID-based join to avoid to_regclass which lowercases unquoted mixed-case identifiers.
-func getInheritedTables(ctx context.Context, tx pgx.Tx, parentOID uint32, parentName string) (map[string]int64, error) {
-	blocksPerTable := make(map[string]int64)
+func getInheritedTables(
+	ctx context.Context,
+	tx pgx.Tx,
+	parentOID uint32,
+	parentName string,
+	visited map[uint32]struct{},
+) (map[string]tableBlockStats, error) {
+	blocksPerTable := make(map[string]tableBlockStats)
+	visited[parentOID] = struct{}{}
 
 	var numBlocks int64
-	if err := tx.QueryRow(ctx,
-		"SELECT (pg_relation_size($1) / current_setting('block_size')::int)::bigint",
-		parentOID).Scan(&numBlocks); err != nil {
+	var blockDensity float64
+	if err := tx.QueryRow(ctx, `
+			SELECT (pg_relation_size($1) / current_setting('block_size')::int)::bigint,
+				(CASE WHEN c.relpages > 0 THEN c.reltuples::float / c.relpages ELSE 0 END)::float
+			FROM pg_class c WHERE c.oid = $1
+		`, parentOID).Scan(&numBlocks, &blockDensity); err != nil {
 		return nil, fmt.Errorf("failed to get block count for %s: %w", parentName, err)
 	}
 	if numBlocks > 0 {
-		blocksPerTable[parentName] = numBlocks
+		blocksPerTable[parentName] = tableBlockStats{
+			blockCount:   numBlocks,
+			blockDensity: blockDensity,
+		}
 	}
 
 	rows, err := tx.Query(ctx, `
 		SELECT c.oid, format('%s.%s', n.nspname, c.relname), c.relhassubclass,
-			(pg_relation_size(c.oid) / current_setting('block_size')::int)::bigint
+			(pg_relation_size(c.oid) / current_setting('block_size')::int)::bigint,
+			(CASE WHEN c.relpages > 0 THEN c.reltuples::float / c.relpages ELSE 0 END)::float
 		FROM pg_inherits i
 		JOIN pg_class c ON i.inhrelid = c.oid
 		JOIN pg_namespace n ON c.relnamespace = n.oid
@@ -414,13 +441,14 @@ func getInheritedTables(ctx context.Context, tx pgx.Tx, parentOID uint32, parent
 	type tableInfo struct {
 		name        string
 		blocks      int64
+		density     float64
 		oid         uint32
 		hasSubclass bool
 	}
 	var children []tableInfo
 	for rows.Next() {
 		var info tableInfo
-		if err := rows.Scan(&info.oid, &info.name, &info.hasSubclass, &info.blocks); err != nil {
+		if err := rows.Scan(&info.oid, &info.name, &info.hasSubclass, &info.blocks, &info.density); err != nil {
 			return nil, fmt.Errorf("failed to scan child table: %w", err)
 		}
 		children = append(children, info)
@@ -431,30 +459,29 @@ func getInheritedTables(ctx context.Context, tx pgx.Tx, parentOID uint32, parent
 
 	for _, child := range children {
 		if child.blocks > 0 {
-			blocksPerTable[child.name] = child.blocks
+			blocksPerTable[child.name] = tableBlockStats{
+				blockCount:   child.blocks,
+				blockDensity: child.density,
+			}
 		}
 		if child.hasSubclass {
-			childTables, err := getInheritedTables(ctx, tx, child.oid, child.name)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get inherited tables of %s: %w", child.name, err)
+			if _, ok := visited[child.oid]; !ok {
+				childTables, err := getInheritedTables(ctx, tx, child.oid, child.name, visited)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get inherited tables of %s: %w", child.name, err)
+				}
+				maps.Copy(blocksPerTable, childTables)
 			}
-			maps.Copy(blocksPerTable, childTables)
 		}
 	}
 
 	return blocksPerTable, nil
 }
 
-// ComputeNumPartitions computes the number of partitions given desired number of rows
-// per partition, with automatic adjustment to respect the maximum partition limit.
-// TODO: use estimated row count for partitioned/inherited tables as well
-func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPartition int64) (int64, error) {
-	const preciseCountTemplate = "SELECT COUNT(*) FROM %s %s"
+func estimatedNumRowsForTable(ctx context.Context, pp PartitionParams) (int64, error) {
 	// Use reltuples/relpages density multiplied by the current on-disk page count
 	// for a more accurate estimate than just reltuples (this is what the planner uses,
 	// see https://www.citusdata.com/blog/2016/10/12/count-performance/#dup_counts_estimated_full).
-	// For inherited/partitioned tables pg_relation_size, reltuples, and relpages
-	// only reflect the parent table, so we return 0 and fall back to precise count query.
 	const estimatedCountTemplate = `SELECT
     		-- for logging/debugging purpose
 			c.reltuples,
@@ -471,34 +498,99 @@ func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPar
 		FROM pg_class c WHERE c.oid = to_regclass($1)`
 
 	var totalRows int64
+	var reltuples float32
+	var relpages int32
+	var relhassubclass bool
+	var relationSize int64
+	var blockSize int32
+	var estimatedCount pgtype.Numeric
+	if err := pp.tx.QueryRow(ctx, estimatedCountTemplate, pp.watermarkTable).Scan(
+		&reltuples, &relpages, &relhassubclass, &relationSize, &blockSize, &estimatedCount,
+	); err != nil {
+		return 0, fmt.Errorf("failed to query for estimated row count: %w", err)
+	}
+
+	pp.logger.Info("estimated row count",
+		slog.String("query", estimatedCountTemplate),
+		slog.String("watermarkTable", pp.watermarkTable),
+		slog.Bool("relhassubclass", relhassubclass),
+		slog.String("formula", fmt.Sprintf("%v / %d * (%d / %d)", reltuples, relpages, relationSize, blockSize)))
+
+	if v, err := estimatedCount.Int64Value(); err != nil {
+		pp.logger.Warn("estimated row count outside int64 range, falling back to precise count",
+			slog.Any("error", err),
+			slog.String("watermarkTable", pp.watermarkTable))
+	} else if v.Valid {
+		totalRows = v.Int64
+	}
+	return totalRows, nil
+}
+
+// ComputeNumPartitions computes the number of partitions given desired number of rows
+// per partition, with automatic adjustment to respect the maximum partition limit.
+func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPartition int64) (int64, error) {
+	const preciseCountTemplate = "SELECT COUNT(*) FROM %s %s"
+
+	var totalRows int64
 	var whereClause string
 	var queryArgs []any
+	rollupSubclassCounts := func(blockStatsPerTable map[string]tableBlockStats) int64 {
+		var invalidCounts int64
+		var runningSum int64
+		for _, blockStats := range blockStatsPerTable {
+			estimatedCount := int64(blockStats.blockDensity * float64(blockStats.blockCount))
+			if estimatedCount <= 0 {
+				invalidCounts++
+			}
+			previousSum := runningSum
+			runningSum += max(0, estimatedCount)
+			if runningSum < previousSum {
+				// This case is only triggered in case of int64 overflow. Fall back to a
+				// zero sum for the return value so we fall through to the precise row
+				// count calculation.
+				return 0
+			}
+		}
+		if float64(invalidCounts) >= 0.2*float64(len(blockStatsPerTable)) {
+			// If more than 20% of all subclasses returned invalid block stats, zero out
+			// return value so we fall through to the precise row count calculation
+			runningSum = 0
+		}
+		return runningSum
+	}
 
 	if pp.lastRangeEnd == nil {
-		var reltuples float32
-		var relpages int32
-		var relhassubclass bool
-		var relationSize int64
-		var blockSize int32
-		var estimatedCount pgtype.Numeric
-		if err := pp.tx.QueryRow(ctx, estimatedCountTemplate, pp.watermarkTable).Scan(
-			&reltuples, &relpages, &relhassubclass, &relationSize, &blockSize, &estimatedCount,
-		); err != nil {
-			return 0, fmt.Errorf("failed to query for estimated row count: %w", err)
+		// Classify the table as inherited, partitioned, or neither. If there are inherited tables or partitions,
+		// we need to sum estimated row counts across all inherited tables or partitions.
+		tc, err := classifyTable(ctx, pp.tx, pp.watermarkTable)
+		if err != nil {
+			return 0, err
 		}
-
-		pp.logger.Info("estimated row count",
-			slog.String("query", estimatedCountTemplate),
-			slog.String("watermarkTable", pp.watermarkTable),
-			slog.Bool("relhassubclass", relhassubclass),
-			slog.String("formula", fmt.Sprintf("%v / %d * (%d / %d)", reltuples, relpages, relationSize, blockSize)))
-
-		if v, err := estimatedCount.Int64Value(); err != nil {
-			pp.logger.Warn("estimated row count outside int64 range, falling back to precise count",
-				slog.Any("error", err),
-				slog.String("watermarkTable", pp.watermarkTable))
-		} else if v.Valid {
-			totalRows = v.Int64
+		switch {
+		case tc.relkind == "p": // Partitioned table
+			blockStatsPerTable, err := getPartitionedTables(ctx, pp.tx, tc.oid)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get child partitioned tables: %w", err)
+			}
+			totalRows = rollupSubclassCounts(blockStatsPerTable)
+			pp.logger.Info("estimated row count for partitioned table",
+				slog.String("watermarkTable", pp.watermarkTable),
+				slog.Int("numPartitions", len(blockStatsPerTable)))
+		case tc.relhassubclass: // Inherited (parent) table
+			visitedOidSet := make(map[uint32]struct{})
+			blockStatsPerTable, err := getInheritedTables(ctx, pp.tx, tc.oid, tc.qualifiedName, visitedOidSet)
+			if err != nil {
+				return 0, fmt.Errorf("failed to get child inherited tables: %w", err)
+			}
+			totalRows = rollupSubclassCounts(blockStatsPerTable)
+			pp.logger.Info("estimated row count for inherited table",
+				slog.String("watermarkTable", pp.watermarkTable),
+				slog.Int("numSubclasses", len(blockStatsPerTable)))
+		default:
+			var err error
+			if totalRows, err = estimatedNumRowsForTable(ctx, pp); err != nil {
+				return 0, err
+			}
 		}
 	} else {
 		whereClause = fmt.Sprintf("WHERE %s > $1", pp.watermarkColumn)
@@ -508,8 +600,8 @@ func ComputeNumPartitions(ctx context.Context, pp PartitionParams, numRowsPerPar
 	// estimated rows is <= 0 if:
 	//   - table has never been analyzed; or
 	//   - row count outside int64 range; or
-	//   - table is inherited/partitioned (see query above); or
-	//   - polling-based flows (estimated row count is skipped)
+	//   - polling-based flows (estimated row count is skipped), or
+	//   - partitioned/inherited table had invalid counts for >= 20% of all subclasses
 	// In all cases, fall back to precise count query
 	if totalRows <= 0 {
 		countQuery := fmt.Sprintf(preciseCountTemplate, pp.watermarkTable, whereClause)

--- a/flow/connectors/postgres/qrep_partition_test.go
+++ b/flow/connectors/postgres/qrep_partition_test.go
@@ -570,10 +570,10 @@ func TestCtidPartitionsForChildTablesOffsetNumberBounds(t *testing.T) {
 		numPartitions: 8,
 		logger:        log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testOffsetBounds"))),
 	}
-	leafBlocks := map[string]int64{
-		"public.t1": 100,
-		"public.t2": 45,
-		"public.t3": 10,
+	leafBlocks := map[string]tableBlockStats{
+		"public.t1": {blockCount: 100},
+		"public.t2": {blockCount: 45},
+		"public.t3": {blockCount: 10},
 	}
 	// blocksPerPartition = DivCeil(155, 8) = 20
 	partitions, err := ctidPartitionsForChildTables(pp, leafBlocks)
@@ -777,6 +777,380 @@ func TestCTIDPartitioningOnEmptyInheritedTable(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	require.Empty(t, partitions)
+}
+
+// analyzeTables runs ANALYZE on each table so that pg_class.reltuples/relpages are
+// populated; without this the density-based row estimate is 0 and ComputeNumPartitions
+// falls back to a precise COUNT(*) instead of exercising the estimation path.
+func analyzeTables(t *testing.T, conn *pgx.Conn, tables []string) {
+	t.Helper()
+	for _, tbl := range tables {
+		if _, err := conn.Exec(t.Context(), "ANALYZE "+tbl); err != nil {
+			t.Fatalf("Failed to ANALYZE %s: %v", tbl, err)
+		}
+	}
+}
+
+// computeNumPartitionsForTest runs ComputeNumPartitions against watermarkTable inside a
+// read-only transaction. It canonicalizes the identifier exactly like GetQRepPartitions so
+// mixed-case names resolve through the OID-based lookups.
+func computeNumPartitionsForTest(t *testing.T, conn *pgx.Conn, watermarkTable string, rowsPerPartition int64) int64 {
+	t.Helper()
+	parsed, err := common.ParseTableIdentifier(watermarkTable)
+	require.NoError(t, err)
+
+	tx, err := conn.BeginTx(t.Context(), pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	require.NoError(t, err)
+	defer tx.Rollback(t.Context()) //nolint:errcheck
+
+	pp := PartitionParams{
+		tx:             tx,
+		watermarkTable: parsed.String(),
+		logger:         log.NewStructuredLogger(slog.With(slog.String(string(shared.FlowNameKey), "testComputeNumPartitions"))),
+	}
+	numPartitions, err := ComputeNumPartitions(t.Context(), pp, rowsPerPartition)
+	require.NoError(t, err)
+	return numPartitions
+}
+
+// sumEstimatedRows walks watermarkTable's partition/inheritance tree and returns the estimated
+// row count summed across the discovered tables (the same value ComputeNumPartitions uses),
+// along with the discovered table names. This directly exercises the density-based estimation,
+// distinguishing it from the precise COUNT(*) fallback.
+func sumEstimatedRows(t *testing.T, conn *pgx.Conn, watermarkTable string) (int64, []string) {
+	t.Helper()
+	parsed, err := common.ParseTableIdentifier(watermarkTable)
+	require.NoError(t, err)
+
+	tx, err := conn.BeginTx(t.Context(), pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	require.NoError(t, err)
+	defer tx.Rollback(t.Context()) //nolint:errcheck
+
+	tc, err := classifyTable(t.Context(), tx, parsed.String())
+	require.NoError(t, err)
+
+	var stats map[string]tableBlockStats
+	switch {
+	case tc.relkind == "p":
+		stats, err = getPartitionedTables(t.Context(), tx, tc.oid)
+	case tc.relhassubclass:
+		stats, err = getInheritedTables(t.Context(), tx, tc.oid, tc.qualifiedName, make(map[uint32]struct{}))
+	default:
+		t.Fatalf("table %s is neither partitioned nor inherited", watermarkTable)
+	}
+	require.NoError(t, err)
+
+	var estimated int64
+	tables := make([]string, 0, len(stats))
+	for name, bs := range stats {
+		estimated += int64(bs.blockDensity * float64(bs.blockCount))
+		tables = append(tables, name)
+	}
+	return estimated, tables
+}
+
+// TestComputeNumPartitionsOnPartitionedTable mirrors TestCTIDPartitioningOnPartitionedTable:
+// a single-level range-partitioned table. ComputeNumPartitions should sum the estimated row
+// counts of the leaf partitions (the partitioned parent itself stores no rows).
+func TestComputeNumPartitionsOnPartitionedTable(t *testing.T) {
+	t.Parallel()
+	schemaName, conn, _ := setupTestSchema(t)
+
+	parentTable := schemaName + ".partitioned_test"
+	_, err := conn.Exec(t.Context(), fmt.Sprintf(`
+		CREATE TABLE %s (
+			id SERIAL,
+			partition_key INT NOT NULL,
+			value TEXT,
+			PRIMARY KEY (partition_key, id)
+		) PARTITION BY RANGE (partition_key)
+	`, parentTable))
+	require.NoError(t, err)
+
+	rowsPerChild := 25
+	numChildTables := 4
+	totalRows := int64(rowsPerChild * numChildTables) // 100
+	tablesToAnalyze := []string{parentTable}
+	for i := range numChildTables {
+		child := fmt.Sprintf("%s.child_%d", schemaName, i)
+		lo := i * rowsPerChild
+		hi := (i + 1) * rowsPerChild
+		_, err = conn.Exec(t.Context(), fmt.Sprintf(
+			`CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (%d) TO (%d)`,
+			child, parentTable, lo, hi))
+		require.NoError(t, err)
+		tablesToAnalyze = append(tablesToAnalyze, child)
+	}
+	for i := range numChildTables {
+		for j := range rowsPerChild {
+			_, err = conn.Exec(t.Context(), fmt.Sprintf(
+				`INSERT INTO %s (partition_key, value) VALUES ($1, $2)`, parentTable),
+				i*rowsPerChild+j, fmt.Sprintf("val_%d_%d", i, j))
+			require.NoError(t, err)
+		}
+	}
+	analyzeTables(t, conn, tablesToAnalyze)
+
+	// The estimate should sum the leaf partitions only and be close to the actual row count.
+	estimated, tables := sumEstimatedRows(t, conn, parentTable)
+	require.Len(t, tables, numChildTables)
+	require.InDelta(t, totalRows, estimated, float64(totalRows)*0.1,
+		"estimated rows %d should be within 10%% of actual %d", estimated, totalRows)
+
+	// 100 estimated rows / 40 per partition = DivCeil(100, 40) = 3
+	rowsPerPartition := int64(40)
+	numPartitions := computeNumPartitionsForTest(t, conn, parentTable, rowsPerPartition)
+	require.Equal(t, shared.DivCeil(totalRows, rowsPerPartition), numPartitions)
+}
+
+// TestComputeNumPartitionsOnMultiLevelPartitionedTable mirrors
+// TestCTIDPartitioningOnMultiLevelPartitionedTable: a multi-level partitioned table with
+// mixed-case schema/table names (to verify OID-based lookups). ComputeNumPartitions should
+// recurse to the leaf partitions and sum their estimated row counts.
+func TestComputeNumPartitionsOnMultiLevelPartitionedTable(t *testing.T) {
+	t.Parallel()
+	_, conn, _ := setupTestSchema(t)
+
+	// Mixed-case schema/table names to verify OID-based lookups (to_regclass lowercases
+	// unquoted identifiers).
+	schemaName := "Test_" + common.RandomString(8)
+	schemaNameDDL := `"` + schemaName + `"`
+	_, err := conn.Exec(t.Context(), `CREATE SCHEMA `+schemaNameDDL)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if _, err := conn.Exec(t.Context(), `DROP SCHEMA `+schemaNameDDL+` CASCADE`); err != nil {
+			t.Logf("Failed to drop schema: %v", err)
+		}
+	})
+
+	rootTable := schemaName + ".MultiLevel"
+	rootTableDDL := schemaNameDDL + `."MultiLevel"`
+	_, err = conn.Exec(t.Context(), fmt.Sprintf(`
+		CREATE TABLE %s (
+			id SERIAL,
+			region INT NOT NULL,
+			category INT NOT NULL,
+			value TEXT,
+			PRIMARY KEY (region, category, id)
+		) PARTITION BY RANGE (region)
+	`, rootTableDDL))
+	require.NoError(t, err)
+
+	rowsPerLeaf := 20
+	numMidLevelTables := 2
+	numLeafPerMid := 3
+	totalRows := int64(rowsPerLeaf * numMidLevelTables * numLeafPerMid) // 120
+	tablesToAnalyze := []string{rootTableDDL}
+	for r := range numMidLevelTables {
+		mid := fmt.Sprintf(`%s."Region_%d"`, schemaNameDDL, r)
+		_, err = conn.Exec(t.Context(), fmt.Sprintf(
+			`CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (%d) TO (%d) PARTITION BY RANGE (category)`,
+			mid, rootTableDDL, r*50, (r+1)*50))
+		require.NoError(t, err)
+		tablesToAnalyze = append(tablesToAnalyze, mid)
+
+		for c := range numLeafPerMid {
+			leaf := fmt.Sprintf(`%s."Region_%d_Cat_%d"`, schemaNameDDL, r, c)
+			_, err = conn.Exec(t.Context(), fmt.Sprintf(
+				`CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (%d) TO (%d)`,
+				leaf, mid, c*33, (c+1)*33))
+			require.NoError(t, err)
+			tablesToAnalyze = append(tablesToAnalyze, leaf)
+		}
+	}
+	for r := range numMidLevelTables {
+		for c := range numLeafPerMid {
+			for j := range rowsPerLeaf {
+				_, err = conn.Exec(t.Context(), fmt.Sprintf(
+					`INSERT INTO %s (region, category, value) VALUES ($1, $2, $3)`, rootTableDDL),
+					r*50, c*33+j%33, fmt.Sprintf("v_%d_%d_%d", r, c, j))
+				require.NoError(t, err)
+			}
+		}
+	}
+	analyzeTables(t, conn, tablesToAnalyze)
+
+	// Only the 6 leaf partitions store rows; mid-level partitioned tables are recursed through.
+	estimated, tables := sumEstimatedRows(t, conn, rootTable)
+	require.Len(t, tables, numMidLevelTables*numLeafPerMid)
+	require.InDelta(t, totalRows, estimated, float64(totalRows)*0.1,
+		"estimated rows %d should be within 10%% of actual %d", estimated, totalRows)
+
+	// 120 estimated rows / 50 per partition = DivCeil(120, 50) = 3
+	rowsPerPartition := int64(50)
+	numPartitions := computeNumPartitionsForTest(t, conn, rootTable, rowsPerPartition)
+	require.Equal(t, shared.DivCeil(totalRows, rowsPerPartition), numPartitions)
+}
+
+// TestComputeNumPartitionsOnEmptyPartitionedTable mirrors
+// TestCTIDPartitioningOnEmptyPartitionedTable: a partitioned table with only empty partitions.
+// The estimate is 0 (which also exercises the relpages=0 guard), so ComputeNumPartitions falls
+// back to COUNT(*) and returns no partitions.
+func TestComputeNumPartitionsOnEmptyPartitionedTable(t *testing.T) {
+	t.Parallel()
+	schemaName, conn, _ := setupTestSchema(t)
+
+	parentTable := schemaName + ".empty_partitioned"
+	_, err := conn.Exec(t.Context(), fmt.Sprintf(`
+		CREATE TABLE %s (
+			id SERIAL,
+			partition_key INT NOT NULL,
+			value TEXT,
+			PRIMARY KEY (partition_key, id)
+		) PARTITION BY RANGE (partition_key)
+	`, parentTable))
+	require.NoError(t, err)
+
+	tablesToAnalyze := []string{parentTable}
+	for i := range 4 {
+		child := fmt.Sprintf("%s.empty_child_%d", schemaName, i)
+		_, err = conn.Exec(t.Context(), fmt.Sprintf(
+			`CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (%d) TO (%d)`,
+			child, parentTable, i*25, (i+1)*25))
+		require.NoError(t, err)
+		tablesToAnalyze = append(tablesToAnalyze, child)
+	}
+	analyzeTables(t, conn, tablesToAnalyze)
+
+	numPartitions := computeNumPartitionsForTest(t, conn, parentTable, 10)
+	require.Zero(t, numPartitions)
+}
+
+// TestComputeNumPartitionsOnInheritedTable mirrors TestCTIDPartitioningOnInheritedTable:
+// a single-level inheritance hierarchy with mixed-case names. ComputeNumPartitions should sum
+// the estimated row counts across the parent (which stores its own rows) and every child.
+func TestComputeNumPartitionsOnInheritedTable(t *testing.T) {
+	t.Parallel()
+	_, conn, _ := setupTestSchema(t)
+
+	// Mixed-case schema/table names to verify OID-based lookups.
+	schemaName := "Test_" + common.RandomString(8)
+	schemaNameDDL := `"` + schemaName + `"`
+	_, err := conn.Exec(t.Context(), `CREATE SCHEMA `+schemaNameDDL)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if _, err := conn.Exec(t.Context(), `DROP SCHEMA `+schemaNameDDL+` CASCADE`); err != nil {
+			t.Logf("Failed to drop schema: %v", err)
+		}
+	})
+
+	parentTable := schemaName + ".ParentInh"
+	parentTableDDL := schemaNameDDL + `."ParentInh"`
+	_, err = conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s (id SERIAL PRIMARY KEY, value TEXT)`, parentTableDDL))
+	require.NoError(t, err)
+
+	numChildren := 3
+	rowsPerTable := 20
+	// The parent stores its own rows in the inheritance case, so it counts toward the total.
+	totalRows := int64(rowsPerTable * (numChildren + 1)) // 80
+	tablesToAnalyze := []string{parentTableDDL}
+	childTablesDDL := make([]string, numChildren)
+	for i := range numChildren {
+		childTablesDDL[i] = fmt.Sprintf(`%s."ChildInh_%d"`, schemaNameDDL, i)
+		_, err = conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s () INHERITS (%s)`, childTablesDDL[i], parentTableDDL))
+		require.NoError(t, err)
+		tablesToAnalyze = append(tablesToAnalyze, childTablesDDL[i])
+	}
+	for j := range rowsPerTable {
+		_, err = conn.Exec(t.Context(), fmt.Sprintf(
+			`INSERT INTO %s (value) VALUES ($1)`, parentTableDDL), fmt.Sprintf("parent_%d", j))
+		require.NoError(t, err)
+	}
+	for i, child := range childTablesDDL {
+		for j := range rowsPerTable {
+			_, err = conn.Exec(t.Context(), fmt.Sprintf(
+				`INSERT INTO %s (value) VALUES ($1)`, child), fmt.Sprintf("child_%d_%d", i, j))
+			require.NoError(t, err)
+		}
+	}
+	analyzeTables(t, conn, tablesToAnalyze)
+
+	// The estimate should cover the parent plus every child.
+	estimated, tables := sumEstimatedRows(t, conn, parentTable)
+	require.Len(t, tables, numChildren+1)
+	require.InDelta(t, totalRows, estimated, float64(totalRows)*0.1,
+		"estimated rows %d should be within 10%% of actual %d", estimated, totalRows)
+
+	// 80 estimated rows / 30 per partition = DivCeil(80, 30) = 3
+	rowsPerPartition := int64(30)
+	numPartitions := computeNumPartitionsForTest(t, conn, parentTable, rowsPerPartition)
+	require.Equal(t, shared.DivCeil(totalRows, rowsPerPartition), numPartitions)
+}
+
+// TestComputeNumPartitionsOnMultiLevelInheritedTable mirrors
+// TestCTIDPartitioningOnMultiLevelInheritedTable: a grandparent -> parents -> leaves hierarchy
+// where every table stores its own rows. ComputeNumPartitions should sum estimates across all
+// of them.
+func TestComputeNumPartitionsOnMultiLevelInheritedTable(t *testing.T) {
+	t.Parallel()
+	schemaName, conn, _ := setupTestSchema(t)
+
+	grandparent := schemaName + ".grandparent"
+	_, err := conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s (id SERIAL PRIMARY KEY, value TEXT)`, grandparent))
+	require.NoError(t, err)
+
+	parent1 := schemaName + ".parent_1"
+	parent2 := schemaName + ".parent_2"
+	_, err = conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s () INHERITS (%s)`, parent1, grandparent))
+	require.NoError(t, err)
+	_, err = conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s () INHERITS (%s)`, parent2, grandparent))
+	require.NoError(t, err)
+
+	leaf1 := schemaName + ".leaf_1"
+	leaf2 := schemaName + ".leaf_2"
+	_, err = conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s () INHERITS (%s)`, leaf1, parent1))
+	require.NoError(t, err)
+	_, err = conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s () INHERITS (%s)`, leaf2, parent2))
+	require.NoError(t, err)
+
+	rowsPerTable := 15
+	allTables := []string{grandparent, parent1, parent2, leaf1, leaf2}
+	totalRows := int64(rowsPerTable * len(allTables)) // 75
+	for _, tbl := range allTables {
+		for j := range rowsPerTable {
+			_, err = conn.Exec(t.Context(), fmt.Sprintf(
+				`INSERT INTO %s (value) VALUES ($1)`, tbl), fmt.Sprintf("v_%d", j))
+			require.NoError(t, err)
+		}
+	}
+	analyzeTables(t, conn, allTables)
+
+	// The estimate should cover every table in the hierarchy.
+	estimated, tables := sumEstimatedRows(t, conn, grandparent)
+	require.Len(t, tables, len(allTables))
+	require.InDelta(t, totalRows, estimated, float64(totalRows)*0.1,
+		"estimated rows %d should be within 10%% of actual %d", estimated, totalRows)
+
+	// 75 estimated rows / 30 per partition = DivCeil(75, 30) = 3
+	rowsPerPartition := int64(30)
+	numPartitions := computeNumPartitionsForTest(t, conn, grandparent, rowsPerPartition)
+	require.Equal(t, shared.DivCeil(totalRows, rowsPerPartition), numPartitions)
+}
+
+// TestComputeNumPartitionsOnEmptyInheritedTable mirrors
+// TestCTIDPartitioningOnEmptyInheritedTable: an inheritance hierarchy with no rows anywhere.
+// The estimate is 0 (also exercising the relpages=0 guard), so ComputeNumPartitions falls back
+// to COUNT(*) and returns no partitions.
+func TestComputeNumPartitionsOnEmptyInheritedTable(t *testing.T) {
+	t.Parallel()
+	schemaName, conn, _ := setupTestSchema(t)
+
+	parentTable := schemaName + ".empty_inh"
+	_, err := conn.Exec(t.Context(), fmt.Sprintf(`CREATE TABLE %s (id SERIAL PRIMARY KEY, value TEXT)`, parentTable))
+	require.NoError(t, err)
+
+	tablesToAnalyze := []string{parentTable}
+	for i := range 3 {
+		child := fmt.Sprintf("%s.empty_inh_child_%d", schemaName, i)
+		_, err = conn.Exec(t.Context(), fmt.Sprintf(
+			`CREATE TABLE %s () INHERITS (%s)`, child, parentTable))
+		require.NoError(t, err)
+		tablesToAnalyze = append(tablesToAnalyze, child)
+	}
+	analyzeTables(t, conn, tablesToAnalyze)
+
+	numPartitions := computeNumPartitionsForTest(t, conn, parentTable, 10)
+	require.Zero(t, numPartitions)
 }
 
 // returns the number of rows inserted


### PR DESCRIPTION
Previously, Postgres tables that other tables inherit from, or that have manually-added partitions, did not go through the estimated row count logic when determining the number of partitions for snapshotting. Instead, we ran a precise COUNT(*) which was an expensive operation.

This change updates the estimation logic to walk through the tree of partitions and children tables and sum up estimated rows across all of them, instead of falling through to the COUNT(*) query.