### PR TITLE
PG-PG: Add feature to clean up older raw table data, behind FF

### DIFF
--- a/flow/cmd/settings.go
+++ b/flow/cmd/settings.go
@@ -47,7 +47,8 @@ func (h *FlowRequestHandler) GetDynamicSettings(
 		filteredSettings := make([]*protos.DynamicSetting, 0)
 		for _, setting := range settings {
 			if setting.TargetForSetting == protos.DynconfTarget_ALL ||
-				setting.TargetForSetting == protos.DynconfTarget_CLICKHOUSE {
+				setting.TargetForSetting == protos.DynconfTarget_CLICKHOUSE ||
+				setting.TargetForSetting == protos.DynconfTarget_POSTGRES {
 				filteredSettings = append(filteredSettings, setting)
 			}
 		}

--- a/flow/connectors/postgres/postgres_destination.go
+++ b/flow/connectors/postgres/postgres_destination.go
@@ -314,11 +314,6 @@ func (c *PostgresConnector) cleanupOldRawBatches(
 	rawTableIdentifier string,
 	normalizeBatchID int64,
 ) {
-	c.logger.Info("raw batch cleanup check",
-		slog.Bool("envNil", env == nil),
-		slog.Int("envLen", len(env)),
-		slog.Int64("normalizeBatchID", normalizeBatchID),
-	)
 	threshold, err := internal.PeerDBPostgresRawBatchCleanupThreshold(ctx, env)
 	if err != nil {
 		c.logger.Warn("failed to read raw batch cleanup threshold setting", slog.Any("error", err))
@@ -333,7 +328,23 @@ func (c *PostgresConnector) cleanupOldRawBatches(
 		return
 	}
 
-	result, err := c.conn.Exec(ctx,
+	tx, err := c.conn.Begin(ctx)
+	if err != nil {
+		c.logger.Warn("failed to begin transaction for raw batch cleanup", slog.Any("error", err))
+		return
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil && err != pgx.ErrTxClosed {
+			c.logger.Warn("failed to rollback raw batch cleanup transaction", slog.Any("error", err))
+		}
+	}()
+
+	if _, err := tx.Exec(ctx, setSessionReplicaRoleSQL); err != nil {
+		c.logger.Warn("failed to set session_replication_role for raw batch cleanup", slog.Any("error", err))
+		return
+	}
+
+	result, err := tx.Exec(ctx,
 		fmt.Sprintf("DELETE FROM %s.%s WHERE _peerdb_batch_id < $1", c.metadataSchema, rawTableIdentifier),
 		cutoffBatchID,
 	)
@@ -342,6 +353,11 @@ func (c *PostgresConnector) cleanupOldRawBatches(
 			slog.Any("error", err),
 			slog.Int64("cutoffBatchID", cutoffBatchID),
 		)
+		return
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		c.logger.Warn("failed to commit raw batch cleanup", slog.Any("error", err))
 		return
 	}
 	c.logger.Info("cleaned up old raw table batches",

--- a/flow/connectors/postgres/postgres_destination.go
+++ b/flow/connectors/postgres/postgres_destination.go
@@ -314,6 +314,11 @@ func (c *PostgresConnector) cleanupOldRawBatches(
 	rawTableIdentifier string,
 	normalizeBatchID int64,
 ) {
+	c.logger.Info("raw batch cleanup check",
+		slog.Bool("envNil", env == nil),
+		slog.Int("envLen", len(env)),
+		slog.Int64("normalizeBatchID", normalizeBatchID),
+	)
 	threshold, err := internal.PeerDBPostgresRawBatchCleanupThreshold(ctx, env)
 	if err != nil {
 		c.logger.Warn("failed to read raw batch cleanup threshold setting", slog.Any("error", err))

--- a/flow/connectors/postgres/postgres_destination.go
+++ b/flow/connectors/postgres/postgres_destination.go
@@ -328,23 +328,7 @@ func (c *PostgresConnector) cleanupOldRawBatches(
 		return
 	}
 
-	tx, err := c.conn.Begin(ctx)
-	if err != nil {
-		c.logger.Warn("failed to begin transaction for raw batch cleanup", slog.Any("error", err))
-		return
-	}
-	defer func() {
-		if err := tx.Rollback(ctx); err != nil && err != pgx.ErrTxClosed {
-			c.logger.Warn("failed to rollback raw batch cleanup transaction", slog.Any("error", err))
-		}
-	}()
-
-	if _, err := tx.Exec(ctx, setSessionReplicaRoleSQL); err != nil {
-		c.logger.Warn("failed to set session_replication_role for raw batch cleanup", slog.Any("error", err))
-		return
-	}
-
-	result, err := tx.Exec(ctx,
+	result, err := c.conn.Exec(ctx,
 		fmt.Sprintf("DELETE FROM %s.%s WHERE _peerdb_batch_id < $1", c.metadataSchema, rawTableIdentifier),
 		cutoffBatchID,
 	)
@@ -353,11 +337,6 @@ func (c *PostgresConnector) cleanupOldRawBatches(
 			slog.Any("error", err),
 			slog.Int64("cutoffBatchID", cutoffBatchID),
 		)
-		return
-	}
-
-	if err := tx.Commit(ctx); err != nil {
-		c.logger.Warn("failed to commit raw batch cleanup", slog.Any("error", err))
 		return
 	}
 	c.logger.Info("cleaned up old raw table batches",

--- a/flow/connectors/postgres/postgres_destination.go
+++ b/flow/connectors/postgres/postgres_destination.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -299,10 +300,49 @@ func (c *PostgresConnector) NormalizeRecords(
 	}
 	c.logger.Info(fmt.Sprintf("normalized %d records", totalRowsAffected))
 
+	c.cleanupOldRawBatches(ctx, req.Env, rawTableIdentifier, req.SyncBatchID)
+
 	return model.NormalizeResponse{
 		StartBatchID: normBatchID + 1,
 		EndBatchID:   req.SyncBatchID,
 	}, nil
+}
+
+func (c *PostgresConnector) cleanupOldRawBatches(
+	ctx context.Context,
+	env map[string]string,
+	rawTableIdentifier string,
+	normalizeBatchID int64,
+) {
+	threshold, err := internal.PeerDBPostgresRawBatchCleanupThreshold(ctx, env)
+	if err != nil {
+		c.logger.Warn("failed to read raw batch cleanup threshold setting", slog.Any("error", err))
+		return
+	}
+	if threshold <= 0 {
+		return
+	}
+
+	cutoffBatchID := normalizeBatchID - threshold
+	if cutoffBatchID <= 0 {
+		return
+	}
+
+	result, err := c.conn.Exec(ctx,
+		fmt.Sprintf("DELETE FROM %s.%s WHERE _peerdb_batch_id < $1", c.metadataSchema, rawTableIdentifier),
+		cutoffBatchID,
+	)
+	if err != nil {
+		c.logger.Warn("failed to clean up old raw table batches",
+			slog.Any("error", err),
+			slog.Int64("cutoffBatchID", cutoffBatchID),
+		)
+		return
+	}
+	c.logger.Info("cleaned up old raw table batches",
+		slog.Int64("cutoffBatchID", cutoffBatchID),
+		slog.Int64("rowsDeleted", result.RowsAffected()),
+	)
 }
 
 type batchEntry struct {

--- a/flow/e2e/postgres_test.go
+++ b/flow/e2e/postgres_test.go
@@ -467,9 +467,9 @@ func (s PeerFlowE2ETestSuitePG) Test_Raw_Batch_Cleanup_PG() {
 	env := ExecutePeerflow(s.t, tc, flowConnConfig)
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
-	mirrorJobsTable := fmt.Sprintf("_peerdb_internal.%s", "peerdb_mirror_jobs")
-	rawTableName := fmt.Sprintf(`_peerdb_internal."_peerdb_raw_%s"`,
-		strings.ToLower(shared.ReplaceIllegalCharactersWithUnderscores(flowConnConfig.FlowJobName)))
+	mirrorJobsTable := "_peerdb_internal.peerdb_mirror_jobs"
+	rawTableName := `_peerdb_internal."_peerdb_raw_` +
+		strings.ToLower(shared.ReplaceIllegalCharactersWithUnderscores(flowConnConfig.FlowJobName)) + `"`
 
 	// insert 5 rounds of 2 rows each to create 5 batches
 	for round := range 5 {
@@ -490,14 +490,16 @@ func (s PeerFlowE2ETestSuitePG) Test_Raw_Batch_Cleanup_PG() {
 		})
 	}
 
-	var rawCount int64
-	err = s.Conn().QueryRow(s.t.Context(),
-		fmt.Sprintf("SELECT count(*) FROM %s", rawTableName),
-	).Scan(&rawCount)
-	EnvNoError(s.t, env, err)
-
-	s.t.Logf("raw table row count after cleanup: %d", rawCount)
-	assert.Equal(s.t, int64(6), rawCount, "expected exactly 6 rows (3 batches) retained in raw table")
+	// wait for cleanup to take effect - with threshold=2 and 5 batches,
+	// cutoff = 5 - 2 = 3, so batches 1,2 are deleted, batches 3,4,5 remain (6 rows)
+	EnvWaitFor(s.t, env, 1*time.Minute, "raw table cleanup", func() bool {
+		var rawCount int64
+		err := s.Conn().QueryRow(s.t.Context(),
+			"SELECT count(*) FROM "+rawTableName,
+		).Scan(&rawCount)
+		s.t.Logf("raw table row count: %d", rawCount)
+		return err == nil && rawCount == 6
+	})
 
 	env.Cancel(s.t.Context())
 	RequireEnvCanceled(s.t, env)

--- a/flow/e2e/postgres_test.go
+++ b/flow/e2e/postgres_test.go
@@ -438,6 +438,71 @@ func (s PeerFlowE2ETestSuitePG) Test_Composite_PKey_PG() {
 	RequireEnvCanceled(s.t, env)
 }
 
+func (s PeerFlowE2ETestSuitePG) Test_Raw_Batch_Cleanup_PG() {
+	tc := NewTemporalClient(s.t)
+
+	srcTableName := s.attachSchemaSuffix("test_raw_cleanup")
+	dstTableName := s.attachSchemaSuffix("test_raw_cleanup_dst")
+
+	_, err := s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+			val TEXT
+		);
+	`, srcTableName))
+	require.NoError(s.t, err)
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("test_raw_cleanup_flow"),
+		TableNameMapping: map[string]string{srcTableName: dstTableName},
+		Destination:      s.Peer().Name,
+	}
+
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.MaxBatchSize = 2
+	flowConnConfig.Env = map[string]string{
+		"PEERDB_POSTGRES_RAW_BATCH_CLEANUP_THRESHOLD": "2",
+	}
+
+	env := ExecutePeerflow(s.t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	mirrorJobsTable := fmt.Sprintf("_peerdb_internal.%s", "peerdb_mirror_jobs")
+	rawTableName := fmt.Sprintf(`_peerdb_internal."_peerdb_raw_%s"`,
+		strings.ToLower(shared.ReplaceIllegalCharactersWithUnderscores(flowConnConfig.FlowJobName)))
+
+	// insert 5 rounds of 2 rows each to create 5 batches
+	for round := range 5 {
+		for j := range 2 {
+			_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
+				INSERT INTO %s(val) VALUES ($1)
+			`, srcTableName), fmt.Sprintf("val_%d_%d", round, j))
+			EnvNoError(s.t, env, err)
+		}
+		expectedBatchID := int64(round + 1)
+		EnvWaitFor(s.t, env, 3*time.Minute, fmt.Sprintf("normalize batch %d", expectedBatchID), func() bool {
+			var normBatchID int64
+			err := s.Conn().QueryRow(s.t.Context(),
+				fmt.Sprintf("SELECT normalize_batch_id FROM %s WHERE mirror_job_name=$1", mirrorJobsTable),
+				flowConnConfig.FlowJobName,
+			).Scan(&normBatchID)
+			return err == nil && normBatchID >= expectedBatchID
+		})
+	}
+
+	var rawCount int64
+	err = s.Conn().QueryRow(s.t.Context(),
+		fmt.Sprintf("SELECT count(*) FROM %s", rawTableName),
+	).Scan(&rawCount)
+	EnvNoError(s.t, env, err)
+
+	s.t.Logf("raw table row count after cleanup: %d", rawCount)
+	assert.Equal(s.t, int64(6), rawCount, "expected exactly 6 rows (3 batches) retained in raw table")
+
+	env.Cancel(s.t.Context())
+	RequireEnvCanceled(s.t, env)
+}
+
 func (s PeerFlowE2ETestSuitePG) Test_Composite_PKey_Toast_1_PG() {
 	tc := NewTemporalClient(s.t)
 

--- a/flow/e2e/postgres_test.go
+++ b/flow/e2e/postgres_test.go
@@ -460,6 +460,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Raw_Batch_Cleanup_PG() {
 
 	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
 	flowConnConfig.MaxBatchSize = 2
+	flowConnConfig.System = protos.TypeSystem_PG
 	flowConnConfig.Env = map[string]string{
 		"PEERDB_POSTGRES_RAW_BATCH_CLEANUP_THRESHOLD": "2",
 		"PEERDB_GROUP_NORMALIZE":                      "1",

--- a/flow/e2e/postgres_test.go
+++ b/flow/e2e/postgres_test.go
@@ -473,6 +473,26 @@ func (s PeerFlowE2ETestSuitePG) Test_Raw_Batch_Cleanup_PG() {
 	rawTableName := `_peerdb_internal."_peerdb_raw_` +
 		strings.ToLower(shared.ReplaceIllegalCharactersWithUnderscores(flowConnConfig.FlowJobName)) + `"`
 
+	// Remove raw table from any publications so DELETE works in CI
+	// (CI uses same PG for source/dest with FOR ALL TABLES publication)
+	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
+		DO $$ DECLARE pub TEXT;
+		BEGIN
+			FOR pub IN
+				SELECT p.pubname FROM pg_publication p
+				JOIN pg_publication_rel pr ON p.oid = pr.prpubid
+				JOIN pg_class c ON c.oid = pr.prrelid
+				JOIN pg_namespace n ON n.oid = c.relnamespace
+				WHERE n.nspname = '_peerdb_internal'
+				AND c.relname = '_peerdb_raw_%s'
+			LOOP
+				EXECUTE format('ALTER PUBLICATION %%I DROP TABLE %s', pub);
+			END LOOP;
+		END $$;
+	`, strings.ToLower(shared.ReplaceIllegalCharactersWithUnderscores(flowConnConfig.FlowJobName)),
+		rawTableName))
+	require.NoError(s.t, err)
+
 	// insert 5 rounds of 2 rows each to create 5 batches
 	for round := range 5 {
 		for j := range 2 {

--- a/flow/e2e/postgres_test.go
+++ b/flow/e2e/postgres_test.go
@@ -473,24 +473,9 @@ func (s PeerFlowE2ETestSuitePG) Test_Raw_Batch_Cleanup_PG() {
 	rawTableName := `_peerdb_internal."_peerdb_raw_` +
 		strings.ToLower(shared.ReplaceIllegalCharactersWithUnderscores(flowConnConfig.FlowJobName)) + `"`
 
-	// Remove raw table from any publications so DELETE works in CI
+	// Set REPLICA IDENTITY FULL so DELETE works when the table is published
 	// (CI uses same PG for source/dest with FOR ALL TABLES publication)
-	_, err = s.Conn().Exec(s.t.Context(), fmt.Sprintf(`
-		DO $$ DECLARE pub TEXT;
-		BEGIN
-			FOR pub IN
-				SELECT p.pubname FROM pg_publication p
-				JOIN pg_publication_rel pr ON p.oid = pr.prpubid
-				JOIN pg_class c ON c.oid = pr.prrelid
-				JOIN pg_namespace n ON n.oid = c.relnamespace
-				WHERE n.nspname = '_peerdb_internal'
-				AND c.relname = '_peerdb_raw_%s'
-			LOOP
-				EXECUTE format('ALTER PUBLICATION %%I DROP TABLE %s', pub);
-			END LOOP;
-		END $$;
-	`, strings.ToLower(shared.ReplaceIllegalCharactersWithUnderscores(flowConnConfig.FlowJobName)),
-		rawTableName))
+	_, err = s.Conn().Exec(s.t.Context(), "ALTER TABLE "+rawTableName+" REPLICA IDENTITY FULL")
 	require.NoError(s.t, err)
 
 	// insert 5 rounds of 2 rows each to create 5 batches

--- a/flow/e2e/postgres_test.go
+++ b/flow/e2e/postgres_test.go
@@ -462,6 +462,7 @@ func (s PeerFlowE2ETestSuitePG) Test_Raw_Batch_Cleanup_PG() {
 	flowConnConfig.MaxBatchSize = 2
 	flowConnConfig.Env = map[string]string{
 		"PEERDB_POSTGRES_RAW_BATCH_CLEANUP_THRESHOLD": "2",
+		"PEERDB_GROUP_NORMALIZE":                      "1",
 	}
 
 	env := ExecutePeerflow(s.t, tc, flowConnConfig)

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -527,6 +527,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
+	{
+		Name:             "PEERDB_POSTGRES_RAW_BATCH_CLEANUP_THRESHOLD",
+		Description:      "Number of normalized batches to retain in raw table. After normalize, batches older than normalize_batch_id minus this value are deleted. 0 disables cleanup",
+		DefaultValue:     "0",
+		ValueType:        protos.DynconfValueType_INT,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_POSTGRES,
+	},
 }
 
 var DynamicIndex = func() map[string]int {
@@ -936,4 +944,8 @@ func PeerDBMongoDBExcludedOperationTypes(ctx context.Context, env map[string]str
 		}
 	}
 	return ops, nil
+}
+
+func PeerDBPostgresRawBatchCleanupThreshold(ctx context.Context, env map[string]string) (int64, error) {
+	return dynamicConfSigned[int64](ctx, env, "PEERDB_POSTGRES_RAW_BATCH_CLEANUP_THRESHOLD")
 }

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -528,8 +528,9 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name:             "PEERDB_POSTGRES_RAW_BATCH_CLEANUP_THRESHOLD",
-		Description:      "Number of normalized batches to retain in raw table. After normalize, batches older than normalize_batch_id minus this value are deleted. 0 disables cleanup",
+		Name: "PEERDB_POSTGRES_RAW_BATCH_CLEANUP_THRESHOLD",
+		Description: "Number of normalized batches to retain in raw table. After normalize, batches older " +
+			"than normalize_batch_id minus this value are deleted. 0 disables cleanup",
 		DefaultValue:     "0",
 		ValueType:        protos.DynconfValueType_INT,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,


### PR DESCRIPTION
## Why
The PeerDB raw table grows large over time and has been seen to take up a lot of storage in the target Postgres peer. We want to provide an inbuilt feature to users to ensure raw table stays at a small size

This is going to be behind a feature flag default OFF for now so that upon rollout, the first occurrence of cleanup will not stall normalize due to large amount of raw table batches.

## What
- Introduces a new Postgres dynconf target 
- Introduces a new dynamic conf setting with above PG target for cleanup threshold
- In PG to PG normalize, introduces a call to clean up raw table data based on the normalize batch ID and above threshold setting
- Adds an E2E test for above functionality
