### PR TITLE
Notify user when MySQL requires secure transport

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -157,6 +157,9 @@ var (
 	ErrorNotifyMySQLCompressedColumnUnsupported = ErrorClass{
 		Class: "NOTIFY_MYSQL_COMPRESSED_COLUMN_UNSUPPORTED", action: NotifyUser,
 	}
+	ErrorNotifyMySQLSecureTransportRequired = ErrorClass{
+		Class: "NOTIFY_MYSQL_SECURE_TRANSPORT_REQUIRED", action: NotifyUser,
+	}
 	ErrorNotifyBinlogRowMetadataInvalid = ErrorClass{
 		Class: "NOTIFY_BINLOG_ROW_METADATA_INVALID", action: NotifyUser,
 	}
@@ -799,11 +802,12 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			1194, // ER_CRASHED_ON_USAGE
 			1195, // ER_CRASHED_ON_REPAIR
 			1226, // ER_USER_LIMIT_REACHED
-			1827, // ER_PASSWORD_FORMAT
+			1827: // ER_PASSWORD_FORMAT
+			return ErrorNotifyConnectivity, myErrorInfo
+		case 3159: // ER_SECURE_TRANSPORT_REQUIRED
 			// The source rejects the handshake because the pipe connects without TLS while the server sets
 			// require_secure_transport=ON. https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_require_secure_transport
-			3159: // ER_SECURE_TRANSPORT_REQUIRED
-			return ErrorNotifyConnectivity, myErrorInfo
+			return ErrorNotifyMySQLSecureTransportRequired, myErrorInfo
 		case 1236: // ER_MASTER_FATAL_ERROR_READING_BINLOG
 			// A single binlog event larger than the replica's max_allowed_packet aborts the binlog stream read
 			if strings.Contains(myErr.Message, "max_allowed_packet") {

--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -799,7 +799,10 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			1194, // ER_CRASHED_ON_USAGE
 			1195, // ER_CRASHED_ON_REPAIR
 			1226, // ER_USER_LIMIT_REACHED
-			1827: // ER_PASSWORD_FORMAT
+			1827, // ER_PASSWORD_FORMAT
+			// The source rejects the handshake because the pipe connects without TLS while the server sets
+			// require_secure_transport=ON. https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_require_secure_transport
+			3159: // ER_SECURE_TRANSPORT_REQUIRED
 			return ErrorNotifyConnectivity, myErrorInfo
 		case 1236: // ER_MASTER_FATAL_ERROR_READING_BINLOG
 			// A single binlog event larger than the replica's max_allowed_packet aborts the binlog stream read

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1072,6 +1072,21 @@ func TestMySQLBinlogEventExceededMaxAllowedPacket(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestMySQLSecureTransportRequiredShouldBeConnectivity(t *testing.T) {
+	mysqlErr := &mysql.MyError{
+		Code:    3159, // ER_SECURE_TRANSPORT_REQUIRED
+		State:   "HY000",
+		Message: "Connections using insecure transport are prohibited while --require_secure_transport=ON.",
+	}
+	err := exceptions.NewMySQLExecuteError(fmt.Errorf("handleAuthResult: %w", mysqlErr))
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("connection to source down: %w", err))
+	assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMySQL,
+		Code:   "3159",
+	}, errInfo, "Unexpected error info")
+}
+
 func TestMySQLBinlogChecksumMismatch(t *testing.T) {
 	err := exceptions.NewMySQLExecuteError(
 		fmt.Errorf("failed checksum for WriteRowsEventV2, log pos 12345: %v", replication.ErrChecksumMismatch),

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1072,7 +1072,7 @@ func TestMySQLBinlogEventExceededMaxAllowedPacket(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
-func TestMySQLSecureTransportRequiredShouldBeConnectivity(t *testing.T) {
+func TestMySQLSecureTransportRequired(t *testing.T) {
 	mysqlErr := &mysql.MyError{
 		Code:    3159, // ER_SECURE_TRANSPORT_REQUIRED
 		State:   "HY000",
@@ -1080,7 +1080,7 @@ func TestMySQLSecureTransportRequiredShouldBeConnectivity(t *testing.T) {
 	}
 	err := exceptions.NewMySQLExecuteError(fmt.Errorf("handleAuthResult: %w", mysqlErr))
 	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("connection to source down: %w", err))
-	assert.Equal(t, ErrorNotifyConnectivity, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorNotifyMySQLSecureTransportRequired, errorClass, "Unexpected error class")
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceMySQL,
 		Code:   "3159",


### PR DESCRIPTION
### Error (sanitized)

A MySQL CDC pipe cannot open a connection to its source. The source is Aurora MySQL on RDS, and the failure happens during the sync phase, at the authentication handshake.

```
connection to source down: MySQL execute error: handleAuthResult: ERROR 3159 (HY000): Connections using insecure transport are prohibited while --require_secure_transport=ON.
```

Today the line emits `errorClass=OTHER` with `errorCode=3159` and source `mysql`. It affected one pipe, and it recurred every few minutes for roughly a day and a half before it stopped.

### Investigation

MySQL refuses any plaintext TCP connection when the server sets `require_secure_transport=ON`; only TLS, a Unix socket, or shared memory count as secure. PeerDB negotiates TLS for a MySQL source unless the pipe itself turns TLS off, so the pipe was connecting without TLS against a source that had begun to demand it. The onset was abrupt on a pipe that had been running, which points at a change on the source side rather than anything in the connector.

- [MySQL server system variables — `require_secure_transport`](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_require_secure_transport) — documents that the server rejects connections over insecure transport when this variable is on.
- [MySQL server error reference — `ER_SECURE_TRANSPORT_REQUIRED`](https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_secure_transport_required) — defines error 3159 and its `HY000` SQLSTATE, with the exact message text.
- [Requiring SSL/TLS for all connections to a MySQL DB instance on Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql-ssl-connections.require-ssl.html) — shows that an RDS or Aurora operator turns this on through a parameter group, on a live instance.
- Logs for the affected pipe — the error repeated at a steady interval for the whole episode and never cleared on its own; normal activity resumed only after the configuration changed.

Confidence is high: the vendor documents the exact condition, and the observed pattern matches it. The customer is the party who can correct it, either by enabling TLS on the pipe or by relaxing the setting on the source, so the error should reach them as a notification. Two things a reviewer may want to weigh. The evidence comes from a single pipe, so the fleet cannot yet show whether the same code arrives by other paths. And `NOTIFY_CONNECTIVITY` is a broad class — the specific remedy reaches the customer only through the error text carried in the user-facing log, not through the class name.

### Change

- Adds `3159` (`ER_SECURE_TRANSPORT_REQUIRED`) to the existing list of MySQL error codes that return `ErrorNotifyConnectivity`, next to codes such as `1045` (`ER_ACCESS_DENIED_ERROR`) and `1130` (`ER_HOST_NOT_PRIVILEGED`), which are the same kind of connection-time rejection.
- The branch sits inside the `*mysql.MyError` case, ahead of the `default` arm that returned `OTHER` for this code. It matches on the numeric code alone, so message wording and quoting cannot break it.
- `ErrorInfo` keeps `Source: ErrorSourceMySQL` and `Code: "3159"`, the same labels the error already reported.

### Verification

- `TestMySQLSecureTransportRequiredShouldBeConnectivity` rebuilds the error with its production nesting — a `*mysql.MyError` inside a `MySQLExecuteError` inside the `connection to source down` wrapper — and asserts both the class and the full `ErrorInfo`.
- The classifier suite passes. Two unrelated Postgres tests fail without a local Postgres server and fail the same way before this change.
- The rebuilt chain was compared against the original production line character by character and matches it, so the branch fires on the real text.

Resolves DBI-964
