### PR TITLE
Return connection errors from GetSelectedColumns and other pgx queries missing them

### DIFF
--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -331,9 +331,8 @@ func (h *FlowRequestHandler) InitialLoadSummary(
 
 	defer rows.Close()
 
-	cloneStatuses := []*protos.CloneTableSummary{}
-	for rows.Next() {
-		if err := rows.Scan(
+	cloneStatuses, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (*protos.CloneTableSummary, error) {
+		if err := row.Scan(
 			&flowName,
 			&destinationTable,
 			&sourceTable,
@@ -345,7 +344,7 @@ func (h *FlowRequestHandler) InitialLoadSummary(
 			&numRowsSynced,
 			&avgTimePerPartitionMs,
 		); err != nil {
-			return nil, NewInternalApiError(fmt.Errorf("unable to scan initial load partition - %s: %w", parentMirrorName, err))
+			return nil, err
 		}
 
 		res := &protos.CloneTableSummary{
@@ -392,7 +391,10 @@ func (h *FlowRequestHandler) InitialLoadSummary(
 			res.AvgTimePerPartitionMs = int64(avgTimePerPartitionMs.Float64)
 		}
 
-		cloneStatuses = append(cloneStatuses, res)
+		return res, nil
+	})
+	if err != nil {
+		return nil, NewInternalApiError(fmt.Errorf("unable to scan initial load partition - %s: %w", parentMirrorName, err))
 	}
 	return &protos.InitialLoadSummaryResponse{
 		TableSummaries: cloneStatuses,
@@ -430,18 +432,15 @@ func (h *FlowRequestHandler) getPartitionStatuses(
 
 	defer rows.Close()
 
-	res := []*protos.PartitionStatus{}
 	var partitionId pgtype.Text
 	var startTime pgtype.Timestamp
 	var endTime pgtype.Timestamp
 	var numRowsInPartition pgtype.Int8
 	var numRowsSynced pgtype.Int8
 
-	for rows.Next() {
-		if err := rows.Scan(&partitionId, &startTime, &endTime, &numRowsInPartition, &numRowsSynced); err != nil {
-			slog.ErrorContext(ctx, "unable to scan qrep partition",
-				slog.String("flow", flowJobName), slog.Any("error", err))
-			return nil, fmt.Errorf("unable to scan qrep partition - %s: %w", flowJobName, err)
+	res, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (*protos.PartitionStatus, error) {
+		if err := row.Scan(&partitionId, &startTime, &endTime, &numRowsInPartition, &numRowsSynced); err != nil {
+			return nil, err
 		}
 
 		partitionStatus := &protos.PartitionStatus{}
@@ -462,7 +461,12 @@ func (h *FlowRequestHandler) getPartitionStatuses(
 			partitionStatus.RowsSynced = numRowsSynced.Int64
 		}
 
-		res = append(res, partitionStatus)
+		return partitionStatus, nil
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to scan qrep partition",
+			slog.String("flow", flowJobName), slog.Any("error", err))
+		return nil, fmt.Errorf("unable to scan qrep partition - %s: %w", flowJobName, err)
 	}
 
 	return res, nil

--- a/flow/connectors/postgres/client.go
+++ b/flow/connectors/postgres/client.go
@@ -404,8 +404,7 @@ func getSlotInfo(
 		return nil, fmt.Errorf("failed to read information for slots: %w", err)
 	}
 	defer rows.Close()
-	var slotInfoRows []*protos.SlotInfo
-	for rows.Next() {
+	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (*protos.SlotInfo, error) {
 		var slotName pgtype.Text
 		var redoLSN pgtype.Text
 		var restartLSN pgtype.Text
@@ -427,7 +426,7 @@ func getSlotInfo(
 		var spillCount *int64
 		var spillBytes *int64
 
-		err := rows.Scan(
+		err := row.Scan(
 			&slotName,
 			&redoLSN,
 			&restartLSN,
@@ -453,7 +452,7 @@ func getSlotInfo(
 			return nil, err
 		}
 
-		slotInfoRows = append(slotInfoRows, &protos.SlotInfo{
+		return &protos.SlotInfo{
 			SlotName:                 slotName.String,
 			RedoLSN:                  redoLSN.String,
 			RestartLSN:               restartLSN.String,
@@ -474,9 +473,8 @@ func getSlotInfo(
 			SpillTxns:                spillTxns,
 			SpillCount:               spillCount,
 			SpillBytes:               spillBytes,
-		})
-	}
-	return slotInfoRows, nil
+		}, nil
+	})
 }
 
 // GetSlotInfo gets the information about the replication slot size and LSNs.

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -433,16 +433,9 @@ func (c *PostgresConnector) GetSelectedColumns(
 		return nil, fmt.Errorf("error getting selected columns for table %s: %w", sourceTable, err)
 	}
 
-	columns := make([]string, 0)
-	for rows.Next() {
-		var columnName string
-		if err := rows.Scan(&columnName); err != nil {
-			return nil, fmt.Errorf("error scanning column while getting selected columns for table %s: %w", sourceTable, err)
-		}
-		columns = append(columns, columnName)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error getting selected columns for table %s: %w", sourceTable, err)
+	columns, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		return nil, fmt.Errorf("error scanning columns while getting selected columns for table %s: %w", sourceTable, err)
 	}
 
 	return columns, nil

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -437,9 +437,12 @@ func (c *PostgresConnector) GetSelectedColumns(
 	for rows.Next() {
 		var columnName string
 		if err := rows.Scan(&columnName); err != nil {
-			return nil, fmt.Errorf("error scanning column while getting selected columns: %w", err)
+			return nil, fmt.Errorf("error scanning column while getting selected columns for table %s: %w", sourceTable, err)
 		}
 		columns = append(columns, columnName)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error getting selected columns for table %s: %w", sourceTable, err)
 	}
 
 	return columns, nil


### PR DESCRIPTION
### Error (sanitized)

Postgres snapshot partitions fail during `qrep` pull with a claim that the source table has no columns:

```
[qrep] failed to pull records: table "public"."ferly_inoculum" doesn't have queriable columns
```

The line emits `errorClass=OTHER` / `errorCode=UNKNOWN` with source `other`. It has appeared on several pipes across multiple regions over the past few weeks, always in a short burst that clears within minutes.

### Investigation

This a bug in PeerDB. `GetSelectedColumns` iterates `pg_attribute` rows but never checks `rows.Err()`, so when the source connection dies after the query is sent, `Next` stops immediately and the function returns an empty column list with a nil error. `corePullQRepRecords` reads that empty list as "this table has no columns" and reports it, hiding the connection failure that actually happened.

- [pgx `Conn.Query`](https://pkg.go.dev/github.com/jackc/pgx/v5#Conn.Query) — documents that `Query` returns before reading any rows, so a failure after the query is sent surfaces only through `Rows.Err()`.
- [PeerDB #4583](https://github.com/PeerDB-io/peerdb/pull/4583) — added this pull path and its empty-column check; the message cannot predate it, and the first occurrences follow it.
- [Postgres error codes](https://www.postgresql.org/docs/current/errcodes-appendix.html) — `57P01` and `57P03` cover the backend terminations that the logs show at the same second as each burst.

Every occurrence in the logs lands in the same second as the source connection dropping: a source restart refusing new connections, an administrator terminating the backend, or an SSH tunnel closing. Partitions for the same table succeed before and after each burst, which rules out a genuine all-columns-excluded configuration. Confidence is high: the pgx contract explains why the empty list appears, and the logs confirm the trigger in each case. Nobody needs to act on the message itself — the fix removes it, and the real connection error takes its place. Two things worth a reviewer's attention: a permanently misconfigured exclusion list would still produce the same message legitimately, and that case belongs in validation rather than here; and `SSH Tunnel Closed: EOF` is matched by the `io.EOF` branch before it reaches the SSH-tunnel branch, which predates this change.

### Change

- `GetSelectedColumns` now checks `rows.Err()` after the iteration loop and wraps it as `error getting selected columns for table %s`, matching the check its sibling function in the same file already performs.
- All three callers — the `qrep` pull, table-schema fetch, and validation — previously read a truncated or empty list as fact; they now receive the underlying error.
- The connection failures that caused these bursts already classify on their own: `57P03` and a closed tunnel as `NOTIFY_CONNECTIVITY`, `57P01` as `NOTIFY_TERMINATE`, a bare `unexpected EOF` as `IGNORE_EOF`. No classifier change is needed.

### Verification

- `TestGetSelectedColumnsReportsMidStreamConnectionLoss` breaks a live connection after the query is sent and asserts that `GetSelectedColumns` returns an error rather than an empty column list. It fails against the unfixed code with a nil error and zero columns, reproducing the production symptom exactly.
- The full classifier suite is green, as is the Postgres connector package.
- An internal check rebuilt each observed production failure with the post-fix wrap chain and confirmed all of them classify into an existing class; none fall through to `OTHER`.

Resolves DBI-979
