### PR TITLE
Retry catalog and Temporal connections at startup

### DIFF
--- a/flow/cmd/api.go
+++ b/flow/cmd/api.go
@@ -204,7 +204,9 @@ func APIMain(ctx context.Context, args *APIServerParams) error {
 		Meter: metricsProvider.Meter("temporal-sdk-go"),
 	})
 
-	tc, err := setupTemporalClient(ctx, clientOptions)
+	tc, err := connectWithRetry(ctx, "temporal", func(ctx context.Context) (client.Client, error) {
+		return setupTemporalClient(ctx, clientOptions)
+	})
 	if err != nil {
 		return fmt.Errorf("unable to create Temporal client: %w", err)
 	}
@@ -240,7 +242,7 @@ func APIMain(ctx context.Context, args *APIServerParams) error {
 		)),
 	)
 
-	catalogPool, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
+	catalogPool, err := connectWithRetry(ctx, "catalog", internal.GetCatalogConnectionPoolFromEnv)
 	if err != nil {
 		return fmt.Errorf("unable to get catalog connection pool: %w", err)
 	}

--- a/flow/cmd/cert.go
+++ b/flow/cmd/cert.go
@@ -68,6 +68,5 @@ func setupTemporalClient(ctx context.Context, clientOptions client.Options) (cli
 		clientOptions.ConnectionOptions = client.ConnectionOptions{TLS: tlsConfig}
 	}
 
-	tc, err := client.Dial(clientOptions)
-	return tc, err
+	return client.DialContext(ctx, clientOptions)
 }

--- a/flow/cmd/maintenance.go
+++ b/flow/cmd/maintenance.go
@@ -56,7 +56,9 @@ func MaintenanceMain(ctx context.Context, args *MaintenanceCLIParams) error {
 		Namespace: args.TemporalNamespace,
 		Logger:    slog.New(shared.NewSlogHandler(slog.NewJSONHandler(os.Stdout, shared.NewSlogHandlerOptions()))),
 	}
-	tc, err := setupTemporalClient(ctx, clientOptions)
+	tc, err := connectWithRetry(ctx, "temporal", func(ctx context.Context) (client.Client, error) {
+		return setupTemporalClient(ctx, clientOptions)
+	})
 	if err != nil {
 		return fmt.Errorf("unable to create Temporal client: %w", err)
 	}
@@ -234,7 +236,7 @@ func constructFlowClient(ctx context.Context, args *MaintenanceCLIParams) (proto
 }
 
 func WriteMaintenanceOutputToCatalog(ctx context.Context, result StartMaintenanceResult) error {
-	pool, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
+	pool, err := connectWithRetry(ctx, "catalog", internal.GetCatalogConnectionPoolFromEnv)
 	if err != nil {
 		return err
 	}
@@ -248,7 +250,7 @@ func WriteMaintenanceOutputToCatalog(ctx context.Context, result StartMaintenanc
 }
 
 func ReadLastMaintenanceOutput(ctx context.Context) (*StartMaintenanceResult, error) {
-	pool, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
+	pool, err := connectWithRetry(ctx, "catalog", internal.GetCatalogConnectionPoolFromEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/flow/cmd/snapshot_worker.go
+++ b/flow/cmd/snapshot_worker.go
@@ -37,7 +37,7 @@ func SnapshotWorkerMain(ctx context.Context, opts *SnapshotWorkerOptions) (*Work
 		},
 	}
 
-	conn, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
+	conn, err := connectWithRetry(ctx, "catalog", internal.GetCatalogConnectionPoolFromEnv)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create catalog connection pool: %w", err)
 	}
@@ -65,7 +65,9 @@ func SnapshotWorkerMain(ctx context.Context, opts *SnapshotWorkerOptions) (*Work
 		clientOptions.Interceptors = append(clientOptions.Interceptors, tracingInterceptor)
 	}
 
-	c, err := setupTemporalClient(ctx, clientOptions)
+	c, err := connectWithRetry(ctx, "temporal", func(ctx context.Context) (client.Client, error) {
+		return setupTemporalClient(ctx, clientOptions)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Temporal client: %w", err)
 	}

--- a/flow/cmd/startup.go
+++ b/flow/cmd/startup.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+const (
+	startupRetryBudget         = 3 * time.Minute
+	startupRetryAttemptTimeout = 30 * time.Second
+	startupRetryInitialWait    = 1 * time.Second
+	startupRetryMaxWait        = 10 * time.Second
+)
+
+func connectWithRetry[T any](ctx context.Context, dependency string, connect func(context.Context) (T, error)) (T, error) {
+	deadline := time.Now().Add(startupRetryBudget)
+	wait := startupRetryInitialWait
+	for attempt := 1; ; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, startupRetryAttemptTimeout)
+		result, err := connect(attemptCtx)
+		cancel()
+		if err == nil {
+			if attempt > 1 {
+				slog.InfoContext(ctx, "Startup dependency reachable",
+					slog.String("dependency", dependency), slog.Int("attempt", attempt))
+			}
+			return result, nil
+		}
+		if ctx.Err() != nil || !time.Now().Add(wait).Before(deadline) {
+			var zero T
+			return zero, err
+		}
+
+		slog.WarnContext(ctx, "Startup dependency unreachable, retrying",
+			slog.String("dependency", dependency), slog.Int("attempt", attempt),
+			slog.Duration("retryIn", wait), slog.Any("error", err))
+		select {
+		case <-ctx.Done():
+			var zero T
+			return zero, err
+		case <-time.After(wait):
+		}
+		wait = min(wait*2, startupRetryMaxWait)
+	}
+}

