### PR TITLE
Move Mongo validation tests to pkg

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -336,6 +336,18 @@ def connector_test(connector, extra_deps=[], vars_overrides={}, name='', test_ru
         allow_parallel=True,
     )
 
+def pkg_test(pkg, extra_deps=[], vars_overrides={}, test_run=''):
+    overrides_str = ' '.join(['%s=%s' % (var, value) for var, value in vars_overrides.items()])
+    test_run_arg = (' -run %s' % test_run) if test_run else ''
+    local_resource(
+        'pkg_' + pkg,
+        cmd='cd flow/pkg && %s go test -count=1 -v%s ./%s/...' % (overrides_str, test_run_arg, pkg),
+        labels=['Test'],
+        auto_init=False,
+        resource_deps=extra_deps,
+        # some tests are stateful so no parallel
+    )
+
 # These are overrides to provide different MySQL flavors with the same test definitions.
 mysql_gtid_vars = {
     'CI_MYSQL_PORT': resolve_env('CI_MYSQL_GTID_PORT'),
@@ -412,3 +424,7 @@ connector_test('mysql', ['provision-mariadb'], vars_overrides=mariadb_vars, name
 connector_test('mongo', ['provision-mongodb'])
 
 connector_test('clickhouse', ['provision-clickhouse'])
+
+# flow/pkg module tests
+
+pkg_test('mongo', ['provision-mongodb'])

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -570,6 +570,40 @@ func (s APITestSuite) TestMirrorValidation_InvalidTableMappings() {
 	}
 }
 
+// This is the canonical test that source validation is wired up.
+// Specific validaton tests go as integration tests in connectors or flow/pkg.
+func (s APITestSuite) TestMirrorValidation_MissingSourceTable() {
+	tableNames := []string{"missing_src_create_a", "missing_src_create_b"}
+	tableNameMapping := make(map[string]string, len(tableNames))
+	for _, tn := range tableNames {
+		tableNameMapping[AttachSchema(s, tn)] = tn
+	}
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      "missing_source_table_" + s.suffix,
+		TableNameMapping: tableNameMapping,
+		Destination:      s.ch.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+
+	_, err := s.ValidateCDCMirror(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.Error(s.t, err)
+	st, ok := status.FromError(err)
+	require.True(s.t, ok, "expected gRPC status error, got %T: %v", err, err)
+	require.Equal(s.t, codes.FailedPrecondition, st.Code(), "expected FailedPrecondition, got %s", st.Code())
+	require.Contains(s.t, st.Message(), "source tables do not exist")
+	for _, tn := range tableNames {
+		require.Contains(s.t, st.Message(), fmt.Sprintf("%s.%s", Schema(s), tn))
+	}
+
+	// creating the mirror has to refuse for the same reason
+	_, err = s.CreateCDCFlow(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
+	require.Error(s.t, err)
+	require.Contains(s.t, err.Error(), "source tables do not exist")
+	for _, tn := range tableNames {
+		require.Contains(s.t, err.Error(), fmt.Sprintf("%s.%s", Schema(s), tn))
+	}
+}
+
 func (s APITestSuite) TestPostgresDestinationValidation_MissingColumns() {
 	_, ok := s.source.(*PostgresSource)
 	if !ok {
@@ -1817,8 +1851,6 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnPausedPipe() {
 	s.waitForFlowDropped(env, flowConnConfig.FlowJobName)
 }
 
-// This is the canonical test that source validation is wired up.
-// Specific validaton tests go as integration tests in connectors or flow/pkg.
 func (s APITestSuite) TestResyncSourceTableMissing() {
 	tableNames := []string{"missing_src_a", "missing_src_b"}
 	qualifiedSourceTables := []string{AttachSchema(s, tableNames[0]), AttachSchema(s, tableNames[1])}

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/pkg/common"
-	"github.com/PeerDB-io/peerdb/flow/pkg/mongo"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
@@ -1228,122 +1227,6 @@ func (s APITestSuite) TestScripts() {
 	}
 }
 
-func (s APITestSuite) TestMongoDBOplogRetentionValidation() {
-	if _, ok := s.source.(*MongoSource); !ok {
-		s.t.Skip("only for MongoDB")
-	}
-
-	adminClient := s.Source().(*MongoSource).AdminClient()
-	err := adminClient.Database(Schema(s)).CreateCollection(s.t.Context(), "t1")
-	require.NoError(s.t, err)
-
-	connectionGen := FlowConnectionGenerationConfig{
-		FlowJobName:      "mongo_validation_" + s.suffix,
-		TableNameMapping: map[string]string{AttachSchema(s, "t1"): "t1"},
-		Destination:      s.ch.Peer().Name,
-	}
-	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
-
-	// test retention hours (< 24 hours) validation failure
-	err = adminClient.Database("admin").RunCommand(s.t.Context(), bson.D{
-		bson.E{Key: "replSetResizeOplog", Value: 1},
-		bson.E{Key: "minRetentionHours", Value: mongo.MinOplogRetentionHours - 1},
-	}).Err()
-	require.NoError(s.t, err)
-	res2, err := s.ValidateCDCMirror(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
-	require.Nil(s.t, res2)
-	require.Error(s.t, err)
-	st, ok := status.FromError(err)
-	require.True(s.t, ok)
-	require.Equal(s.t, codes.FailedPrecondition, st.Code())
-	require.Contains(s.t, st.Message(), "oplog retention must be set to >= 24 hours")
-
-	// test retention hours (>= 24 hours) validation success
-	err = adminClient.Database("admin").RunCommand(s.t.Context(), bson.D{
-		bson.E{Key: "replSetResizeOplog", Value: 1},
-		bson.E{Key: "minRetentionHours", Value: mongo.MinOplogRetentionHours},
-	}).Err()
-	require.NoError(s.t, err)
-	res1, err := s.ValidateCDCMirror(s.t.Context(), &protos.CreateCDCFlowRequest{ConnectionConfigs: flowConnConfig})
-	require.NoError(s.t, err)
-	require.NotNil(s.t, res1)
-}
-
-func (s APITestSuite) TestMongoDBUserRolesValidation() {
-	if _, ok := s.source.(*MongoSource); !ok {
-		s.t.Skip("only for MongoDB")
-	}
-
-	adminClient := s.Source().(*MongoSource).AdminClient()
-	user := "test_role_validation_user"
-	pass := "test_role_validation_pass"
-	mongoConfig := s.source.GeneratePeer(s.t).GetMongoConfig()
-	mongoConfig.Username = user
-	mongoConfig.Password = pass
-	peer := &protos.Peer{
-		Name:   AddSuffix(s, "mongo"),
-		Type:   protos.DBType_MONGO,
-		Config: &protos.Peer_MongoConfig{MongoConfig: mongoConfig},
-	}
-
-	defer func() {
-		_ = adminClient.Database("admin").RunCommand(s.t.Context(), bson.D{
-			bson.E{Key: "dropUser", Value: user},
-		})
-	}()
-
-	// case 1: user without `readAnyDatabase` and `clusterMonitor` roles
-	require.NoError(s.t, adminClient.Database("admin").RunCommand(s.t.Context(), bson.D{
-		{Key: "createUser", Value: user},
-		{Key: "pwd", Value: pass},
-		{Key: "roles", Value: bson.A{}},
-	}).Err())
-	_, err := s.ValidatePeer(s.t.Context(), &protos.ValidatePeerRequest{Peer: peer})
-	require.Error(s.t, err)
-	grpcStatus, ok := status.FromError(err)
-	require.True(s.t, ok, "expected error to be gRPC status")
-	require.Equal(s.t, codes.FailedPrecondition, grpcStatus.Code())
-	require.Contains(s.t, grpcStatus.Message(), "missing required role: readAnyDatabase")
-
-	// case 2: user with only `readAnyDatabase` role (missing `clusterMonitor`)
-	require.NoError(s.t, adminClient.Database("admin").RunCommand(s.t.Context(), bson.D{
-		bson.E{Key: "grantRolesToUser", Value: user},
-		bson.E{Key: "roles", Value: bson.A{"readAnyDatabase"}},
-	}).Err())
-	_, err = s.ValidatePeer(s.t.Context(), &protos.ValidatePeerRequest{Peer: peer})
-	require.Error(s.t, err)
-	grpcStatus, ok = status.FromError(err)
-	require.True(s.t, ok, "expected error to be gRPC status")
-	require.Equal(s.t, codes.FailedPrecondition, grpcStatus.Code())
-	require.Contains(s.t, grpcStatus.Message(), "missing required role: clusterMonitor")
-
-	// case 3: user with only `clusterMonitor` role (missing `readAnyDatabase`)
-	require.NoError(s.t, adminClient.Database("admin").RunCommand(s.t.Context(), bson.D{
-		bson.E{Key: "revokeRolesFromUser", Value: user},
-		bson.E{Key: "roles", Value: bson.A{"readAnyDatabase"}},
-	}).Err())
-	require.NoError(s.t, adminClient.Database("admin").RunCommand(s.t.Context(), bson.D{
-		bson.E{Key: "grantRolesToUser", Value: user},
-		bson.E{Key: "roles", Value: bson.A{"clusterMonitor"}},
-	}).Err())
-	_, err = s.ValidatePeer(s.t.Context(), &protos.ValidatePeerRequest{Peer: peer})
-	require.Error(s.t, err)
-	grpcStatus, ok = status.FromError(err)
-	require.True(s.t, ok, "expected error to be gRPC status")
-	require.Equal(s.t, codes.FailedPrecondition, grpcStatus.Code())
-	require.Contains(s.t, grpcStatus.Message(), "missing required role: readAnyDatabase")
-
-	// case 4: user with both `readAnyDatabase` and `clusterMonitor` roles
-	require.NoError(s.t, adminClient.Database("admin").RunCommand(s.t.Context(), bson.D{
-		bson.E{Key: "grantRolesToUser", Value: user},
-		bson.E{Key: "roles", Value: bson.A{"readAnyDatabase", "clusterMonitor"}},
-	}).Err())
-	response, err := s.ValidatePeer(s.t.Context(), &protos.ValidatePeerRequest{Peer: peer})
-	require.NoError(s.t, err)
-	require.NotNil(s.t, response)
-	require.Equal(s.t, protos.ValidatePeerStatus_VALID, response.Status)
-}
-
 func (s APITestSuite) TestMySQLFlavorSwap() {
 	my, ok := s.source.(*MySqlSource)
 	if !ok {
@@ -1934,6 +1817,8 @@ func (s APITestSuite) TestResyncWithSnapshotConfigOnPausedPipe() {
 	s.waitForFlowDropped(env, flowConnConfig.FlowJobName)
 }
 
+// This is the canonical test that source validation is wired up.
+// Specific validaton tests go as integration tests in connectors or flow/pkg.
 func (s APITestSuite) TestResyncSourceTableMissing() {
 	tableNames := []string{"missing_src_a", "missing_src_b"}
 	qualifiedSourceTables := []string{AttachSchema(s, tableNames[0]), AttachSchema(s, tableNames[1])}

--- a/flow/e2e/mongo.go
+++ b/flow/e2e/mongo.go
@@ -15,8 +15,8 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/connectors"
 	connmongo "github.com/PeerDB-io/peerdb/flow/connectors/mongo"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
-	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/pkg/testutil"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
@@ -96,7 +96,7 @@ func GetTestDatabase(suffix string) string {
 func SetupMongo(t *testing.T, suffix string) (*MongoSource, error) {
 	t.Helper()
 
-	admin := internal.MongoAdminTestCredentials(t)
+	admin := testutil.MongoAdminTestCredentials(t)
 	adminClient, err := mongo.Connect(options.Client().
 		ApplyURI(admin.URI).
 		SetAppName("Mongo admin client").
@@ -108,7 +108,7 @@ func SetupMongo(t *testing.T, suffix string) (*MongoSource, error) {
 		}))
 	require.NoError(t, err, "failed to setup mongo admin client")
 
-	user := internal.MongoUserTestCredentials(t)
+	user := testutil.MongoUserTestCredentials(t)
 
 	mongoConfig := &protos.MongoConfig{
 		Uri:        user.URI,

--- a/flow/internal/test_env.go
+++ b/flow/internal/test_env.go
@@ -286,35 +286,3 @@ func RDSIAMAuthMySQLTestConnectionInfo(t *testing.T) RDSIAMAuthTestConnectionInf
 	require.NotEmpty(t, info.Username, "missing FLOW_TESTS_RDS_IAM_AUTH_USERNAME_MYSQL env var")
 	return info
 }
-
-type MongoTestCredentials struct {
-	URI      string
-	Username string
-	Password string
-}
-
-func MongoAdminTestCredentials(t *testing.T) MongoTestCredentials {
-	t.Helper()
-	creds := MongoTestCredentials{
-		URI:      os.Getenv("CI_MONGO_ADMIN_URI"),
-		Username: os.Getenv("CI_MONGO_ADMIN_USERNAME"),
-		Password: os.Getenv("CI_MONGO_ADMIN_PASSWORD"),
-	}
-	require.NotEmpty(t, creds.URI, "missing CI_MONGO_ADMIN_URI env var")
-	require.NotEmpty(t, creds.Username, "missing CI_MONGO_ADMIN_USERNAME env var")
-	require.NotEmpty(t, creds.Password, "missing CI_MONGO_ADMIN_PASSWORD env var")
-	return creds
-}
-
-func MongoUserTestCredentials(t *testing.T) MongoTestCredentials {
-	t.Helper()
-	creds := MongoTestCredentials{
-		URI:      os.Getenv("CI_MONGO_URI"),
-		Username: os.Getenv("CI_MONGO_USERNAME"),
-		Password: os.Getenv("CI_MONGO_PASSWORD"),
-	}
-	require.NotEmpty(t, creds.URI, "missing CI_MONGO_URI env var")
-	require.NotEmpty(t, creds.Username, "missing CI_MONGO_USERNAME env var")
-	require.NotEmpty(t, creds.Password, "missing CI_MONGO_PASSWORD env var")
-	return creds
-}

--- a/flow/pkg/mongo/validation_test.go
+++ b/flow/pkg/mongo/validation_test.go
@@ -1,0 +1,142 @@
+package mongo
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/PeerDB-io/peerdb/flow/pkg/common"
+	"github.com/PeerDB-io/peerdb/flow/pkg/testutil"
+)
+
+func init() {
+	testutil.LoadEnv()
+}
+
+func connectMongo(t *testing.T, creds testutil.MongoTestCredentials, readPreference string) *mongo.Client {
+	t.Helper()
+
+	clientOptions, err := BuildClientOptions(ClientConfig{
+		Uri:            creds.URI,
+		Username:       creds.Username,
+		Password:       creds.Password,
+		ReadPreference: readPreference,
+		DisableTls:     true,
+	})
+	require.NoError(t, err)
+
+	client, err := mongo.Connect(clientOptions)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		disconnectCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, client.Disconnect(disconnectCtx))
+	})
+	return client
+}
+
+// oplog retention is replica-set-wide state, so this test must not run in parallel with
+// anything else that validates a mongo mirror
+func TestValidateOplogRetention(t *testing.T) {
+	ctx := t.Context()
+
+	adminClient := connectMongo(t, testutil.MongoAdminTestCredentials(t), ReadPreferencePrimary)
+	userClient := connectMongo(t, testutil.MongoUserTestCredentials(t), "")
+
+	initialStatus, err := GetServerStatus(ctx, adminClient)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		restoreCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, adminClient.Database("admin").RunCommand(restoreCtx, bson.D{
+			bson.E{Key: "replSetResizeOplog", Value: 1},
+			bson.E{Key: "minRetentionHours", Value: initialStatus.OplogTruncation.OplogMinRetentionHours},
+		}).Err())
+	})
+
+	// test retention hours (< 24 hours) validation failure
+	require.NoError(t, adminClient.Database("admin").RunCommand(ctx, bson.D{
+		bson.E{Key: "replSetResizeOplog", Value: 1},
+		bson.E{Key: "minRetentionHours", Value: MinOplogRetentionHours - 1},
+	}).Err())
+	require.ErrorContains(t, ValidateOplogRetention(ctx, userClient), "oplog retention must be set to >= 24 hours")
+
+	// test retention hours (>= 24 hours) validation success
+	require.NoError(t, adminClient.Database("admin").RunCommand(ctx, bson.D{
+		bson.E{Key: "replSetResizeOplog", Value: 1},
+		bson.E{Key: "minRetentionHours", Value: MinOplogRetentionHours},
+	}).Err())
+	require.NoError(t, ValidateOplogRetention(ctx, userClient))
+}
+
+func TestValidateUserRoles(t *testing.T) {
+	adminCreds := testutil.MongoAdminTestCredentials(t)
+	adminClient := connectMongo(t, adminCreds, ReadPreferencePrimary)
+
+	tests := []struct {
+		name    string
+		wantErr string
+		roles   bson.A
+	}{
+		{
+			name:    "no roles",
+			roles:   bson.A{},
+			wantErr: "missing required role: readAnyDatabase",
+		},
+		{
+			name:    "readAnyDatabase only",
+			roles:   bson.A{"readAnyDatabase"},
+			wantErr: "missing required role: clusterMonitor",
+		},
+		{
+			name:    "clusterMonitor only",
+			roles:   bson.A{"clusterMonitor"},
+			wantErr: "missing required role: readAnyDatabase",
+		},
+		{
+			name:  "both required roles",
+			roles: bson.A{"readAnyDatabase", "clusterMonitor"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			// a user per case, so the cases stay independent and a failure cannot
+			// strand a user that the next run would collide with
+			user := "pkgmongo_" + strings.ToLower(common.RandomString(8))
+			password := common.RandomString(16)
+			require.NoError(t, adminClient.Database("admin").RunCommand(ctx, bson.D{
+				bson.E{Key: "createUser", Value: user},
+				bson.E{Key: "pwd", Value: password},
+				bson.E{Key: "roles", Value: tt.roles},
+			}).Err())
+			t.Cleanup(func() {
+				dropCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				require.NoError(t, adminClient.Database("admin").RunCommand(dropCtx, bson.D{
+					bson.E{Key: "dropUser", Value: user},
+				}).Err())
+			})
+
+			userClient := connectMongo(t, testutil.MongoTestCredentials{
+				URI:      adminCreds.URI,
+				Username: user,
+				Password: password,
+			}, "")
+
+			err := ValidateUserRoles(ctx, userClient)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/flow/pkg/testutil/env.go
+++ b/flow/pkg/testutil/env.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
 )
 
 const timeZoneEnvKey = "TZ"
@@ -99,4 +101,36 @@ func ClickHouseTestPort() uint32 {
 		return 9000
 	}
 	return uint32(port)
+}
+
+type MongoTestCredentials struct {
+	URI      string
+	Username string
+	Password string
+}
+
+func MongoAdminTestCredentials(t *testing.T) MongoTestCredentials {
+	t.Helper()
+	creds := MongoTestCredentials{
+		URI:      os.Getenv("CI_MONGO_ADMIN_URI"),
+		Username: os.Getenv("CI_MONGO_ADMIN_USERNAME"),
+		Password: os.Getenv("CI_MONGO_ADMIN_PASSWORD"),
+	}
+	require.NotEmpty(t, creds.URI, "missing CI_MONGO_ADMIN_URI env var")
+	require.NotEmpty(t, creds.Username, "missing CI_MONGO_ADMIN_USERNAME env var")
+	require.NotEmpty(t, creds.Password, "missing CI_MONGO_ADMIN_PASSWORD env var")
+	return creds
+}
+
+func MongoUserTestCredentials(t *testing.T) MongoTestCredentials {
+	t.Helper()
+	creds := MongoTestCredentials{
+		URI:      os.Getenv("CI_MONGO_URI"),
+		Username: os.Getenv("CI_MONGO_USERNAME"),
+		Password: os.Getenv("CI_MONGO_PASSWORD"),
+	}
+	require.NotEmpty(t, creds.URI, "missing CI_MONGO_URI env var")
+	require.NotEmpty(t, creds.Username, "missing CI_MONGO_USERNAME env var")
+	require.NotEmpty(t, creds.Password, "missing CI_MONGO_PASSWORD env var")
+	return creds
 }


### PR DESCRIPTION
Validation tests can now comfortably live in pkg. The oplog one has a dependency on global DB state and can [cause flakes](https://github.com/PeerDB-io/peerdb/pull/4655#issuecomment-5186696449) so moving it out of the suite allows to not add t.Parallel() and make CI greener as well.

TestMirrorValidation_MissingSourceTable becomes the canonical one verifying the validation is hooked up for all sources.