### PR TITLE
fix: avoid NOT NULL in Snowflake merge casts

### DIFF
--- a/flow/connectors/snowflake/merge_stmt_generator.go
+++ b/flow/connectors/snowflake/merge_stmt_generator.go
@@ -36,8 +36,9 @@ func (m *mergeStmtGenerator) generateMergeStmt(ctx context.Context, env map[stri
 	for _, column := range columns {
 		genericColumnType := column.Type
 		qvKind := types.QValueKind(genericColumnType)
+		// Snowflake does not support NOT NULL in a CAST type.
 		sfType, err := qvalue.ToDWHColumnType(
-			ctx, qvKind, env, protos.DBType_SNOWFLAKE, nil, column, normalizedTableSchema.NullableEnabled, nil)
+			ctx, qvKind, env, protos.DBType_SNOWFLAKE, nil, column, false, nil)
 		if err != nil {
 			return "", fmt.Errorf("failed to convert column type %s to snowflake type: %w", genericColumnType, err)
 		}

--- a/flow/connectors/snowflake/merge_stmt_generator_test.go
+++ b/flow/connectors/snowflake/merge_stmt_generator_test.go
@@ -1,12 +1,69 @@
 package connsnowflake
 
 import (
+	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
+
+func TestGenerateMergeStatementNullableSchemaDoesNotAddNotNullToCasts(t *testing.T) {
+	destinationTable := "public.events"
+	requiredTimestamp := &protos.FieldDescription{
+		Name:     "created_at",
+		Type:     string(types.QValueKindTimestampTZ),
+		Nullable: false,
+	}
+	generator := &mergeStmtGenerator{
+		tableSchemaMapping: map[string]*protos.TableSchema{
+			destinationTable: {
+				Columns: []*protos.FieldDescription{
+					{Name: "id", Type: string(types.QValueKindInt64), Nullable: false},
+					requiredTimestamp,
+					{Name: "deleted_at", Type: string(types.QValueKindTimestampTZ), Nullable: true},
+				},
+				PrimaryKeyColumns: []string{"id"},
+				NullableEnabled:   true,
+			},
+		},
+		unchangedToastColumnsMap: map[string][]string{destinationTable: {""}},
+		peerdbCols:               &protos.PeerDBColumns{},
+		rawTableName:             "raw_events",
+		mergeBatchId:             1,
+	}
+
+	statement, err := generator.generateMergeStmt(context.Background(), nil, destinationTable)
+	if err != nil {
+		t.Fatalf("generate merge statement: %v", err)
+	}
+	if strings.Contains(statement, "NOT NULL") {
+		t.Fatalf("merge statement contains invalid NOT NULL cast: %s", statement)
+	}
+	for _, expected := range []string{
+		`CAST(VAR_COLS:"created_at" AS TIMESTAMP_TZ) AS "CREATED_AT"`,
+		`CAST(VAR_COLS:"deleted_at" AS TIMESTAMP_TZ) AS "DELETED_AT"`,
+	} {
+		if !strings.Contains(statement, expected) {
+			t.Errorf("merge statement missing %q: %s", expected, statement)
+		}
+	}
+
+	requiredType, err := qvalue.ToDWHColumnType(
+		context.Background(), types.QValueKindTimestampTZ, nil, protos.DBType_SNOWFLAKE,
+		nil, requiredTimestamp, true, nil,
+	)
+	if err != nil {
+		t.Fatalf("convert required destination column type: %v", err)
+	}
+	if requiredType != "TIMESTAMP_TZ NOT NULL" {
+		t.Fatalf("required destination column type = %q, want TIMESTAMP_TZ NOT NULL", requiredType)
+	}
+}
 
 func TestGenerateUpdateStatement(t *testing.T) {
 	allCols := []string{"col1", "col2", "col3"}


### PR DESCRIPTION
## Summary

- generate Snowflake MERGE cast types without column nullability constraints
- preserve NOT NULL generation for destination DDL types
- add a regression test covering required and nullable timestamp columns

## Context

PR #3893 fixed the same Snowflake syntax failure by keeping nullability out of CAST types. PR #3923 later routed `TableSchema.NullableEnabled` into `ToDWHColumnType` from the MERGE generator, which can emit invalid expressions such as `CAST(... AS TIMESTAMP_TZ NOT NULL)`.

The Snowflake connector is deprecated, but this is a focused regression repair for existing deployments.

## Test

`go test ./connectors/snowflake -run '^TestGenerateMergeStatementNullableSchemaDoesNotAddNotNullToCasts$'`
