### PR TITLE
Add test cases for detecting incompatible Temporal history

### DIFF
--- a/flow/workflows/autoenv_test.go
+++ b/flow/workflows/autoenv_test.go
@@ -1,0 +1,12 @@
+package peerflow
+
+import (
+	"github.com/PeerDB-io/peerdb/flow/pkg/testutil"
+)
+
+// The replay fixture generator reaches the catalog through local activities,
+// so load connection settings from the project-root .env like the other
+// test suites do.
+func init() {
+	testutil.LoadEnv()
+}

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -589,20 +589,20 @@ func CDCFlowWorkflow(
 	originalRunID := workflow.GetInfo(ctx).OriginalRunID
 	state.SyncFlowOptions.NumberOfSyncs = 0 // removed feature
 
-	// MIGRATION: Migrate Postgres table OIDs to catalog before starting/resuming the flow
-	migrateCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 1 * time.Hour,
-		HeartbeatTimeout:    2 * time.Minute,
-	})
-	if err := workflow.ExecuteActivity(
-		migrateCtx,
-		flowable.MigratePostgresTableOIDs,
-		cfg.FlowJobName,
-		state.SyncFlowOptions.SrcTableIdNameMapping,
-		state.SyncFlowOptions.TableMappings,
-	).Get(migrateCtx, nil); err != nil {
-		return state, fmt.Errorf("failed to migrate Postgres table OIDs: %w", err)
-	}
+	//// MIGRATION: Migrate Postgres table OIDs to catalog before starting/resuming the flow
+	//migrateCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+	//	StartToCloseTimeout: 1 * time.Hour,
+	//	HeartbeatTimeout:    2 * time.Minute,
+	//})
+	//if err := workflow.ExecuteActivity(
+	//	migrateCtx,
+	//	flowable.MigratePostgresTableOIDs,
+	//	cfg.FlowJobName,
+	//	state.SyncFlowOptions.SrcTableIdNameMapping,
+	//	state.SyncFlowOptions.TableMappings,
+	//).Get(migrateCtx, nil); err != nil {
+	//	return state, fmt.Errorf("failed to migrate Postgres table OIDs: %w", err)
+	//}
 
 	for {
 		if err := ctx.Err(); err != nil {

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -589,20 +589,20 @@ func CDCFlowWorkflow(
 	originalRunID := workflow.GetInfo(ctx).OriginalRunID
 	state.SyncFlowOptions.NumberOfSyncs = 0 // removed feature
 
-	//// MIGRATION: Migrate Postgres table OIDs to catalog before starting/resuming the flow
-	//migrateCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-	//	StartToCloseTimeout: 1 * time.Hour,
-	//	HeartbeatTimeout:    2 * time.Minute,
-	//})
-	//if err := workflow.ExecuteActivity(
-	//	migrateCtx,
-	//	flowable.MigratePostgresTableOIDs,
-	//	cfg.FlowJobName,
-	//	state.SyncFlowOptions.SrcTableIdNameMapping,
-	//	state.SyncFlowOptions.TableMappings,
-	//).Get(migrateCtx, nil); err != nil {
-	//	return state, fmt.Errorf("failed to migrate Postgres table OIDs: %w", err)
-	//}
+	// MIGRATION: Migrate Postgres table OIDs to catalog before starting/resuming the flow
+	migrateCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 1 * time.Hour,
+		HeartbeatTimeout:    2 * time.Minute,
+	})
+	if err := workflow.ExecuteActivity(
+		migrateCtx,
+		flowable.MigratePostgresTableOIDs,
+		cfg.FlowJobName,
+		state.SyncFlowOptions.SrcTableIdNameMapping,
+		state.SyncFlowOptions.TableMappings,
+	).Get(migrateCtx, nil); err != nil {
+		return state, fmt.Errorf("failed to migrate Postgres table OIDs: %w", err)
+	}
 
 	for {
 		if err := ctx.Err(); err != nil {

--- a/flow/workflows/cdc_flow_replay_fixtures_test.go
+++ b/flow/workflows/cdc_flow_replay_fixtures_test.go
@@ -30,10 +30,6 @@ import (
 // The replay test TestCDCFlowWorkflowReplay re-executes the workflow code
 // against these recorded histories and checks for the same command sequence.
 //
-// To generate fixture, start the catalog and run the following command:
-//
-//	PEERDB_GENERATE_REPLAY_FIXTURES=1 go test -count=1 -timeout 10m -run TestGenerateCDCFlowReplayFixtures ./workflows/
-//
 // Note that fake activity implementations are registered under production names
 // to generate history. This is sufficient because replay never re-executes
 // activities, it validates only the command sequence the workflow  code issues.
@@ -41,7 +37,16 @@ import (
 //
 // IMPORTANT: fixtures must be generated from the workflow code that is currently
 // deployed, never from the branch under test. Otherwise, replay compares new code
-// against history that new code generates and trivially passes.
+// against history that new code generates and trivially passes. To regenerate
+// fixtures:
+//  1. Check out the commit corresponding to the version currently deployed in production.
+//  2. Make the desired changes to this file only (e.g. add or modify scenarios)
+//  3. Start the catalog:
+//     docker compose -f docker-compose-dev.yml up -d catalog
+//  4. Regenerate fixtures:
+//     PEERDB_GENERATE_REPLAY_FIXTURES=1 go test -count=1 -timeout 10m -run TestGenerateCDCFlowReplayFixtures ./workflows/
+//  5. Check out the development branch.
+//  6. Commit the fixture changes (TestCDCFlowWorkflowReplay should pass).
 func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
 	if os.Getenv("PEERDB_GENERATE_REPLAY_FIXTURES") != "1" {
 		t.Skip("set PEERDB_GENERATE_REPLAY_FIXTURES=1 to regenerate replay fixtures")
@@ -50,7 +55,6 @@ func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
-	setCatalogEnvDefaults(t)
 	ensureFlowsTable(ctx, t)
 
 	devServer := startDevServer(ctx, t)
@@ -109,21 +113,6 @@ func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
 		exportHistory(ctx, t, c, wfID, firstRunID, "running_sync_finish")
 		terminateWorkflow(ctx, t, c, wfID)
 	})
-}
-
-func setCatalogEnvDefaults(t *testing.T) {
-	t.Helper()
-	for key, val := range map[string]string{
-		"PEERDB_CATALOG_HOST":     "localhost",
-		"PEERDB_CATALOG_PORT":     "9901",
-		"PEERDB_CATALOG_USER":     "postgres",
-		"PEERDB_CATALOG_PASSWORD": "postgres",
-		"PEERDB_CATALOG_DATABASE": "postgres",
-	} {
-		if os.Getenv(key) == "" {
-			t.Setenv(key, val)
-		}
-	}
 }
 
 func ensureFlowsTable(ctx context.Context, t *testing.T) {

--- a/flow/workflows/cdc_flow_replay_fixtures_test.go
+++ b/flow/workflows/cdc_flow_replay_fixtures_test.go
@@ -109,7 +109,6 @@ func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
 		exportHistory(ctx, t, c, wfID, firstRunID, "running_sync_finish")
 		terminateWorkflow(ctx, t, c, wfID)
 	})
-
 }
 
 func setCatalogEnvDefaults(t *testing.T) {

--- a/flow/workflows/cdc_flow_replay_fixtures_test.go
+++ b/flow/workflows/cdc_flow_replay_fixtures_test.go
@@ -1,0 +1,319 @@
+package peerflow
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
+	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/shared"
+	"github.com/PeerDB-io/peerdb/flow/workflows/cdc_state"
+)
+
+// TestGenerateCDCFlowReplayFixtures records real CDCFlowWorkflow histories into
+// testdata/replay/*.json for TestCDCFlowWorkflowReplay. History records the
+// commands the workflow issued in order and the result the activity returned.
+// The replay test TestCDCFlowWorkflowReplay re-executes the workflow code
+// against these recorded histories and checks for the same command sequence.
+//
+// To generate fixture, start the catalog and run the following command:
+//
+//	PEERDB_GENERATE_REPLAY_FIXTURES=1 go test -count=1 -timeout 10m -run TestGenerateCDCFlowReplayFixtures ./workflows/
+//
+// Note that fake activity implementations are registered under production names
+// to generate history. This is sufficient because replay never re-executes
+// activities, it validates only the command sequence the workflow  code issues.
+// The one exception is local activities, which is why the catalog must be running.
+//
+// IMPORTANT: fixtures must be generated from the workflow code that is currently
+// deployed, never from the branch under test. Otherwise, replay compares new code
+// against history that new code generates and trivially passes.
+func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
+	if os.Getenv("PEERDB_GENERATE_REPLAY_FIXTURES") != "1" {
+		t.Skip("set PEERDB_GENERATE_REPLAY_FIXTURES=1 to regenerate replay fixtures")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	setCatalogEnvDefaults(t)
+	ensureFlowsTable(ctx, t)
+
+	devServer := startDevServer(ctx, t)
+	defer func() { _ = devServer.Stop() }()
+	c := devServer.Client()
+
+	w := worker.New(c, internal.PeerFlowTaskQueueName(shared.PeerFlowTaskQueue), worker.Options{})
+	w.RegisterWorkflow(CDCFlowWorkflow)
+	registerFakeActivities(w)
+	require.NoError(t, w.Start())
+	defer w.Stop()
+
+	require.NoError(t, os.MkdirAll(filepath.Join("testdata", "replay"), 0o755))
+
+	t.Run("parked_resume", func(t *testing.T) {
+		wfID, firstRunID := startParkedFlow(ctx, t, c, "parked-resume")
+		require.NoError(t, c.SignalWorkflow(ctx, wfID, firstRunID, model.FlowSignal.Name, model.NoopSignal))
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		exportHistory(ctx, t, c, wfID, firstRunID, "parked_resume")
+		terminateWorkflow(ctx, t, c, wfID)
+	})
+
+	t.Run("parked_config_update", func(t *testing.T) {
+		wfID, firstRunID := startParkedFlow(ctx, t, c, "parked-config-update")
+		update := &protos.CDCFlowConfigUpdate{BatchSize: 250, IdleTimeout: 33}
+		require.NoError(t, c.SignalWorkflow(ctx, wfID, firstRunID, model.CDCDynamicPropertiesSignal.Name, update))
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		exportHistory(ctx, t, c, wfID, firstRunID, "parked_config_update")
+		terminateWorkflow(ctx, t, c, wfID)
+	})
+
+	t.Run("running_pause", func(t *testing.T) {
+		wfID, firstRunID := startRunningFlow(ctx, t, c, "running-pause")
+		waitPendingActivity(ctx, t, c, wfID, firstRunID, "SyncFlow")
+		require.NoError(t, c.SignalWorkflow(ctx, wfID, firstRunID, model.FlowSignal.Name, model.PauseSignal))
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		exportHistory(ctx, t, c, wfID, firstRunID, "running_pause")
+		terminateWorkflow(ctx, t, c, wfID)
+	})
+
+	t.Run("running_terminate", func(t *testing.T) {
+		wfID, firstRunID := startRunningFlow(ctx, t, c, "running-terminate")
+		waitPendingActivity(ctx, t, c, wfID, firstRunID, "SyncFlow")
+		req := &protos.FlowStateChangeRequest{RequestedFlowState: protos.FlowStatus_STATUS_TERMINATING}
+		require.NoError(t, c.SignalWorkflow(ctx, wfID, firstRunID, model.FlowSignalStateChange.Name, req))
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		exportHistory(ctx, t, c, wfID, firstRunID, "running_terminate")
+		terminateWorkflow(ctx, t, c, wfID)
+	})
+
+	t.Run("running_sync_finish", func(t *testing.T) {
+		// the fake SyncFlow returns promptly for this flow name, exercising the
+		// steady-state "sync finished -> ContinueAsNew" path
+		wfID, firstRunID := startRunningFlow(ctx, t, c, "running-sync-finish")
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		exportHistory(ctx, t, c, wfID, firstRunID, "running_sync_finish")
+		terminateWorkflow(ctx, t, c, wfID)
+	})
+
+}
+
+func setCatalogEnvDefaults(t *testing.T) {
+	t.Helper()
+	for key, val := range map[string]string{
+		"PEERDB_CATALOG_HOST":     "localhost",
+		"PEERDB_CATALOG_PORT":     "9901",
+		"PEERDB_CATALOG_USER":     "postgres",
+		"PEERDB_CATALOG_PASSWORD": "postgres",
+		"PEERDB_CATALOG_DATABASE": "postgres",
+	} {
+		if os.Getenv(key) == "" {
+			t.Setenv(key, val)
+		}
+	}
+}
+
+func ensureFlowsTable(ctx context.Context, t *testing.T) {
+	t.Helper()
+	pool, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
+	require.NoError(t, err, "catalog Postgres unreachable; see generator doc comment for setup")
+	_, err = pool.Exec(ctx,
+		"CREATE TABLE IF NOT EXISTS flows (workflow_id text, name text, status integer, updated_at timestamptz DEFAULT now())")
+	require.NoError(t, err)
+}
+
+func startDevServer(ctx context.Context, t *testing.T) *testsuite.DevServer {
+	t.Helper()
+	opts := testsuite.DevServerOptions{
+		// CDCFlowWorkflow attaches the MirrorName search attribute
+		// (shared.NewSearchAttributes) to child workflows it schedules; register
+		// it so the server doesn't reject commands with BadSearchAttributes
+		ExtraArgs: []string{"--search-attribute", "MirrorName=Text"},
+	}
+	if path, err := exec.LookPath("temporal"); err == nil {
+		opts.ExistingPath = path
+	}
+	devServer, err := testsuite.StartDevServer(ctx, opts)
+	require.NoError(t, err)
+	return devServer
+}
+
+// registerFakeActivities registers fake CDCFlowWorkflow activities under the production name.
+func registerFakeActivities(w worker.Worker) {
+	w.RegisterActivityWithOptions(
+		func(ctx context.Context, flowName string, srcTableIdNameMapping map[uint32]string, tableMappings []*protos.TableMapping) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "MigratePostgresTableOIDs"},
+	)
+	w.RegisterActivityWithOptions(
+		func(ctx context.Context, input *protos.FlowContextMetadataInput) (*protos.FlowContextMetadata, error) {
+			return &protos.FlowContextMetadata{FlowName: input.FlowName}, nil
+		},
+		activity.RegisterOptions{Name: "GetFlowMetadata"},
+	)
+	w.RegisterActivityWithOptions(
+		func(ctx context.Context, cfg *protos.FlowConnectionConfigsCore) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "UpdateCDCConfigInCatalogActivity"},
+	)
+	w.RegisterActivityWithOptions(
+		func(ctx context.Context, cfg *protos.FlowConnectionConfigsCore, opts *protos.SyncFlowOptions) error {
+			// one registration serves all scenarios, so behavior is keyed on flow
+			// name: running-sync-finish needs SyncFlow to complete (recording the
+			// sync-finished -> ContinueAsNew path), while running-pause/-terminate
+			// need it stuck in flight so the signal cancels an active sync
+			if cfg.FlowJobName == fixtureFlowName("running-sync-finish") {
+				time.Sleep(2 * time.Second)
+				return nil
+			}
+			// block until canceled; heartbeats are required both by the 1-minute
+			// HeartbeatTimeout and to receive the cancellation from the server
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(time.Second):
+					activity.RecordHeartbeat(ctx)
+				}
+			}
+		},
+		activity.RegisterOptions{Name: "SyncFlow"},
+	)
+}
+
+func fixtureFlowName(scenario string) string {
+	return "replay-fixture-" + scenario
+}
+
+func fixtureConfig(scenario string) *protos.FlowConnectionConfigsCore {
+	return &protos.FlowConnectionConfigsCore{
+		FlowJobName:        fixtureFlowName(scenario),
+		MaxBatchSize:       100,
+		IdleTimeoutSeconds: 10,
+		TableMappings: []*protos.TableMapping{
+			{SourceTableIdentifier: "public.replay_src", DestinationTableIdentifier: "replay_dst"},
+		},
+	}
+}
+
+func fixtureState(cfg *protos.FlowConnectionConfigsCore, signal model.CDCFlowSignal, status protos.FlowStatus) *cdc_state.CDCFlowWorkflowState {
+	return &cdc_state.CDCFlowWorkflowState{
+		ActiveSignal:      signal,
+		CurrentFlowStatus: status,
+		SyncFlowOptions: &protos.SyncFlowOptions{
+			BatchSize:          cfg.MaxBatchSize,
+			IdleTimeoutSeconds: cfg.IdleTimeoutSeconds,
+			TableMappings:      cfg.TableMappings,
+		},
+	}
+}
+
+// startParkedFlow starts a run whose carried-over state has ActiveSignal=PauseSignal,
+// mimicking the run created by ContinueAsNew when a mirror is paused, and waits for
+// it to park in the pause loop.
+func startParkedFlow(ctx context.Context, t *testing.T, c client.Client, scenario string) (string, string) {
+	t.Helper()
+	cfg := fixtureConfig(scenario)
+	state := fixtureState(cfg, model.PauseSignal, protos.FlowStatus_STATUS_PAUSING)
+	run, err := c.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        fixtureFlowName(scenario),
+		TaskQueue: internal.PeerFlowTaskQueueName(shared.PeerFlowTaskQueue),
+	}, CDCFlowWorkflow, cfg, state)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		val, err := c.QueryWorkflow(ctx, run.GetID(), run.GetRunID(), shared.CDCFlowStateQuery)
+		if err != nil {
+			return false
+		}
+		var st cdc_state.CDCFlowWorkflowState
+		if err := val.Get(&st); err != nil {
+			return false
+		}
+		return st.CurrentFlowStatus == protos.FlowStatus_STATUS_PAUSED
+	}, time.Minute, 200*time.Millisecond, "workflow never parked in pause loop")
+
+	return run.GetID(), run.GetRunID()
+}
+
+// startRunningFlow starts a run whose carried-over state is already RUNNING, so the
+// workflow skips setup/snapshot and goes straight to the main loop.
+func startRunningFlow(ctx context.Context, t *testing.T, c client.Client, scenario string) (string, string) {
+	t.Helper()
+	cfg := fixtureConfig(scenario)
+	state := fixtureState(cfg, model.NoopSignal, protos.FlowStatus_STATUS_RUNNING)
+	run, err := c.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        fixtureFlowName(scenario),
+		TaskQueue: internal.PeerFlowTaskQueueName(shared.PeerFlowTaskQueue),
+	}, CDCFlowWorkflow, cfg, state)
+	require.NoError(t, err)
+	return run.GetID(), run.GetRunID()
+}
+
+func waitPendingActivity(ctx context.Context, t *testing.T, c client.Client, wfID, runID, activityName string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		resp, err := c.DescribeWorkflowExecution(ctx, wfID, runID)
+		if err != nil {
+			return false
+		}
+		for _, pending := range resp.PendingActivities {
+			if pending.ActivityType.GetName() == activityName {
+				return true
+			}
+		}
+		return false
+	}, time.Minute, 200*time.Millisecond, "activity %s never became pending", activityName)
+}
+
+func waitContinuedAsNew(ctx context.Context, t *testing.T, c client.Client, wfID, runID string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		resp, err := c.DescribeWorkflowExecution(ctx, wfID, runID)
+		if err != nil {
+			return false
+		}
+		return resp.WorkflowExecutionInfo.Status == enums.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
+	}, time.Minute, 200*time.Millisecond, "run %s never continued-as-new", runID)
+}
+
+func exportHistory(ctx context.Context, t *testing.T, c client.Client, wfID, runID, name string) {
+	t.Helper()
+	iter := c.GetWorkflowHistory(ctx, wfID, runID, false, enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	var history historypb.History
+	for iter.HasNext() {
+		event, err := iter.Next()
+		require.NoError(t, err)
+		history.Events = append(history.Events, event)
+	}
+	require.NotEmpty(t, history.Events)
+
+	data, err := protojson.MarshalOptions{Indent: "  "}.Marshal(&history)
+	require.NoError(t, err)
+	path := filepath.Join("testdata", "replay", name+".json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	t.Logf("wrote %s (%d events)", path, len(history.Events))
+}
+
+func terminateWorkflow(ctx context.Context, t *testing.T, c client.Client, wfID string) {
+	t.Helper()
+	if err := c.TerminateWorkflow(ctx, wfID, "", "replay fixture generation complete"); err != nil {
+		t.Logf("failed to terminate %s: %v", wfID, err)
+	}
+}

--- a/flow/workflows/cdc_flow_replay_test.go
+++ b/flow/workflows/cdc_flow_replay_test.go
@@ -1,0 +1,35 @@
+package peerflow
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/worker"
+)
+
+// TestCDCFlowWorkflowReplay replays recorded CDCFlowWorkflow histories against the
+// current workflow code. A failure here means the current code produces a different
+// command sequence than the code that recorded the history, which would cause
+// TMPRL1100 non-determinism errors on live workflows after a deploy.
+//
+// The fixtures that the test runs against reside in testdata/replay/. Since we don't
+// employ patching or versioning today; the event history should always replay successfully.
+//
+// If this test fails after an intentional change, the change may NOT be safe to deploy
+// while any mirror has a run recorded by the previous release.
+func TestCDCFlowWorkflowReplay(t *testing.T) {
+	files, err := filepath.Glob(filepath.Join("testdata", "replay", "*.json"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files,
+		"no replay fixtures found under testdata/replay; regenerate with the instructions in cdc_flow_replay_fixtures_test.go")
+
+	for _, file := range files {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			replayer := worker.NewWorkflowReplayer()
+			replayer.RegisterWorkflow(CDCFlowWorkflow)
+			require.NoError(t, replayer.ReplayWorkflowHistoryFromJSONFile(nil, file),
+				"replay diverged from recorded history: this change breaks determinism for in-flight CDCFlowWorkflow runs")
+		})
+	}
+}

