### PR TITLE
fix(mysql): avoid double-counting fetched bytes

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -847,7 +847,6 @@ func (c *MySqlConnector) PullRecords(
 					c.logger.Error(e.Error())
 					return e
 				}
-				otelManager.Metrics.FetchedBytesCounter.Add(ctx, int64(len(event.RawData)))
 				fetchedBytes.Add(int64(len(event.RawData)))
 				totalFetchedBytes.Add(int64(len(event.RawData)))
 				inTx = true


### PR DESCRIPTION
## Summary

- remove the immediate MySQL fetched-bytes counter increment
- retain the atomic accumulator and its periodic/deferred flush
- align MySQL CDC metric reporting with the PostgreSQL buffered implementation

Each qualifying MySQL row event was previously added once immediately and once again when the accumulator flushed, inflating fetched_bytes by approximately 2x.

## Tests

- go test ./connectors/mysql -run ^TestCheckTableMapForCompressedColumns$ -count=1
- go test ./otel_metrics -count=1