### PR TITLE
Classify invalid destination table definitions to notify users

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -268,6 +268,8 @@ var (
 	// Creating the destination table failed because a user-provided part of its definition
 	// (e.g. a PARTITION BY/ORDER BY expression or a custom column type) is invalid,
 	// such as referencing a column that does not exist in the normalized table
+	// or has a wrong type (this is the only practical case where validation might not
+	// caught the issues with PARTITION BY expressions).
 	ErrorNotifyInvalidDestinationTableDefinition = ErrorClass{
 		Class: "NOTIFY_INVALID_DESTINATION_TABLE_DEFINITION", action: NotifyUser,
 	}

--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -265,6 +265,12 @@ var (
 	ErrorNotifyClickHousePermissionsError = ErrorClass{
 		Class: "NOTIFY_CLICKHOUSE_PERMISSIONS_ERROR", action: NotifyUser,
 	}
+	// Creating the destination table failed because a user-provided part of its definition
+	// (e.g. a PARTITION BY/ORDER BY expression or a custom column type) is invalid,
+	// such as referencing a column that does not exist in the normalized table
+	ErrorNotifyInvalidDestinationTableDefinition = ErrorClass{
+		Class: "NOTIFY_INVALID_DESTINATION_TABLE_DEFINITION", action: NotifyUser,
+	}
 	// Catch-all for misc ClickHouse errors
 	ErrorNotifyClickHouseError = ErrorClass{
 		Class: "NOTIFY_CLICKHOUSE_ERROR", action: NotifyUser,
@@ -1086,6 +1092,17 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			chproto.ErrUnknownElementOfEnum,
 			chproto.ErrNoCommonType,
 			chproto.ErrIllegalTypeOfArgument:
+			// during table creation these come from user-provided pieces of the table
+			// definition, e.g. PARTITION BY toYYYYMM(col) referencing a nonexistent column
+			if tableCreationErr, ok := errors.AsType[*exceptions.ClickHouseNormalizedTableCreationError](err); ok {
+				return ErrorNotifyInvalidDestinationTableDefinition, ErrorInfo{
+					Source: chErrorInfo.Source,
+					Code:   chErrorInfo.Code,
+					AdditionalAttributes: map[AdditionalErrorAttributeKey]string{
+						ErrorAttributeKeyTable: tableCreationErr.DestinationTable,
+					},
+				}
+			}
 			if _, ok := errors.AsType[*exceptions.ClickHouseQRepSyncError](err); ok {
 				// could cause false positives, but should be rare
 				return ErrorNotifyMVOrView, chErrorInfo

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -435,6 +435,26 @@ func TestClickHouseChaoticNormalizeErrorShouldBeNotifyMVNow(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestClickHouseCreateNormalizedTableUnknownIdentifierShouldBeNotifyInvalidDestinationTableDefinition(t *testing.T) {
+	err := &clickhouse.Exception{
+		Code: int32(chproto.ErrUnknownIdentifier),
+		Message: "Missing columns: 'created_at' while processing: 'toYYYYMM(created_at)', required columns: 'created_at', " +
+			"available columns: 'userId' 'currency' '_peerdb_is_deleted' '_peerdb_synced_at' '_peerdb_version' 'createdAt' 'updatedAt'",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("failed to setup normalized table bonuses: %w",
+			exceptions.NewClickHouseNormalizedTableCreationError(
+				fmt.Errorf("[clickhouse] error while creating destination ClickHouse table: %w", err), "bonuses")))
+	assert.Equal(t, ErrorNotifyInvalidDestinationTableDefinition, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceClickHouse,
+		Code:   strconv.Itoa(int(chproto.ErrUnknownIdentifier)),
+		AdditionalAttributes: map[AdditionalErrorAttributeKey]string{
+			ErrorAttributeKeyTable: "bonuses",
+		},
+	}, errInfo, "Unexpected error info")
+}
+
 func TestPostgresPublicationDoesNotExistErrorShouldBePublicationMissing(t *testing.T) {
 	// Simulate a publication does not exist error
 	err := &exceptions.PostgresWalError{

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -22,6 +22,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
 	peerdb_clickhouse "github.com/PeerDB-io/peerdb/flow/pkg/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
+	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
@@ -75,7 +76,10 @@ func (c *ClickHouseConnector) SetupNormalizedTable(
 
 	for _, sql := range normalizedTableCreateSQL {
 		if err := c.execWithLogging(ctx, sql); err != nil {
-			return false, fmt.Errorf("[clickhouse] error while creating destination ClickHouse table: %w", err)
+			return false, exceptions.NewClickHouseNormalizedTableCreationError(
+				fmt.Errorf("[clickhouse] error while creating destination ClickHouse table: %w", err),
+				destinationTableIdentifier,
+			)
 		}
 	}
 	return false, nil

--- a/flow/shared/exceptions/clickhouse.go
+++ b/flow/shared/exceptions/clickhouse.go
@@ -17,3 +17,16 @@ func (e *ClickHouseQRepSyncError) Error() string {
 func (e *ClickHouseQRepSyncError) Unwrap() error {
 	return e.error
 }
+
+type ClickHouseNormalizedTableCreationError struct {
+	error
+	DestinationTable string
+}
+
+func NewClickHouseNormalizedTableCreationError(err error, destinationTable string) *ClickHouseNormalizedTableCreationError {
+	return &ClickHouseNormalizedTableCreationError{err, destinationTable}
+}
+
+func (e *ClickHouseNormalizedTableCreationError) Unwrap() error {
+	return e.error
+}


### PR DESCRIPTION
## Problem

When a user configures a destination table option with an invalid expression — e.g. `PARTITION BY toYYYYMM(created_at)` where the normalized table's column is actually `createdAt` — `CreateNormalizedTable` fails on the `CREATE TABLE` statement with a ClickHouse semantic analysis error:

```
failed to setup normalized table <table>: [clickhouse] error while creating destination ClickHouse table:
code: 47, message: Missing columns: 'created_at' while processing: 'toYYYYMM(created_at)', ...
```

This currently lands in the unclassified `OTHER` error class, so it pages us instead of notifying the user, even though only the user can fix it (by correcting their destination table options).

#4599 added upfront validation for `PARTITION BY` expressions, but validation will never cover every failure mode, so errors that do slip through should still be classified and routed to the user.

## Change

- Wrap `CREATE TABLE` failures in `SetupNormalizedTable` in a new `ClickHouseNormalizedTableCreationError` exception carrying the destination table name.
- Add a new `NOTIFY_INVALID_DESTINATION_TABLE_DEFINITION` error class with the `notify_user` action.
- In the classifier, route ClickHouse semantic analysis errors (`UNKNOWN_IDENTIFIER`, `ILLEGAL_COLUMN`, `UNKNOWN_FUNCTION`, `TYPE_MISMATCH`, etc. — the existing case group) to the new class when they originate from normalized table creation, attaching the destination table as an additional error attribute. These codes can only be caused by user-provided pieces of the table definition (custom `PARTITION BY`/ordering key expressions, custom column types), since the rest of the statement is generated by PeerDB.
- Add a classifier test reproducing the production error shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)