--- a/flow/workflows/testdata/replay/parked_config_update.json
+++ b/flow/workflows/testdata/replay/parked_config_update.json
@@ -1,0 +1,383 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-07T06:47:13.496510Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048626",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXBhcmtlZC1jb25maWctdXBkYXRlIiwidGFibGVNYXBwaW5ncyI6W3sic291cmNlVGFibGVJZGVudGlmaWVyIjoicHVibGljLnJlcGxheV9zcmMiLCJkZXN0aW5hdGlvblRhYmxlSWRlbnRpZmllciI6InJlcGxheV9kc3QifV0sIm1heEJhdGNoU2l6ZSI6MTAwLCJpZGxlVGltZW91dFNlY29uZHMiOiIxMCJ9"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MiwiQ3VycmVudEZsb3dTdGF0dXMiOjMsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "019fdaf9-d358-77c8-be5d-3c007e105968",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "firstExecutionRunId": "019fdaf9-d358-77c8-be5d-3c007e105968",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "replay-fixture-parked-config-update"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-07T06:47:13.496535Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048627",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-07T06:47:13.497554Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048632",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "c46dcf8a-f7bb-44ca-8a51-fe0d409caa35",
+        "historySizeBytes": "1060",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-07T06:47:13.500652Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048636",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.45.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-07T06:47:13.500678Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048637",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJBY3Rpdml0eUlEIjoiMSIsIkFjdGl2aXR5VHlwZSI6InVwZGF0ZUZsb3dTdGF0dXNJbkNhdGFsb2dBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDI2LTA4LTA3VDA2OjQ3OjEzLjQ5ODkwNTQxN1oiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "Mg=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-07T06:47:13.501665Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048640",
+      "workflowExecutionSignaledEventAttributes": {
+        "signalName": "cdc-dynamic-properties",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuQ0RDRmxvd0NvbmZpZ1VwZGF0ZQ=="
+              },
+              "data": "eyJiYXRjaFNpemUiOjI1MCwiaWRsZVRpbWVvdXQiOiIzMyJ9"
+            }
+          ]
+        },
+        "identity": "21176@macbook-pro-ch.lan@",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-07T06:47:13.501667Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048641",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-07T06:47:13.502209Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048645",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "7",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "d88b77f6-ccbc-4067-bb39-bc89d0db8fd3",
+        "historySizeBytes": "1900",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-07T06:47:13.503612Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048649",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "7",
+        "startedEventId": "8",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            5,
+            8
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-07T06:47:13.503642Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048650",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "10",
+        "activityType": {
+          "name": "UpdateCDCConfigInCatalogActivity"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXBhcmtlZC1jb25maWctdXBkYXRlIiwidGFibGVNYXBwaW5ncyI6W3sic291cmNlVGFibGVJZGVudGlmaWVyIjoicHVibGljLnJlcGxheV9zcmMiLCJkZXN0aW5hdGlvblRhYmxlSWRlbnRpZmllciI6InJlcGxheV9kc3QifV0sIm1heEJhdGNoU2l6ZSI6MjUwLCJpZGxlVGltZW91dFNlY29uZHMiOiIzMyJ9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "300s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "9",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-07T06:47:13.504711Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048655",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "10",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "78dc84db-b029-4ad4-8f20-7666a940827c",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-07T06:47:13.505965Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048656",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "10",
+        "startedEventId": "11",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-07T06:47:13.505968Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048657",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-07T06:47:13.506633Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048661",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "13",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "49b9ca00-d1dd-4a39-9a45-8f67ad0ec4e6",
+        "historySizeBytes": "2872",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-07T06:47:13.510523Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048665",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "13",
+        "startedEventId": "14",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-07T06:47:13.510542Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048666",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJBY3Rpdml0eUlEIjoiMiIsIkFjdGl2aXR5VHlwZSI6InVwZGF0ZUZsb3dTdGF0dXNJbkNhdGFsb2dBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDI2LTA4LTA3VDA2OjQ3OjEzLjUwOTE1NDg3NVoiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "MQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "15"
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-07T06:47:13.510723Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW",
+      "taskId": "1048667",
+      "workflowExecutionContinuedAsNewEventAttributes": {
+        "newExecutionRunId": "e670421f-0ed0-4eda-bb11-0b42eeabe80e",
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXBhcmtlZC1jb25maWctdXBkYXRlIiwidGFibGVNYXBwaW5ncyI6W3sic291cmNlVGFibGVJZGVudGlmaWVyIjoicHVibGljLnJlcGxheV9zcmMiLCJkZXN0aW5hdGlvblRhYmxlSWRlbnRpZmllciI6InJlcGxheV9kc3QifV0sIm1heEJhdGNoU2l6ZSI6MTAwLCJpZGxlVGltZW91dFNlY29uZHMiOiIxMCJ9"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MjUwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MzMsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MCwiQ3VycmVudEZsb3dTdGF0dXMiOjEsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "workflowTaskCompletedEventId": "15",
+        "header": {},
+        "inheritBuildId": true
+      }
+    }
+  ]
+}

