### PR TITLE
Classify missing pg_logical snapshot temp file as recoverable

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -72,9 +72,11 @@ var (
 	PostgresSpillFileMissingRe         = regexp.MustCompile(`Unable to restore changes for xid \d+`)
 	// e.g. could not rename file "pg_logical/snapshots/25-3370F40.snap.19943.tmp" to "pg_logical/snapshots/25-3370F40.snap"
 	PostgresCouldNotRenameSnapshotRe = regexp.MustCompile(`could not rename file ".*\.snap\..*\.tmp" to ".*\.snap"`)
-	PostgresNeonDonorWalLaggingRe    = regexp.MustCompile(`requested WAL up to [0-9A-F]+/[0-9A-F]+, but current donor \S+ has only up to`)
-	MySqlRdsBinlogFileNotFoundRe     = regexp.MustCompile(`File '/rdsdbdata/log/binlog/mysql-bin-changelog.\d+' not found`)
-	MongoPoolClearedErrorRe          = regexp.MustCompile(`connection pool for .+ was cleared because another operation failed with`)
+	// e.g. could not open file "pg_logical/snapshots/2-8B023150.snap.8007.tmp": No such file or directory
+	PostgresCouldNotOpenSnapshotRe = regexp.MustCompile(`could not open file ".*\.snap\..*\.tmp"`)
+	PostgresNeonDonorWalLaggingRe  = regexp.MustCompile(`requested WAL up to [0-9A-F]+/[0-9A-F]+, but current donor \S+ has only up to`)
+	MySqlRdsBinlogFileNotFoundRe   = regexp.MustCompile(`File '/rdsdbdata/log/binlog/mysql-bin-changelog.\d+' not found`)
+	MongoPoolClearedErrorRe        = regexp.MustCompile(`connection pool for .+ was cleared because another operation failed with`)
 )
 
 func (e ErrorAction) String() string {
@@ -595,6 +597,15 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				return ErrorRetryRecoverable, pgErrorInfo
 			}
 
+			//nolint:lll
+			// Transient failure creating or renaming a logical decoding snapshot temp file, recovers on retry.
+			// The serialize path opens the temp file with O_CREAT, so ENOENT means pg_logical/snapshots itself went away.
+			// https://github.com/postgres/postgres/blob/1416f304d2c9514fe65f112514accc9b653902ad/src/backend/replication/logical/snapbuild.c#L1814-L1821
+			if PostgresCouldNotOpenSnapshotRe.MatchString(pgErr.Message) ||
+				PostgresCouldNotRenameSnapshotRe.MatchString(pgErr.Message) {
+				return ErrorRetryRecoverable, pgErrorInfo
+			}
+
 		case pgerrcode.InternalError:
 			// Handle logical decoding error in ReorderBufferPreserveLastSpilledSnapshot routine
 			if strings.HasPrefix(pgErr.Message, "Internal error encountered during logical decoding of aborted sub-transaction") &&
@@ -662,8 +673,10 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				return ErrorRetryRecoverable, pgErrorInfo
 			}
 
