### PR TITLE
fix(clickhouse): enable ReplacingMergeTree cleanup merges when deleteOnMerge is set

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -282,6 +282,30 @@ func (c *ClickHouseConnector) generateCreateTableSQLForNormalizedTable(
 			// non-empty if a resync is triggered on top of another resync that is mid-snapshot.
 			chSettings.Add(chinternal.SettingMaxTableSizeToDrop, "0")
 		}
+		if isDeletedColumnPart != "" &&
+			(tmEngine == protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE ||
+				tmEngine == protos.TableEngine_CH_ENGINE_REPLICATED_REPLACING_MERGE_TREE) {
+			// The is_deleted engine parameter alone only affects deduplication (which version of a row
+			// wins); it does NOT make ClickHouse drop deleted rows during merges. That requires opting
+			// into cleanup merges, and making it automatic (rather than needing a manual
+			// OPTIMIZE ... FINAL CLEANUP) additionally requires forcing a full merge once parts age out.
+			chSettings.Add(chinternal.SettingAllowExperimentalReplacingMergeWithCleanup, "1")
+			if chinternal.SupportsSetting(chVersion, chinternal.SettingEnableReplacingMergeWithCleanupForMinAgeToForceMerge) {
+				minAgeHours, err := internal.PeerDBClickHouseReplacingMergeCleanupMinAgeHours(ctx, config.Env)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load ReplacingMergeTree cleanup min age: %w", err)
+				}
+				chSettings.Add(chinternal.SettingEnableReplacingMergeWithCleanupForMinAgeToForceMerge, "1")
+				chSettings.Add(chinternal.SettingMinAgeToForceMergeSeconds, strconv.FormatUint(uint64(minAgeHours)*3600, 10))
+				chSettings.Add(chinternal.SettingMinAgeToForceMergeOnPartitionOnly, "1")
+			} else {
+				internal.LoggerFromCtx(ctx).Warn(
+					"ClickHouse version predates automatic ReplacingMergeTree cleanup merges; "+
+						"deleted rows will only be purged via a manual OPTIMIZE ... FINAL CLEANUP",
+					"table", tableIdentifier,
+				)
+			}
+		}
 		stmtBuilder.WriteString(chSettings.String())
 
 		if c.Config.Cluster != "" {

--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -441,11 +441,12 @@ func TestGenerateCreateTableSQLForNormalizedTable(t *testing.T) {
 	}
 
 	tests := []struct {
-		chVersion   *chproto.Version
-		name        string
-		contains    []string
-		notContains []string
-		isResync    bool
+		chVersion        *chproto.Version
+		name             string
+		contains         []string
+		notContains      []string
+		isResync         bool
+		softDeleteColumn string
 	}{
 		{
 			name:      "basic non-resync 'create table if not exists' test",
@@ -484,6 +485,45 @@ func TestGenerateCreateTableSQLForNormalizedTable(t *testing.T) {
 			contains:    []string{"CREATE OR REPLACE TABLE `tbl`"},
 			notContains: []string{"max_table_size_to_drop"},
 		},
+		{
+			name:             "deleteOnMerge on recent CH version enables automatic cleanup merges",
+			chVersion:        &chproto.Version{Major: 25, Minor: 8, Patch: 0},
+			softDeleteColumn: "_peerdb_is_deleted",
+			contains: []string{
+				"ENGINE = ReplacingMergeTree(`_peerdb_version`, `_peerdb_is_deleted`)",
+				"allow_experimental_replacing_merge_with_cleanup=1",
+				"enable_replacing_merge_with_cleanup_for_min_age_to_force_merge=1",
+				"min_age_to_force_merge_on_partition_only=1",
+				"min_age_to_force_merge_seconds=86400",
+			},
+		},
+		{
+			name:             "deleteOnMerge on CH version predating automatic cleanup only sets cleanup flag",
+			chVersion:        &chproto.Version{Major: 24, Minor: 1, Patch: 0},
+			softDeleteColumn: "_peerdb_is_deleted",
+			contains: []string{
+				"ENGINE = ReplacingMergeTree(`_peerdb_version`, `_peerdb_is_deleted`)",
+				"allow_experimental_replacing_merge_with_cleanup=1",
+			},
+			notContains: []string{
+				"enable_replacing_merge_with_cleanup_for_min_age_to_force_merge",
+				"min_age_to_force_merge_on_partition_only",
+				"min_age_to_force_merge_seconds",
+			},
+		},
+		{
+			name:      "deleteOnMerge disabled never sets cleanup settings",
+			chVersion: &chproto.Version{Major: 25, Minor: 8, Patch: 0},
+			contains: []string{
+				"ENGINE = ReplacingMergeTree(`_peerdb_version`)",
+			},
+			notContains: []string{
+				"allow_experimental_replacing_merge_with_cleanup",
+				"enable_replacing_merge_with_cleanup_for_min_age_to_force_merge",
+				"min_age_to_force_merge_on_partition_only",
+				"min_age_to_force_merge_seconds",
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -494,14 +534,18 @@ func TestGenerateCreateTableSQLForNormalizedTable(t *testing.T) {
 				chVersion: tc.chVersion,
 			}
 			config := &protos.SetupNormalizedTableBatchInput{
-				Env: map[string]string{"PEERDB_SOURCE_SCHEMA_AS_DESTINATION_COLUMN": "false"},
+				Env: map[string]string{
+					"PEERDB_SOURCE_SCHEMA_AS_DESTINATION_COLUMN":              "false",
+					"PEERDB_CLICKHOUSE_REPLACING_MERGE_CLEANUP_MIN_AGE_HOURS": "24",
+				},
 				TableMappings: []*protos.TableMapping{
 					{
 						SourceTableIdentifier:      tableIdentifier,
 						DestinationTableIdentifier: tableIdentifier,
 					},
 				},
-				IsResync: tc.isResync,
+				IsResync:          tc.isResync,
+				SoftDeleteColName: tc.softDeleteColumn,
 			}
 
 			result, err := c.generateCreateTableSQLForNormalizedTable(ctx, config, tableIdentifier, tableSchema, tc.chVersion, nil)

--- a/flow/internal/clickhouse/settings.go
+++ b/flow/internal/clickhouse/settings.go
@@ -20,6 +20,16 @@ const (
 	SettingThrowOnMaxPartitionsPerInsertBlock CHSetting = "throw_on_max_partitions_per_insert_block"
 	SettingParallelDistributedInsertSelect    CHSetting = "parallel_distributed_insert_select"
 	SettingMaxTableSizeToDrop                 CHSetting = "max_table_size_to_drop"
+	// SettingAllowExperimentalReplacingMergeWithCleanup allows OPTIMIZE ... FINAL CLEANUP to physically
+	// drop rows marked via a ReplacingMergeTree is_deleted column.
+	SettingAllowExperimentalReplacingMergeWithCleanup CHSetting = "allow_experimental_replacing_merge_with_cleanup"
+	// SettingEnableReplacingMergeWithCleanupForMinAgeToForceMerge, together with SettingMinAgeToForceMergeSeconds
+	// and SettingMinAgeToForceMergeOnPartitionOnly, makes cleanup merges happen automatically in the background
+	// once all parts in a partition are older than the configured age, instead of requiring a manual
+	// OPTIMIZE ... FINAL CLEANUP.
+	SettingEnableReplacingMergeWithCleanupForMinAgeToForceMerge CHSetting = "enable_replacing_merge_with_cleanup_for_min_age_to_force_merge"
+	SettingMinAgeToForceMergeSeconds                            CHSetting = "min_age_to_force_merge_seconds"
+	SettingMinAgeToForceMergeOnPartitionOnly                    CHSetting = "min_age_to_force_merge_on_partition_only"
 )
 
 // CHSettingMinVersions maps setting names to their minimum required ClickHouse versions that PeerDB supports.
@@ -28,6 +38,11 @@ var CHSettingMinVersions = map[CHSetting]chproto.Version{
 	SettingJsonTypeEscapeDotsInKeys:    {Major: 25, Minor: 8, Patch: 0},
 	SettingTypeJsonSkipDuplicatedPaths: {Major: 24, Minor: 8, Patch: 0},
 	SettingMaxTableSizeToDrop:          {Major: 23, Minor: 12, Patch: 0},
+	// Re-introduced (after a data-corruption revert) in https://github.com/ClickHouse/ClickHouse/pull/58316,
+	// first released in 24.1.
+	SettingAllowExperimentalReplacingMergeWithCleanup: {Major: 24, Minor: 1, Patch: 0},
+	// Introduced in https://github.com/ClickHouse/ClickHouse/pull/76440, first released in 25.3.
+	SettingEnableReplacingMergeWithCleanupForMinAgeToForceMerge: {Major: 25, Minor: 3, Patch: 0},
 }
 
 type CHSetting string
@@ -47,6 +62,16 @@ func GetMinVersion(name CHSetting) (chproto.Version, bool) {
 		return minVersion, true
 	}
 	return chproto.Version{}, false
+}
+
+// SupportsSetting reports whether the given ClickHouse server version supports the setting.
+// A nil version is treated as supporting every setting, matching CHSettings.String's behavior.
+func SupportsSetting(version *chproto.Version, name CHSetting) bool {
+	minVersion, exists := GetMinVersion(name)
+	if !exists || version == nil {
+		return true
+	}
+	return chproto.CheckMinVersion(minVersion, *version)
 }
 
 // NewCHSettingsString is a one-liner method to generate an immutable settings string

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -338,6 +338,16 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 	{
+		Name: "PEERDB_CLICKHOUSE_REPLACING_MERGE_CLEANUP_MIN_AGE_HOURS",
+		Description: "Hours all parts in a partition must age past before ClickHouse automatically force-merges " +
+			"them and physically drops deleted rows, for ReplacingMergeTree tables created with deleteOnMerge " +
+			"enabled. Applies to newly created tables",
+		DefaultValue:     "24",
+		ValueType:        protos.DynconfValueType_UINT,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_NEW_MIRROR,
+		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
+	},
+	{
 		Name:             "PEERDB_INTERVAL_SINCE_LAST_NORMALIZE_THRESHOLD_MINUTES",
 		Description:      "Duration in minutes since last normalize to start alerting, 0 disables all alerting entirely",
 		DefaultValue:     "240",
@@ -808,6 +818,10 @@ func PeerDBClickHouseClientName(ctx context.Context, env map[string]string) (str
 
 func PeerDBClickHouseRawTableTTLDays(ctx context.Context, env map[string]string) (uint32, error) {
 	return dynamicConfUnsigned[uint32](ctx, env, "PEERDB_CLICKHOUSE_RAW_TABLE_TTL_DAYS")
+}
+
+func PeerDBClickHouseReplacingMergeCleanupMinAgeHours(ctx context.Context, env map[string]string) (uint32, error) {
+	return dynamicConfUnsigned[uint32](ctx, env, "PEERDB_CLICKHOUSE_REPLACING_MERGE_CLEANUP_MIN_AGE_HOURS")
 }
 
 func PeerDBSnowflakeMergeParallelism(ctx context.Context, env map[string]string) (int64, error) {


### PR DESCRIPTION
## Summary

`deleteOnMerge` (ClickPipes' "Remove deleted rows during merges" toggle) currently only wires `_peerdb_is_deleted` in as the `ReplacingMergeTree(ver, is_deleted)` engine parameter. That parameter alone only affects *deduplication* (which version of a row wins) — it does not make ClickHouse physically drop deleted rows. Doing that requires `allow_experimental_replacing_merge_with_cleanup`, which PeerDB never set, so deleted rows accumulated forever with `_peerdb_is_deleted=1` regardless of the toggle. Reported by a customer via CX (crimsongcp-cx-77).

- `flow/connectors/clickhouse/normalize.go`: when a ReplacingMergeTree/ReplicatedReplacingMergeTree table is created with a soft-delete column configured, always set `allow_experimental_replacing_merge_with_cleanup=1`. When the ClickHouse server is >= 25.3 (which added `enable_replacing_merge_with_cleanup_for_min_age_to_force_merge`), additionally enable fully automatic cleanup by force-merging partitions once all their parts age past a configurable threshold (new dynamic setting `PEERDB_CLICKHOUSE_REPLACING_MERGE_CLEANUP_MIN_AGE_HOURS`, default 24h). On older ClickHouse versions, only the cleanup flag is set, and a warning is logged noting that cleanup then requires a manual `OPTIMIZE TABLE ... FINAL CLEANUP`.
- `flow/internal/clickhouse/settings.go`: new `CHSetting` constants and version gates for the two settings above, plus a `SupportsSetting` helper.
- `flow/internal/dynamicconf.go`: new `PEERDB_CLICKHOUSE_REPLACING_MERGE_CLEANUP_MIN_AGE_HOURS` dynamic setting + getter.

This only affects newly created tables (new mirrors, or resyncs). It does not retroactively fix tables created before this change — those need a manual `ALTER TABLE ... MODIFY SETTING allow_experimental_replacing_merge_with_cleanup = 1` followed by `OPTIMIZE TABLE ... FINAL CLEANUP` (or a resync).

## Test plan

- [x] Added `TestGenerateCreateTableSQLForNormalizedTable` cases: cleanup settings appear for `deleteOnMerge` on a recent CH version (with automatic age-based settings), cleanup-flag-only on an old CH version, and no cleanup settings at all when `deleteOnMerge` is disabled.
- [x] `go test ./connectors/clickhouse/... ./internal/...` passes (excluding pre-existing tests that require a live catalog Postgres connection, unrelated to this change).
- [x] `golangci-lint run` clean on changed packages.