--- a/flow/workflows/testdata/replay/parked_resume.json
+++ b/flow/workflows/testdata/replay/parked_resume.json
@@ -1,0 +1,271 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-07T06:47:13.268297Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048587",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXBhcmtlZC1yZXN1bWUiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XSwibWF4QmF0Y2hTaXplIjoxMDAsImlkbGVUaW1lb3V0U2Vjb25kcyI6IjEwIn0="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MiwiQ3VycmVudEZsb3dTdGF0dXMiOjMsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "019fdaf9-d274-7488-91ad-a1bd6312437d",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "firstExecutionRunId": "019fdaf9-d274-7488-91ad-a1bd6312437d",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "replay-fixture-parked-resume"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-07T06:47:13.268369Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048588",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-07T06:47:13.272763Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048593",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "be22a9bb-0f71-4c91-abcd-e94ca5e869ab",
+        "historySizeBytes": "1044",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-07T06:47:13.287807Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048597",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.45.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-07T06:47:13.287888Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048598",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJBY3Rpdml0eUlEIjoiMSIsIkFjdGl2aXR5VHlwZSI6InVwZGF0ZUZsb3dTdGF0dXNJbkNhdGFsb2dBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDI2LTA4LTA3VDA2OjQ3OjEzLjI4Mjg5NDgzM1oiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "Mg=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-07T06:47:13.289539Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048601",
+      "workflowExecutionSignaledEventAttributes": {
+        "signalName": "peer-flow-signal",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "MA=="
+            }
+          ]
+        },
+        "identity": "21176@macbook-pro-ch.lan@",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-07T06:47:13.289541Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048602",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-07T06:47:13.290293Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048606",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "7",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "9c66b666-bdcd-422a-83de-d74f199fcab6",
+        "historySizeBytes": "1790",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-07T06:47:13.294515Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048610",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "7",
+        "startedEventId": "8",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            5,
+            8
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-07T06:47:13.294543Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048611",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJBY3Rpdml0eUlEIjoiMiIsIkFjdGl2aXR5VHlwZSI6InVwZGF0ZUZsb3dTdGF0dXNJbkNhdGFsb2dBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDI2LTA4LTA3VDA2OjQ3OjEzLjI5MjAyNDgzM1oiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "MQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "9"
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-07T06:47:13.294758Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW",
+      "taskId": "1048612",
+      "workflowExecutionContinuedAsNewEventAttributes": {
+        "newExecutionRunId": "6cdc0614-459b-4846-9f13-f2f9a3a48e07",
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXBhcmtlZC1yZXN1bWUiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XSwibWF4QmF0Y2hTaXplIjoxMDAsImlkbGVUaW1lb3V0U2Vjb25kcyI6IjEwIn0="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MCwiQ3VycmVudEZsb3dTdGF0dXMiOjEsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "workflowTaskCompletedEventId": "9",
+        "header": {},
+        "inheritBuildId": true
+      }
+    }
+  ]
+}