-			// Transient failure renaming a logical decoding snapshot temp file, recovers on retry
-			if PostgresCouldNotRenameSnapshotRe.MatchString(pgErr.Message) {
+			// Same transient snapshot temp file failure as under UndefinedFile above, which some
+			// providers report as an internal error instead of a file access error.
+			if PostgresCouldNotOpenSnapshotRe.MatchString(pgErr.Message) ||
+				PostgresCouldNotRenameSnapshotRe.MatchString(pgErr.Message) {
 				return ErrorRetryRecoverable, pgErrorInfo
 			}
 

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -311,6 +311,47 @@ func TestPostgresCouldNotRenameSnapshotErrorShouldBeRecoverable(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresCouldNotOpenSnapshotErrorShouldBeRecoverable(t *testing.T) {
+	for _, code := range []string{pgerrcode.UndefinedFile, pgerrcode.InternalError} {
+		t.Run(code, func(t *testing.T) {
+			// Simulate a transient logical decoding snapshot temp file creation failure
+			err := &exceptions.PostgresWalError{
+				Msg: &pgproto3.ErrorResponse{
+					Severity: "ERROR",
+					Code:     code,
+					Message:  `could not open file "pg_logical/snapshots/2-8B023150.snap.8007.tmp": No such file or directory`,
+					File:     "snapbuild.c",
+					Line:     1821,
+					Routine:  "SnapBuildSerialize",
+				},
+			}
+			errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed in pull records when: %w", err))
+			assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
+			assert.Equal(t, ErrorInfo{
+				Source: ErrorSourcePostgres,
+				Code:   code,
+			}, errInfo, "Unexpected error info")
+		})
+	}
+}
+
+func TestPostgresCouldNotRenameSnapshotErrorUnderUndefinedFileShouldBeRecoverable(t *testing.T) {
+	// The rename variant of the same failure, reported as a file access error instead of an internal error
+	err := &exceptions.PostgresWalError{
+		Msg: &pgproto3.ErrorResponse{
+			Severity: "ERROR",
+			Code:     pgerrcode.UndefinedFile,
+			Message:  `could not rename file "pg_logical/snapshots/25-3370F40.snap.19943.tmp" to "pg_logical/snapshots/25-3370F40.snap": `,
+		},
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("error in WAL: %w", err))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.UndefinedFile,
+	}, errInfo, "Unexpected error info")
+}
+
 func TestPostgresUnrecognizedSIMessageIDErrorShouldBeRecoverable(t *testing.T) {
 	// Simulate shared invalidation message corruption error
 	err := &exceptions.PostgresWalError{


### PR DESCRIPTION
### Error (sanitized)

A PostgreSQL CDC pipe on a managed serverless provider stopped mid-replication when the source server failed to create a temporary logical decoding snapshot file.

```
Postgres WAL error: received error response, message: &{Severity:ERROR SeverityUnlocalized:ERROR Code:58P01 Message:could not open file "pg_logical/snapshots/2-8B023150.snap.8007.tmp": No such file or directory Detail: Hint: Position:0 InternalPosition:0 InternalQuery: Where: SchemaName: TableName: ColumnName: DataTypeName: ConstraintName: File:snapbuild.c Line:1821 Routine:SnapBuildSerialize UnknownFields:map[]}
```

Today the line emits `errorClass: OTHER` with `errorCode: UNKNOWN` and source `other`. It has hit one pipe one time in the past few months, and replication resumed on its own within minutes from the same LSN.

### Investigation

`SnapBuildSerialize` writes a logical decoding snapshot by creating a temp file under `pg_logical/snapshots` with `O_CREAT | O_EXCL`. Because the open creates the file, `No such file or directory` can only mean the `pg_logical/snapshots` directory itself was gone, and Postgres maps that errno to SQLSTATE `58P01`. On this provider the compute node holding that directory was recycled underneath the walsender: connection failures against the same endpoint appear seconds after the error, and replication restarted from the last LSN a few minutes later.

- [snapbuild.c#L1814-L1821](https://github.com/postgres/postgres/blob/1416f304d2c9514fe65f112514accc9b653902ad/src/backend/replication/logical/snapbuild.c#L1814-L1821) — the exact file, line, and routine from the error; shows the `O_CREAT` open and the `errcode_for_file_access()` call that yields `58P01`.
- [snapbuild.c#L1878](https://github.com/postgres/postgres/blob/1416f304d2c9514fe65f112514accc9b653902ad/src/backend/replication/logical/snapbuild.c#L1878) — the rename of the same temp file, a few lines below, whose failure the classifier already treats as recoverable.
- Fleet logs — the episode is one-time and self-healing; the recurring `pg_logical/snapshots` errors in the same period are the disk-full variant, which a separate branch already routes to a user notification.

Confidence is high: the upstream source names the cause, and the surrounding logs place the compute restart on top of the error. Nobody can act on it — not the customer, not PeerDB — and the pipe recovers by itself, so `ERROR_RETRY_RECOVERABLE` keeps the error visible without escalating a transient event. Two things worth a reviewer's eye: only one occurrence exists, so the recovery pattern rests on that single episode plus the behavior of its already-classified sibling; and the branch also covers the internal-error SQLSTATE, which this variant has not been seen under, on the grounds that the rename variant from the same routine does arrive that way.

### Change

- Adds `PostgresCouldNotOpenSnapshotRe`, matching `could not open file ".*\.snap\..*\.tmp"`, and pairs it with the existing rename regex in one recoverable branch. The regex requires the `.tmp` suffix, so it does not touch the restore path that opens the finished `.snap` file.
- Places the branch in `case pgerrcode.UndefinedFile` after the spill-file check, and mirrors it in `case pgerrcode.InternalError` in place of the former rename-only branch. Both sit after the more specific checks for their SQLSTATE, and the disk-full variant still returns earlier from its own case.
- Returns `ErrorInfo{Source: postgres, Code: <the original SQLSTATE>}`. No new class, no new wrapper.

### Verification

- `TestPostgresCouldNotOpenSnapshotErrorShouldBeRecoverable` rebuilds the error inside `PostgresWalError` under both SQLSTATEs, with the real `snapbuild.c` file, line, and routine, and asserts the class and the full `ErrorInfo`.
- `TestPostgresCouldNotRenameSnapshotErrorUnderUndefinedFileShouldBeRecoverable` covers the sibling variant on the newly added case; the original rename test is unchanged and still passes.
- The classifier suite is green apart from two tests that need a local PostgreSQL and fail the same way before the change. A throwaway test confirmed the branch fires on the original production text under its full wrap chain.

Resolves DBI-919
