### PR TITLE
Classify replication slot state rename failure as recoverable

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -667,6 +667,12 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				return ErrorRetryRecoverable, pgErrorInfo
 			}
 
+			// Transient failure renaming the replication slot state file, recovers when replication restarts
+			// https://github.com/postgres/postgres/blob/1416f304d2c9514fe65f112514accc9b653902ad/src/backend/replication/slot.c#L2187
+			if pgErr.Routine == "SaveSlotToPath" && strings.Contains(pgErr.Message, "could not rename file") {
+				return ErrorRetryRecoverable, pgErrorInfo
+			}
+
 			// Shared invalidation message corruption - usually transient, reconnect helps
 			// https://github.com/postgres/postgres/blob/e82e9aaa6a2942505c2c328426778787e4976ea6/src/backend/utils/cache/inval.c#L901
 			if strings.Contains(pgErr.Message, "unrecognized SI message ID:") {

--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -667,12 +667,6 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				return ErrorRetryRecoverable, pgErrorInfo
 			}
 
-			// Transient failure renaming the replication slot state file, recovers when replication restarts
-			// https://github.com/postgres/postgres/blob/1416f304d2c9514fe65f112514accc9b653902ad/src/backend/replication/slot.c#L2187
-			if pgErr.Routine == "SaveSlotToPath" && strings.Contains(pgErr.Message, "could not rename file") {
-				return ErrorRetryRecoverable, pgErrorInfo
-			}
-
 			// Shared invalidation message corruption - usually transient, reconnect helps
 			// https://github.com/postgres/postgres/blob/e82e9aaa6a2942505c2c328426778787e4976ea6/src/backend/utils/cache/inval.c#L901
 			if strings.Contains(pgErr.Message, "unrecognized SI message ID:") {
@@ -681,6 +675,12 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 
 			if strings.Contains(pgErr.Message, "Create the replication slot from the writer node instead") {
 				return ErrNotifyPostgresCreatingSlotOnReader, pgErrorInfo
+			}
+
+			// Transient failure renaming the replication slot state file, recovers when replication restarts
+			// https://github.com/postgres/postgres/blob/1416f304d2c9514fe65f112514accc9b653902ad/src/backend/replication/slot.c#L2187
+			if pgErr.Routine == "SaveSlotToPath" && strings.Contains(pgErr.Message, "could not rename file") {
+				return ErrorRetryRecoverable, pgErrorInfo
 			}
 
 			// low-level Postgres memory management bug, single occurrence and fixed by retry

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -311,6 +311,23 @@ func TestPostgresCouldNotRenameSnapshotErrorShouldBeRecoverable(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresUnrecognizedSIMessageIDErrorShouldBeRecoverable(t *testing.T) {
+	// Simulate shared invalidation message corruption error
+	err := &exceptions.PostgresWalError{
+		Msg: &pgproto3.ErrorResponse{
+			Severity: "FATAL",
+			Code:     pgerrcode.InternalError,
+			Message:  "unrecognized SI message ID: -60",
+		},
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("ReceiveMessage failed: %w", err))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.InternalError,
+	}, errInfo, "Unexpected error info")
+}
+
 func TestPostgresCouldNotRenameSlotStateFileErrorShouldBeRecoverable(t *testing.T) {
 	// Simulate a transient replication slot state file rename failure, in both the
 	// upstream wording and the "rename file from" wording of patched managed builds
@@ -340,23 +357,6 @@ func TestPostgresCouldNotRenameSlotStateFileErrorShouldBeRecoverable(t *testing.
 			}, errInfo, "Unexpected error info")
 		})
 	}