--- a/flow/workflows/testdata/replay/running_pause.json
+++ b/flow/workflows/testdata/replay/running_pause.json
@@ -1,0 +1,642 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-07T06:47:13.707829Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048681",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctcGF1c2UiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XSwibWF4QmF0Y2hTaXplIjoxMDAsImlkbGVUaW1lb3V0U2Vjb25kcyI6IjEwIn0="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MCwiQ3VycmVudEZsb3dTdGF0dXMiOjEsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "019fdaf9-d42b-7ca6-ab80-f23b40980cf0",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "firstExecutionRunId": "019fdaf9-d42b-7ca6-ab80-f23b40980cf0",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "replay-fixture-running-pause"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-07T06:47:13.707856Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048682",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-07T06:47:13.709101Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048687",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "feb0c386-90d3-4528-8651-02b999a7206e",
+        "historySizeBytes": "1046",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-07T06:47:13.710421Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048691",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.45.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-07T06:47:13.710447Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048692",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "MigratePostgresTableOIDs"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InJlcGxheS1maXh0dXJlLXJ1bm5pbmctcGF1c2Ui"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "bnVsbA=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "W3sic291cmNlX3RhYmxlX2lkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uX3RhYmxlX2lkZW50aWZpZXIiOiJyZXBsYXlfZHN0In1d"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "3600s",
+        "heartbeatTimeout": "120s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-07T06:47:13.711585Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048698",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "3b7343e8-1ddd-4ee9-b578-1818c7e9ec79",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-07T06:47:13.712656Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048699",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-07T06:47:13.712659Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048700",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-07T06:47:13.713123Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048704",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "eeaff7a3-6486-4c3f-b7fd-ef2ecda3902a",
+        "historySizeBytes": "1951",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-07T06:47:13.714191Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048708",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-07T06:47:13.714209Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048709",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "11",
+        "activityType": {
+          "name": "GetFlowMetadata"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0NvbnRleHRNZXRhZGF0YUlucHV0"
+              },
+              "data": "eyJmbG93TmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctcGF1c2UiLCJzdGF0dXMiOiJTVEFUVVNfUlVOTklORyJ9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "60s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-07T06:47:13.714689Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048714",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "4109ff0e-9a70-45da-bb95-89a67636a625",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-07T06:47:13.715661Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048715",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0NvbnRleHRNZXRhZGF0YQ=="
+              },
+              "data": "eyJmbG93TmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctcGF1c2UifQ=="
+            }
+          ]
+        },
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-07T06:47:13.715663Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048716",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-07T06:47:13.716108Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048720",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "7b66f0ff-4033-4c0e-88fb-51fb6e024246",
+        "historySizeBytes": "2890",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-07T06:47:13.720189Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048724",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-07T06:47:13.720210Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048725",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "17",
+        "activityType": {
+          "name": "SyncFlow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctcGF1c2UiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XSwibWF4QmF0Y2hTaXplIjoxMDAsImlkbGVUaW1lb3V0U2Vjb25kcyI6IjEwIn0="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuU3luY0Zsb3dPcHRpb25z"
+              },
+              "data": "eyJiYXRjaFNpemUiOjEwMCwiaWRsZVRpbWVvdXRTZWNvbmRzIjoiMTAiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "31536000s",
+        "heartbeatTimeout": "60s",
+        "workflowTaskCompletedEventId": "16",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s",
+          "maximumAttempts": 1
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": "2026-08-07T06:47:13.720225Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048726",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJBY3Rpdml0eUlEIjoiMSIsIkFjdGl2aXR5VHlwZSI6InVwZGF0ZUZsb3dTdGF0dXNJbkNhdGFsb2dBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDI2LTA4LTA3VDA2OjQ3OjEzLjcxODgyOTcwOVoiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "MQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "16"
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": "2026-08-07T06:47:13.911025Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048731",
+      "workflowExecutionSignaledEventAttributes": {
+        "signalName": "peer-flow-signal",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "Mg=="
+            }
+          ]
+        },
+        "identity": "21176@macbook-pro-ch.lan@",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2026-08-07T06:47:13.911027Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048732",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2026-08-07T06:47:13.911668Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048736",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "20",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "b8913e1f-a456-44c1-bbc9-dc12f0225ad2",
+        "historySizeBytes": "4241",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": "2026-08-07T06:47:13.915217Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048740",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "20",
+        "startedEventId": "21",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            5,
+            8
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": "2026-08-07T06:47:13.915239Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048741",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJBY3Rpdml0eUlEIjoiMiIsIkFjdGl2aXR5VHlwZSI6InVwZGF0ZUZsb3dTdGF0dXNJbkNhdGFsb2dBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDI2LTA4LTA3VDA2OjQ3OjEzLjkxMzY0OVoiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "Mw=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "22"
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": "2026-08-07T06:47:13.915249Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED",
+      "taskId": "1048742",
+      "activityTaskCancelRequestedEventAttributes": {
+        "scheduledEventId": "17",
+        "workflowTaskCompletedEventId": "22"
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": "2026-08-07T06:47:13.720882Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048744",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "cf2cbe9a-9913-46fb-86bc-2a5241cef72c",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": "2026-08-07T06:47:14.724670Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_CANCELED",
+      "taskId": "1048745",
+      "activityTaskCanceledEventAttributes": {
+        "latestCancelRequestedEventId": "24",
+        "scheduledEventId": "17",
+        "startedEventId": "25",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "27",
+      "eventTime": "2026-08-07T06:47:14.724691Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048746",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "28",
+      "eventTime": "2026-08-07T06:47:14.725469Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048750",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "27",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "b2ba13b3-d074-4f97-9f83-ccc27c7aac1c",
+        "historySizeBytes": "5046",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "29",
+      "eventTime": "2026-08-07T06:47:14.727032Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048754",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "27",
+        "startedEventId": "28",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "30",
+      "eventTime": "2026-08-07T06:47:14.727154Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW",
+      "taskId": "1048755",
+      "workflowExecutionContinuedAsNewEventAttributes": {
+        "newExecutionRunId": "e6e2056d-6d86-4501-929c-37f9f8a8fe2d",
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctcGF1c2UiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XSwibWF4QmF0Y2hTaXplIjoxMDAsImlkbGVUaW1lb3V0U2Vjb25kcyI6IjEwIn0="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MiwiQ3VycmVudEZsb3dTdGF0dXMiOjMsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "workflowTaskCompletedEventId": "29",
+        "header": {},
+        "inheritBuildId": true
+      }
+    }
+  ]
+}

