### PR TITLE
Fix external contributor flow and Claude review that got it missed

### DIFF
--- a/.github/workflows/claude-code-review-dependencies-updates.yml
+++ b/.github/workflows/claude-code-review-dependencies-updates.yml
@@ -43,3 +43,9 @@ jobs:
       - name: Print Claude execution output
         if: always()
         run: cat /home/runner/work/_temp/claude-execution-output.json || echo "No execution output found"
+
+      - name: Fail if the review was skipped
+        if: steps.claude-review.outputs.skipped_due_to_workflow_validation_mismatch == 'true'
+        run: |
+          echo "::error::Claude review did not run: this PR modifies its own review workflow, so claude-code-action skipped the token exchange. Review the upstream release notes for the bumped dependencies by hand before merging."
+          exit 1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,3 +46,9 @@ jobs:
       - name: Print Claude execution output
         if: always()
         run: cat /home/runner/work/_temp/claude-execution-output.json || echo "No execution output found"
+
+      - name: Fail if the review was skipped
+        if: steps.claude-review.outputs.skipped_due_to_workflow_validation_mismatch == 'true'
+        run: |
+          echo "::error::Claude review did not run: this PR modifies its own review workflow, so claude-code-action skipped the token exchange. This PR needs a manual review."
+          exit 1

--- a/.github/workflows/tilt-flow.yml
+++ b/.github/workflows/tilt-flow.yml
@@ -209,6 +209,9 @@ jobs:
           # Empty = the event's default checkout; callers on pull_request_target
           # pass the PR head SHA here.
           ref: ${{ inputs.checkout_ref }}
+          # checkout refuses fork code under pull_request_target unless opted in;
+          # flow.yml's external-contributor environment gate is the human review.
+          allow-unsafe-pr-checkout: true
 
       # Combination id for test-results ingestion steps
       - name: Compute run identity


### PR DESCRIPTION
Actions dependencies upgrade https://github.com/PeerDB-io/peerdb/pull/4627 brought in https://github.com/actions/checkout/pull/2454 that [broke](https://github.com/PeerDB-io/peerdb/actions/runs/30993374499/job/92368164796?pr=4663) the external contributor flow. Claude Code dependenices action is supposed to catch breaking changes but it itself was bumped and it refuses to run in those cases.

Do the opt-in into checkout for external PRs and make Claude fail loudly to signal the need for a human review.