### PR TITLE
feat(pg-pg): add notification for constraint violation

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -193,6 +193,9 @@ var (
 	ErrorNotifyInvalidEnumValue = ErrorClass{
 		Class: "NOTIFY_INVALID_ENUM_VALUE", action: NotifyUser,
 	}
+	ErrorNotifyConstraintViolation = ErrorClass{
+		Class: "NOTIFY_CONSTRAINT_VIOLATION", action: NotifyUser,
+	}
 	ErrorNotifyInvalidSynchronizedStandbySlots = ErrorClass{
 		Class: "NOTIFY_INVALID_SYNCHRONIZED_STANDBY_SLOTS", action: NotifyUser,
 	}
@@ -729,6 +732,9 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			if strings.Contains(pgErr.Message, "invalid input value for enum") {
 				return ErrorNotifyInvalidEnumValue, pgErrorInfo
 			}
+
+		case pgerrcode.CheckViolation, pgerrcode.UniqueViolation:
+			return ErrorNotifyConstraintViolation, pgErrorInfo
 
 		case pgerrcode.TooManyConnections, // Maybe we can return something else?
 			pgerrcode.ConnectionException,

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -516,6 +516,36 @@ func TestPostgresInvalidEnumValueOnNormalize(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresCheckConstraintViolationOnNormalize(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.CheckViolation,
+		Message:  `new row for relation "products" violates check constraint "product_kind_constraint"`,
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("failed to normalize records: error executing normalize statement for table public.products: %w", err))
+	assert.Equal(t, ErrorNotifyConstraintViolation, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.CheckViolation,
+	}, errInfo, "Unexpected error info")
+}
+
+func TestPostgresUniqueViolationOnNormalize(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.UniqueViolation,
+		Message:  `duplicate key value violates unique constraint "products_pkey"`,
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("failed to normalize records: error executing normalize statement for table public.products: %w", err))
+	assert.Equal(t, ErrorNotifyConstraintViolation, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.UniqueViolation,
+	}, errInfo, "Unexpected error info")
+}
+
 func TestPostgresLogicalDecodingNotSupportedOnStandby(t *testing.T) {
 	err := &pgconn.PgError{
 		Severity: "ERROR",


### PR DESCRIPTION
We need to notify users to drop and recreate constraints for PG - PG mirrors if they cause constraint violations during normalize