### PR TITLE
fix(clickhouse): check for S3 grant before validating CH-bound pipe

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -77,8 +77,15 @@ func NewClickHouseConnector(
 func (c *ClickHouseConnector) ValidateCheck(ctx context.Context) error {
 	allowedDomains := internal.PeerDBClickHouseAllowedDomains()
 
+	var stagingAccessMethod string
+	switch c.staging.(type) {
+	case *s3StagingStore:
+		stagingAccessMethod = "S3"
+	case *gcsStagingStore:
+		stagingAccessMethod = "URL"
+	}
 	if err := peerdb_clickhouse.ValidateClickHousePeer(
-		ctx, c.logger, allowedDomains, c.Config.Host, c.database,
+		ctx, c.logger, allowedDomains, c.Config.Host, c.database, stagingAccessMethod,
 	); err != nil {
 		return err
 	}

--- a/flow/pkg/clickhouse/validation.go
+++ b/flow/pkg/clickhouse/validation.go
@@ -137,12 +137,49 @@ func ValidateClickHouseHost(ctx context.Context, chHost string, allowedDomainStr
 		chHost, strings.Join(allowedDomains, ","))
 }
 
+func validateBucketGrant(ctx context.Context, logger log.Logger, conn clickhouse.Conn, storageType string) error {
+	// First check under the new syntax, where the object to check is storageType.
+	// Eg. CHECK GRANT READ on S3. This also passes for users holding the legacy
+	// GRANT S3 ON *.* style grant, so a definitive failure here is final.
+	var grantExists bool
+	if err := QueryRow(ctx, logger, conn, "CHECK GRANT READ ON "+storageType).Scan(&grantExists); err != nil {
+		// Do not return an error on syntax error; this could mean we're on a
+		// CH version that does not support this syntax.
+		var chException *clickhouse.Exception
+		if !errors.As(err, &chException) || chproto.Error(chException.Code) != chproto.ErrSyntaxError {
+			return fmt.Errorf("failed to validate %s read grant: %w", storageType, err)
+		}
+		// NB: syntax error falls through to the next check.
+	} else if !grantExists {
+		return fmt.Errorf("failed to validate %s read grant: user lacks READ on %s (fix with GRANT READ ON %s)",
+			storageType, storageType, storageType)
+	} else {
+		// grantExists and no error.
+		return nil
+	}
+	// Now check under the old syntax, where the object to check is *.*.
+	// Eg. CHECK GRANT S3 on *.*.
+	if err := QueryRow(ctx, logger, conn, fmt.Sprintf("CHECK GRANT %s ON *.*", storageType)).Scan(&grantExists); err != nil {
+		// Similarly, do not error on syntax errors; instead, just log that the check failed.
+		var chException *clickhouse.Exception
+		if !errors.As(err, &chException) || chproto.Error(chException.Code) != chproto.ErrSyntaxError {
+			return fmt.Errorf("failed to validate %s read grant: %w", storageType, err)
+		}
+		logger.Warn("[clickhouse] CHECK GRANT not supported by this ClickHouse version, skipping grant validation")
+	} else if !grantExists {
+		return fmt.Errorf("failed to validate %s read grant: user lacks READ on %s (fix with GRANT %s on *.*)",
+			storageType, storageType, storageType)
+	}
+	return nil
+}
+
 func ValidateClickHousePeer(
 	ctx context.Context,
 	logger log.Logger,
 	allowedDomains string,
 	serviceHost string,
 	conn clickhouse.Conn,
+	stagingAccessMethod string,
 ) error {
 	// Hostname validation
 	if err := ValidateClickHouseHost(ctx, serviceHost, allowedDomains); err != nil {
@@ -211,6 +248,11 @@ func ValidateClickHousePeer(
 	// drop the table
 	if err := Exec(ctx, logger, conn, "DROP TABLE IF EXISTS "+validateDummyTableNameRenamed); err != nil {
 		return fmt.Errorf("failed to drop validation table %s: %w", validateDummyTableNameRenamed, err)
+	}
+
+	// Validate that ClickHouse has access permissions to the staging access bucket.
+	if err := validateBucketGrant(ctx, logger, conn, stagingAccessMethod); err != nil {
+		return err
 	}
 
 	return nil

--- a/flow/pkg/clickhouse/validation_test.go
+++ b/flow/pkg/clickhouse/validation_test.go
@@ -267,3 +267,108 @@ func TestBuildPartitionByValidationQuery(t *testing.T) {
 		require.Equal(t, "SELECT (id % 2) FROM (SELECT CAST(NULL, 'Dynamic') AS `id`) LIMIT 0", query)
 	})
 }
+
+func TestCheckBucketGrantInValidatePeer(t *testing.T) {
+	ctx := t.Context()
+	addr := fmt.Sprintf("%s:%d", testutil.ClickHouseTestHost(), testutil.ClickHouseTestPort())
+	adminConn, err := clickhouse.Open(&clickhouse.Options{Addr: []string{addr}})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, adminConn.Close())
+	})
+	require.NoError(t, adminConn.Ping(ctx))
+
+	database := "pkgch_" + strings.ToLower(common.RandomString(8))
+	require.NoError(t, adminConn.Exec(ctx, "CREATE DATABASE "+QuoteIdentifier(database)))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, adminConn.Exec(cleanupCtx, "DROP DATABASE IF EXISTS "+QuoteIdentifier(database)))
+	})
+
+	// Create a test user to test grants with.
+	username := "testuser_" + common.RandomString(8)
+	require.NoError(t, adminConn.Exec(ctx, fmt.Sprintf("CREATE USER %s IDENTIFIED BY 'testpassword';", username)))
+	require.NoError(t, adminConn.Exec(ctx, fmt.Sprintf("GRANT CREATE TABLE, ALTER TABLE, DROP TABLE, INSERT, SELECT ON "+
+		"%s.* TO %s;", QuoteIdentifier(database), username)))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, adminConn.Exec(cleanupCtx, "DROP USER IF EXISTS "+username))
+	})
+
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{addr},
+		Auth: clickhouse.Auth{
+			Database: database,
+			Username: username,
+			Password: "testpassword",
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+	require.NoError(t, conn.Ping(ctx))
+
+	// Staging bucket access methods to test.
+	testCases := []struct {
+		storageAccessType string
+		fineScopedSyntax  bool
+	}{
+		{
+			storageAccessType: "S3",
+			fineScopedSyntax:  false,
+		},
+		{
+			storageAccessType: "URL",
+			fineScopedSyntax:  false,
+		},
+		{
+			storageAccessType: "S3",
+			fineScopedSyntax:  true,
+		},
+		{
+			storageAccessType: "URL",
+			fineScopedSyntax:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		// Expect an error
+		err = ValidateClickHousePeer(
+			t.Context(),
+			nopLogger{},
+			"clickhouse.cloud",
+			"something.clickhouse.cloud",
+			conn,
+			tc.storageAccessType,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fmt.Sprintf("failed to validate %s read grant", tc.storageAccessType))
+
+		// Grant the appropriate privilege, then verify there's no error.
+		if tc.fineScopedSyntax {
+			require.NoError(t, adminConn.Exec(ctx, fmt.Sprintf("GRANT READ ON %s TO %s", tc.storageAccessType, username)))
+		} else {
+			require.NoError(t, adminConn.Exec(ctx, fmt.Sprintf("GRANT %s ON *.* TO %s", tc.storageAccessType, username)))
+		}
+
+		err = ValidateClickHousePeer(
+			t.Context(),
+			nopLogger{},
+			"clickhouse.cloud",
+			"something.clickhouse.cloud",
+			conn,
+			tc.storageAccessType,
+		)
+		require.NoError(t, err)
+
+		// Drop the grant that was added earlier.
+		if tc.fineScopedSyntax {
+			require.NoError(t, adminConn.Exec(ctx, fmt.Sprintf("REVOKE READ ON %s FROM %s", tc.storageAccessType, username)))
+		} else {
+			require.NoError(t, adminConn.Exec(ctx, fmt.Sprintf("REVOKE %s ON *.* FROM %s", tc.storageAccessType, username)))
+		}
+	}
+}


### PR DESCRIPTION
Previously, if custom roles were selected instead of all access when creating a pipe, we did not validate that the ClickHouse user can read from the staging S3 bucket in the final step of ingestion. This would result in pipes getting stuck in provisioning without an obvious user-facing error.

This change updates the ValidateClickHousePeer function to also run a CHECK GRANT that's as version-agnostic as possible, to confirm if the user can actually read from S3. If the CHECK GRANT returns a 0, we throw a validation failure.

