### PR TITLE
optimize hot path by caching contexual attribute

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -458,6 +458,7 @@ func (c *MongoConnector) PullRecords(
 		return nil
 	}
 
+	var lastEventGaugesRecordedAt time.Time
 	for recordCount < req.MaxBatchSize {
 		if ok := changeStream.Next(timeoutCtx); !ok {
 			err := changeStream.Err()
@@ -513,9 +514,14 @@ func (c *MongoConnector) PullRecords(
 			commitTime = changeEvent.WallTime.UTC()
 		}
 		commitTimeNanos := commitTime.UnixNano()
-		otelManager.Metrics.LatestConsumedLogEventGauge.Record(ctx, clusterTime.Unix())
-		otelManager.Metrics.SourceLagGauge.Record(ctx,
-			time.Now().UTC().Add(mongoClockOffset).Sub(commitTime).Milliseconds())
+
+		if time.Since(lastEventGaugesRecordedAt) >= time.Second {
+			// recording gauges per event is wasteful on CPU given this is on the hot path
+			otelManager.Metrics.LatestConsumedLogEventGauge.Record(ctx, clusterTime.Unix())
+			otelManager.Metrics.SourceLagGauge.Record(ctx,
+				time.Now().UTC().Add(mongoClockOffset).Sub(commitTime).Milliseconds())
+			lastEventGaugesRecordedAt = time.Now()
+		}
 
 		sourceTableName := fmt.Sprintf("%s.%s", changeEvent.Ns.Db, changeEvent.Ns.Coll)
 		destinationTableName := req.TableNameMapping[sourceTableName].Name

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -152,30 +153,55 @@ func buildContextualAttributes(ctx context.Context) metric.MeasurementOption {
 	return metric.WithAttributeSet(attribute.NewSet(attributes...))
 }
 
+// contextAttributesCache memoize buildContextualAttributes for the last seen context.
+// This avoids rebuilding the contextual attributes with the same context, which is
+// expensive in the hot path. The attrs rebuild when different context is seen.
+type contextAttributesCache struct {
+	last atomic.Pointer[contextAttributesCacheEntry]
+}
+
+type contextAttributesCacheEntry struct {
+	//nolint:containedctx // the context is a cache key compared by identity, not a stored dependency
+	ctx   context.Context
+	attrs metric.MeasurementOption
+}
+
+func (c *contextAttributesCache) forContext(ctx context.Context) metric.MeasurementOption {
+	if cached := c.last.Load(); cached != nil && cached.ctx == ctx {
+		return cached.attrs
+	}
+	attrs := buildContextualAttributes(ctx)
+	c.last.Store(&contextAttributesCacheEntry{ctx: ctx, attrs: attrs})
+	return attrs
+}
+
 type ContextAwareInt64SyncGauge struct {
 	metric.Int64Gauge
+	attrsCache contextAttributesCache
 }
 
 func (a *ContextAwareInt64SyncGauge) Record(ctx context.Context, value int64, options ...metric.RecordOption) {
-	newOptions := append([]metric.RecordOption{buildContextualAttributes(ctx)}, options...)
+	newOptions := append([]metric.RecordOption{a.attrsCache.forContext(ctx)}, options...)
 	a.Int64Gauge.Record(ctx, value, newOptions...)
 }
 
 type ContextAwareFloat64SyncGauge struct {
 	metric.Float64Gauge
+	attrsCache contextAttributesCache
 }
 
 func (a *ContextAwareFloat64SyncGauge) Record(ctx context.Context, value float64, options ...metric.RecordOption) {
-	newOptions := append([]metric.RecordOption{buildContextualAttributes(ctx)}, options...)
+	newOptions := append([]metric.RecordOption{a.attrsCache.forContext(ctx)}, options...)
 	a.Float64Gauge.Record(ctx, value, newOptions...)
 }
 
 type ContextAwareInt64Counter struct {
 	metric.Int64Counter
+	attrsCache contextAttributesCache
 }
 
 func (a *ContextAwareInt64Counter) Add(ctx context.Context, value int64, options ...metric.AddOption) {
-	newOptions := append([]metric.AddOption{buildContextualAttributes(ctx)}, options...)
+	newOptions := append([]metric.AddOption{a.attrsCache.forContext(ctx)}, options...)
 	a.Int64Counter.Add(ctx, value, newOptions...)
 }
 

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -153,11 +152,11 @@ func buildContextualAttributes(ctx context.Context) metric.MeasurementOption {
 	return metric.WithAttributeSet(attribute.NewSet(attributes...))
 }
 
-// contextAttributesCache memoize buildContextualAttributes for the last seen context.
-// This avoids rebuilding the contextual attributes with the same context, which is
-// expensive in the hot path. The attrs rebuild when different context is seen.
+// contextAttributesCache memoize buildContextualAttributes, which is expensive in the
+// hot path. Since gauges are singletons shared across mirrors, cache entries are keyed
+// by flow name (when exists) to so they don't evict each other across mirrors.
 type contextAttributesCache struct {
-	last atomic.Pointer[contextAttributesCacheEntry]
+	entries sync.Map
 }
 
 type contextAttributesCacheEntry struct {
@@ -167,11 +166,17 @@ type contextAttributesCacheEntry struct {
 }
 
 func (c *contextAttributesCache) forContext(ctx context.Context) metric.MeasurementOption {
-	if cached := c.last.Load(); cached != nil && cached.ctx == ctx {
-		return cached.attrs
+	var flowName string
+	if flowMetadata := internal.GetFlowMetadata(ctx); flowMetadata != nil {
+		flowName = flowMetadata.FlowName
+	}
+	if cached, ok := c.entries.Load(flowName); ok {
+		if entry := cached.(*contextAttributesCacheEntry); entry.ctx == ctx {
+			return entry.attrs
+		}
 	}
 	attrs := buildContextualAttributes(ctx)
-	c.last.Store(&contextAttributesCacheEntry{ctx: ctx, attrs: attrs})
+	c.entries.Store(flowName, &contextAttributesCacheEntry{ctx: ctx, attrs: attrs})
 	return attrs
 }
 

--- a/flow/otel_metrics/observables_test.go
+++ b/flow/otel_metrics/observables_test.go
@@ -1,0 +1,109 @@
+package otel_metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
+)
+
+type capturingInt64Gauge struct {
+	embedded.Int64Gauge
+	values []int64
+	attrs  []attribute.Set
+}
+
+func (g *capturingInt64Gauge) Enabled(context.Context) bool { return true }
+
+func (g *capturingInt64Gauge) Record(ctx context.Context, value int64, options ...metric.RecordOption) {
+	g.values = append(g.values, value)
+	g.attrs = append(g.attrs, metric.NewRecordConfig(options).Attributes())
+}
+
+func flowContext(flowName string) context.Context {
+	ctx := context.WithValue(context.Background(), internal.FlowMetadataKey, &protos.FlowContextMetadata{
+		FlowName: flowName,
+		Source: &protos.PeerContextMetadata{
+			Name: "src", Type: protos.DBType_MONGO, Hostname: "src-host",
+		},
+		Destination: &protos.PeerContextMetadata{
+			Name: "dst", Type: protos.DBType_CLICKHOUSE, Hostname: "dst-host",
+		},
+		Status: protos.FlowStatus_STATUS_RUNNING,
+	})
+	return internal.WithOperationContext(ctx, protos.FlowOperation_FLOW_OPERATION_SYNC)
+}
+
+func attrValue(t *testing.T, attrs attribute.Set, key string) string {
+	t.Helper()
+	value, ok := attrs.Value(attribute.Key(key))
+	require.True(t, ok, "missing attribute %s", key)
+	return value.String()
+}
+
+func TestContextAwareInt64SyncGaugeRecordsContextualAttributes(t *testing.T) {
+	inner := &capturingInt64Gauge{}
+	gauge := &ContextAwareInt64SyncGauge{Int64Gauge: inner}
+
+	gauge.Record(flowContext("test-flow"), 42)
+
+	require.Equal(t, []int64{42}, inner.values)
+	require.Equal(t, "test-flow", attrValue(t, inner.attrs[0], FlowNameKey))
+	require.Equal(t, "src", attrValue(t, inner.attrs[0], SourcePeerName))
+	require.Equal(t, protos.FlowOperation_FLOW_OPERATION_SYNC.String(),
+		attrValue(t, inner.attrs[0], FlowOperationKey))
+}
+
+func TestContextAttributesCache(t *testing.T) {
+	inner := &capturingInt64Gauge{}
+	gauge := &ContextAwareInt64SyncGauge{Int64Gauge: inner}
+
+	// same context twice: identical attributes (served from cache)
+	ctxA := flowContext("flow-a")
+	gauge.Record(ctxA, 1)
+	gauge.Record(ctxA, 2)
+	require.Equal(t, inner.attrs[0], inner.attrs[1])
+	require.Equal(t, "flow-a", attrValue(t, inner.attrs[1], FlowNameKey))
+
+	// a different context must not be served stale attributes
+	gauge.Record(flowContext("flow-b"), 3)
+	require.Equal(t, "flow-b", attrValue(t, inner.attrs[2], FlowNameKey))
+
+	// switching back rebuilds correctly too
+	gauge.Record(ctxA, 4)
+	require.Equal(t, "flow-a", attrValue(t, inner.attrs[3], FlowNameKey))
+
+	// a derived context with a different operation is a different context value
+	normalizeCtx := internal.WithOperationContext(ctxA, protos.FlowOperation_FLOW_OPERATION_NORMALIZE)
+	gauge.Record(normalizeCtx, 5)
+	require.Equal(t, protos.FlowOperation_FLOW_OPERATION_NORMALIZE.String(),
+		attrValue(t, inner.attrs[4], FlowOperationKey))
+}
+
+func BenchmarkContextAwareGaugeRecord(b *testing.B) {
+	meter := noop.NewMeterProvider().Meter("bench")
+	inner, err := NewInt64SyncGauge(meter, "bench_gauge")
+	require.NoError(b, err)
+	gauge := &ContextAwareInt64SyncGauge{Int64Gauge: inner}
+	ctx1 := flowContext("bench-flow")
+	ctx2 := flowContext("bench-flow")
+
+	b.Run("cache-hit", func(b *testing.B) {
+		for b.Loop() {
+			gauge.Record(ctx1, 1)
+		}
+	})
+	b.Run("cache-miss", func(b *testing.B) {
+		for b.Loop() {
+			gauge.attrsCache.last.Store(&contextAttributesCacheEntry{ctx: ctx2})
+			gauge.Record(ctx1, 1)
+		}
+	})
+}

--- a/flow/otel_metrics/observables_test.go
+++ b/flow/otel_metrics/observables_test.go
@@ -65,26 +65,66 @@ func TestContextAttributesCache(t *testing.T) {
 	inner := &capturingInt64Gauge{}
 	gauge := &ContextAwareInt64SyncGauge{Int64Gauge: inner}
 
-	// same context twice: identical attributes (served from cache)
 	ctxA := flowContext("flow-a")
+	ctxB := flowContext("flow-b")
+	derivedCtxA := internal.WithOperationContext(ctxA, protos.FlowOperation_FLOW_OPERATION_NORMALIZE)
+
+	// same context twice: identical attributes (served from cache)
 	gauge.Record(ctxA, 1)
 	gauge.Record(ctxA, 2)
 	require.Equal(t, inner.attrs[0], inner.attrs[1])
 	require.Equal(t, "flow-a", attrValue(t, inner.attrs[1], FlowNameKey))
+	entryA, ok := gauge.attrsCache.entries.Load("flow-a")
+	require.True(t, ok)
 
-	// a different context must not be served stale attributes
-	gauge.Record(flowContext("flow-b"), 3)
+	// a different flow's context must not be served stale attributes
+	gauge.Record(ctxB, 3)
 	require.Equal(t, "flow-b", attrValue(t, inner.attrs[2], FlowNameKey))
 
-	// switching back rebuilds correctly too
+	// switching back rebuilds correctly too (and served from cache)
 	gauge.Record(ctxA, 4)
 	require.Equal(t, "flow-a", attrValue(t, inner.attrs[3], FlowNameKey))
+	entryA2, ok := gauge.attrsCache.entries.Load("flow-a")
+	require.True(t, ok)
+	require.Same(t, entryA, entryA2)
 
 	// a derived context with a different operation is a different context value
-	normalizeCtx := internal.WithOperationContext(ctxA, protos.FlowOperation_FLOW_OPERATION_NORMALIZE)
-	gauge.Record(normalizeCtx, 5)
+	gauge.Record(derivedCtxA, 5)
 	require.Equal(t, protos.FlowOperation_FLOW_OPERATION_NORMALIZE.String(),
 		attrValue(t, inner.attrs[4], FlowOperationKey))
+
+	// the original context is unaffected
+	gauge.Record(ctxA, 6)
+	require.Equal(t, "flow-a", attrValue(t, inner.attrs[5], FlowNameKey))
+	require.Equal(t, protos.FlowOperation_FLOW_OPERATION_SYNC.String(),
+		attrValue(t, inner.attrs[5], FlowOperationKey))
+}
+
+func TestContextAttributesWithoutFlowName(t *testing.T) {
+	inner := &capturingInt64Gauge{}
+	gauge := &ContextAwareInt64SyncGauge{Int64Gauge: inner}
+
+	_, ok := gauge.attrsCache.entries.Load("")
+	require.False(t, ok) // cache is empty
+
+	ctx := context.Background()
+	gauge.Record(ctx, 1)
+	_, hasFlowName := inner.attrs[0].Value(FlowNameKey)
+	require.False(t, hasFlowName)
+	_, ok = gauge.attrsCache.entries.Load("")
+	require.True(t, ok) // cache is populated
+
+	// same context is served from cache
+	gauge.Record(ctx, 2)
+	require.Equal(t, inner.attrs[0], inner.attrs[1])
+
+	// different context (also without flow name) rebuilds its own attributes
+	otherCtx := internal.WithOperationContext(context.Background(), protos.FlowOperation_FLOW_OPERATION_SYNC)
+	gauge.Record(otherCtx, 3)
+	require.Equal(t, protos.FlowOperation_FLOW_OPERATION_SYNC.String(),
+		attrValue(t, inner.attrs[2], FlowOperationKey))
+	_, hasFlowName = inner.attrs[2].Value(FlowNameKey)
+	require.False(t, hasFlowName)
 }
 
 func BenchmarkContextAwareGaugeRecord(b *testing.B) {
@@ -102,8 +142,21 @@ func BenchmarkContextAwareGaugeRecord(b *testing.B) {
 	})
 	b.Run("cache-miss", func(b *testing.B) {
 		for b.Loop() {
-			gauge.attrsCache.last.Store(&contextAttributesCacheEntry{ctx: ctx2})
+			gauge.attrsCache.entries.Store("bench-flow", &contextAttributesCacheEntry{ctx: ctx2})
 			gauge.Record(ctx1, 1)
+		}
+	})
+
+	interleavedCtxs := []context.Context{
+		flowContext("bench-interleaved-1"),
+		flowContext("bench-interleaved-2"),
+		flowContext("bench-interleaved-3"),
+	}
+	b.Run("cache-hit-interleaved-ctx", func(b *testing.B) {
+		i := 0
+		for b.Loop() {
+			gauge.Record(interleavedCtxs[i%len(interleavedCtxs)], 1)
+			i++
 		}
 	})
 }


### PR DESCRIPTION
Two related fixes in this PR

### 1. Cache contextual attribute

All our counters/gauges are implemented with `ContextAware*`, which when executing `Record` will attempt to build attributes based on context:
```
func (a *ContextAwareInt64SyncGauge) Record(ctx context.Context, value int64, options ...metric.RecordOption) {
	newOptions := append([]metric.RecordOption{buildContextualAttributes(ctx)}, options...)
	a.Int64Gauge.Record(ctx, value, newOptions...)
}
```
This is intentional to standardize attributes (see `buildContextualAttributes`). However, on hot path like in the `PullRecord` loop, this can get pretty expensive and wasteful. We have observed flow-worker spending ~14% CPU just rebuilding attributes from the same context and generating the same result:

<img width="3454" height="1772" alt="Screenshot 2026-08-12 at 19 03 38@2x" src="https://github.com/user-attachments/assets/b7fab60a-3eff-4256-9724-1bcff4c4c4f0" />

Fix here is to front the context building with a cache. Benchmark result on my machine shows ~3.6x improvement:

```
BenchmarkContextAwareGaugeRecord
BenchmarkContextAwareGaugeRecord/cache-hit
BenchmarkContextAwareGaugeRecord/cache-hit-14         	 2929458	       405.3 ns/op
BenchmarkContextAwareGaugeRecord/cache-miss
BenchmarkContextAwareGaugeRecord/cache-miss-14        	  781149	      1489 ns/op
```

### 2. Reduce gauge record frequency for MongoDB

A second optimization is in the MongoDB PullRecord loop, where instead of recording the gauge on every change event, only do so once per second. This is because SyncGauge is still not free (as seen in benchmark above), and Record just updates the cached value in the Gauge, not actually exporting it, so is essentially wasted work. This was attributing to another 5% of the cpu:

<img width="3446" height="1784" alt="Screenshot 2026-08-12 at 19 04 55@2x" src="https://github.com/user-attachments/assets/4e5e1530-ceff-4ecc-af5e-95ac7ba290d0" />

As a follow-up, worth also apply this change for PG/MySQL, but Mongo tends to be the most bottlenecked on CDC due to slow JSON processing, so prioritizing it here (also considered generalizing this mechanism into the gauge itself, but it's a bit unconventional to build sampling into gauge (more reasonable for traces). 