### PR TITLE
Notify user when the replication slot is read on an Aurora reader node

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -246,6 +246,12 @@ var (
 	ErrNotifyPostgresCreatingSlotOnReader = ErrorClass{
 		Class: "NOTIFY_POSTGRES_CREATING_SLOT_ON_READER", action: NotifyUser,
 	}
+	// Aurora keeps logical replication slots on the writer only, so an in-flight failover makes the
+	// slot unusable until the new writer takes over
+	// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pglogical.handle-slots.html
+	ErrorNotifyAuroraFailover = ErrorClass{
+		Class: "NOTIFY_AURORA_FAILOVER", action: NotifyUser,
+	}
 	// Mongo specific, equivalent to slot invalidation in Postgres
 	ErrorNotifyChangeStreamHistoryLost = ErrorClass{
 		Class: "NOTIFY_CHANGE_STREAM_HISTORY_LOST", action: NotifyUser,
@@ -711,7 +717,7 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 
 			// Aurora failover: reader was promoted, slot can't be used on old RO node
 			if strings.Contains(pgErr.Message, "replication slots cannot be used on RO (Read Only) node") {
-				return ErrorRetryRecoverable, pgErrorInfo
+				return ErrorNotifyAuroraFailover, pgErrorInfo
 			}
 
 		case pgerrcode.InvalidParameterValue:

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1265,15 +1265,15 @@ func TestYugabyteDBSnapshotExportDisabledShouldBeSnapshotExportDisabled(t *testi
 	}, errInfo)
 }
 
-func TestAuroraFailoverRONodeShouldBeRecoverable(t *testing.T) {
+func TestAuroraFailoverRONodeShouldBeAuroraFailover(t *testing.T) {
 	pgErr := &pgconn.PgError{
 		Severity: "ERROR",
 		Code:     pgerrcode.ObjectNotInPrerequisiteState,
 		Message:  "replication slots cannot be used on RO (Read Only) node",
 	}
-	err := fmt.Errorf("error starting replication at startLsn - 18598145761: %w", pgErr)
+	err := fmt.Errorf("error starting replication at startLsn - 327224340680633: %w", pgErr)
 	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed in pull records when: %w", err))
-	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorNotifyAuroraFailover, errorClass)
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourcePostgres,
 		Code:   pgerrcode.ObjectNotInPrerequisiteState,


### PR DESCRIPTION
### Error (sanitized)

A PostgreSQL CDC pipe fails to start replication against Amazon Aurora PostgreSQL because the node it reached is read-only.

```
failed in pull records when: error starting replication at startLsn - 327224340680633: ERROR: replication slots cannot be used on RO (Read Only) node (SQLSTATE 55000)
```

Today the line emits `errorClass=ERROR_RETRY_RECOVERABLE` with `errorCode=55000` and source `postgres`. It appeared once in the past few weeks, hitting multiple pipes from the same source at the same moment, and cleared on its own.

### Investigation

Aurora keeps a logical replication slot on the writer node only. While a cluster fails over, the endpoint can still land on a node that is read-only or in recovery, and Postgres refuses to open the slot there. The episode matches that shape: the same source stopped every pipe within one minute, and the surrounding logs show the source rejecting transaction IDs during recovery and refusing connections on both nodes.

- [Managing logical replication slots for Aurora PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Appendix.PostgreSQL.CommonDBATasks.pglogical.handle-slots.html) — AWS documents that logical slots live on the writer and must be re-established around a failover.
- [Replication with Amazon Aurora PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Replication.html) — describes the writer/reader split that makes a slot unusable on a reader.
- Production logs — every affected pipe resumed normal syncing within about an hour with no intervention, and the error has not returned since.

Confidence is high: the vendor documents why the error exists, and the timing across the affected pipes pins it to one failover. Nothing in PeerDB can prevent or shorten it, so the change routes the error to the customer, who owns the source cluster and is the only party able to look into the failover. Two doubts are worth a reviewer's attention. First, the evidence rests on a single observed failover, so the notification text should stay descriptive rather than prescriptive. Second, during that same failover the affected pipes also reported that their replication slot did not exist, which currently classifies as `NOTIFY_REPLICATION_SLOT_MISSING` — the slot was intact and came back with the writer, so that path can tell a customer to rebuild a pipe that needs no rebuilding. That is a separate signature and is left for its own change.

### Change

- Adds the class `ErrorNotifyAuroraFailover` (`NOTIFY_AURORA_FAILOVER`, `NotifyUser`), placed next to `ErrNotifyPostgresCreatingSlotOnReader`, which covers the neighbouring case of pointing a new pipe at a reader. The two stay separate because the customer message differs: one is a transient failover, the other a misconfigured endpoint.
- Retargets the existing `55000` branch that matches `replication slots cannot be used on RO (Read Only) node` from `ErrorRetryRecoverable` to the new class. The branch keeps its position — after the slot-invalid and `was not created in this database` checks, before the `InvalidParameterValue` cases — so it steals nothing and loses nothing.
- `ErrorInfo` is unchanged: source `postgres`, code `55000`.

### Verification

- `TestAuroraFailoverRONodeShouldBeAuroraFailover` rebuilds the error with the production wrapping — the `pgconn.PgError` inside `error starting replication at startLsn - …` inside `failed in pull records when: …` — and asserts both the class and the full `ErrorInfo`.
- The classifier suite passes. Two Postgres connectivity tests fail only because they need a local Postgres socket, and they fail the same way without this change.
- The branch was checked against the original production text, including the Temporal activity wrapper and a second observed LSN, and matches in every form.

Resolves DBI-933
