### PR TITLE
support parallel_view_processing

### DIFF
--- a/flow/connectors/clickhouse/clickhouse.go
+++ b/flow/connectors/clickhouse/clickhouse.go
@@ -217,6 +217,11 @@ func Connect(ctx context.Context, env map[string]string, config *protos.Clickhou
 	} else if maxInsertThreads != 0 {
 		settings["max_insert_threads"] = maxInsertThreads
 	}
+	if parallelViewProcessing, err := internal.PeerDBClickHouseParallelViewProcessing(ctx, env); err != nil {
+		return nil, fmt.Errorf("failed to load parallel_view_processing config: %w", err)
+	} else if parallelViewProcessing {
+		settings["parallel_view_processing"] = uint64(1)
+	}
 	if config.Cluster != "" {
 		settings["insert_distributed_sync"] = uint64(1)
 	}

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -298,8 +298,9 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 	{
-		Name:             "PEERDB_CLICKHOUSE_PARALLEL_VIEW_PROCESSING",
-		Description:      "Enables parallel_view_processing setting on clickhouse, pushing to attached materialized views concurrently during inserts",
+		Name: "PEERDB_CLICKHOUSE_PARALLEL_VIEW_PROCESSING",
+		Description: "Enables parallel_view_processing setting on clickhouse, pushing to attached materialized views " +
+			"concurrently during inserts",
 		DefaultValue:     "false",
 		ValueType:        protos.DynconfValueType_BOOL,
 		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -298,6 +298,14 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 	{
+		Name:             "PEERDB_CLICKHOUSE_PARALLEL_VIEW_PROCESSING",
+		Description:      "Enables parallel_view_processing setting on clickhouse, pushing to attached materialized views concurrently during inserts",
+		DefaultValue:     "false",
+		ValueType:        protos.DynconfValueType_BOOL,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
+	},
+	{
 		Name:             "PEERDB_CLICKHOUSE_PARALLEL_NORMALIZE",
 		Description:      "Divide tables in batch into N insert selects. Helps distribute load to multiple nodes",
 		DefaultValue:     "0",
@@ -788,6 +796,10 @@ func PeerDBEnableClickHousePrimaryUpdate(ctx context.Context, env map[string]str
 
 func PeerDBClickHouseMaxInsertThreads(ctx context.Context, env map[string]string) (int64, error) {
 	return dynamicConfSigned[int64](ctx, env, "PEERDB_CLICKHOUSE_MAX_INSERT_THREADS")
+}
+
+func PeerDBClickHouseParallelViewProcessing(ctx context.Context, env map[string]string) (bool, error) {
+	return dynamicConfBool(ctx, env, "PEERDB_CLICKHOUSE_PARALLEL_VIEW_PROCESSING")
 }
 
 func PeerDBClickHouseParallelNormalize(ctx context.Context, env map[string]string) (int, error) {


### PR DESCRIPTION
`parallel_view_processing` allow for concurrent view processing, and can benefit from `max_threads` and `max_insert_threads`. 

The setting had been available since clickhouse 19.4 (2019) so is available on most ClickHouse versions. It is also behind a setting and not set by default. 

Fixes: DBI-1033