### PR TITLE
feat(postgres): emit source replication log space metrics for Postgres

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -1373,6 +1373,7 @@ func (a *FlowableActivity) RecordSlotSizes(ctx context.Context) error {
 	slotMetricGauges.RestartToConfirmedMBGauge = a.OtelManager.Metrics.RestartToConfirmedMBGauge
 	slotMetricGauges.ConfirmedToCurrentMBGauge = a.OtelManager.Metrics.ConfirmedToCurrentMBGauge
 	slotMetricGauges.SafeWalSizeGauge = a.OtelManager.Metrics.SafeWalSizeGauge
+	slotMetricGauges.LogSpace = a.OtelManager.Metrics.LogSpace
 	slotMetricGauges.SlotActiveGauge = a.OtelManager.Metrics.SlotActiveGauge
 	slotMetricGauges.WalSenderStateGauge = a.OtelManager.Metrics.WalSenderStateGauge
 	slotMetricGauges.WalStatusGauge = a.OtelManager.Metrics.WalStatusGauge

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -479,6 +479,62 @@ func getSlotInfo(
 	return slotInfoRows, nil
 }
 
+type walRetentionSettings struct {
+	// Both are nil when the setting does not exist (PG<13) or does not impose a cap:
+	// max_slot_wal_keep_size defaults to -1 (unlimited) and wal_keep_size to 0.
+	MaxSlotWalKeepSizeBytes *int64
+	WalKeepSizeBytes        *int64
+}
+
+// LimitBytes mirrors how Postgres derives safe_wal_size: the cap only exists when
+// max_slot_wal_keep_size is non-negative, and wal_keep_size can raise it. Compare
+// `failSeg = targetSeg + Max(slotKeepSegs, keepSegs) + 1` in pg_get_replication_slots. Postgres
+// rounds both settings down to whole WAL segments and adds one, so this is accurate to within a
+// segment, which is immaterial at the cap sizes we recommend.
+func (s walRetentionSettings) LimitBytes() *int64 {
+	if s.MaxSlotWalKeepSizeBytes == nil {
+		return nil
+	}
+	limit := *s.MaxSlotWalKeepSizeBytes
+	if s.WalKeepSizeBytes != nil && *s.WalKeepSizeBytes > limit {
+		limit = *s.WalKeepSizeBytes
+	}
+	return &limit
+}
+
+// getWalRetentionSettings reads the settings bounding how much WAL a slot may retain. Both are
+// readable by any role, and pg_settings is an in-memory scan.
+func getWalRetentionSettings(ctx context.Context, conn *pgx.Conn) (walRetentionSettings, error) {
+	rows, err := conn.Query(ctx, `SELECT
+			name,
+			CASE WHEN setting::bigint < 0 THEN NULL
+				ELSE pg_size_bytes(setting || COALESCE(unit, '')) END
+		FROM pg_settings WHERE name IN ('max_slot_wal_keep_size', 'wal_keep_size')`)
+	if err != nil {
+		return walRetentionSettings{}, fmt.Errorf("failed to read WAL retention settings: %w", err)
+	}
+	defer rows.Close()
+
+	var settings walRetentionSettings
+	for rows.Next() {
+		var name string
+		var bytes *int64
+		if err := rows.Scan(&name, &bytes); err != nil {
+			return walRetentionSettings{}, err
+		}
+		switch name {
+		case "max_slot_wal_keep_size":
+			settings.MaxSlotWalKeepSizeBytes = bytes
+		case "wal_keep_size":
+			settings.WalKeepSizeBytes = bytes
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return walRetentionSettings{}, err
+	}
+	return settings, nil
+}
+
 // GetSlotInfo gets the information about the replication slot size and LSNs.
 // If slotName is non-empty, only that slot is returned.
 // If slotName is empty and peerdbManagedOnly is false, all slots in the database are returned.

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -486,11 +486,8 @@ type walRetentionSettings struct {
 	WalKeepSizeBytes        *int64
 }
 
-// LimitBytes mirrors how Postgres derives safe_wal_size: the cap only exists when
-// max_slot_wal_keep_size is non-negative, and wal_keep_size can raise it. Compare
-// `failSeg = targetSeg + Max(slotKeepSegs, keepSegs) + 1` in pg_get_replication_slots. Postgres
-// rounds both settings down to whole WAL segments and adds one, so this is accurate to within a
-// segment, which is immaterial at the cap sizes we recommend.
+// LimitBytes returns the effective WAL retention cap used to normalize safe_wal_size.
+// It is nil when max_slot_wal_keep_size is unlimited or unavailable; wal_keep_size can raise it.
 func (s walRetentionSettings) LimitBytes() *int64 {
 	if s.MaxSlotWalKeepSizeBytes == nil {
 		return nil

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -932,6 +932,21 @@ func (c *PostgresConnector) HandleSlotInfo(
 		slotMetricGauges.SafeWalSizeGauge.Record(ctx, *slotInfo.SafeWalSize, attributeSet)
 	}
 
+	// safe_wal_size alone cannot be thresholded at a percentage, and it is NULL whenever
+	// max_slot_wal_keep_size is -1, so emit the retained bytes against the configured cap.
+	if currentLSN < restartLSN {
+		// Either LSN failing to parse above leaves it at zero, so don't report a negative size.
+		logger.Warn("current LSN precedes restart LSN, skipping log space metrics",
+			slog.String("currentLSN", slotInfo.CurrentLSN), slog.String("restartLSN", slotInfo.RestartLSN))
+	} else if walRetention, err := getWalRetentionSettings(ctx, c.conn); err != nil {
+		logger.Warn("error reading WAL retention settings", slog.Any("error", err))
+	} else {
+		slotMetricGauges.LogSpace.Record(ctx, otel_metrics.LogSpaceInfo{
+			UsedBytes:  int64(currentLSN) - int64(restartLSN),
+			LimitBytes: walRetention.LimitBytes(),
+		}, attributeSet)
+	}
+
 	var activeValue int64
 	if slotInfo.Active {
 		activeValue = 1

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -935,17 +935,23 @@ func (c *PostgresConnector) HandleSlotInfo(
 	// safe_wal_size is the remaining safe WAL headroom. Normalize it by Postgres's effective
 	// retention limit so alerts can threshold it as a percentage. It is NULL whenever
 	// max_slot_wal_keep_size is -1.
+	var usedBytes *int64
 	if currentLSN < restartLSN {
 		// Either LSN failing to parse above leaves it at zero, so don't report a negative size.
 		logger.Warn("current LSN precedes restart LSN, skipping log space metrics",
 			slog.String("currentLSN", slotInfo.CurrentLSN), slog.String("restartLSN", slotInfo.RestartLSN))
-	} else if walRetention, err := getWalRetentionSettings(ctx, c.conn); err != nil {
+	} else {
+		value := int64(currentLSN) - int64(restartLSN)
+		usedBytes = &value
+	}
+
+	if walRetention, err := getWalRetentionSettings(ctx, c.conn); err != nil {
 		logger.Warn("error reading WAL retention settings", slog.Any("error", err))
 	} else {
 		slotMetricGauges.LogSpace.Record(ctx, otel_metrics.LogSpaceInfo{
-			UsedBytes:  int64(currentLSN) - int64(restartLSN),
 			LimitBytes: walRetention.LimitBytes(),
 			SafeBytes:  slotInfo.SafeWalSize,
+			UsedBytes:  usedBytes,
 		}, attributeSet)
 	}
 

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -902,9 +902,9 @@ func (c *PostgresConnector) HandleSlotInfo(
 	slotMetricGauges.RestartToConfirmedMBGauge.Record(ctx, float64(slotInfo.RestartToConfirmedMb), attributeSet)
 	slotMetricGauges.ConfirmedToCurrentMBGauge.Record(ctx, float64(slotInfo.ConfirmedToCurrentMb), attributeSet)
 
-	currentLSN, err := pglogrepl.ParseLSN(slotInfo.CurrentLSN)
-	if err != nil {
-		logger.Warn("error parsing current LSN", slog.Any("error", err))
+	currentLSN, currentLSNErr := pglogrepl.ParseLSN(slotInfo.CurrentLSN)
+	if currentLSNErr != nil {
+		logger.Warn("error parsing current LSN", slog.Any("error", currentLSNErr))
 	}
 	slotMetricGauges.CurrentWalLSNGauge.Record(ctx, int64(currentLSN), attributeSet)
 
@@ -922,9 +922,9 @@ func (c *PostgresConnector) HandleSlotInfo(
 	}
 	slotMetricGauges.ConfirmedFlushLSNGauge.Record(ctx, int64(confirmedFlushLSN), attributeSet)
 
-	restartLSN, err := pglogrepl.ParseLSN(slotInfo.RestartLSN)
-	if err != nil {
-		logger.Warn("error parsing restart LSN", slog.Any("error", err))
+	restartLSN, restartLSNErr := pglogrepl.ParseLSN(slotInfo.RestartLSN)
+	if restartLSNErr != nil {
+		logger.Warn("error parsing restart LSN", slog.Any("error", restartLSNErr))
 	}
 	slotMetricGauges.RestartLSNGauge.Record(ctx, int64(restartLSN), attributeSet)
 
@@ -933,8 +933,11 @@ func (c *PostgresConnector) HandleSlotInfo(
 	}
 
 	var usedBytes *int64
-	if currentLSN < restartLSN {
-		logger.Warn("current LSN precedes restart LSN, skipping log space metrics",
+	if currentLSNErr != nil || restartLSNErr != nil {
+		logger.Warn("current or restart LSN couldn't be parsed, skipping used bytes metric",
+			slog.String("currentLSN", slotInfo.CurrentLSN), slog.String("restartLSN", slotInfo.RestartLSN))
+	} else if currentLSN < restartLSN {
+		logger.Warn("current LSN precedes restart LSN, skipping used bytes metric",
 			slog.String("currentLSN", slotInfo.CurrentLSN), slog.String("restartLSN", slotInfo.RestartLSN))
 	} else {
 		value := int64(currentLSN) - int64(restartLSN)

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -932,8 +932,9 @@ func (c *PostgresConnector) HandleSlotInfo(
 		slotMetricGauges.SafeWalSizeGauge.Record(ctx, *slotInfo.SafeWalSize, attributeSet)
 	}
 
-	// safe_wal_size alone cannot be thresholded at a percentage, and it is NULL whenever
-	// max_slot_wal_keep_size is -1, so emit the retained bytes against the configured cap.
+	// safe_wal_size is the remaining safe WAL headroom. Normalize it by Postgres's effective
+	// retention limit so alerts can threshold it as a percentage. It is NULL whenever
+	// max_slot_wal_keep_size is -1.
 	if currentLSN < restartLSN {
 		// Either LSN failing to parse above leaves it at zero, so don't report a negative size.
 		logger.Warn("current LSN precedes restart LSN, skipping log space metrics",
@@ -944,6 +945,7 @@ func (c *PostgresConnector) HandleSlotInfo(
 		slotMetricGauges.LogSpace.Record(ctx, otel_metrics.LogSpaceInfo{
 			UsedBytes:  int64(currentLSN) - int64(restartLSN),
 			LimitBytes: walRetention.LimitBytes(),
+			SafeBytes:  slotInfo.SafeWalSize,
 		}, attributeSet)
 	}
 

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -932,12 +932,8 @@ func (c *PostgresConnector) HandleSlotInfo(
 		slotMetricGauges.SafeWalSizeGauge.Record(ctx, *slotInfo.SafeWalSize, attributeSet)
 	}
 
-	// safe_wal_size is the remaining safe WAL headroom. Normalize it by Postgres's effective
-	// retention limit so alerts can threshold it as a percentage. It is NULL whenever
-	// max_slot_wal_keep_size is -1.
 	var usedBytes *int64
 	if currentLSN < restartLSN {
-		// Either LSN failing to parse above leaves it at zero, so don't report a negative size.
 		logger.Warn("current LSN precedes restart LSN, skipping log space metrics",
 			slog.String("currentLSN", slotInfo.CurrentLSN), slog.String("restartLSN", slotInfo.RestartLSN))
 	} else {

--- a/flow/connectors/postgres/wal_retention_test.go
+++ b/flow/connectors/postgres/wal_retention_test.go
@@ -1,0 +1,56 @@
+package connpostgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalRetentionSettingsLimitBytes(t *testing.T) {
+	t.Parallel()
+	oneGB := int64(1024 * 1024 * 1024)
+	tenGB := 10 * oneGB
+	for _, tc := range []struct {
+		name     string
+		settings walRetentionSettings
+		expected *int64
+	}{
+		{
+			name:     "no settings, as on PG<13",
+			settings: walRetentionSettings{},
+			expected: nil,
+		},
+		{
+			name: "max_slot_wal_keep_size unlimited, the default, imposes no cap even with wal_keep_size set",
+			// wal_keep_size is a retention floor, not a cap, so on its own it bounds nothing.
+			settings: walRetentionSettings{WalKeepSizeBytes: &oneGB},
+			expected: nil,
+		},
+		{
+			name:     "max_slot_wal_keep_size alone",
+			settings: walRetentionSettings{MaxSlotWalKeepSizeBytes: &tenGB},
+			expected: &tenGB,
+		},
+		{
+			name:     "wal_keep_size below max_slot_wal_keep_size",
+			settings: walRetentionSettings{MaxSlotWalKeepSizeBytes: &tenGB, WalKeepSizeBytes: &oneGB},
+			expected: &tenGB,
+		},
+		{
+			name:     "wal_keep_size raises the cap above max_slot_wal_keep_size",
+			settings: walRetentionSettings{MaxSlotWalKeepSizeBytes: &oneGB, WalKeepSizeBytes: &tenGB},
+			expected: &tenGB,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tc.settings.LimitBytes()
+			if tc.expected == nil {
+				require.Nil(t, actual)
+				return
+			}
+			require.NotNil(t, actual)
+			require.Equal(t, *tc.expected, *actual)
+		})
+	}
+}

--- a/flow/otel_metrics/log_space.go
+++ b/flow/otel_metrics/log_space.go
@@ -1,0 +1,30 @@
+package otel_metrics
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+// LogSpaceInfo describes the WAL retained by a Postgres replication slot against the configured
+// retention limit.
+type LogSpaceInfo struct {
+	// nil when max_slot_wal_keep_size is unlimited or unavailable
+	LimitBytes *int64
+	UsedBytes  int64
+}
+
+type LogSpaceGauges struct {
+	UsedGauge      metric.Int64Gauge
+	LimitGauge     metric.Int64Gauge
+	UsedRatioGauge metric.Float64Gauge
+}
+
+func (g LogSpaceGauges) Record(ctx context.Context, info LogSpaceInfo, attributeSet metric.RecordOption) {
+	g.UsedGauge.Record(ctx, info.UsedBytes, attributeSet)
+	if info.LimitBytes == nil || *info.LimitBytes <= 0 {
+		return
+	}
+	g.LimitGauge.Record(ctx, *info.LimitBytes, attributeSet)
+	g.UsedRatioGauge.Record(ctx, float64(info.UsedBytes)/float64(*info.LimitBytes), attributeSet)
+}

--- a/flow/otel_metrics/log_space.go
+++ b/flow/otel_metrics/log_space.go
@@ -11,13 +11,15 @@ import (
 type LogSpaceInfo struct {
 	// nil when max_slot_wal_keep_size is unlimited or unavailable
 	LimitBytes *int64
-	UsedBytes  int64
+	// nil when safe_wal_size is unavailable or max_slot_wal_keep_size is unlimited
+	SafeBytes *int64
+	UsedBytes int64
 }
 
 type LogSpaceGauges struct {
 	UsedGauge      metric.Int64Gauge
 	LimitGauge     metric.Int64Gauge
-	UsedRatioGauge metric.Float64Gauge
+	SafeRatioGauge metric.Float64Gauge
 }
 
 func (g LogSpaceGauges) Record(ctx context.Context, info LogSpaceInfo, attributeSet metric.RecordOption) {
@@ -26,5 +28,7 @@ func (g LogSpaceGauges) Record(ctx context.Context, info LogSpaceInfo, attribute
 		return
 	}
 	g.LimitGauge.Record(ctx, *info.LimitBytes, attributeSet)
-	g.UsedRatioGauge.Record(ctx, float64(info.UsedBytes)/float64(*info.LimitBytes), attributeSet)
+	if info.SafeBytes != nil {
+		g.SafeRatioGauge.Record(ctx, float64(*info.SafeBytes)/float64(*info.LimitBytes), attributeSet)
+	}
 }

--- a/flow/otel_metrics/log_space.go
+++ b/flow/otel_metrics/log_space.go
@@ -13,7 +13,8 @@ type LogSpaceInfo struct {
 	LimitBytes *int64
 	// nil when safe_wal_size is unavailable or max_slot_wal_keep_size is unlimited
 	SafeBytes *int64
-	UsedBytes int64
+	// nil when the current and restart LSNs cannot be safely compared
+	UsedBytes *int64
 }
 
 type LogSpaceGauges struct {
@@ -23,7 +24,9 @@ type LogSpaceGauges struct {
 }
 
 func (g LogSpaceGauges) Record(ctx context.Context, info LogSpaceInfo, attributeSet metric.RecordOption) {
-	g.UsedGauge.Record(ctx, info.UsedBytes, attributeSet)
+	if info.UsedBytes != nil {
+		g.UsedGauge.Record(ctx, *info.UsedBytes, attributeSet)
+	}
 	if info.LimitBytes == nil || *info.LimitBytes <= 0 {
 		return
 	}

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -43,6 +43,9 @@ const (
 	ConfirmedToCurrentMBGaugeName        = "confirmed_to_current_lsn"
 	WalStatusGaugeName                   = "wal_status"
 	SafeWalSizeGaugeName                 = "safe_wal_size"
+	SourceLogSpaceUsedGaugeName          = "source_log_space_used"
+	SourceLogSpaceLimitGaugeName         = "source_log_space_limit"
+	SourceLogSpaceUsedRatioGaugeName     = "source_log_space_used_ratio"
 	SlotActiveGaugeName                  = "slot_active"
 	WalSenderStateGaugeName              = "walsender_state"
 	LogicalDecodingWorkMemGaugeName      = "logical_decoding_work_mem"
@@ -105,6 +108,7 @@ type Metrics struct {
 	ConfirmedToCurrentMBGauge        metric.Float64Gauge
 	WalStatusGauge                   metric.Int64Gauge
 	SafeWalSizeGauge                 metric.Int64Gauge
+	LogSpace                         LogSpaceGauges
 	SlotActiveGauge                  metric.Int64Gauge
 	WalSenderStateGauge              metric.Int64Gauge
 	StatsResetGauge                  metric.Int64Gauge
@@ -160,6 +164,7 @@ type SlotMetricGauges struct {
 	ConfirmedToCurrentMBGauge       metric.Float64Gauge
 	WalStatusGauge                  metric.Int64Gauge
 	SafeWalSizeGauge                metric.Int64Gauge
+	LogSpace                        LogSpaceGauges
 	SlotActiveGauge                 metric.Int64Gauge
 	WalSenderStateGauge             metric.Int64Gauge
 	StatsResetGauge                 metric.Int64Gauge
@@ -347,6 +352,31 @@ func (om *OtelManager) setupMetrics(ctx context.Context) error {
 	if om.Metrics.SafeWalSizeGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(SafeWalSizeGaugeName),
 		metric.WithUnit("By"),
 		metric.WithDescription("Slot's safe_wal_size field (available PG13+)"),
+	); err != nil {
+		return err
+	}
+
+	if om.Metrics.LogSpace.UsedGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(SourceLogSpaceUsedGaugeName),
+		metric.WithUnit("By"),
+		metric.WithDescription("WAL bytes retained by a Postgres replication slot"),
+	); err != nil {
+		return err
+	}
+
+	// Only emitted when the source enforces a cap, so its absence means "unbounded".
+	if om.Metrics.LogSpace.LimitGauge, err = om.GetOrInitInt64Gauge(BuildMetricName(SourceLogSpaceLimitGaugeName),
+		metric.WithUnit("By"),
+		metric.WithDescription("Postgres replication slot WAL retention limit derived from "+
+			"max(max_slot_wal_keep_size, wal_keep_size)"),
+	); err != nil {
+		return err
+	}
+
+	if om.Metrics.LogSpace.UsedRatioGauge, err = om.GetOrInitFloat64Gauge(
+		BuildMetricName(SourceLogSpaceUsedRatioGaugeName),
+		metric.WithUnit("1"),
+		metric.WithDescription("Fraction of a Postgres replication slot's WAL retention limit in use; "+
+			"only emitted when a limit is configured and can exceed 1 once breached"),
 	); err != nil {
 		return err
 	}

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -45,7 +45,7 @@ const (
 	SafeWalSizeGaugeName                 = "safe_wal_size"
 	SourceLogSpaceUsedGaugeName          = "source_log_space_used"
 	SourceLogSpaceLimitGaugeName         = "source_log_space_limit"
-	SourceLogSpaceUsedRatioGaugeName     = "source_log_space_used_ratio"
+	SourceLogSpaceSafeRatioGaugeName     = "source_log_space_safe_ratio"
 	SlotActiveGaugeName                  = "slot_active"
 	WalSenderStateGaugeName              = "walsender_state"
 	LogicalDecodingWorkMemGaugeName      = "logical_decoding_work_mem"
@@ -372,11 +372,11 @@ func (om *OtelManager) setupMetrics(ctx context.Context) error {
 		return err
 	}
 
-	if om.Metrics.LogSpace.UsedRatioGauge, err = om.GetOrInitFloat64Gauge(
-		BuildMetricName(SourceLogSpaceUsedRatioGaugeName),
+	if om.Metrics.LogSpace.SafeRatioGauge, err = om.GetOrInitFloat64Gauge(
+		BuildMetricName(SourceLogSpaceSafeRatioGaugeName),
 		metric.WithUnit("1"),
-		metric.WithDescription("Fraction of a Postgres replication slot's WAL retention limit in use; "+
-			"only emitted when a limit is configured and can exceed 1 once breached"),
+		metric.WithDescription("Fraction of a Postgres replication slot's effective WAL retention limit "+
+			"that remains safe; only emitted when safe_wal_size and a finite limit are available"),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Adds PostgreSQL replication-slot WAL-capacity metrics so we can alert before a source invalidates a slot because retained WAL has reached its configured limit.

- `source_log_space_used`: WAL bytes retained for the slot.
- `source_log_space_limit`: effective retention cap, derived from `max_slot_wal_keep_size` and `wal_keep_size`; omitted when retention is unbounded.
- `source_log_space_safe_ratio`: remaining safe WAL headroom divided by the effective retention cap.

`safe_wal_size` is already emitted as a raw byte metric. The normalized safe ratio makes alerting straightforward: alert when `source_log_space_safe_ratio < 0.1`. A value at or below zero means the configured limit has been reached or exceeded.

The safe ratio is emitted only when PostgreSQL provides `safe_wal_size` and a finite retention cap is configured (PostgreSQL 13+). Its absence means the source has no finite slot-WAL cap or does not support `safe_wal_size`, not that the slot is healthy.

## Validation

- `go test ./otel_metrics`
- `go test ./connectors/postgres -run '^TestWalRetentionSettingsLimitBytes$' -count=1`