### PR TITLE
disable aborts missing during db migration

### DIFF
--- a/nexus/catalog/src/lib.rs
+++ b/nexus/catalog/src/lib.rs
@@ -141,6 +141,9 @@ async fn gcp_kms_decrypt(_encrypted_payload: &str, _kms_key_id: &str) -> anyhow:
 
 async fn run_migrations(client: &mut Client) -> anyhow::Result<()> {
     let migration_report = embedded::migrations::runner()
+        // Tolerate a schema history that is ahead of the binary to support release rollbacks.
+        // Divergent migrations with same version but different checksum will still abort.
+        .set_abort_missing(false)
         .run_async(client)
         .await
         .context("Failed to run migrations")?;


### PR DESCRIPTION
[`set_abort_missing`](https://docs.rs/refinery/latest/refinery/struct.Runner.html#method.set_abort_missing) determines whether the migration runner should abort its process if it detects "missing" migrations. 

When set to true (default), rollback causes migration to be aborted with errors like:
```
Error: Failed to run migrations
Caused by:
    migration V55__xxx_xxx_xxx_xxx is missing from the filesystem
```

This error can happen when rollbacking a release that has already applied a db migration. Setting `set_abort_missing(false)` ignores missing versions and carry on with the rollback. 

The trade-off here is if v55 is applied, but v54 is not (for example, v54 gets merged after v55 is released), then when deploying v54 it will be silently ignored (vs. today where it would fail loudly). Given our current process, this is still  less bad overall than migration getting stuck, as we could roll back the code changes. 