### PR TITLE
Classify GCS HTTP/2 connection loss as recoverable

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -50,6 +50,12 @@ const (
 	// go-geos library when a LinearRing's points do not close. Used to give a more specific code
 	// once we already know the error came from MySQL geometry parsing.
 	mysqlGeometryLinearRingNotClosedError = "Points of LinearRing do not form a closed linestring"
+
+	// http2ClientConnectionLost is raised by golang.org/x/net/http2 in ClientConn.closeForLostPing,
+	// which tears down the connection and aborts every in-flight request when a keepalive ping goes
+	// unanswered: https://github.com/golang/net/blob/master/http2/transport.go
+	// The error is created with errors.New, so there is no sentinel or type to match on.
+	http2ClientConnectionLost = "http2: client connection lost"
 )
 
 var (
@@ -1000,6 +1006,12 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			default:
 				return ErrorOther, gcsErrorInfo
 			}
+		}
+		// A lost transport connection never reaches the API layer, so it carries no googleapi.Error
+		// and is retried by dialing a new connection.
+		if strings.Contains(err.Error(), http2ClientConnectionLost) {
+			gcsErrorInfo.Code = "CONNECTION_LOST"
+			return ErrorRetryRecoverable, gcsErrorInfo
 		}
 		return ErrorOther, gcsErrorInfo
 	}

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"strconv"
 	"syscall"
 	"testing"
@@ -1378,6 +1379,30 @@ func TestGCSTransientErrorsShouldBeRecoverable(t *testing.T) {
 	assert.Equal(t, ErrorInfo{
 		Source: ErrorSourceGCS,
 		Code:   strconv.Itoa(503),
+	}, errInfo)
+}
+
+func TestGCSUploadHTTP2ConnectionLostShouldBeRecoverable(t *testing.T) {
+	t.Parallel()
+
+	key := "clickpipes-svc-ccb33053-eb59-403c-924f-a2374632f8f3/mirror_5b2e0f87__3057__4542__b092__5574e781ecb7/" +
+		"mirror_5b2e0f87__3057__4542__b092__5574e781ecb7/t7o0Jf93kvjVS8J6_23855.avro"
+	transportErr := &url.Error{
+		Op: "Post",
+		URL: "https://storage.googleapis.com/upload/storage/v1/b/maddle-unwaked-highroad/o?alt=json&name=" +
+			"clickpipes-svc-ccb33053-eb59-403c-924f-a2374632f8f3%2Fmirror_5b2e0f87__3057__4542__b092__5574e781ecb7%2F" +
+			"mirror_5b2e0f87__3057__4542__b092__5574e781ecb7%2Ft7o0Jf93kvjVS8J6_23855.avro" +
+			"&prettyPrint=false&projection=full&uploadType=multipart",
+		Err: errors.New("http2: client connection lost"),
+	}
+	err := exceptions.NewGCSError(fmt.Errorf("failed to finalize GCS upload for %s: %w", key, transportErr))
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf(
+		"failed to push records: failed to upload to staging: %w", err,
+	))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceGCS,
+		Code:   "CONNECTION_LOST",
 	}, errInfo)
 }
 


### PR DESCRIPTION
### Error (sanitized)

A CDC sync failed while uploading an Avro batch to the GCS staging bucket. The HTTP/2 connection to `storage.googleapis.com` died mid-request, so the upload never reached the API.

```text
failed to push records: failed to upload to staging: GCS Error: failed to finalize GCS upload for clickpipes-svc-ccb33053-eb59-403c-924f-a2374632f8f3/mirror_5b2e0f87__3057__4542__b092__5574e781ecb7/mirror_5b2e0f87__3057__4542__b092__5574e781ecb7/t7o0Jf93kvjVS8J6_23855.avro: Post "https://storage.googleapis.com/upload/storage/v1/b/maddle-unwaked-highroad/o?alt=json&name=clickpipes-svc-ccb33053-eb59-403c-924f-a2374632f8f3%2Fmirror_5b2e0f87__3057__4542__b092__5574e781ecb7%2Fmirror_5b2e0f87__3057__4542__b092__5574e781ecb7%2Ft7o0Jf93kvjVS8J6_23855.avro&prettyPrint=false&projection=full&uploadType=multipart": http2: client connection lost
```

Today the line emits `errorClass=OTHER` with `errorCode=UNKNOWN` and source `gcs`. It happened once, on one pipe, in the past couple of months, and the pipe resumed syncing batches within minutes with no intervention.

### Investigation

`golang.org/x/net/http2` produces this exact text in `ClientConn.closeForLostPing`: when a keepalive ping goes unanswered, the transport declares the connection dead and aborts every in-flight request on it. Nothing reached the GCS API, so the error carries no `googleapi.Error` and no HTTP status. The next attempt dials a fresh connection, which is why the pipe recovered on its own.

- [x/net http2 transport.go](https://github.com/golang/net/blob/master/http2/transport.go) — `closeForLostPing` creates this error and tears down the connection, aborting in-flight requests.
- [google-cloud-go#7905](https://github.com/googleapis/google-cloud-go/issues/7905) — the storage client historically did not retry this error; it is a transient network failure.
- [GCS retry strategy](https://cloud.google.com/storage/docs/retry-strategy) — an object insert without preconditions is only conditionally idempotent, so the default `RetryIdempotent` policy does not retry it. `storage.ShouldRetry` in the pinned client does list `client connection lost` as retryable, but the staging writer sets no preconditions, so the retry never runs and the error surfaces.

Confidence is high: the upstream source names the cause, and the one observed episode healed within minutes. No one can correct a lost transport connection — a retry fixes it — so the change makes it `ERROR_RETRY_RECOVERABLE` rather than a user notification or a silent ignore, keeping it visible if it ever starts looping. Two things worth a reviewer's attention: the match is a string check, because the upstream error is built with `errors.New` and offers no sentinel or type to test; and a complementary fix would be to set `DoesNotExist` preconditions or `RetryAlways` on the staging writer, so the storage client retries the upload itself instead of failing the whole sync.

### Change

- Adds a branch inside the existing `*exceptions.GCSError` block in `GetErrorClass`, after the `*googleapi.Error` handling and before the trailing `return ErrorOther`. A connection lost in transit never carries a `googleapi.Error`, so the two cases do not overlap.
- Matches with `strings.Contains` on the new `http2ClientConnectionLost` constant, which holds the fixed text from `x/net/http2`. No wrapper was added.
- Returns `ErrorRetryRecoverable` with `ErrorInfo{Source: ErrorSourceGCS, Code: "CONNECTION_LOST"}`, sitting alongside the existing GCS 503 case.

### Verification

- `TestGCSUploadHTTP2ConnectionLostShouldBeRecoverable` rebuilds the production chain — a `*url.Error` around the http2 error, wrapped by `exceptions.NewGCSError`, then by the staging-upload and push-records messages — and asserts both the class and the full `ErrorInfo`.
- The classifier suite passes; the only failures are two Postgres tests that need a live local database.
- The branch was checked against the original production line and matches it byte for byte.

Resolves DBI-968
