### PR TITLE
Classify ALTER PUBLICATION in a read-only transaction as recoverable

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -715,7 +715,6 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			}
 
 		case pgerrcode.ReadOnlySQLTransaction:
-			//nolint:lll
 			// A server still in recovery forces every transaction read-only regardless of what the client asked for,
 			// https://github.com/postgres/postgres/blob/b4dfae2ffac25ea6caf116091b5ed15e140ddfc0/src/backend/access/transam/xact.c#L2164
 			// and the check runs before the command's own ownership check, so this is never a privilege problem:

--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -714,6 +714,22 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				return ErrorRetryRecoverable, pgErrorInfo
 			}
 
+		case pgerrcode.ReadOnlySQLTransaction:
+			//nolint:lll
+			// A server still in recovery forces every transaction read-only regardless of what the client asked for,
+			// https://github.com/postgres/postgres/blob/b4dfae2ffac25ea6caf116091b5ed15e140ddfc0/src/backend/access/transam/xact.c#L2164
+			// and the check runs before the command's own ownership check, so this is never a privilege problem:
+			// https://github.com/postgres/postgres/blob/b4dfae2ffac25ea6caf116091b5ed15e140ddfc0/src/backend/tcop/utility.c#L409
+			// A failover that leaves the endpoint on a not-yet-promoted node therefore rejects publication DDL
+			// until promotion completes, and the same statement then succeeds.
+			// Scoped to this message on purpose: we open read-only transactions ourselves for QRep reads,
+			// so a bare 25006 branch would hide a write wrongly issued inside one of those.
+			if strings.Contains(pgErr.Message, "cannot execute ALTER PUBLICATION in a read-only transaction") {
+				return ErrorRetryRecoverable, pgErrorInfo
+			}
+			// Every other read-only statement keeps the labels the switch default would have given it
+			return ErrorOther, pgErrorInfo
+
 		case pgerrcode.InvalidParameterValue:
 			if strings.Contains(pgErr.Message, "invalid snapshot identifier") {
 				return ErrorNotifyInvalidSnapshotIdentifier, pgErrorInfo

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -546,6 +546,35 @@ func TestPostgresCreatingSlotOnReader(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresAlterPublicationInReadOnlyTransactionShouldBeRecoverable(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.ReadOnlySQLTransaction,
+		Message:  "cannot execute ALTER PUBLICATION in a read-only transaction",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed to alter publication: %w", err))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.ReadOnlySQLTransaction,
+	}, errInfo, "Unexpected error info")
+}
+
+func TestPostgresCopyFromInReadOnlyTransactionStaysOther(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.ReadOnlySQLTransaction,
+		Message:  "cannot execute COPY FROM in a read-only transaction",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("failed to sync records: failed to copy records into destination table: %w", err))
+	assert.Equal(t, ErrorOther, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.ReadOnlySQLTransaction,
+	}, errInfo, "Unexpected error info")
+}
+
 func TestPostgresStaleFileHandleErrorShouldBeRecoverable(t *testing.T) {
 	// Simulate a stale file handle error
 	err := &exceptions.PostgresWalError{


### PR DESCRIPTION
### Error (sanitized)

A PostgreSQL CDC pipe failed while removing tables from its publication. The source server rejected the DDL:

```
failed to alter publication: ERROR: cannot execute ALTER PUBLICATION in a read-only transaction (SQLSTATE 25006)
```

Today this emits `errorClass=OTHER` with `errorCode=25006` and source `postgres`. It has shown up on one pipe over the past few months, as a short burst of failures that cleared within minutes when the identical statement succeeded on a later retry.

### Investigation

SQLSTATE 25006 means the source server, not PeerDB, put the transaction in read-only mode. PostgreSQL forces every transaction read-only while an instance is in recovery, so a failover that leaves the endpoint on a node that has not finished promotion rejects publication DDL until promotion completes. PeerDB opens no read-only transaction on this path — the DDL runs on the ordinary source connection — and reads kept flowing throughout the episode, which fits a server that accepts reads but refuses writes.

- [postgres/src/backend/access/transam/xact.c#L2164](https://github.com/postgres/postgres/blob/b4dfae2ffac25ea6caf116091b5ed15e140ddfc0/src/backend/access/transam/xact.c#L2164) — a server in recovery sets every transaction read-only, whatever the client asked for.
- [postgres/src/backend/tcop/utility.c#L409](https://github.com/postgres/postgres/blob/b4dfae2ffac25ea6caf116091b5ed15e140ddfc0/src/backend/tcop/utility.c#L409) — this check raises 25006 before the command's own ownership check, so 25006 is never a missing-privilege error; that case returns 42501 instead.
- [Fast failover with Amazon Aurora PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.BestPractices.FastFailover.html) — after a failover the cluster endpoint can point at an instance that is still a reader, and the vendor's remedy is to retry.
- [Azure Database for PostgreSQL support note](https://techcommunity.microsoft.com/blog/azuredbsupport/azure-postgresql-lesson-learned1fix-cannot-execute-in-a-read-only-transaction-af/4464467) — the same error is documented after an HA failover on another managed provider.

Confidence is medium: why the error exists is settled by the PostgreSQL source, but what set it off on this pipe is not, because the server-side state at the time was never captured. The change classifies the error as `ERROR_RETRY_RECOVERABLE`, which suits a condition nobody needs to act on when it is a failover, and which still escalates if it persists — and a persistent read-only source is a customer problem, fixed by pointing the pipe at the writable endpoint or clearing the read-only setting. Two things worth a reviewer's attention. First, the earlier reading of this incident was a permissions problem on the source user; the PostgreSQL source rules that out, since the read-only check runs first and a privilege failure carries a different SQLSTATE. Second, if a source stays read-only for a long time, the customer learns about it later under this class than under a direct notification, which is the price of not paging on a failover that heals itself.

### Change

- Adds a `pgerrcode.ReadOnlySQLTransaction` case to the Postgres error switch, placed after `ObjectNotInPrerequisiteState` — whose neighbouring branch already treats an Aurora failover onto a read-only node as recoverable — and before `InvalidParameterValue`.
- Matches with `strings.Contains` on `cannot execute ALTER PUBLICATION in a read-only transaction`, text the engine generates and does not vary, and returns `ErrorRetryRecoverable` with `ErrorInfo.Source` `postgres` and `Code` `25006`. No wrapper was added.
- Scopes the branch to that one message on purpose. PeerDB opens read-only transactions itself for QRep reads, so a bare 25006 branch would hide a write wrongly issued inside one of them. Every other 25006 message returns `ErrorOther` with the same labels the switch default gave it before, so existing telemetry grouping is unchanged.

### Verification

- `TestPostgresAlterPublicationInReadOnlyTransactionShouldBeRecoverable` rebuilds the driver error inside the same `failed to alter publication` wrap the connector applies, and asserts the class along with the full `ErrorInfo`.
- `TestPostgresCopyFromInReadOnlyTransactionStaysOther` pins the other 25006 message to `ErrorOther` with source and code intact, guarding the label regression the narrow scope avoids.
- The classifier suite passes, apart from two tests that need a live PostgreSQL instance and already fail without this change. A throwaway check confirmed the branch fires on the original production text, byte for byte.

Resolves DBI-931