--- a/flow/cmd/startup_test.go
+++ b/flow/cmd/startup_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectWithRetrySucceedsImmediately(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	got, err := connectWithRetry(t.Context(), "test", func(context.Context) (int, error) {
+		attempts++
+		return 42, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 42, got)
+	assert.Equal(t, 1, attempts)
+}
+
+func TestConnectWithRetrySucceedsAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	got, err := connectWithRetry(t.Context(), "test", func(context.Context) (int, error) {
+		attempts++
+		if attempts < 2 {
+			return 0, errors.New("not ready")
+		}
+		return 42, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 42, got)
+	assert.Equal(t, 2, attempts)
+}
+
+func TestConnectWithRetryStopsOnCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	connectErr := errors.New("not ready")
+	attempts := 0
+	_, err := connectWithRetry(ctx, "test", func(context.Context) (int, error) {
+		attempts++
+		cancel()
+		return 0, connectErr
+	})
+	require.ErrorIs(t, err, connectErr)
+	assert.Equal(t, 1, attempts)
+}
+
+func TestConnectWithRetryBoundsEachAttempt(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var attemptDeadline time.Time
+	_, err := connectWithRetry(ctx, "test", func(attemptCtx context.Context) (int, error) {
+		attemptDeadline, _ = attemptCtx.Deadline()
+		cancel()
+		return 0, errors.New("not ready")
+	})
+	require.Error(t, err)
+	assert.WithinDuration(t, time.Now().Add(startupRetryAttemptTimeout), attemptDeadline, time.Second)
+}

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -53,7 +53,7 @@ func (w *WorkerSetupResponse) Close(ctx context.Context) {
 }
 
 func WorkerSetup(ctx context.Context, opts *WorkerSetupOptions) (*WorkerSetupResponse, error) {
-	conn, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
+	conn, err := connectWithRetry(ctx, "catalog", internal.GetCatalogConnectionPoolFromEnv)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create catalog connection pool: %w", err)
 	}
@@ -91,7 +91,9 @@ func WorkerSetup(ctx context.Context, opts *WorkerSetupOptions) (*WorkerSetupRes
 		clientOptions.Interceptors = append(clientOptions.Interceptors, tracingInterceptor)
 	}
 
-	c, err := setupTemporalClient(ctx, clientOptions)
+	c, err := connectWithRetry(ctx, "temporal", func(ctx context.Context) (client.Client, error) {
+		return setupTemporalClient(ctx, clientOptions)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Temporal client: %w", err)
 	}


### PR DESCRIPTION
## Why

`WorkerSetup`, `SnapshotWorkerMain` and `APIMain` each dial the catalog and Temporal exactly once. Any error propagates to `main.go`, which panics — so a single slow dial takes the pod down.

We hit this during releases, most often on `maintenance-worker` (a Helm pre/post-upgrade hook, so it cold-starts twice per release while everything else is churning):

```
panic: unable to create Temporal client: failed reaching server: context deadline exceeded
panic: unable to create catalog connection pool: unable to establish connection with catalog: failed to connect to ...
```

Neither dependency recovers on its own: Temporal's `GetSystemInfo` deadline is a single-shot 5s, and pgxpool defaults `ConnectTimeout` to 2 minutes.

## What

- `connectWithRetry` in `flow/cmd/startup.go`: exponential backoff (1s → 10s) over a 3 minute budget, each attempt bounded at 30s so a hanging dial can't eat the budget. Logs a warning per failed attempt so a genuinely misconfigured secret still surfaces.
- Applied to the catalog and Temporal dials in worker, snapshot-worker and api.
- `client.Dial` → `client.DialContext`. `Dial` ignores the caller's context and uses `context.Background()`, so without this the per-attempt timeout and SIGTERM handling had no effect on the Temporal dial.

Unit tests cover immediate success, success after a failure, abort on cancellation, and the per-attempt deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)