--- a/flow/workflows/testdata/replay/running_sync_finish.json
+++ b/flow/workflows/testdata/replay/running_sync_finish.json
@@ -1,0 +1,530 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-07T06:47:16.128271Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048890",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1maW5pc2giLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XSwibWF4QmF0Y2hTaXplIjoxMDAsImlkbGVUaW1lb3V0U2Vjb25kcyI6IjEwIn0="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MCwiQ3VycmVudEZsb3dTdGF0dXMiOjEsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "019fdaf9-dda0-741e-927a-18cfce0f8c1e",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "firstExecutionRunId": "019fdaf9-dda0-741e-927a-18cfce0f8c1e",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "replay-fixture-running-sync-finish"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-07T06:47:16.128300Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048891",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-07T06:47:16.129807Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048896",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "7ae19aaf-5acd-455c-b505-88e771a86d98",
+        "historySizeBytes": "1056",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-07T06:47:16.132075Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048900",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.45.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-07T06:47:16.132119Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048901",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "MigratePostgresTableOIDs"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1maW5pc2gi"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "bnVsbA=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "W3sic291cmNlX3RhYmxlX2lkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uX3RhYmxlX2lkZW50aWZpZXIiOiJyZXBsYXlfZHN0In1d"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "3600s",
+        "heartbeatTimeout": "120s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-07T06:47:16.133381Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048907",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "b73c56bf-f26f-466b-868a-4d949c21eb44",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-07T06:47:16.135072Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048908",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-07T06:47:16.135075Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048909",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-07T06:47:16.135708Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048913",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "43f82c64-2e34-4bce-ad65-153afc240177",
+        "historySizeBytes": "1961",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-07T06:47:16.136867Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048917",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-07T06:47:16.136886Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048918",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "11",
+        "activityType": {
+          "name": "GetFlowMetadata"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0NvbnRleHRNZXRhZGF0YUlucHV0"
+              },
+              "data": "eyJmbG93TmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1maW5pc2giLCJzdGF0dXMiOiJTVEFUVVNfUlVOTklORyJ9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "60s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-07T06:47:16.137995Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048923",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "d757c3ab-9cb0-45e8-8a25-319c1f18eed5",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-07T06:47:16.139229Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048924",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0NvbnRleHRNZXRhZGF0YQ=="
+              },
+              "data": "eyJmbG93TmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1maW5pc2gifQ=="
+            }
+          ]
+        },
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-07T06:47:16.139234Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048925",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-07T06:47:16.140024Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048929",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "803b8bc2-a1de-4395-902c-fed3ee75a655",
+        "historySizeBytes": "2907",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-07T06:47:16.149705Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048933",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-07T06:47:16.149728Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048934",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "17",
+        "activityType": {
+          "name": "SyncFlow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1maW5pc2giLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XSwibWF4QmF0Y2hTaXplIjoxMDAsImlkbGVUaW1lb3V0U2Vjb25kcyI6IjEwIn0="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuU3luY0Zsb3dPcHRpb25z"
+              },
+              "data": "eyJiYXRjaFNpemUiOjEwMCwiaWRsZVRpbWVvdXRTZWNvbmRzIjoiMTAiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "31536000s",
+        "heartbeatTimeout": "60s",
+        "workflowTaskCompletedEventId": "16",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s",
+          "maximumAttempts": 1
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": "2026-08-07T06:47:16.149743Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048935",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJBY3Rpdml0eUlEIjoiMSIsIkFjdGl2aXR5VHlwZSI6InVwZGF0ZUZsb3dTdGF0dXNJbkNhdGFsb2dBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDI2LTA4LTA3VDA2OjQ3OjE2LjE0Nzc0MTg3NVoiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "MQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "16"
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": "2026-08-07T06:47:16.150382Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048940",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "d93c2835-ed42-40a0-a181-4d7ef3ccde1e",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2026-08-07T06:47:18.152208Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048941",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "17",
+        "startedEventId": "19",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2026-08-07T06:47:18.152214Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048942",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": "2026-08-07T06:47:18.153051Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048946",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "21",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "0a4f7460-55c2-408f-a27f-766447e92e4e",
+        "historySizeBytes": "4343",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": "2026-08-07T06:47:18.154771Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048950",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "21",
+        "startedEventId": "22",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": "2026-08-07T06:47:18.155088Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW",
+      "taskId": "1048951",
+      "workflowExecutionContinuedAsNewEventAttributes": {
+        "newExecutionRunId": "7a2af914-29f2-470c-adbb-d5263507e7ab",
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1maW5pc2giLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XSwibWF4QmF0Y2hTaXplIjoxMDAsImlkbGVUaW1lb3V0U2Vjb25kcyI6IjEwIn0="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MCwiQ3VycmVudEZsb3dTdGF0dXMiOjEsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "workflowTaskCompletedEventId": "23",
+        "header": {},
+        "inheritBuildId": true
+      }
+    }
+  ]
+}

