### PR TITLE
fix string partitioning edge case to avoid rabbit-holing into single-row partitions

### DIFF
--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -253,7 +253,7 @@ func (c *MySqlConnector) setSessionSettings() error {
 
 	// MariaDB <= 11.5 defaults to latin1, which can result in Unicode to not be replicated correctly
 	if _, err := conn.Execute("SET NAMES utf8mb4"); err != nil {
-		c.logger.Warn("utf8mb4 not supported, ignoring", slog.Any("error", err))
+		return fmt.Errorf("fail to set session to utf8mb4: %w", err)
 	}
 
 	switch c.Flavor() {

--- a/flow/connectors/mysql/qrep_partition.go
+++ b/flow/connectors/mysql/qrep_partition.go
@@ -136,7 +136,7 @@ func stringMidpoint(s1 string, s2 string) (string, bool) {
 	s1, s2 = s1[i:], s2[i:]
 
 	// When the first differing byte in both strings are outside printable ASCII
-	// (both below or both above), treat it as unsplittable so we don't rabbit-holing
+	// (both below or both above), treat it as unsplittable so we aren't rabbit-holing
 	// into generating a lot of single-row partitions.
 	var b1, b2 byte
 	if s1 != "" {

--- a/flow/connectors/mysql/qrep_partition.go
+++ b/flow/connectors/mysql/qrep_partition.go
@@ -116,7 +116,11 @@ const (
 	base95Width = 8 // 95^8 to fit in an uint64
 )
 
-func stringMidpoint(s1 string, s2 string) string {
+func stringMidpoint(s1 string, s2 string) (string, bool) {
+	if s1 == s2 {
+		return "", false
+	}
+
 	i := 0
 	for i < len(s1) && i < len(s2) && s1[i] == s2[i] {
 		i++
@@ -130,8 +134,23 @@ func stringMidpoint(s1 string, s2 string) string {
 	}
 	sharedPrefix := s1[:i]
 	s1, s2 = s1[i:], s2[i:]
+
+	// When the first differing byte in both strings are outside printable ASCII
+	// (both below or both above), treat it as unsplittable so we don't rabbit-holing
+	// into generating a lot of single-row partitions.
+	var b1, b2 byte
+	if s1 != "" {
+		b1 = s1[0]
+	}
+	if s2 != "" {
+		b2 = s2[0]
+	}
+	if max(b1, b2) < base95Min || min(b1, b2) > base95Max {
+		return "", false
+	}
+
 	mid := (stringToBase95Integer(s1) + stringToBase95Integer(s2)) / 2
-	return strings.TrimRight(sharedPrefix+base95IntegerToString(mid), " ")
+	return strings.TrimRight(sharedPrefix+base95IntegerToString(mid), " "), true
 }
 
 func stringToBase95Integer(s string) uint64 {
@@ -227,12 +246,12 @@ func buildAdaptiveStringPartitions(
 	for int64(len(outputs)+h.Len()) < numPartitions && h.Len() > 0 {
 		p := heap.Pop(h).(stringPartitionEntry)
 
-		if p.start == p.end {
+		mid, exists := stringMidpoint(p.start, p.end)
+		if !exists {
 			outputs = append(outputs, p)
 			continue
 		}
 
-		mid := stringMidpoint(p.start, p.end)
 		k, found, err := prober.fetchNextRealKey(ctx, tableName, quotedCol, mid, p.start, p.end)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch next real key: %w", err)

--- a/flow/connectors/mysql/qrep_partition_test.go
+++ b/flow/connectors/mysql/qrep_partition_test.go
@@ -177,46 +177,48 @@ func TestBuildUuidStringPartitionsInvalid(t *testing.T) {
 }
 
 func TestStringMidpoint(t *testing.T) {
-	cases := []struct {
+	splittableCases := []struct {
 		name     string
 		s1       string
 		s2       string
 		expected string
 	}{
-		{"identical", "abc", "abc", "abc"},
-		{"empty bounds", "", "", ""},
 		{"with spaces", " m e", " o ghi", " n fDDOOO"},
 		{"numeric string", "111", "999", "555"},
 		{"with shared prefix", "prefix-hello", "prefix-world", "prefix-p;@=:"},
 		{"max length", "qwertyuiop", "zxcvbnmlkj", "vHdtktB;"},
+		{"one prefix of the other", "app", "apple", "appFBOOOOOO"},
+		{"non-ascii shared prefix", "🍕-0001", "🍕-9999", "🍕-4d4dOOOO"},
+		{"spans ascii boundary", "café", "🍟fries", "q@r~rIDr"},
+		{"empty lower bound", "", "hello", "DBuuw"},
+		{"ascii vs multibyte", "a", "日", "o~~OOOOO"},
 	}
-	for _, tc := range cases {
+	nonSplittableCases := []struct {
+		name string
+		s1   string
+		s2   string
+	}{
+		{"identical", "same", "same"},
+		{"empty bounds", "", ""},
+		{"2-byte char", "café", "cafü"},
+		{"3-byte char", "日", "本"},
+		{"4-byte char", "😀", "😂"},
+		{"divergence on a rune boundary", "日本語あ", "日本語漢"},
+	}
+	for _, tc := range splittableCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mid := stringMidpoint(tc.s1, tc.s2)
-			assert.Equal(t, tc.expected, mid)
-			assert.LessOrEqual(t, tc.s1, mid)
-			assert.LessOrEqual(t, mid, tc.s2)
+			midpoint, exists := stringMidpoint(tc.s1, tc.s2)
+			require.True(t, exists)
+			assert.Equal(t, tc.expected, midpoint)
+			assert.LessOrEqual(t, tc.s1, midpoint)
+			assert.LessOrEqual(t, midpoint, tc.s2)
+			require.True(t, utf8.ValidString(midpoint))
 		})
 	}
-}
-
-func TestStringMidpointRemainsValidUTF8(t *testing.T) {
-	cases := []struct {
-		name  string
-		left  string
-		right string
-	}{
-		{"partial 2-byte char", "café", "cafü"},
-		{"partial 3-byte char", "日", "本"},
-		{"partial 4-byte emoji", "😀", "😂"},
-		{"full runes then partial char", "日本語", "日本誰"},
-		{"divergence on a rune boundary", "日本語あ", "日本語漢"},
-		{"no shared prefix", "а", "я"},
-		{"ascii vs multibyte", "a", "日"},
-	}
-	for _, tc := range cases {
+	for _, tc := range nonSplittableCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.True(t, utf8.ValidString(stringMidpoint(tc.left, tc.right)))
+			_, exists := stringMidpoint(tc.s1, tc.s2)
+			require.False(t, exists)
 		})
 	}
 }
@@ -473,7 +475,9 @@ func TestBuildAdaptiveStringPartitions_NarrowRange(t *testing.T) {
 	// demonstrate fetchNextRealKey would not return a valid key
 	// (e.g. "key_00_" sorts after "key_0099") so splitting these
 	// keys relies on the fetchPrevRealKey fallback
-	require.Equal(t, "key_00_`", stringMidpoint("key_0001", "key_0100"))
+	midpoint, ok := stringMidpoint("key_0001", "key_0100")
+	require.True(t, ok)
+	require.Equal(t, "key_00_`", midpoint)
 
 	partitions := runAdaptiveStringPartitions(t, keys, binaryLess, 8)
 	require.Len(t, partitions, 8)


### PR DESCRIPTION
Follow up to https://github.com/PeerDB-io/peerdb/pull/4522

Main thing to clean up is the edge case where if both start and end boundary string's first differing byte (the most significant byte for determining the midpoint) are below or above printable ascii, continuing with midpoint interpolation in the extreme case can result in generating a lot of single-row partitions, until we are left with one large final partition. Terminate early when this happens to avoid introducing unnecessary latency. It may still be a full table snapshot, but we don't want to generate a lot of meaningless partitions. 