### PR TITLE
CI/Upload test results action: Fail with error when the upload log doesn't contain the summary header

### DIFF
--- a/.github/actions/ingest-test-results/action.yml
+++ b/.github/actions/ingest-test-results/action.yml
@@ -64,7 +64,7 @@ runs:
           "$O11Y_QUERY_ENDPOINT" \
           --data-binary @logs/normalized-test-results.ndjson \
           | tee upload.log
-        WRITTEN_ROWS=$(cat upload.log | grep $SUMMARY_HEADER | sed "s/$SUMMARY_HEADER: //" | jq '.written_rows' -r)
+        WRITTEN_ROWS=$(cat upload.log | grep $SUMMARY_HEADER | sed "s/$SUMMARY_HEADER: //" | jq '.written_rows' -r || true)
         if [ -z "$WRITTEN_ROWS" ] || [ "$WRITTEN_ROWS" -eq 0 ]; then
             echo "No results uploaded. Query client logs:"
             cat upload.log


### PR DESCRIPTION
This addressed the improbable corner case of missing results reports being silently ignored resulting in not failed builds were test results ingestion haven't actually happened.