### PR TITLE
fix(mysql): avoid unsafe inactive offset checkpoints

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -283,7 +283,19 @@ func pullAndSyncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDC
 			return nil, fmt.Errorf("failed to sync schema: %w", err)
 		}
 
-		return nil, a.applySchemaDeltas(ctx, config, recordBatchSync.SchemaDeltas)
+		if err := a.applySchemaDeltas(ctx, config, recordBatchSync.SchemaDeltas); err != nil {
+			return nil, err
+		}
+
+		// Deltas are durable now, so it is safe to move the offset past the DDL that produced them.
+		// Skip zero-value checkpoints: last_text has no monotonicity guard in the catalog, so writing
+		// one would clobber a stored offset such as a MySQL GTID set.
+		if checkpoint := recordBatchSync.GetLastCheckpoint(); checkpoint.Text != "" || checkpoint.ID != 0 {
+			if err := srcConn.UpdateReplStateLastOffset(ctx, checkpoint); err != nil {
+				return nil, a.Alerter.LogFlowError(ctx, flowName, err)
+			}
+		}
+		return nil, nil
 	}
 
 	var res *model.SyncResponse

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -1067,9 +1067,16 @@ func (c *MySqlConnector) PullRecords(
 					}
 
 					if recordCount == 0 {
+						if !inTx && len(req.RecordStream.SchemaDeltas) > 0 {
+							// Schema deltas only become durable once the batch ends, so end it here instead of
+							// checkpointing an offset that is already past the DDL that produced them.
+							c.logger.Info("[mysql] ending empty batch to apply pending schema deltas",
+								slog.Int("deltas", len(req.RecordStream.SchemaDeltas)))
+							return nil
+						}
 						// progress offset while no records read to avoid falling behind when all tables inactive
-						// do not checkpoint across an in-flight transaction or pending schema change
-						if updatedOffset != "" && !inTx && len(req.RecordStream.SchemaDeltas) == 0 {
+						// never checkpoint mid-transaction, updatedOffset can be a mid-group position in file/pos mode
+						if updatedOffset != "" && !inTx {
 							c.logger.Info("[mysql] updating inactive offset", slog.Any("offset", updatedOffset))
 							if err := c.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{Text: updatedOffset}); err != nil {
 								c.logger.Error("[mysql] failed to update offset, ignoring", slog.Any("error", err))

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -1068,7 +1068,8 @@ func (c *MySqlConnector) PullRecords(
 
 					if recordCount == 0 {
 						// progress offset while no records read to avoid falling behind when all tables inactive
-						if updatedOffset != "" {
+						// do not checkpoint across an in-flight transaction or pending schema change
+						if updatedOffset != "" && !inTx && len(req.RecordStream.SchemaDeltas) == 0 {
 							c.logger.Info("[mysql] updating inactive offset", slog.Any("offset", updatedOffset))
 							if err := c.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{Text: updatedOffset}); err != nil {
 								c.logger.Error("[mysql] failed to update offset, ignoring", slog.Any("error", err))


### PR DESCRIPTION
## Problem
We always advance the offset when there is no records and we've got a timeout from MySQL binlog reader. It's wrong, because there could be schema changes that we haven't persisted yet.

## Solution
- advance offset when there is no activity on the pipe other than DDLs ONLY after we applied DDLs to destination
- avoid persisting an inactive MySQL offset while a transaction is in progress (not directly related to the problem, but still a valid fix as it doesn't make sense to advance the offset while tx is in progress)