--- a/flow/workflows/testdata/replay/running_terminate.json
+++ b/flow/workflows/testdata/replay/running_terminate.json
@@ -1,0 +1,716 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-07T06:47:14.917556Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048778",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctdGVybWluYXRlIiwidGFibGVNYXBwaW5ncyI6W3sic291cmNlVGFibGVJZGVudGlmaWVyIjoicHVibGljLnJlcGxheV9zcmMiLCJkZXN0aW5hdGlvblRhYmxlSWRlbnRpZmllciI6InJlcGxheV9kc3QifV0sIm1heEJhdGNoU2l6ZSI6MTAwLCJpZGxlVGltZW91dFNlY29uZHMiOiIxMCJ9"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MCwiQ3VycmVudEZsb3dTdGF0dXMiOjEsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "019fdaf9-d8e5-7877-946d-003174783116",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "firstExecutionRunId": "019fdaf9-d8e5-7877-946d-003174783116",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "replay-fixture-running-terminate"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-07T06:47:14.917584Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048779",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-07T06:47:14.918549Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048784",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "168533a8-2eaa-482e-9f6f-2cbb59567db5",
+        "historySizeBytes": "1054",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-07T06:47:14.919985Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048788",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.45.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-07T06:47:14.920012Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048789",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "MigratePostgresTableOIDs"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InJlcGxheS1maXh0dXJlLXJ1bm5pbmctdGVybWluYXRlIg=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "bnVsbA=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "W3sic291cmNlX3RhYmxlX2lkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uX3RhYmxlX2lkZW50aWZpZXIiOiJyZXBsYXlfZHN0In1d"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "3600s",
+        "heartbeatTimeout": "120s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-07T06:47:14.920801Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048795",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "1ffcf13b-198c-4790-a2fd-a709e82e1a7f",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-07T06:47:14.922265Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048796",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-07T06:47:14.922268Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048797",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-07T06:47:14.922866Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048801",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "90a34484-84ba-4824-b525-79ea0b38f7ce",
+        "historySizeBytes": "1963",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-07T06:47:14.924316Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048805",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-07T06:47:14.924335Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048806",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "11",
+        "activityType": {
+          "name": "GetFlowMetadata"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0NvbnRleHRNZXRhZGF0YUlucHV0"
+              },
+              "data": "eyJmbG93TmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctdGVybWluYXRlIiwic3RhdHVzIjoiU1RBVFVTX1JVTk5JTkcifQ=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "60s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-07T06:47:14.924885Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048811",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "9ae5e1bf-a15d-406d-9b55-80efdffe644b",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-07T06:47:14.925746Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048812",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0NvbnRleHRNZXRhZGF0YQ=="
+              },
+              "data": "eyJmbG93TmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctdGVybWluYXRlIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-07T06:47:14.925748Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048813",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-07T06:47:14.926148Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048817",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "dcff0be3-faaf-4056-9c8b-4fe2d46497b9",
+        "historySizeBytes": "2910",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-07T06:47:14.930540Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048821",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-07T06:47:14.930563Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048822",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "17",
+        "activityType": {
+          "name": "SyncFlow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctdGVybWluYXRlIiwidGFibGVNYXBwaW5ncyI6W3sic291cmNlVGFibGVJZGVudGlmaWVyIjoicHVibGljLnJlcGxheV9zcmMiLCJkZXN0aW5hdGlvblRhYmxlSWRlbnRpZmllciI6InJlcGxheV9kc3QifV0sIm1heEJhdGNoU2l6ZSI6MTAwLCJpZGxlVGltZW91dFNlY29uZHMiOiIxMCJ9"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuU3luY0Zsb3dPcHRpb25z"
+              },
+              "data": "eyJiYXRjaFNpemUiOjEwMCwiaWRsZVRpbWVvdXRTZWNvbmRzIjoiMTAiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "31536000s",
+        "heartbeatTimeout": "60s",
+        "workflowTaskCompletedEventId": "16",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s",
+          "maximumAttempts": 1
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": "2026-08-07T06:47:14.930577Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048823",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJBY3Rpdml0eUlEIjoiMSIsIkFjdGl2aXR5VHlwZSI6InVwZGF0ZUZsb3dTdGF0dXNJbkNhdGFsb2dBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDI2LTA4LTA3VDA2OjQ3OjE0LjkyOTIzMjA0MloiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "MQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "16"
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": "2026-08-07T06:47:15.121625Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048828",
+      "workflowExecutionSignaledEventAttributes": {
+        "signalName": "flow-state-change-signal",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX3JvdXRlLkZsb3dTdGF0ZUNoYW5nZVJlcXVlc3Q="
+              },
+              "data": "eyJyZXF1ZXN0ZWRGbG93U3RhdGUiOiJTVEFUVVNfVEVSTUlOQVRJTkcifQ=="
+            }
+          ]
+        },
+        "identity": "21176@macbook-pro-ch.lan@",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2026-08-07T06:47:15.121636Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048829",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2026-08-07T06:47:15.123025Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048833",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "20",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "6d50c2db-a566-4d54-a8a9-f41ddb42557d",
+        "historySizeBytes": "4370",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": "2026-08-07T06:47:15.125358Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048837",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "20",
+        "startedEventId": "21",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            5,
+            8
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": "2026-08-07T06:47:15.125394Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048838",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "23",
+        "activityType": {
+          "name": "UpdateCDCConfigInCatalogActivity"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctdGVybWluYXRlIiwidGFibGVNYXBwaW5ncyI6W3sic291cmNlVGFibGVJZGVudGlmaWVyIjoicHVibGljLnJlcGxheV9zcmMiLCJkZXN0aW5hdGlvblRhYmxlSWRlbnRpZmllciI6InJlcGxheV9kc3QifV0sIm1heEJhdGNoU2l6ZSI6MTAwLCJpZGxlVGltZW91dFNlY29uZHMiOiIxMCJ9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "300s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "22",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": "2026-08-07T06:47:15.127079Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048842",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "23",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "096ae723-9be7-416f-a0d8-a116a5530805",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": "2026-08-07T06:47:15.129008Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048843",
+      "activityTaskCompletedEventAttributes": {
+        "scheduledEventId": "23",
+        "startedEventId": "24",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": "2026-08-07T06:47:15.130014Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048844",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "27",
+      "eventTime": "2026-08-07T06:47:15.131658Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048848",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "26",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "bb0b3c15-9589-4178-93ac-804e9a6fef67",
+        "historySizeBytes": "5333",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "28",
+      "eventTime": "2026-08-07T06:47:15.137198Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048852",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "26",
+        "startedEventId": "27",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "29",
+      "eventTime": "2026-08-07T06:47:15.137283Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED",
+      "taskId": "1048853",
+      "activityTaskCancelRequestedEventAttributes": {
+        "scheduledEventId": "17",
+        "workflowTaskCompletedEventId": "28"
+      }
+    },
+    {
+      "eventId": "30",
+      "eventTime": "2026-08-07T06:47:14.931297Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048855",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "6fbaad74-a934-495e-8ed9-8c033b434a1e",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "31",
+      "eventTime": "2026-08-07T06:47:15.935337Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_CANCELED",
+      "taskId": "1048856",
+      "activityTaskCanceledEventAttributes": {
+        "latestCancelRequestedEventId": "29",
+        "scheduledEventId": "17",
+        "startedEventId": "30",
+        "identity": "21176@macbook-pro-ch.lan@"
+      }
+    },
+    {
+      "eventId": "32",
+      "eventTime": "2026-08-07T06:47:15.935340Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048857",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "macbook-pro-ch.lan:47b9466a-02c0-446a-bb6d-714d68f411a1",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "cdc-flow-replay-fixtures"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "33",
+      "eventTime": "2026-08-07T06:47:15.935995Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048861",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "32",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "requestId": "1e144dfe-c879-4b88-84a2-c7c52ec535ad",
+        "historySizeBytes": "5866",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        }
+      }
+    },
+    {
+      "eventId": "34",
+      "eventTime": "2026-08-07T06:47:15.937352Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048865",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "32",
+        "startedEventId": "33",
+        "identity": "21176@macbook-pro-ch.lan@",
+        "workerVersion": {
+          "buildId": "c51654525dce2425056473fbd85b139f"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "35",
+      "eventTime": "2026-08-07T06:47:15.937477Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW",
+      "taskId": "1048866",
+      "workflowExecutionContinuedAsNewEventAttributes": {
+        "newExecutionRunId": "0c0d0e60-8cd3-4747-a04f-2f7e6a9159d5",
+        "workflowType": {
+          "name": "DropFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "cdc-flow-replay-fixtures",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRHJvcEZsb3dJbnB1dA=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctdGVybWluYXRlIiwiZmxvd0Nvbm5lY3Rpb25Db25maWdzIjp7ImZsb3dKb2JOYW1lIjoicmVwbGF5LWZpeHR1cmUtcnVubmluZy10ZXJtaW5hdGUiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XSwibWF4QmF0Y2hTaXplIjoxMDAsImlkbGVUaW1lb3V0U2Vjb25kcyI6IjEwIn19"
+            }
+          ]
+        },
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "workflowTaskCompletedEventId": "34",
+        "header": {},
+        "inheritBuildId": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add tests for detecting Temporal history replay incompatibility. We've been bitten by this in the past. And this will make it easier to refactor CDCFlowWorkflow, which is currently a 1000+ loc that is very difficult to reason about, especially the continue-as-new logic that we currently employ to avoid patching. 

Verified by removing critical code (that are not deleted by continue-as-new) has caused CI to fail as expected. 