### PR TITLE
fix: Add error detail for validation errors in ValidatePeer

### DIFF
--- a/flow/cmd/api_error.go
+++ b/flow/cmd/api_error.go
@@ -121,6 +121,13 @@ func NewSourceTableMissingErrorInfo() *rpc.ErrorInfo {
 	}
 }
 
+func NewSourceValidationFailedErrorInfo() *rpc.ErrorInfo {
+	return &rpc.ErrorInfo{
+		Reason: common.ErrorInfoReasonSourceValidationFailed,
+		Domain: common.ErrorInfoDomain,
+	}
+}
+
 // NewSourceTableMissingPreconditionFailure builds the per-table breakdown detail
 // that accompanies the SOURCE_TABLE_MISSING ErrorInfo on FailedPrecondition.
 func NewSourceTableMissingPreconditionFailure(tables []common.QualifiedTable) protoadapt.MessageV1 {

--- a/flow/cmd/validate_peer.go
+++ b/flow/cmd/validate_peer.go
@@ -43,7 +43,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 		return &protos.ValidatePeerResponse{
 			Status:  protos.ValidatePeerStatus_INVALID,
 			Message: displayErr.Error(),
-		}, NewFailedPreconditionApiError(displayErr)
+		}, NewFailedPreconditionApiError(displayErr, NewSourceValidationFailedErrorInfo())
 	}
 	defer conn.Close()
 
@@ -53,7 +53,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 			return &protos.ValidatePeerResponse{
 				Status:  protos.ValidatePeerStatus_INVALID,
 				Message: displayErr.Error(),
-			}, NewFailedPreconditionApiError(displayErr)
+			}, NewFailedPreconditionApiError(displayErr, NewSourceValidationFailedErrorInfo())
 		}
 	}
 
@@ -62,7 +62,7 @@ func (h *FlowRequestHandler) ValidatePeer(
 		return &protos.ValidatePeerResponse{
 			Status:  protos.ValidatePeerStatus_INVALID,
 			Message: displayErr.Error(),
-		}, NewFailedPreconditionApiError(displayErr)
+		}, NewFailedPreconditionApiError(displayErr, NewSourceValidationFailedErrorInfo())
 	}
 
 	return &protos.ValidatePeerResponse{

--- a/flow/pkg/common/errors.go
+++ b/flow/pkg/common/errors.go
@@ -12,6 +12,7 @@ const (
 	ErrorInfoReasonMirror                 = "MIRROR"
 	ErrorInfoReasonSourceTableMissing     = "SOURCE_TABLE_MISSING"
 	ErrorInfoReasonTablesNotInPublication = "TABLES_NOT_IN_PUBLICATION"
+	ErrorInfoReasonSourceValidationFailed = "SOURCE_VALIDATION_FAILED"
 
 	ErrorMetadataOffendingField = "offendingField"
 	ErrorMetadataPublication    = "publication"


### PR DESCRIPTION
Previously, the FailedPreconditionApiError in ValidatePeer() had no error details, making it harder to be able to tease this error apart from the caller. This change adds a new error detail,
ErrorInfoReasonSourceValidationFailed, that allows callers to be able to distinguish validation failures from calls to this method.