### PR TITLE
fix(postgres): correct TLS host resolution for pg_dump schema migration

### DIFF
--- a/flow/connectors/postgres/pgdump_schema.go
+++ b/flow/connectors/postgres/pgdump_schema.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"regexp"
@@ -30,7 +32,17 @@ var incompatibleLineRE = regexp.MustCompile(`^(SET\s+transaction_timeout\s*=|\\(
 // RunPgDumpSchema streams a schema-only pg_dump from source directly into psql
 // on the destination, piping stdout into stdin without intermediate files.
 func RunPgDumpSchema(ctx context.Context, srcConfig *protos.PostgresConfig, dstConfig *protos.PostgresConfig) error {
-	if err := pipeCommand(ctx, srcConfig, dstConfig, "pg_dump", buildPgDumpArgs(srcConfig)); err != nil {
+	srcAddr, err := resolvePgAddr(ctx, srcConfig)
+	if err != nil {
+		return fmt.Errorf("source: %w", err)
+	}
+	dstAddr, err := resolvePgAddr(ctx, dstConfig)
+	if err != nil {
+		return fmt.Errorf("destination: %w", err)
+	}
+
+	if err := pipeCommand(ctx, srcConfig, dstConfig, srcAddr, dstAddr,
+		"pg_dump", buildPgDumpArgs(srcConfig, srcAddr.host)); err != nil {
 		return fmt.Errorf("pg_dump schema migration failed: %w", err)
 	}
 
@@ -42,10 +54,12 @@ func pipeCommand(
 	ctx context.Context,
 	srcConfig *protos.PostgresConfig,
 	dstConfig *protos.PostgresConfig,
+	srcAddr pgAddr,
+	dstAddr pgAddr,
 	srcBinary string,
 	srcArgs []string,
 ) error {
-	psqlArgs := buildPsqlArgs(dstConfig)
+	psqlArgs := buildPsqlArgs(dstConfig, dstAddr.host)
 
 	srcCmd := exec.CommandContext(ctx, srcBinary, srcArgs...)
 	psqlCmd := exec.CommandContext(ctx, "psql", psqlArgs...)
@@ -54,9 +68,16 @@ func pipeCommand(
 	srcCmd.Env = append(os.Environ(), "PGPASSWORD="+srcConfig.Password)
 	psqlCmd.Env = append(os.Environ(), "PGPASSWORD="+dstConfig.Password)
 
+	if srcAddr.hostaddr != "" {
+		srcCmd.Env = append(srcCmd.Env, "PGHOSTADDR="+srcAddr.hostaddr)
+	}
+	if dstAddr.hostaddr != "" {
+		psqlCmd.Env = append(psqlCmd.Env, "PGHOSTADDR="+dstAddr.hostaddr)
+	}
+
 	// handle TLS env vars
-	appendTLSEnv(ctx, srcCmd, srcConfig)
-	appendTLSEnv(ctx, psqlCmd, dstConfig)
+	appendTLSEnv(ctx, srcCmd, srcConfig, srcAddr)
+	appendTLSEnv(ctx, psqlCmd, dstConfig, dstAddr)
 
 	return runPipeline(ctx, srcCmd, psqlCmd, srcBinary, "psql", filterIncompatibleLines)
 }
@@ -233,14 +254,55 @@ func runPipeline(
 	return nil
 }
 
-func tlsHostOrHost(config *protos.PostgresConfig) string {
-	if config.TlsHost != "" {
-		return config.TlsHost
-	}
-	return config.Host
+// pgAddr is how a raw libpq invocation (pg_dump/psql) should address one peer.
+type pgAddr struct {
+	// host is the -h value. When hostaddr is empty, it is simply what libpq
+	// resolves and dials. When hostaddr is set, libpq dials hostaddr instead
+	// and host is only the SNI name sent and the name the server certificate
+	// is checked against.
+	host string
+	// hostaddr is the numeric IP libpq dials (PGHOSTADDR), bypassing DNS.
+	// Set only when the dial target and the certificate name differ.
+	hostaddr string
 }
 
-func buildPgDumpArgs(config *protos.PostgresConfig) []string {
+// lookupHost is swappable for tests.
+var lookupHost = func(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// resolvePgAddr mirrors the pgx path's semantics (ParseConfig/CreateTlsConfig):
+// always dial Host; TlsHost, when TLS is in play, is only the name the server
+// certificate is checked against.
+func resolvePgAddr(ctx context.Context, config *protos.PostgresConfig) (pgAddr, error) {
+	host := internal.SanitizePGHost(config.Host)
+	tlsHost := internal.SanitizePGHost(config.TlsHost)
+
+	hasRootCA := config.RootCa != nil && *config.RootCa != ""
+	shouldUseTls := internal.PGMustUseTlsConnection(config) || hasRootCA
+
+	if !shouldUseTls || tlsHost == "" || tlsHost == host {
+		return pgAddr{host: host}, nil
+	}
+
+	// Connect to Host, verify as TlsHost: libpq spells it host=TlsHost
+	// hostaddr=Host, but hostaddr only accepts numeric IPs, so resolve
+	// hostnames ourselves.
+	hostaddr := host
+	if _, err := netip.ParseAddr(hostaddr); err != nil {
+		addrs, err := lookupHost(ctx, host)
+		if err != nil {
+			return pgAddr{}, fmt.Errorf("failed to resolve host %s: %w", host, err)
+		}
+		if len(addrs) == 0 {
+			return pgAddr{}, fmt.Errorf("host %s resolved to no addresses", host)
+		}
+		hostaddr = addrs[0]
+	}
+	return pgAddr{host: tlsHost, hostaddr: hostaddr}, nil
+}
+
+func buildPgDumpArgs(config *protos.PostgresConfig, host string) []string {
 	port := config.Port
 	if port == 0 {
 		port = 5432
@@ -250,7 +312,7 @@ func buildPgDumpArgs(config *protos.PostgresConfig) []string {
 		"--schema-only",
 		"--no-owner",
 		"--no-privileges",
-		"-h", tlsHostOrHost(config),
+		"-h", host,
 		"-p", strconv.FormatUint(uint64(port), 10),
 		"-d", config.Database,
 	}
@@ -260,14 +322,14 @@ func buildPgDumpArgs(config *protos.PostgresConfig) []string {
 	return args
 }
 
-func buildPsqlArgs(config *protos.PostgresConfig) []string {
+func buildPsqlArgs(config *protos.PostgresConfig, host string) []string {
 	port := config.Port
 	if port == 0 {
 		port = 5432
 	}
 
 	args := []string{
-		"-h", tlsHostOrHost(config),
+		"-h", host,
 		"-p", strconv.FormatUint(uint64(port), 10),
 		"-d", config.Database,
 		// Wrap the entire dump in a single transaction so partial failures
@@ -287,19 +349,34 @@ func buildPsqlArgs(config *protos.PostgresConfig) []string {
 	return args
 }
 
-func appendTLSEnv(ctx context.Context, cmd *exec.Cmd, config *protos.PostgresConfig) {
+func appendTLSEnv(ctx context.Context, cmd *exec.Cmd, config *protos.PostgresConfig, addr pgAddr) {
 	hasRootCA := config.RootCa != nil && *config.RootCa != ""
 	if !internal.PGMustUseTlsConnection(config) && !hasRootCA {
 		return
 	}
 
+	// libpq checks the certificate name against the -h value (addr.host).
+	// Mirror CreateTlsConfig: a cert presented on an IP connection may not
+	// carry a matching IP SAN, so we only do name verification for hostnames.
+	_, ipErr := netip.ParseAddr(addr.host)
+	hostIsIP := ipErr == nil
+
 	switch {
 	case config.SkipCertVerification:
 		cmd.Env = append(cmd.Env, "PGSSLMODE=require")
-	case hasRootCA:
+	case hasRootCA && hostIsIP:
 		cmd.Env = append(cmd.Env, "PGSSLMODE=verify-ca")
-	default:
+	case hasRootCA:
+		cmd.Env = append(cmd.Env, "PGSSLMODE=verify-full")
+	case hostIsIP:
+		// No CA and an IP host: libpq can't verify the chain without also
+		// checking the name (sslrootcert=system forces verify-full), so
+		// encryption only.
 		cmd.Env = append(cmd.Env, "PGSSLMODE=require")
+	default:
+		// No CA and a hostname: verify against the system trust store.
+		// sslrootcert=system needs libpq 16+.
+		cmd.Env = append(cmd.Env, "PGSSLMODE=verify-full", "PGSSLROOTCERT=system")
 	}
 
 	if hasRootCA && !config.SkipCertVerification {
@@ -316,9 +393,5 @@ func appendTLSEnv(ctx context.Context, cmd *exec.Cmd, config *protos.PostgresCon
 		}
 		tmpFile.Close()
 		cmd.Env = append(cmd.Env, "PGSSLROOTCERT="+tmpFile.Name())
-	}
-
-	if config.TlsHost != "" {
-		cmd.Env = append(cmd.Env, "PGHOSTADDR="+config.Host)
 	}
 }

--- a/flow/connectors/postgres/pgdump_schema_test.go
+++ b/flow/connectors/postgres/pgdump_schema_test.go
@@ -307,37 +307,11 @@ func TestBuildPgDumpArgs(t *testing.T) {
 				"-h", "localhost", "-p", "5432", "-d", "test",
 			},
 		},
-		{
-			name: "custom port no user",
-			config: &protos.PostgresConfig{
-				Host:     "remote",
-				Port:     6543,
-				Database: "prod",
-			},
-			wantArgs: []string{
-				"--schema-only", "--no-owner", "--no-privileges",
-				"-h", "remote", "-p", "6543", "-d", "prod",
-			},
-		},
-		{
-			name: "TlsHost overrides -h",
-			config: &protos.PostgresConfig{
-				Host:     "10.0.0.1",
-				Port:     5432,
-				Database: "mydb",
-				User:     "admin",
-				TlsHost:  "db.example.com",
-			},
-			wantArgs: []string{
-				"--schema-only", "--no-owner", "--no-privileges",
-				"-h", "db.example.com", "-p", "5432", "-d", "mydb", "-U", "admin",
-			},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildPgDumpArgs(tt.config)
+			got := buildPgDumpArgs(tt.config, tt.config.Host)
 			if !slices.Equal(got, tt.wantArgs) {
 				t.Fatalf("buildPgDumpArgs = %v, want %v", got, tt.wantArgs)
 			}
@@ -381,33 +355,110 @@ func TestBuildPsqlArgs(t *testing.T) {
 				"--quiet",
 			},
 		},
-		{
-			name: "TlsHost overrides -h",
-			config: &protos.PostgresConfig{
-				Host:     "10.0.0.1",
-				Port:     5432,
-				Database: "db",
-				User:     "u",
-				TlsHost:  "db.example.com",
-			},
-			wantArgs: []string{
-				"-h", "db.example.com", "-p", "5432", "-d", "db",
-				"--single-transaction",
-				"-v", "ON_ERROR_STOP=1",
-				"--quiet",
-				"-U", "u",
-			},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildPsqlArgs(tt.config)
+			got := buildPsqlArgs(tt.config, tt.config.Host)
 			if !slices.Equal(got, tt.wantArgs) {
 				t.Fatalf("buildPsqlArgs = %v, want %v", got, tt.wantArgs)
 			}
 		})
 	}
+}
+
+func TestResolvePgAddr(t *testing.T) {
+	ctx := t.Context()
+
+	tests := []struct {
+		name   string
+		config *protos.PostgresConfig
+		want   pgAddr
+	}{
+		{
+			name:   "TLS off ignores TlsHost",
+			config: &protos.PostgresConfig{Host: "10.0.0.1", TlsHost: "db.example.com"},
+			want:   pgAddr{host: "10.0.0.1"},
+		},
+		{
+			name:   "TLS on without TlsHost dials host directly",
+			config: &protos.PostgresConfig{Host: "db.example.com", RequireTls: true},
+			want:   pgAddr{host: "db.example.com"},
+		},
+		{
+			name:   "TlsHost with IP host splits identity and address",
+			config: &protos.PostgresConfig{Host: "10.0.0.1", TlsHost: "db.example.com", RequireTls: true},
+			want:   pgAddr{host: "db.example.com", hostaddr: "10.0.0.1"},
+		},
+		{
+			name:   "hosts are sanitized",
+			config: &protos.PostgresConfig{Host: "[2001:db8::1]", TlsHost: " db.example.com ", RequireTls: true},
+			want:   pgAddr{host: "db.example.com", hostaddr: "2001:db8::1"},
+		},
+		{
+			name: "root CA alone enables the TlsHost split",
+			config: &protos.PostgresConfig{
+				Host: "10.0.0.1", TlsHost: "db.example.com",
+				RootCa: strPtr("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
+			},
+			want: pgAddr{host: "db.example.com", hostaddr: "10.0.0.1"},
+		},
+		{
+			name:   "empty root CA treated as absent",
+			config: &protos.PostgresConfig{Host: "10.0.0.1", TlsHost: "db.example.com", RootCa: strPtr("")},
+			want:   pgAddr{host: "10.0.0.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolvePgAddr(ctx, tt.config)
+			if err != nil {
+				t.Fatalf("resolvePgAddr error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolvePgAddr = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("TlsHost with hostname host resolves via DNS", func(t *testing.T) {
+		var lookedUp string
+		orig := lookupHost
+		lookupHost = func(_ context.Context, host string) ([]string, error) {
+			lookedUp = host
+			return []string{"192.0.2.10", "192.0.2.11"}, nil
+		}
+		defer func() { lookupHost = orig }()
+
+		got, err := resolvePgAddr(ctx, &protos.PostgresConfig{
+			Host: "internal.db.local/junk", TlsHost: "db.example.com", RequireTls: true,
+		})
+		if err != nil {
+			t.Fatalf("resolvePgAddr error: %v", err)
+		}
+		if lookedUp != "internal.db.local" {
+			t.Errorf("lookupHost called with %q, want sanitized %q", lookedUp, "internal.db.local")
+		}
+		want := pgAddr{host: "db.example.com", hostaddr: "192.0.2.10"}
+		if got != want {
+			t.Fatalf("resolvePgAddr = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("DNS failure returns error", func(t *testing.T) {
+		orig := lookupHost
+		lookupHost = func(context.Context, string) ([]string, error) {
+			return nil, errors.New("no such host")
+		}
+		defer func() { lookupHost = orig }()
+
+		if _, err := resolvePgAddr(ctx, &protos.PostgresConfig{
+			Host: "internal.db.local", TlsHost: "db.example.com", RequireTls: true,
+		}); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
 }
 
 // envValue returns the last value for key in cmd.Env, or "" if absent.
@@ -424,91 +475,116 @@ func envValue(cmd *exec.Cmd, key string) string {
 func TestAppendTLSEnv(t *testing.T) {
 	ctx := t.Context()
 
+	testCA := strPtr("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----")
+
 	tests := []struct {
-		name            string
-		config          *protos.PostgresConfig
-		wantSSLMode     string
-		wantRootCertSet bool
+		name        string
+		config      *protos.PostgresConfig
+		addr        pgAddr
+		wantSSLMode string
+		// "" = unset, "file" = temp file with the CA PEM, "system" = literal
+		wantRootCert string
 	}{
 		{
 			name: "no TLS when not required and no root CA",
 			config: &protos.PostgresConfig{
-				Host: "h", Port: 5432, Database: "d",
+				Host: "db.example.com", Port: 5432, Database: "d",
 			},
+			addr:        pgAddr{host: "db.example.com"},
 			wantSSLMode: "",
-		},
-		{
-			name: "require TLS via RequireTls flag",
-			config: &protos.PostgresConfig{
-				Host: "h", Port: 5432, Database: "d",
-				RequireTls: true,
-			},
-			wantSSLMode: "require",
-		},
-		{
-			name: "require TLS via DisableTls=false",
-			config: &protos.PostgresConfig{
-				Host: "h", Port: 5432, Database: "d",
-				DisableTls: boolPtr(false),
-			},
-			wantSSLMode: "require",
 		},
 		{
 			name: "no TLS when DisableTls=true",
 			config: &protos.PostgresConfig{
-				Host: "h", Port: 5432, Database: "d",
+				Host: "db.example.com", Port: 5432, Database: "d",
 				DisableTls: boolPtr(true),
 			},
+			addr:        pgAddr{host: "db.example.com"},
 			wantSSLMode: "",
+		},
+		{
+			name: "system roots verify-full for hostname identity",
+			config: &protos.PostgresConfig{
+				Host: "db.example.com", Port: 5432, Database: "d",
+				RequireTls: true,
+			},
+			addr:         pgAddr{host: "db.example.com"},
+			wantSSLMode:  "verify-full",
+			wantRootCert: "system",
+		},
+		{
+			name: "system roots fall back to require for IP identity",
+			config: &protos.PostgresConfig{
+				Host: "10.0.0.1", Port: 5432, Database: "d",
+				RequireTls: true,
+			},
+			addr:        pgAddr{host: "10.0.0.1"},
+			wantSSLMode: "require",
 		},
 		{
 			name: "require with skip cert verification",
 			config: &protos.PostgresConfig{
-				Host: "h", Port: 5432, Database: "d",
+				Host: "db.example.com", Port: 5432, Database: "d",
 				RequireTls:           true,
 				SkipCertVerification: true,
 			},
+			addr:        pgAddr{host: "db.example.com"},
 			wantSSLMode: "require",
 		},
 		{
-			name: "verify-ca when root CA provided with RequireTls",
+			name: "skip cert verification takes precedence over root CA",
 			config: &protos.PostgresConfig{
-				Host: "h", Port: 5432, Database: "d",
-				RequireTls: true,
-				RootCa:     strPtr("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
-			},
-			wantSSLMode:     "verify-ca",
-			wantRootCertSet: true,
-		},
-		{
-			name: "root CA alone triggers TLS with verify-ca",
-			config: &protos.PostgresConfig{
-				Host: "h", Port: 5432, Database: "d",
-				RootCa: strPtr("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
-			},
-			wantSSLMode:     "verify-ca",
-			wantRootCertSet: true,
-		},
-		{
-			name: "skip cert verification with root CA uses require",
-			config: &protos.PostgresConfig{
-				Host: "h", Port: 5432, Database: "d",
+				Host: "db.example.com", Port: 5432, Database: "d",
 				RequireTls:           true,
 				SkipCertVerification: true,
-				RootCa:               strPtr("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
+				RootCa:               testCA,
 			},
-			wantSSLMode:     "require",
-			wantRootCertSet: false, // skip_cert_verification takes precedence, no sslrootcert needed
+			addr:        pgAddr{host: "db.example.com"},
+			wantSSLMode: "require",
+		},
+		{
+			name: "provided CA verify-full for hostname identity",
+			config: &protos.PostgresConfig{
+				Host: "db.example.com", Port: 5432, Database: "d",
+				RequireTls: true,
+				RootCa:     testCA,
+			},
+			addr:         pgAddr{host: "db.example.com"},
+			wantSSLMode:  "verify-full",
+			wantRootCert: "file",
+		},
+		{
+			name: "provided CA alone verify-ca for IP identity",
+			config: &protos.PostgresConfig{
+				Host: "10.0.0.1", Port: 5432, Database: "d",
+				RootCa: testCA,
+			},
+			addr:         pgAddr{host: "10.0.0.1"},
+			wantSSLMode:  "verify-ca",
+			wantRootCert: "file",
+		},
+		{
+			name: "identity comes from the endpoint, not config.Host",
+			config: &protos.PostgresConfig{
+				Host: "10.0.0.1", Port: 5432, Database: "d",
+				RequireTls: true,
+				TlsHost:    "db.example.com",
+				RootCa:     testCA,
+			},
+			addr:         pgAddr{host: "db.example.com", hostaddr: "10.0.0.1"},
+			wantSSLMode:  "verify-full",
+			wantRootCert: "file",
 		},
 		{
 			name: "empty root CA string is treated as absent",
 			config: &protos.PostgresConfig{
-				Host: "h", Port: 5432, Database: "d",
+				Host: "db.example.com", Port: 5432, Database: "d",
 				RequireTls: true,
 				RootCa:     strPtr(""),
 			},
-			wantSSLMode:     "require",
-			wantRootCertSet: false,
+			addr:         pgAddr{host: "db.example.com"},
+			wantSSLMode:  "verify-full",
+			wantRootCert: "system",
 		},
 	}
 
@@ -517,7 +593,7 @@ func TestAppendTLSEnv(t *testing.T) {
 			cmd := exec.CommandContext(ctx, "echo")
 			cmd.Env = os.Environ()
 
-			appendTLSEnv(ctx, cmd, tt.config)
+			appendTLSEnv(ctx, cmd, tt.config, tt.addr)
 
 			gotSSLMode := envValue(cmd, "PGSSLMODE")
 			if gotSSLMode != tt.wantSSLMode {
@@ -525,7 +601,16 @@ func TestAppendTLSEnv(t *testing.T) {
 			}
 
 			gotRootCert := envValue(cmd, "PGSSLROOTCERT")
-			if tt.wantRootCertSet {
+			switch tt.wantRootCert {
+			case "":
+				if gotRootCert != "" {
+					t.Errorf("expected PGSSLROOTCERT to be empty, got %q", gotRootCert)
+				}
+			case "system":
+				if gotRootCert != "system" {
+					t.Errorf("PGSSLROOTCERT = %q, want %q", gotRootCert, "system")
+				}
+			case "file":
 				if gotRootCert == "" {
 					t.Error("expected PGSSLROOTCERT to be set, but it was empty")
 				} else {
@@ -539,73 +624,9 @@ func TestAppendTLSEnv(t *testing.T) {
 					}
 					os.Remove(gotRootCert)
 				}
-			} else if gotRootCert != "" {
-				t.Errorf("expected PGSSLROOTCERT to be empty, got %q", gotRootCert)
 			}
 		})
 	}
-}
-
-func TestAppendTLSEnv_TlsHost(t *testing.T) {
-	ctx := t.Context()
-
-	t.Run("PGHOSTADDR set when TlsHost configured", func(t *testing.T) {
-		cmd := exec.CommandContext(ctx, "echo")
-		cmd.Env = os.Environ()
-
-		config := &protos.PostgresConfig{
-			Host: "10.0.0.1", Port: 5432, Database: "d",
-			RequireTls: true,
-			TlsHost:    "db.example.com",
-		}
-		appendTLSEnv(ctx, cmd, config)
-
-		if got := envValue(cmd, "PGHOSTADDR"); got != "10.0.0.1" {
-			t.Errorf("PGHOSTADDR = %q, want %q", got, "10.0.0.1")
-		}
-		if got := envValue(cmd, "PGSSLMODE"); got != "require" {
-			t.Errorf("PGSSLMODE = %q, want %q", got, "require")
-		}
-	})
-
-	t.Run("PGHOSTADDR not set when TlsHost empty", func(t *testing.T) {
-		cmd := exec.CommandContext(ctx, "echo")
-		cmd.Env = os.Environ()
-
-		config := &protos.PostgresConfig{
-			Host: "10.0.0.1", Port: 5432, Database: "d",
-			RequireTls: true,
-		}
-		appendTLSEnv(ctx, cmd, config)
-
-		if got := envValue(cmd, "PGHOSTADDR"); got != "" {
-			t.Errorf("PGHOSTADDR should be empty, got %q", got)
-		}
-	})
-
-	t.Run("PGHOSTADDR with root CA and TlsHost", func(t *testing.T) {
-		cmd := exec.CommandContext(ctx, "echo")
-		cmd.Env = os.Environ()
-
-		config := &protos.PostgresConfig{
-			Host: "10.0.0.1", Port: 5432, Database: "d",
-			RequireTls: true,
-			TlsHost:    "db.example.com",
-			RootCa:     strPtr("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
-		}
-		appendTLSEnv(ctx, cmd, config)
-
-		if got := envValue(cmd, "PGHOSTADDR"); got != "10.0.0.1" {
-			t.Errorf("PGHOSTADDR = %q, want %q", got, "10.0.0.1")
-		}
-		if got := envValue(cmd, "PGSSLMODE"); got != "verify-ca" {
-			t.Errorf("PGSSLMODE = %q, want %q", got, "verify-ca")
-		}
-		// clean up temp file
-		if f := envValue(cmd, "PGSSLROOTCERT"); f != "" {
-			os.Remove(f)
-		}
-	})
 }
 
 func TestIncompatibleLineRegex(t *testing.T) {

--- a/flow/internal/postgres.go
+++ b/flow/internal/postgres.go
@@ -24,10 +24,20 @@ func PGMustUseTlsConnection(pgConfig *protos.PostgresConfig) bool {
 	return pgConfig.RequireTls || (pgConfig.DisableTls != nil && !*pgConfig.DisableTls)
 }
 
-func GetPGConnectionString(pgConfig *protos.PostgresConfig, flowName string) string {
-	// strip path and query params that may be present in the host
-	host, _, _ := strings.Cut(pgConfig.Host, "/")
+// SanitizePGHost strips pasted connection-string junk (path/query suffixes,
+// whitespace, IPv6 brackets) from a stored host, yielding a bare hostname or IP.
+func SanitizePGHost(host string) string {
+	host = strings.TrimSpace(host)
+	host, _, _ = strings.Cut(host, "/")
 	host, _, _ = strings.Cut(host, "?")
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = host[1 : len(host)-1]
+	}
+	return host
+}
+
+func GetPGConnectionString(pgConfig *protos.PostgresConfig, flowName string) string {
+	host := SanitizePGHost(pgConfig.Host)
 
 	u := &url.URL{
 		Scheme: "postgres",

--- a/flow/internal/postgres_test.go
+++ b/flow/internal/postgres_test.go
@@ -74,6 +74,27 @@ func TestPGMustUseTlsConnection(t *testing.T) {
 	}
 }
 
+func TestSanitizePGHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{name: "plain hostname", host: "db.example.com", expected: "db.example.com"},
+		{name: "bracketed ipv6", host: "[2001:db8::1]", expected: "2001:db8::1"},
+		{name: "path junk", host: "some-host.azure.neon.tech/results", expected: "some-host.azure.neon.tech"},
+		{name: "query junk", host: "some-host.azure.neon.tech?sslmode=require", expected: "some-host.azure.neon.tech"},
+		{name: "surrounding whitespace", host: " db.example.com ", expected: "db.example.com"},
+		{name: "empty", host: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, SanitizePGHost(tt.host))
+		})
+	}
+}
+
 func TestGetPGConnectionString(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -128,18 +149,6 @@ func TestGetPGConnectionString(t *testing.T) {
 			name: "host with path and query params",
 			config: &protos.PostgresConfig{
 				Host:       "some-host.azure.neon.tech/results?sslmode=require&channel_binding=require",
-				Port:       5432,
-				Database:   "testdb",
-				User:       "testuser",
-				Password:   "password",
-				RequireTls: false,
-			},
-			expectedHost: "some-host.azure.neon.tech",
-		},
-		{
-			name: "host with query params only",
-			config: &protos.PostgresConfig{
-				Host:       "some-host.azure.neon.tech?sslmode=require&channel_binding=require",
 				Port:       5432,
 				Database:   "testdb",
 				User:       "testuser",


### PR DESCRIPTION
The pg_dump→psql schema-migration path shelled out to libpq CLIs but handled TLS host resolution differently from the native pgx path, so some peers that connect fine via pgx would fail cert verification (or silently skip it) during schema migration.

Rework it to mirror pgx's `ParseConfig/CreateTlsConfig` semantics for both source and destination:

- Dial Host and treat TlsHost purely as the SNI / cert-check name; when TlsHost is set under TLS, resolve Host to a numeric PGHOSTADDR ourselves (libpq's hostaddr only accepts IPs).
- Treat TlsHost as inert when TLS is off
- Choose PGSSLMODE by cert-check identity:
  - hostname:
    - with CA: `verify-full`
    - without CA: `verify-full` against system roots
  - IP:
    - with CA: `verify-ca`
    - without CA: `require`
  - skip_cert_verification always forces require.

Sanitize stored hosts (path/query junk, IPv6 brackets, whitespace) before handing them to the libpq CLIs.