### PR TITLE
Notify user when the MySQL binlog connection goes stale

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -1239,8 +1239,12 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		}
 	}
 
+	// The source sends a heartbeat whenever the binlog has no unsent events, so silence across several
+	// heartbeat periods means the connection to the source is broken rather than merely idle, and the
+	// documented remedy is to reconnect: https://dev.mysql.com/worklog/task/?id=342
+	// Only the customer can act on the source server or on the network path in between.
 	if _, ok := errors.AsType[*exceptions.MySQLStaleConnectionError](err); ok {
-		return ErrorRetryRecoverable, ErrorInfo{
+		return ErrorNotifyConnectivity, ErrorInfo{
 			Source: ErrorSourceMySQL,
 			Code:   "CONNECTION_STALE",
 		}

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"syscall"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/storage"
@@ -1492,4 +1493,33 @@ func TestMySQLUnsupportedCompressedColumnErrorShouldBeNotifyUser(t *testing.T) {
 			ErrorAttributeKeyTable: "mydb.mytable",
 		},
 	}, errInfo)
+}
+
+func TestMySQLStaleConnectionErrorShouldBeNotifyConnectivity(t *testing.T) {
+	t.Parallel()
+
+	err := exceptions.NewMySQLStaleConnectionError(3*time.Minute+943414*time.Nanosecond, time.Minute)
+	require.Equal(t, "MySQL connection is stale: no events received in 3m0.000943414s (heartbeat=1m0s)", err.Error())
+
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed in pull records when: %w", err))
+	assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMySQL,
+		Code:   "CONNECTION_STALE",
+	}, errInfo, "Unexpected error info")
+}
+
+// The SyncFlow activity joins the pull error before returning it, so the wrapper must be traversed too.
+func TestMySQLStaleConnectionErrorJoinedShouldBeNotifyConnectivity(t *testing.T) {
+	t.Parallel()
+
+	err := exceptions.NewMySQLStaleConnectionError(3*time.Minute+735889*time.Nanosecond, time.Minute)
+	joined := errors.Join(fmt.Errorf("failed in pull records when: %w", err))
+
+	errorClass, errInfo := GetErrorClass(t.Context(), joined)
+	assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMySQL,
+		Code:   "CONNECTION_STALE",
+	}, errInfo, "Unexpected error info")
 }


### PR DESCRIPTION
### Error (sanitized)

A MySQL CDC mirror stops receiving both row events and the server's replication heartbeats, so the connector gives up on the binlog connection and reconnects. The pull phase reports:

```
failed in pull records when: MySQL connection is stale: no events received in 3m0.000943414s (heartbeat=1m0s)
```

Today the line emits `errorClass=ERROR_RETRY_RECOVERABLE` with `errorCode=CONNECTION_STALE` and source `mysql`. It shows up on several pipes across a couple of regions over the past few weeks: a slow drip on some, and occasional episodes of a few hours on others. Every episode ended on its own, and the affected pipes kept streaming throughout.

### Investigation

MySQL sends a heartbeat whenever the binary log has no unsent events, so an idle source still puts traffic on the wire once per heartbeat period. Silence across several periods therefore means the connection is broken, not that the source is quiet, and the documented response is to drop it and reconnect — which is exactly what the connector does. What set it off on these pipes is a source-side or network-path condition that swallows the connection: the pipes that see it see it repeatedly, and the rest of the MySQL fleet never does.

- [MySQL WL#342, Replication Heartbeat](https://dev.mysql.com/worklog/task/?id=342) — defines the heartbeat as the signal that separates an idle source from a dead connection.
- [MySQL replication status reference](https://dev.mysql.com/doc/refman/8.0/en/replication-administration-status.html) — a replica that reaches its timeout with no data and no heartbeat reconnects; this is normal replica behavior, not a fault.
- [Debezium MySQL connector](https://debezium.io/documentation/reference/stable/connectors/mysql.html) — another CDC tool keeps its own once-per-minute liveness check and treats a failure as a retriable connection problem.
- Fleet history — only a small minority of MySQL pipes ever produce this error, it recovers within minutes without intervention, and its first appearance came weeks after the staleness check shipped, so it does not track a PeerDB release.

Confidence is high on why the error exists, because the vendor documents the behavior and another CDC tool handles it the same way, and moderate on what triggers it on these specific pipes. The customer is the party who can correct it: the source server and the network path in between are theirs, and PeerDB's own handling — reconnect and resume — is already correct. Two things a reviewer should weigh. The logs cannot separate a source-side stall from a network-path stall, so the notification has to point at both. And a single three-minute blip that heals itself now reaches the customer, which is more contact than the event deserves on its own; the pipes that hit it hit it repeatedly, so the notification lands where it is useful.

### Change

- The `MySQLStaleConnectionError` branch now returns `ErrorNotifyConnectivity` instead of `ErrorRetryRecoverable`. It keeps its place after the binlog-specific MySQL branches and before the MySQL catch-alls, and it still matches on the typed error rather than on message text.
- `ErrorInfo` is unchanged: `Source: ErrorSourceMySQL`, `Code: "CONNECTION_STALE"`, so existing telemetry keeps grouping the same way.
- `NOTIFY_CONNECTIVITY` is an existing class already used for source-side connection loss, including a closed SSH tunnel and a closed Postgres connection, so no new class or mapping is needed.

### Verification

- `TestMySQLStaleConnectionErrorShouldBeNotifyConnectivity` builds the error with the production durations, asserts the message text matches byte-for-byte, wraps it in the pull-records wrapper the activity adds, and asserts the class and the full `ErrorInfo`.
- `TestMySQLStaleConnectionErrorJoinedShouldBeNotifyConnectivity` covers the joined form the sync activity returns, so both delivery paths are checked.
- The classifier suite passes, except two Postgres tests that need a local Postgres and already fail on an unmodified tree. The branch was also checked internally against the original production line and matches.

Resolves DBI-957
