### PR TITLE
Classify DocumentDB Invalid resume token

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -45,6 +45,7 @@ const (
 	MongoInterruptedDueToReplStateChange = "(InterruptedDueToReplStateChange) operation was interrupted"
 	MongoIncompleteReadOfMessageHeader   = "incomplete read of message header"
 	MongoTLSInvalidServerCertSignature   = "tls: invalid signature by the server certificate"
+	MongoInvalidResumeToken              = "Invalid resume token"
 
 	// mysqlGeometryLinearRingNotClosedError is the specific WKB parse failure raised by the
 	// go-geos library when a LinearRing's points do not close. Used to give a more specific code
@@ -928,6 +929,11 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 		switch mongoCmdErr.Code {
 		case 6: // HostUnreachable
 			return ErrorRetryRecoverable, mongoErrorInfo
+		case 9: // FailedToParse
+			if mongoCmdErr.HasErrorMessage(MongoInvalidResumeToken) {
+				return ErrorNotifyChangeStreamHistoryLost, mongoErrorInfo
+			}
+			return ErrorOther, mongoErrorInfo
 		case 13: // Unauthorized
 			return ErrorNotifyConnectivity, mongoErrorInfo
 		case 18: // AuthenticationFailed

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1144,6 +1144,34 @@ func TestMongoCursorErrors(t *testing.T) {
 	}, errInfo)
 }
 
+func TestMongoInvalidResumeTokenShouldNotifyChangeStreamHistoryLost(t *testing.T) {
+	// Name stays empty because DocumentDB sends no codeName
+	err := mongo.CommandError{
+		Code:    9,
+		Message: "Invalid resume token: {_data: '82F54892F8B8B8D4C53CCAEF364BB84E'}",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed to create change stream: %w", err))
+	assert.Equal(t, ErrorNotifyChangeStreamHistoryLost, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMongoDB,
+		Code:   "9",
+	}, errInfo, "Unexpected error info")
+}
+
+func TestMongoFailedToParseWithoutResumeTokenStaysOther(t *testing.T) {
+	err := mongo.CommandError{
+		Code:    9,
+		Name:    "FailedToParse",
+		Message: "unknown operator: $notAnOperator",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed to create change stream: %w", err))
+	assert.Equal(t, ErrorOther, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMongoDB,
+		Code:   "9",
+	}, errInfo, "Unexpected error info")
+}
+
 func TestMongoTLSInvalidServerCertSignatureShouldBeRecoverable(t *testing.T) {
 	de := driver.Error{
 		Labels: []string{driver.NetworkError},


### PR DESCRIPTION
### Error (sanitized)

CDC fails on a MongoDB-API source backed by Amazon DocumentDB, at the point where `PullRecords` in the Mongo connector opens the change stream with the stored resume token. The server rejects the command:

```
failed to create change stream:  Invalid resume token: {_data: '82F54892F8B8B8D4C53CCAEF364BB84E'}
```

The line emits `errorClass=OTHER`, `errorCode=9` today. One pipe, one time: a short burst of retries over a few minutes that did not self-heal, and the mirror recovered only after a resync.

### Investigation

A server that cannot decode a `resumeAfter` token rejects the command with the generic `FailedToParse` code 9 and the message `Invalid resume token`. That differs from `ChangeStreamHistoryLost` (286) and `CappedPositionLost` (136), which cover well-formed tokens that aged out of the change stream log. Here the source was unreachable for several weeks with the stored token frozen, and when connectivity returned the pipe reached a different backing database through a different bastion host.

- [MongoDB KeyString, `kTimestamp = 130`](https://github.com/mongodb/mongo/blob/ebe22809e0641182af43c9e3d00b1e1d6fcb52cc/src/mongo/db/storage/key_string/key_string.cpp#L91) — `0x82` leads a MongoDB-format token; the rejected token decodes as well-formed KeyString whose cluster time matches the pipe's last progress, while tokens the new server mints start with `0x01`.
- [Amazon DocumentDB change streams](https://docs.aws.amazon.com/documentdb/latest/developerguide/change_streams.html) — DocumentDB keeps its own change stream log, token format, and retention window.
- [Recover from an Invalid Resume Token](https://www.mongodb.com/docs/kafka-connector/current/troubleshooting/recover-from-invalid-resume-token/) — the vendor remedy for a token the server will not accept is to drop it and re-establish the stream, which for a CDC pipe means a resync.
- [Go driver `CommandError.Error()`](https://github.com/mongodb/mongo-go-driver/blob/master/mongo/errors.go) — renders an optional `(name)`, then a space, then the message; DocumentDB sends no `codeName`, which accounts for the doubled space after `change stream:`.

Confidence is high: the token decodes cleanly, its cluster time lines up with the last successful sync, the connection details show the source moved hosts during the outage, and a resync is what fixed production. The action is to notify the user, since only the customer can resync the mirror. Two doubts are worth attention — code 9 is generic enough that a malformed PeerDB aggregation pipeline carries it too, so the match stays pinned to the message; and this wording was observed once, from DocumentDB, so a real MongoDB server may phrase it differently and still fall through to `OTHER`.

Resolves DBI-1002
