### PR TITLE
CI Code review: Use latest Opus models

### DIFF
--- a/.github/workflows/claude-code-review-dependencies-updates.yml
+++ b/.github/workflows/claude-code-review-dependencies-updates.yml
@@ -30,7 +30,7 @@ jobs:
           allowed_bots: 'renovate'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model claude-opus-4-6
+            --model opus
             --allowed-tools "Bash(gh:*),Bash(git fetch:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),WebFetch,WebSearch"
           prompt: |
             Review PR ${{ github.repository }}#${{ github.event.pull_request.number }}.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
           # so pass github_token only there; internal PRs keep the App token flow.
           github_token: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && github.token || '' }}
           claude_args: |
-            --model claude-opus-4-6
+            --model opus
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'


### PR DESCRIPTION
Before this PR Claude models for PR reviews were anchored to version 4.6 of Opus model.
This PR removes the version anchor, just selecting the model: Opus.

The effect at the time of writing this lines is that it will move to Opus 5, future runs will use the most recent model always.