### PR TITLE
remove feature flag and connector type conditional

### DIFF
--- a/flow/activities/snapshot_activity.go
+++ b/flow/activities/snapshot_activity.go
@@ -192,34 +192,18 @@ func (a *SnapshotActivity) GetDefaultPartitionKeyForTables(
 	}
 	defer connClose(ctx)
 
-	srcType, err := connectors.LoadPeerType(ctx, a.CatalogPool, input.SourceName)
-	if err != nil {
-		return nil, a.Alerter.LogFlowError(ctx, input.FlowJobName, fmt.Errorf("failed to load source peer type: %w", err))
+	dstTableNames := make([]string, 0, len(input.TableMappings))
+	for _, tm := range input.TableMappings {
+		dstTableNames = append(dstTableNames, tm.DestinationTableIdentifier)
 	}
-
-	var tableSchemaMapping map[string]*protos.TableSchema
-	if srcType == protos.DBType_MYSQL {
-		mysqlDefaultPartitionKeyEnabled, err := internal.PeerDBMySQLDefaultPartitionKeyEnabled(ctx, input.Env)
-		if err != nil {
-			return nil, a.Alerter.LogFlowError(ctx, input.FlowJobName,
-				fmt.Errorf("failed to check if mysql default partition key detection is enabled: %w", err))
-		}
-
-		if mysqlDefaultPartitionKeyEnabled {
-			dstTableNames := make([]string, 0, len(input.TableMappings))
-			for _, tm := range input.TableMappings {
-				dstTableNames = append(dstTableNames, tm.DestinationTableIdentifier)
-			}
-			schemasByDstTable, err := internal.LoadTableSchemasFromCatalog(ctx, a.CatalogPool.Pool, input.FlowJobName, dstTableNames)
-			if err != nil {
-				return nil, a.Alerter.LogFlowError(ctx, input.FlowJobName, fmt.Errorf("failed to load table schemas from catalog: %w", err))
-			}
-			tableSchemaMapping = make(map[string]*protos.TableSchema, len(input.TableMappings))
-			for _, tm := range input.TableMappings {
-				if schema, ok := schemasByDstTable[tm.DestinationTableIdentifier]; ok {
-					tableSchemaMapping[tm.SourceTableIdentifier] = schema
-				}
-			}
+	schemasByDstTable, err := internal.LoadTableSchemasFromCatalog(ctx, a.CatalogPool.Pool, input.FlowJobName, dstTableNames)
+	if err != nil {
+		return nil, a.Alerter.LogFlowError(ctx, input.FlowJobName, fmt.Errorf("failed to load table schemas from catalog: %w", err))
+	}
+	tableSchemaMapping := make(map[string]*protos.TableSchema, len(input.TableMappings))
+	for _, tm := range input.TableMappings {
+		if schema, ok := schemasByDstTable[tm.DestinationTableIdentifier]; ok {
+			tableSchemaMapping[tm.SourceTableIdentifier] = schema
 		}
 	}
 

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -469,14 +469,6 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 	{
-		Name:             "PEERDB_MYSQL_DEFAULT_PARTITION_KEY_ENABLED",
-		Description:      "Enables automatic detection of a default partition key from primary key for MySQL initial load",
-		DefaultValue:     "true",
-		ValueType:        protos.DynconfValueType_BOOL,
-		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
-		TargetForSetting: protos.DynconfTarget_ALL,
-	},
-	{
 		Name:             "PEERDB_OFFLOAD_PARTITION_RANGES",
 		Description:      "Encrypt QRep partition ranges and offload them to the catalog instead of passing them through Temporal",
 		DefaultValue:     "true",
@@ -919,10 +911,6 @@ func PeerDBMetricsRecordAggregatesEnabled(ctx context.Context, env map[string]st
 
 func PeerDBPostgresApplyCtidBlockPartitioning(ctx context.Context, env map[string]string) (bool, error) {
 	return dynamicConfBool(ctx, env, "PEERDB_POSTGRES_APPLY_CTID_BLOCK_PARTITIONING_OVERRIDE")
-}
-
-func PeerDBMySQLDefaultPartitionKeyEnabled(ctx context.Context, env map[string]string) (bool, error) {
-	return dynamicConfBool(ctx, env, "PEERDB_MYSQL_DEFAULT_PARTITION_KEY_ENABLED")
 }
 
 func PeerDBOffloadPartitionRanges(ctx context.Context, env map[string]string) (bool, error) {


### PR DESCRIPTION
Now that MySQL's parallel snapshotting has been running for a while, we can remove the dynamic config.

Also removing the conditional, and always populate `tableSchemaMapping` as now CockroachDB also has a depending for it ([related context](https://github.com/PeerDB-io/peerdb/pull/4668#discussion_r3763304499)). It adds an additional single query during snapshot so is cheap even though PG/MongoDB/BigQuery don't need it (and removes need to check type with `LoadPeerType` so we are 1-for-1). 

