### PR TITLE
Optimize ValidateMirrorDestination to only fetchCustomTypeMapping once

### DIFF
--- a/flow/connectors/postgres/validate.go
+++ b/flow/connectors/postgres/validate.go
@@ -286,6 +286,11 @@ func (c *PostgresConnector) ValidateMirrorDestination(
 		return nil // pg_dump will create the schema and tables on the destination
 	}
 
+	customTypeMapping, err := c.fetchCustomTypeMapping(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch custom type mapping: %w", err)
+	}
+
 	// Validate that all source columns exist in destination tables
 	checkedSchemas := make(map[string]struct{})
 	for _, tableMapping := range cfg.TableMappings {
@@ -303,7 +308,7 @@ func (c *PostgresConnector) ValidateMirrorDestination(
 		}
 
 		// Get destination table columns with types
-		dstColumns, err := pkg_pg.GetDestinationTableSchema(ctx, c.conn, dstTableIdentifier)
+		dstColumns, err := pkg_pg.GetDestinationTableSchema(ctx, c.conn, dstTableIdentifier, customTypeMapping)
 		if err != nil {
 			// If table doesn't exist, check that the schema does before continuing
 			if errors.Is(err, pgx.ErrNoRows) || strings.Contains(err.Error(), "does not exist") {

--- a/flow/pkg/postgres/dest_validation.go
+++ b/flow/pkg/postgres/dest_validation.go
@@ -41,15 +41,15 @@ func CheckSchemaExists(ctx context.Context, conn *pgx.Conn, schema string) error
 // GetDestinationTableSchema queries a PostgreSQL table's column type information
 // using SELECT * FROM tableIdentifier LIMIT 0 to get field descriptions with OIDs.
 // Returns pgx.ErrNoRows if the table exists but has no columns.
-func GetDestinationTableSchema(ctx context.Context, conn *pgx.Conn, tableIdentifier string) (map[string]ColumnSchema, error) {
+func GetDestinationTableSchema(
+	ctx context.Context,
+	conn *pgx.Conn,
+	tableIdentifier string,
+	customTypeMapping map[uint32]CustomDataType,
+) (map[string]ColumnSchema, error) {
 	parsedTable, err := common.ParseTableIdentifier(tableIdentifier)
 	if err != nil {
 		return nil, fmt.Errorf("invalid table identifier %s: %w", tableIdentifier, err)
-	}
-
-	customTypeMapping, err := GetCustomDataTypes(ctx, conn)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch custom type mapping: %w", err)
 	}
 
 	rows, err := conn.Query(ctx,

--- a/flow/pkg/postgres/oid.go
+++ b/flow/pkg/postgres/oid.go
@@ -15,16 +15,15 @@ type CustomDataType struct {
 	Delim byte // non-zero for array types
 }
 
-// GetCustomDataTypes fetches all user-defined types from the PostgreSQL catalog.
+// GetCustomDataTypes fetches all types from the PostgreSQL catalog.
+// pg_catalog stays included: pgtype's map does not know every built-in (regclass, pg_lsn, oidvector, ...) and OIDToName falls back here.
 func GetCustomDataTypes(ctx context.Context, conn *pgx.Conn) (map[uint32]CustomDataType, error) {
 	rows, err := conn.Query(ctx, `
 		SELECT t.oid, t.typname, coalesce(at.typtype, t.typtype), coalesce(at.typdelim, 0::"char")
 		FROM pg_catalog.pg_type t
-		LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
 		LEFT JOIN pg_catalog.pg_class c ON c.oid = t.typrelid
 		LEFT JOIN pg_catalog.pg_type at ON at.typarray = t.oid
 		WHERE t.typrelid = 0 OR c.relkind = 'c'
-		AND n.nspname NOT IN ('pg_catalog', 'information_schema');
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get customTypeMapping: %w", err)


### PR DESCRIPTION
Also `AND` only applied to c.relkind = 'c' due to precedence, just get rid of that optimization, there are many types pgx ignores in pg_catalog