### PR TITLE
report normalize batch id more frequently

### DIFF
--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -698,6 +698,12 @@ func (a *FlowableActivity) startNormalize(
 ) error {
 	logger := internal.LoggerFromCtx(ctx)
 
+	// record gauge on error as well
+	defer func() {
+		a.OtelManager.Metrics.LastNormalizedBatchIdGauge.Record(ctx, normalizeResponses.Load(),
+			metric.WithAttributeSet(attribute.NewSet(attribute.String(otel_metrics.FlowNameKey, config.FlowJobName))))
+	}()
+
 	dstConn, dstClose, err := connectors.GetByNameAs[connectors.CDCNormalizeConnector](
 		ctx,
 		config.Env,
@@ -761,6 +767,8 @@ func (a *FlowableActivity) startNormalize(
 		logger.Info("normalized batches",
 			slog.Int64("startBatchID", res.StartBatchID), slog.Int64("endBatchID", res.EndBatchID), slog.Int64("syncBatchID", batchID))
 		normalizeResponses.Update(res.EndBatchID)
+		a.OtelManager.Metrics.LastNormalizedBatchIdGauge.Record(ctx, res.EndBatchID,
+			metric.WithAttributeSet(attribute.NewSet(attribute.String(otel_metrics.FlowNameKey, config.FlowJobName))))
 		if res.EndBatchID >= batchID {
 			return nil
 		}
@@ -845,19 +853,11 @@ func (a *FlowableActivity) normalizeLoop(
 					default:
 						time.Sleep(retryInterval)
 						retryInterval = min(retryInterval*2, 5*time.Minute)
-						// record the last normalized batch ID even if retry fails to populate metrics consistently
-						a.OtelManager.Metrics.LastNormalizedBatchIdGauge.Record(
-							ctx, lastNormalizedBatchID, metric.WithAttributeSet(attribute.NewSet(
-								attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
-							)))
 						reqBatchID = normalizeRequests.Load()
 						continue retryLoop
 					}
 				}
 			}
-			a.OtelManager.Metrics.LastNormalizedBatchIdGauge.Record(ctx, reqBatchID, metric.WithAttributeSet(attribute.NewSet(
-				attribute.String(otel_metrics.FlowNameKey, config.FlowJobName),
-			)))
 			break
 		}
 	}


### PR DESCRIPTION
Previously we were reporting normalize batch id upon the completion of every NormalizeRequest request. 

However a single NormalizeRequest is generated for every (last_normalize_batch_id, last_sync_batch_id]  range; and the inner loop will work on the batches sequentially until the request is fulfilled. This means when normalize is behind and normalize lag is growing, this NormalizeRequest can take longer and longer to fill, making this metric infrequent and less useful than it's intended (per image).  Fix is to move the metric to the inner loop. 

<img width="1320" height="466" alt="Screenshot 2026-08-12 at 16 36 40@2x" src="https://github.com/user-attachments/assets/51fce3e8-daf7-4583-9290-9baa0c190c34" />

