### PR TITLE
handle edge case where batch fails but some tables succeeded

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -748,6 +748,18 @@ func (a *FlowableActivity) startNormalize(
 			)
 			return res, nil
 		}()
+		// Persist schema corrections before handling the normalize error: a table may
+		// have succeeded and advanced its per-table watermark before another table failed.
+		if len(res.RemovedColumnsMapping) > 0 {
+			if applyErr := a.applyRemovedColumnsFromNormalize(
+				ctx, logger, config.FlowJobName, res.RemovedColumnsMapping, tableNameSchemaMapping,
+			); applyErr != nil {
+				return exceptions.NewNormalizationError(errors.Join(
+					fmt.Errorf("failed to persist normalize schema corrections: %w", applyErr),
+					err,
+				))
+			}
+		}
 		if err != nil {
 			return exceptions.NewNormalizationError(fmt.Errorf("failed to normalize records: %w", err))
 		}
@@ -758,9 +770,6 @@ func (a *FlowableActivity) startNormalize(
 		}
 
 		a.recordDeliveryLag(ctx, config.FlowJobName, res.StartBatchID, res.EndBatchID)
-		if len(res.RemovedColumnsMapping) > 0 {
-			a.applyRemovedColumnsFromNormalize(ctx, logger, config.FlowJobName, res.RemovedColumnsMapping, tableNameSchemaMapping)
-		}
 
 		logger.Info("normalized batches",
 			slog.Int64("startBatchID", res.StartBatchID), slog.Int64("endBatchID", res.EndBatchID), slog.Int64("syncBatchID", batchID))
@@ -777,13 +786,13 @@ func (a *FlowableActivity) applyRemovedColumnsFromNormalize(
 	flowJobName string,
 	removedColumnsMapping map[string][]string,
 	tableNameSchemaMapping map[string]*protos.TableSchema,
-) {
+) error {
 	tableNames := make([]string, 0, len(removedColumnsMapping))
 	for name := range removedColumnsMapping {
 		tableNames = append(tableNames, name)
 	}
 	// Remove only the dropped columns from the schemas read within the transaction to prevent any race condition.
-	updateErr := internal.ReadModifyWriteTableSchemasToCatalog(
+	if updateErr := internal.ReadModifyWriteTableSchemasToCatalog(
 		ctx, a.CatalogPool, logger, flowJobName, tableNames,
 		func(schemas map[string]*protos.TableSchema) (map[string]*protos.TableSchema, error) {
 			result := make(map[string]*protos.TableSchema, len(schemas))
@@ -792,22 +801,21 @@ func (a *FlowableActivity) applyRemovedColumnsFromNormalize(
 			}
 			return result, nil
 		},
-	)
-	if updateErr != nil {
+	); updateErr != nil {
 		logger.Error("failed to persist auto-removed destination columns to catalog",
 			slog.Any("error", updateErr))
+		return updateErr
 	}
 
 	for name, removed := range removedColumnsMapping {
 		if schema, ok := tableNameSchemaMapping[name]; ok {
 			tableNameSchemaMapping[name] = removeColumnsFromSchema(schema, removed)
 		}
-		if updateErr == nil {
-			a.Alerter.LogFlowWarning(ctx, flowJobName,
-				fmt.Errorf("destination column(s) were dropped from table %s and automatically removed "+
-					"from the mirror schema; future syncs will omit those columns", name))
-		}
+		a.Alerter.LogFlowWarning(ctx, flowJobName,
+			fmt.Errorf("destination column(s) %s were dropped from table %s and automatically removed "+
+				"from the mirror schema; future syncs will omit those columns", removed, name))
 	}
+	return nil
 }
 
 func removeColumnsFromSchema(schema *protos.TableSchema, columns []string) *protos.TableSchema {

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -560,7 +560,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 	}
 
 	// wrap query generation logic in a function to ensure queriesCh always closes once
-	if err := func() error {
+	queryGenErr := func() error {
 		defer close(queriesCh)
 
 		for _, tbl := range destinationTableNames {
@@ -621,25 +621,25 @@ func (c *ClickHouseConnector) NormalizeRecords(
 			}
 		}
 		return nil
-	}(); err != nil {
-		return model.NormalizeResponse{}, err
-	}
+	}()
 
-	if err := group.Wait(); err != nil {
-		return model.NormalizeResponse{}, err
+	groupErr := group.Wait()
+	resp := model.NormalizeResponse{}
+	if len(removedColumnsMapping) > 0 {
+		resp.RemovedColumnsMapping = removedColumnsMapping
+	}
+	// Return schema corrections even when another table failed. A recovered table may
+	// already have advanced its per-table watermark and be skipped on the retry.
+	if err := errors.Join(queryGenErr, groupErr); err != nil {
+		return resp, err
 	}
 	if err := c.UpdateNormalizeBatchID(ctx, req.FlowJobName, endBatchID); err != nil {
 		c.logger.Error("[clickhouse] error while updating normalize batch id",
 			slog.Int64("batchID", endBatchID), slog.Any("error", err))
-		return model.NormalizeResponse{}, err
+		return resp, err
 	}
-	resp := model.NormalizeResponse{
-		StartBatchID: lastNormBatchID + 1,
-		EndBatchID:   endBatchID,
-	}
-	if len(removedColumnsMapping) > 0 {
-		resp.RemovedColumnsMapping = removedColumnsMapping
-	}
+	resp.StartBatchID = lastNormBatchID + 1
+	resp.EndBatchID = endBatchID
 	return resp, nil
 }
 
@@ -836,6 +836,9 @@ func (c *ClickHouseConnector) getDistinctTableNamesInBatch(
 		return nil, fmt.Errorf("failed to read rows: %w", err)
 	}
 
+	// Keep table dispatch deterministic. Note that query completion remains concurrent
+	// and nondeterministic when PEERDB_CLICKHOUSE_PARALLEL_NORMALIZE > 1
+	slices.Sort(tableNames)
 	return tableNames, nil
 }
 

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -2499,6 +2499,111 @@ func (s ClickHouseSuite) Test_Normalize_Metadata_With_Retry() {
 	RequireEnvCanceled(s.t, env)
 }
 
