### PR TITLE
Match all variants of the logical decoding on standby error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -686,7 +686,11 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorOther, pgErrorInfo
 
 		case pgerrcode.ObjectNotInPrerequisiteState:
-			if pgErr.Message == "logical decoding on standby requires \"wal_level\" >= \"logical\" on the primary" {
+			// the GUC names in this message are unquoted on PG16, quoted from PG17 on, and renamed to
+			// "effective_wal_level" on PG19, so only the prefix is stable across versions
+			// https://github.com/postgres/postgres/blob/REL_16_10/src/backend/replication/logical/logical.c#L140
+			// https://github.com/postgres/postgres/blob/REL_17_6/src/backend/replication/logical/logical.c#L143
+			if strings.Contains(pgErr.Message, "logical decoding on standby requires") {
 				return ErrorNotifyReplicationStandbySetup, pgErrorInfo
 			}
 

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	peerdb_clickhouse "github.com/PeerDB-io/peerdb/flow/pkg/clickhouse"
+	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
 )
 
@@ -528,6 +529,29 @@ func TestPostgresLogicalDecodingNotSupportedOnStandby(t *testing.T) {
 		Source: ErrorSourcePostgres,
 		Code:   pgerrcode.FeatureNotSupported,
 	}, errInfo)
+}
+
+func TestPostgresLogicalDecodingOnStandbyRequiresWalLevel(t *testing.T) {
+	for name, message := range map[string]string{
+		"pg16": "logical decoding on standby requires wal_level >= logical on the primary",
+		"pg17": `logical decoding on standby requires "wal_level" >= "logical" on the primary`,
+		"pg19": `logical decoding on standby requires "effective_wal_level" >= "logical" on the primary`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := &pgconn.PgError{
+				Severity: "ERROR",
+				Code:     pgerrcode.ObjectNotInPrerequisiteState,
+				Message:  message,
+			}
+			errorClass, errInfo := GetErrorClass(t.Context(),
+				shared.WrapError("slot error", fmt.Errorf("[slot] error creating replication slot: %w", err)))
+			assert.Equal(t, ErrorNotifyReplicationStandbySetup, errorClass, "Unexpected error class")
+			assert.Equal(t, ErrorInfo{
+				Source: ErrorSourcePostgres,
+				Code:   pgerrcode.ObjectNotInPrerequisiteState,
+			}, errInfo, "Unexpected error info")
+		})
+	}
 }
 
 func TestPostgresCreatingSlotOnReader(t *testing.T) {


### PR DESCRIPTION
### Error (sanitized)

A Postgres CDC pipe on Amazon RDS fails during initial snapshot setup, when `SetupReplication` tries to create the logical replication slot on a read replica.

```
slot error: [slot] error creating replication slot: ERROR: logical decoding on standby requires wal_level >= logical on the primary (SQLSTATE 55000)
```

The line lands as `errorClass=OTHER`, `errorCode=UNKNOWN`, source `other`. It shows up on several pipes over the past few months, one pipe at a time, repeating for about a day before the pipe stops retrying.

### Investigation

A branch for this failure already exists and returns `NOTIFY_REPLICATION_STANDBY_SETUP`, but it compares the message with `==` against the quoted wording. Postgres changed how it renders GUC names in this message across major versions, so the comparison only matches one of them. The pipes that hit this all point at a standby whose primary runs `wal_level` below `logical`.

- [PG16 `logical.c:140`](https://github.com/postgres/postgres/blob/REL_16_10/src/backend/replication/logical/logical.c#L140) — emits `logical decoding on standby requires wal_level >= logical on the primary`, with no quotes.
- [PG17 `logical.c:143`](https://github.com/postgres/postgres/blob/REL_17_6/src/backend/replication/logical/logical.c#L143) — same error, GUC names now quoted; this is the only wording the old check matched.
- [PG master `logical.c:132`](https://github.com/postgres/postgres/blob/master/src/backend/replication/logical/logical.c#L132) — renames the GUC to `effective_wal_level`, a third wording of the same error.
- Fleet logs — every occurrence carries SQLSTATE 55000 and the unquoted PG16 wording, and none were classified.

Confidence is high: the upstream source names all three wordings and the SQLSTATE, and the observed text matches PG16 exactly. The customer is the one who can correct this — raise `wal_level` on the primary, or point the pipe at the primary — so the existing `NotifyUser` action stays. Two things worth a reviewer's eye: the `effective_wal_level` wording comes from master and may still change before release, and Postgres uses a similar sentence in the slot-invalidation *detail* field, which this branch cannot reach because it only reads `Message`.

### Change

- The `pgerrcode.ObjectNotInPrerequisiteState` branch now uses `strings.Contains(pgErr.Message, "logical decoding on standby requires")` instead of an exact match, matching the style of every sibling check in the same case.
- Placement and class are unchanged: still first in the 55000 case, still `ErrorNotifyReplicationStandbySetup`. The prefix appears in no other message handled by later branches in that case.
- `ErrorInfo` keeps `Source: ErrorSourcePostgres` and `Code: 55000`.

### Verification

- `TestPostgresLogicalDecodingOnStandbyRequiresWalLevel` rebuilds the error as a `*pgconn.PgError` under the production wrapping (`shared.WrapError("slot error", ...)` around `[slot] error creating replication slot`) and asserts the class and full `ErrorInfo` for all three wordings.
- The full `flow/alerting` suite passes, except two tests that need a local Postgres socket and fail the same way before this change.
- A throwaway check confirmed the rebuilt chain renders byte-for-byte as the original production line and classifies correctly.

Resolves DBI-779