-}
-
-func TestPostgresUnrecognizedSIMessageIDErrorShouldBeRecoverable(t *testing.T) {
-	// Simulate shared invalidation message corruption error
-	err := &exceptions.PostgresWalError{
-		Msg: &pgproto3.ErrorResponse{
-			Severity: "FATAL",
-			Code:     pgerrcode.InternalError,
-			Message:  "unrecognized SI message ID: -60",
-		},
-	}
-	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("ReceiveMessage failed: %w", err))
-	assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
-	assert.Equal(t, ErrorInfo{
-		Source: ErrorSourcePostgres,
-		Code:   pgerrcode.InternalError,
-	}, errInfo, "Unexpected error info")
 }
 
 func TestClickHouseAccessEntityNotFoundErrorShouldBeRecoverable(t *testing.T) {

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -311,6 +311,37 @@ func TestPostgresCouldNotRenameSnapshotErrorShouldBeRecoverable(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresCouldNotRenameSlotStateFileErrorShouldBeRecoverable(t *testing.T) {
+	// Simulate a transient replication slot state file rename failure, in both the
+	// upstream wording and the "rename file from" wording of patched managed builds
+	for name, message := range map[string]string{
+		"upstream": `could not rename file "pg_replslot/peerflow_slot_mirror_cc397dd6__c4f0__4d10__82ad__d68bcc8c4944/state.tmp" ` +
+			`to "pg_replslot/peerflow_slot_mirror_cc397dd6__c4f0__4d10__82ad__d68bcc8c4944/state": Success`,
+		"patched": `could not rename file from "pg_replslot/peerflow_slot_mirror_cc397dd6__c4f0__4d10__82ad__d68bcc8c4944/state.tmp" ` +
+			`to "pg_replslot/peerflow_slot_mirror_cc397dd6__c4f0__4d10__82ad__d68bcc8c4944/state": Success`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := &exceptions.PostgresWalError{
+				Msg: &pgproto3.ErrorResponse{
+					Severity: "ERROR",
+					Code:     pgerrcode.InternalError,
+					Message:  message,
+					File:     "slot.c",
+					Line:     2096,
+					Routine:  "SaveSlotToPath",
+				},
+			}
+			errorClass, errInfo := GetErrorClass(t.Context(),
+				fmt.Errorf("failed in pull records when: %w", fmt.Errorf("Postgres WAL error: %w", err)))
+			assert.Equal(t, ErrorRetryRecoverable, errorClass, "Unexpected error class")
+			assert.Equal(t, ErrorInfo{
+				Source: ErrorSourcePostgres,
+				Code:   pgerrcode.InternalError,
+			}, errInfo, "Unexpected error info")
+		})
+	}
+}
+
 func TestPostgresUnrecognizedSIMessageIDErrorShouldBeRecoverable(t *testing.T) {
 	// Simulate shared invalidation message corruption error
 	err := &exceptions.PostgresWalError{


### PR DESCRIPTION
### Error (sanitized)

A CDC pipe reading from a managed PostgreSQL source fails while the server saves replication slot state to disk. The server reports `XX000` from `slot.c`, routine `SaveSlotToPath`, and the walsender ends the replication stream.

```
could not rename file from "pg_replslot/peerflow_slot_mirror_cc397dd6__c4f0__4d10__82ad__d68bcc8c4944/state.tmp" to "pg_replslot/peerflow_slot_mirror_cc397dd6__c4f0__4d10__82ad__d68bcc8c4944/state": Success
```

Today this emits `errorClass=OTHER` with `errorCode=XX000` and source `postgres`. It has appeared as isolated one-time episodes on a small number of unrelated pipes over the past few months, and each one cleared on its own within minutes.

### Investigation

PostgreSQL writes slot state to `state.tmp` and renames it over `state` on every slot save. When that `rename()` returns non-zero, `SaveSlotToPath` raises an error and the walsender exits. The reported reason is `Success`, so the underlying `errno` was never set — the rename failed spuriously at the storage layer rather than for a durable reason such as a full or read-only filesystem. Replication restarts from the last synced position and the next slot save succeeds.

- [postgres/slot.c `SaveSlotToPath`](https://github.com/postgres/postgres/blob/1416f304d2c9514fe65f112514accc9b653902ad/src/backend/replication/slot.c#L2187) — shows the rename of the slot state file and the error it raises when the rename fails.
- Pipe logs around one episode — the error appears once, replication restarts about a minute later, and normal pulling continues with no further errors.
- Fleet history over the past few months — the same error text and routine on unrelated pipes in different regions, each a single occurrence, never recurring.
- [PeerDB#4407](https://github.com/PeerDB-io/peerdb/pull/4407) — classified the sibling `pg_logical/snapshots` rename failure from `SnapBuildSerialize` as `ERROR_RETRY_RECOVERABLE`; this variant hits the same rename pattern in a different directory.

Confidence is high: the upstream source explains why the error exists, and every observed episode self-healed without intervention. No one needs to act — the failure is on the source server's storage and replication resumes by itself — so the branch returns `ERROR_RETRY_RECOVERABLE` rather than a class that notifies the customer. Two things are worth a reviewer's attention. First, the exact cause of the failed rename is not visible from ClickPipes logs, since the source server's own logs are not available. Second, `ERROR_RETRY_RECOVERABLE` is deliberately chosen over `ignore`: a source with a genuinely broken filesystem would repeat this error, and the recoverable class stays visible when it does.

### Change

- Adds a branch under `pgerrcode.InternalError`, directly after the existing `PostgresCouldNotRenameSnapshotRe` branch and before the fall-through that returns `ErrorOther`, returning `ErrorRetryRecoverable`.
- Matches on `pgErr.Routine == "SaveSlotToPath"` together with `strings.Contains(pgErr.Message, "could not rename file")`. The routine name is set by the server and is stable across versions, unlike the file name, the line number, and the slot path. No branch below it matches this routine, so nothing is shadowed.
- `ErrorInfo` keeps the standard PostgreSQL values: `Source: ErrorSourcePostgres`, `Code: XX000`. No new class and no new wrapper.

### Verification

- `TestPostgresCouldNotRenameSlotStateFileErrorShouldBeRecoverable` rebuilds the error as a `PostgresWalError` inside the same wrapping the sync path applies, and asserts both `ErrorRetryRecoverable` and the full `ErrorInfo`. It runs two subtests: the upstream message wording and the `rename file from` wording that patched managed builds emit.
- The full `flow/alerting` suite passes; the only failures are two pre-existing tests that need a local PostgreSQL server.
- The branch was checked against the unmodified production error text in a throwaway test before submission, and matched.

Resolves DBI-958