+func (s ClickHouseSuite) Test_Normalize_Schema_Correction_After_Partial_Failure() {
+	recoveredSrcTable := "test_normalize_schema_correction_partial_1"
+	recoveredSrcFullName := s.attachSchemaSuffix(recoveredSrcTable)
+	recoveredDstTable := "test_normalize_schema_correction_partial_dst_1"
+	failingSrcTable := "test_normalize_schema_correction_partial_2"
+	failingSrcFullName := s.attachSchemaSuffix(failingSrcTable)
+	failingDstTable := "test_normalize_schema_correction_partial_dst_2"
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id INT PRIMARY KEY,
+			"key" TEXT NOT NULL,
+			val TEXT NOT NULL
+		)
+	`, recoveredSrcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id INT PRIMARY KEY,
+			"key" TEXT NOT NULL
+		)
+	`, failingSrcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
+		`INSERT INTO %s (id, "key", val) VALUES (1, 'initial', 'initial')`, recoveredSrcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
+		`INSERT INTO %s (id, "key") VALUES (1, 'initial')`, failingSrcFullName)))
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName: s.attachSuffix("normalize_schema_correction_partial"),
+		TableNameMapping: map[string]string{
+			recoveredSrcFullName: recoveredDstTable,
+			failingSrcFullName:   failingDstTable,
+		},
+		Destination: s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+	// A single worker guarantees that the recovered table advances before
+	// normalization reaches the failing table.
+	flowConnConfig.Env = map[string]string{"PEERDB_CLICKHOUSE_PARALLEL_NORMALIZE": "1"}
+
+	tc := NewTemporalClient(s.t)
+	env := ExecutePeerflow(s.t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+	EnvWaitForEqualTablesWithNames(
+		env, s, "initial recovered table", recoveredSrcTable, recoveredDstTable, "id,\"key\",val",
+	)
+	EnvWaitForEqualTablesWithNames(
+		env, s, "initial failing table", failingSrcTable, failingDstTable, "id,\"key\"",
+	)
+
+	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	require.NoError(s.t, err)
+	fakeFailingDstTable := failingDstTable + "_fake"
+	onCluster := ""
+	if s.cluster {
+		onCluster = " ON CLUSTER cicluster"
+		require.NoError(s.t, ch.Exec(s.t.Context(),
+			fmt.Sprintf("ALTER TABLE `%s_shard` ON CLUSTER cicluster DROP COLUMN `val`", recoveredDstTable)))
+		require.NoError(s.t, ch.Exec(s.t.Context(),
+			fmt.Sprintf("ALTER TABLE `%s` ON CLUSTER cicluster DROP COLUMN `val`", recoveredDstTable)))
+	} else {
+		require.NoError(s.t, ch.Exec(s.t.Context(),
+			fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `val`", recoveredDstTable)))
+	}
+	require.NoError(s.t, ch.Exec(s.t.Context(),
+		fmt.Sprintf("RENAME TABLE `%s` TO `%s`%s", failingDstTable, fakeFailingDstTable, onCluster)))
+
+	// Put both updates in one CDC batch. The first table recovers the dropped column;
+	// normalization then fails because the second destination table is unavailable.
+	require.NoError(s.t, s.source.Exec(s.t.Context(), "BEGIN"))
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
+		`UPDATE %s SET "key" = 'updated', val = 'updated'`, recoveredSrcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(
+		`UPDATE %s SET "key" = 'updated'`, failingSrcFullName)))
+	require.NoError(s.t, s.source.Exec(s.t.Context(), "COMMIT"))
+
+	EnvWaitFor(s.t, env, 5*time.Minute, "waiting for normalize error", func() bool {
+		errorCount, err := GetLogCount(
+			s.t.Context(), s.catalog, flowConnConfig.FlowJobName, "error", "error while inserting into target clickhouse table",
+		)
+		return err == nil && errorCount > 0
+	})
+	EnvWaitFor(s.t, env, time.Minute, "catalog correction persisted despite normalize error", func() bool {
+		schema, err := internal.LoadTableSchemaFromCatalog(
+			s.t.Context(), s.catalog, flowConnConfig.FlowJobName, recoveredDstTable,
+		)
+		if err != nil {
+			return false
+		}
+		return !slices.ContainsFunc(schema.Columns, func(col *protos.FieldDescription) bool {
+			return col.Name == "val"
+		})
+	})
+
+	// Restore the renamed table so cleanup does not leave the fake table behind.
+	require.NoError(s.t, ch.Exec(s.t.Context(),
+		fmt.Sprintf("RENAME TABLE `%s` TO `%s`%s", fakeFailingDstTable, failingDstTable, onCluster)))
+	require.NoError(s.t, ch.Close())
+
+	env.Cancel(s.t.Context())
+	RequireEnvCanceled(s.t, env)
+	dropEnv := ExecuteDropFlow(s.t.Context(), tc, flowConnConfig, 0)
+	EnvWaitForFinished(s.t, dropEnv, 3*time.Minute)
+}
+
 func (s ClickHouseSuite) Test_Geometric_Types() {
 	if _, ok := s.source.(*PostgresSource); !ok {
 		s.t.Skip("only applies to postgres")


### PR DESCRIPTION
Handling an edge case for https://github.com/PeerDB-io/peerdb/pull/4609. Scenario described [here](https://github.com/PeerDB-io/peerdb/pull/4609#issuecomment-5222982539). The fix is to always process removed columns when normalize returns, whether it succeeds or fails. This is safe even if `SetLastNormalizedBatchIDForTable` flakes and normalize retries: the catalog would have the schema removed and subsequent normalize of the same table will succeed.