### PR TITLE
feat(bigquery): snapshot export as of BigQuery-clock timestamp T

### DIFF
--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -343,15 +343,7 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 	c.logger.Info("Run snapshot staging path", slog.String("path", runSnapshotStagingPath))
 
 	// snapshotTime (T) anchors every table's export below via FOR SYSTEM_TIME AS OF, so all
-	// tables are read as of the same consistent point in time. It's queried from BigQuery's
-	// own clock rather than local wall-clock so it lines up with BigQuery's time-travel
-	// semantics.
-	//
-	// Known limitation: T must stay within BigQuery's time-travel window (7 days by default)
-	// for the entire snapshot duration across all tables, or later tables' exports will fail.
-	// Not addressed here -- no retry/adjustment logic; a snapshot that runs long enough to
-	// walk outside the window needs a shorter export or a larger table-level time-travel
-	// setting.
+	// tables are read as of the same consistent point in time.
 	snapshotTime, err := c.currentBigQueryTimestamp(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get current BigQuery timestamp for snapshot: %w", err)
@@ -364,9 +356,6 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 	return &protos.ExportTxSnapshotOutput{SnapshotStagingPath: runSnapshotStagingPath}, runSnapshotStagingPath, nil
 }
 
-// exportTablesAsOf runs EXPORT DATA for every table in tableMappings, each read as of
-// snapshotTime, writing Parquet to stagingPath. Shared by ExportTxSnapshot (pure
-// snapshot-only flows) and SetupReplication (initial load for flows that continue into CDC).
 func (c *BigQueryConnector) exportTablesAsOf(
 	ctx context.Context,
 	flowName string,
@@ -450,9 +439,7 @@ func (c *BigQueryConnector) bigQueryExportQueryStatement(
 	return buildBigQueryExportSQL(dsTable, metadata.Schema, snapshotStagingPath, sourceTableIdentifier, snapshotTime), nil
 }
 
-// buildBigQueryExportSQL builds the EXPORT DATA SQL string given an already-resolved schema, so
-// it can be unit tested without a live BigQuery client. See bigQueryExportQueryStatement, which
-// resolves the schema and delegates here.
+// buildBigQueryExportSQL builds the EXPORT DATA SQL string
 func buildBigQueryExportSQL(
 	dsTable datasetTable,
 	schema bigquery.Schema,
@@ -480,8 +467,6 @@ func buildBigQueryExportSQL(
 	}
 
 	uri := fmt.Sprintf("%s/%s/*.parquet", snapshotStagingPath, url.PathEscape(sourceTableIdentifier))
-	// BigQuery's TIMESTAMP literal format; matches the precision/format validated against a
-	// live instance (see the FOR SYSTEM_TIME AS OF syntax docs referenced above).
 	snapshotLiteral := snapshotTime.UTC().Format("2006-01-02 15:04:05.999999")
 
 	return fmt.Sprintf(`EXPORT DATA OPTIONS(
@@ -576,10 +561,7 @@ func (c *BigQueryConnector) PullFlowCleanup(context.Context, string) error {
 // MySQL/Postgres, BigQuery's initial load can't query the live table at pull time - QRep
 // pulls read pre-exported Parquet from GCS - so when the mirror wants an initial load
 // (req.DoInitialSnapshot), this also runs that export as of the same T, the same way
-// ExportTxSnapshot does for pure snapshot-only flows. It returns a zero-value
-// model.SetupReplicationResult (no slot/snapshot name), matching MySQL: cloneTablesWithSlot
-// falls back to the mirror's configured SnapshotStagingPath when no override is given, which
-// is exactly where this export writes.
+// ExportTxSnapshot does for pure snapshot-only flows.
 func (c *BigQueryConnector) SetupReplication(
 	ctx context.Context,
 	catalogPool shared.CatalogPool,

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -469,13 +469,9 @@ func buildBigQueryExportSQL(
 	uri := fmt.Sprintf("%s/%s/*.parquet", snapshotStagingPath, url.PathEscape(sourceTableIdentifier))
 	snapshotLiteral := snapshotTime.UTC().Format("2006-01-02 15:04:05.999999")
 
-	return fmt.Sprintf(`EXPORT DATA OPTIONS(
-			uri='%s',
-			format='PARQUET',
-			compression='GZIP',
-			overwrite=true
-		) AS
-		SELECT %s FROM %s FOR SYSTEM_TIME AS OF TIMESTAMP('%s UTC')`,
+	return fmt.Sprintf(
+		"EXPORT DATA OPTIONS(uri='%s', format='PARQUET', compression='GZIP', overwrite=true)"+
+			" AS SELECT %s FROM %s FOR SYSTEM_TIME AS OF TIMESTAMP('%s UTC')",
 		uri,
 		strings.Join(columnSelects, ", "),
 		dsTable.stringQuoted(),

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/url"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/storage"
@@ -341,9 +342,26 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 	runSnapshotStagingPath := basePath.JoinPath(activityInfo.WorkflowExecution.RunID).String()
 	c.logger.Info("Run snapshot staging path", slog.String("path", runSnapshotStagingPath))
 
+	// snapshotTime (T) anchors every table's export below via FOR SYSTEM_TIME AS OF, so all
+	// tables are read as of the same consistent point in time. It's queried from BigQuery's
+	// own clock rather than local wall-clock so it lines up with BigQuery's time-travel
+	// semantics. When the mirror continues into CDC, T also becomes the initial poll
+	// checkpoint (see below) so a later PullRecords resumes from exactly where this snapshot
+	// left off.
+	//
+	// Known limitation: T must stay within BigQuery's time-travel window (7 days by default)
+	// for the entire snapshot duration across all tables, or later tables' exports will fail.
+	// Not addressed here -- no retry/adjustment logic; a snapshot that runs long enough to
+	// walk outside the window needs a shorter export or a larger table-level time-travel
+	// setting.
+	snapshotTime, err := c.currentBigQueryTimestamp(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get current BigQuery timestamp for snapshot: %w", err)
+	}
+
 	jobs := make(map[string]*bigquery.Job)
 	for _, tm := range cfg.TableMappings {
-		exportSQL, err := c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, runSnapshotStagingPath)
+		exportSQL, err := c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, runSnapshotStagingPath, snapshotTime)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to build export SQL for table %s: %w", tm.SourceTableIdentifier, err)
 		}
@@ -375,7 +393,41 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 		_ = c.LogFlowInfo(ctx, flowName, "Exported snapshot data to GCS for table "+sourceTableIdentifier)
 	}
 
+	// Persist T as the initial CDC checkpoint only when this mirror will keep polling for
+	// changes after the snapshot. Pure-snapshot flows (InitialSnapshotOnly) have no CDC
+	// follow-up, so there's nothing to resume and no checkpoint should be written.
+	//
+	// This is done here, in ExportTxSnapshot, rather than in SetupReplication (as
+	// CDCPullConnectorCore's other implementations do for their equivalent offsets): for
+	// BigQuery, SetupReplication and ExportTxSnapshot are called from disjoint branches of
+	// SnapshotFlowWorkflow depending on InitialSnapshotOnly, so T (captured above, specific to
+	// this export) is never in scope inside SetupReplication. See the workflow branching in
+	// flow/workflows/snapshot_flow.go: SetupReplication runs only when InitialSnapshotOnly is
+	// false, i.e. exactly when ExportTxSnapshot does *not* run.
+	if !cfg.InitialSnapshotOnly {
+		checkpoint := model.CdcCheckpoint{Text: snapshotTime.Format(time.RFC3339Nano)}
+		if err := c.SetLastOffset(ctx, flowName, checkpoint); err != nil {
+			return nil, nil, fmt.Errorf("failed to persist snapshot checkpoint: %w", err)
+		}
+	}
+
 	return &protos.ExportTxSnapshotOutput{SnapshotStagingPath: runSnapshotStagingPath}, runSnapshotStagingPath, nil
+}
+
+// currentBigQueryTimestamp queries BigQuery's own clock (rather than local wall-clock) so the
+// returned timestamp is consistent with BigQuery's FOR SYSTEM_TIME AS OF time-travel semantics.
+func (c *BigQueryConnector) currentBigQueryTimestamp(ctx context.Context) (time.Time, error) {
+	it, err := c.client.Query("SELECT CURRENT_TIMESTAMP() AS ts").Read(ctx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to query current BigQuery timestamp: %w", err)
+	}
+	var row struct {
+		Ts time.Time `bigquery:"ts"`
+	}
+	if err := it.Next(&row); err != nil {
+		return time.Time{}, fmt.Errorf("failed to read current BigQuery timestamp: %w", err)
+	}
+	return row.Ts, nil
 }
 
 // bigQueryExportQueryStatement builds the EXPORT DATA SQL statement for exporting data from BigQuery to GCS in Parquet format.
@@ -386,6 +438,7 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 func (c *BigQueryConnector) bigQueryExportQueryStatement(
 	ctx context.Context,
 	sourceTableIdentifier, snapshotStagingPath string,
+	snapshotTime time.Time,
 ) (string, error) {
 	dsTable, err := c.convertToDatasetTable(sourceTableIdentifier)
 	if err != nil {
@@ -398,8 +451,20 @@ func (c *BigQueryConnector) bigQueryExportQueryStatement(
 		return "", fmt.Errorf("failed to get table metadata for %s: %w", sourceTableIdentifier, err)
 	}
 
-	columnSelects := make([]string, 0, len(metadata.Schema))
-	for _, field := range metadata.Schema {
+	return buildBigQueryExportSQL(dsTable, metadata.Schema, snapshotStagingPath, sourceTableIdentifier, snapshotTime), nil
+}
+
+// buildBigQueryExportSQL builds the EXPORT DATA SQL string given an already-resolved schema, so
+// it can be unit tested without a live BigQuery client. See bigQueryExportQueryStatement, which
+// resolves the schema and delegates here.
+func buildBigQueryExportSQL(
+	dsTable datasetTable,
+	schema bigquery.Schema,
+	snapshotStagingPath, sourceTableIdentifier string,
+	snapshotTime time.Time,
+) string {
+	columnSelects := make([]string, 0, len(schema))
+	for _, field := range schema {
 		quotedName := quotedIdentifier(field.Name)
 		columnSelect := quotedName
 		switch field.Type {
@@ -419,20 +484,22 @@ func (c *BigQueryConnector) bigQueryExportQueryStatement(
 	}
 
 	uri := fmt.Sprintf("%s/%s/*.parquet", snapshotStagingPath, url.PathEscape(sourceTableIdentifier))
+	// BigQuery's TIMESTAMP literal format; matches the precision/format validated against a
+	// live instance (see the FOR SYSTEM_TIME AS OF syntax docs referenced above).
+	snapshotLiteral := snapshotTime.UTC().Format("2006-01-02 15:04:05.999999")
 
-	exportSQL := fmt.Sprintf(`EXPORT DATA OPTIONS(
+	return fmt.Sprintf(`EXPORT DATA OPTIONS(
 			uri='%s',
 			format='PARQUET',
 			compression='GZIP',
 			overwrite=true
 		) AS
-		SELECT %s FROM %s`,
+		SELECT %s FROM %s FOR SYSTEM_TIME AS OF TIMESTAMP('%s UTC')`,
 		uri,
 		strings.Join(columnSelects, ", "),
 		dsTable.stringQuoted(),
+		snapshotLiteral,
 	)
-
-	return exportSQL, nil
 }
 
 func (c *BigQueryConnector) FinishExport(v any) error {

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -345,9 +345,7 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 	// snapshotTime (T) anchors every table's export below via FOR SYSTEM_TIME AS OF, so all
 	// tables are read as of the same consistent point in time. It's queried from BigQuery's
 	// own clock rather than local wall-clock so it lines up with BigQuery's time-travel
-	// semantics. When the mirror continues into CDC, T also becomes the initial poll
-	// checkpoint (see below) so a later PullRecords resumes from exactly where this snapshot
-	// left off.
+	// semantics.
 	//
 	// Known limitation: T must stay within BigQuery's time-travel window (7 days by default)
 	// for the entire snapshot duration across all tables, or later tables' exports will fail.
@@ -359,11 +357,28 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 		return nil, nil, fmt.Errorf("failed to get current BigQuery timestamp for snapshot: %w", err)
 	}
 
-	jobs := make(map[string]*bigquery.Job)
-	for _, tm := range cfg.TableMappings {
-		exportSQL, err := c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, runSnapshotStagingPath, snapshotTime)
+	if err := c.exportTablesAsOf(ctx, flowName, cfg.TableMappings, runSnapshotStagingPath, snapshotTime); err != nil {
+		return nil, nil, err
+	}
+
+	return &protos.ExportTxSnapshotOutput{SnapshotStagingPath: runSnapshotStagingPath}, runSnapshotStagingPath, nil
+}
+
+// exportTablesAsOf runs EXPORT DATA for every table in tableMappings, each read as of
+// snapshotTime, writing Parquet to stagingPath. Shared by ExportTxSnapshot (pure
+// snapshot-only flows) and SetupReplication (initial load for flows that continue into CDC).
+func (c *BigQueryConnector) exportTablesAsOf(
+	ctx context.Context,
+	flowName string,
+	tableMappings []*protos.TableMapping,
+	stagingPath string,
+	snapshotTime time.Time,
+) error {
+	jobs := make(map[string]*bigquery.Job, len(tableMappings))
+	for _, tm := range tableMappings {
+		exportSQL, err := c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, stagingPath, snapshotTime)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to build export SQL for table %s: %w", tm.SourceTableIdentifier, err)
+			return fmt.Errorf("failed to build export SQL for table %s: %w", tm.SourceTableIdentifier, err)
 		}
 
 		q := c.client.Query(exportSQL)
@@ -379,39 +394,20 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 				}
 			}
 
-			return nil, nil, fmt.Errorf("failed to start export job for table %s: %w", tm.SourceTableIdentifier, err)
+			return fmt.Errorf("failed to start export job for table %s: %w", tm.SourceTableIdentifier, err)
 		}
 		jobs[tm.SourceTableIdentifier] = job
 	}
 	for sourceTableIdentifier, job := range jobs {
 		if status, err := job.Wait(ctx); err != nil {
-			return nil, nil, fmt.Errorf("error waiting for export job to complete: %w", err)
+			return fmt.Errorf("error waiting for export job to complete: %w", err)
 		} else if err := status.Err(); err != nil {
-			return nil, nil, fmt.Errorf("export job completed with error: %w", err)
+			return fmt.Errorf("export job completed with error: %w", err)
 		}
 
 		_ = c.LogFlowInfo(ctx, flowName, "Exported snapshot data to GCS for table "+sourceTableIdentifier)
 	}
-
-	// Persist T as the initial CDC checkpoint only when this mirror will keep polling for
-	// changes after the snapshot. Pure-snapshot flows (InitialSnapshotOnly) have no CDC
-	// follow-up, so there's nothing to resume and no checkpoint should be written.
-	//
-	// This is done here, in ExportTxSnapshot, rather than in SetupReplication (as
-	// CDCPullConnectorCore's other implementations do for their equivalent offsets): for
-	// BigQuery, SetupReplication and ExportTxSnapshot are called from disjoint branches of
-	// SnapshotFlowWorkflow depending on InitialSnapshotOnly, so T (captured above, specific to
-	// this export) is never in scope inside SetupReplication. See the workflow branching in
-	// flow/workflows/snapshot_flow.go: SetupReplication runs only when InitialSnapshotOnly is
-	// false, i.e. exactly when ExportTxSnapshot does *not* run.
-	if !cfg.InitialSnapshotOnly {
-		checkpoint := model.CdcCheckpoint{Text: snapshotTime.Format(time.RFC3339Nano)}
-		if err := c.SetLastOffset(ctx, flowName, checkpoint); err != nil {
-			return nil, nil, fmt.Errorf("failed to persist snapshot checkpoint: %w", err)
-		}
-	}
-
-	return &protos.ExportTxSnapshotOutput{SnapshotStagingPath: runSnapshotStagingPath}, runSnapshotStagingPath, nil
+	return nil
 }
 
 // currentBigQueryTimestamp queries BigQuery's own clock (rather than local wall-clock) so the
@@ -574,9 +570,42 @@ func (c *BigQueryConnector) PullFlowCleanup(context.Context, string) error {
 	return nil
 }
 
+// SetupReplication is BigQuery's equivalent of capturing a starting replication position
+// (like MySQL's GTID/file-position capture): it has no replication slot to open, so it just
+// captures a BigQuery-clock timestamp T and persists it as the initial CDC checkpoint. Unlike
+// MySQL/Postgres, BigQuery's initial load can't query the live table at pull time - QRep
+// pulls read pre-exported Parquet from GCS - so when the mirror wants an initial load
+// (req.DoInitialSnapshot), this also runs that export as of the same T, the same way
+// ExportTxSnapshot does for pure snapshot-only flows. It returns a zero-value
+// model.SetupReplicationResult (no slot/snapshot name), matching MySQL: cloneTablesWithSlot
+// falls back to the mirror's configured SnapshotStagingPath when no override is given, which
+// is exactly where this export writes.
 func (c *BigQueryConnector) SetupReplication(
-	context.Context, shared.CatalogPool,
-	*protos.SetupReplicationInput,
+	ctx context.Context,
+	catalogPool shared.CatalogPool,
+	req *protos.SetupReplicationInput,
 ) (model.SetupReplicationResult, error) {
+	cfg, err := internal.FetchConfigFromDB(ctx, catalogPool, req.FlowJobName)
+	if err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to fetch flow config from db: %w", err)
+	}
+
+	snapshotTime, err := c.currentBigQueryTimestamp(ctx)
+	if err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to get current BigQuery timestamp: %w", err)
+	}
+
+	if req.DoInitialSnapshot {
+		_ = c.LogFlowInfo(ctx, req.FlowJobName, "Starting initial-load BigQuery export to GCS staging bucket")
+		if err := c.exportTablesAsOf(ctx, req.FlowJobName, cfg.TableMappings, cfg.SnapshotStagingPath, snapshotTime); err != nil {
+			return model.SetupReplicationResult{}, err
+		}
+	}
+
+	checkpoint := model.CdcCheckpoint{Text: snapshotTime.Format(time.RFC3339Nano)}
+	if err := c.SetLastOffset(ctx, req.FlowJobName, checkpoint); err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to persist initial CDC checkpoint: %w", err)
+	}
+
 	return model.SetupReplicationResult{}, nil
 }

--- a/flow/connectors/bigquery/qrep_object_pull_test.go
+++ b/flow/connectors/bigquery/qrep_object_pull_test.go
@@ -19,13 +19,18 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 		expected              string
 	}{
 		{
-			name:                  "basic",
-			dsTable:               datasetTable{dataset: "my_dataset", table: "my_table"},
-			schema:                bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}, {Name: "name", Type: bigquery.StringFieldType}},
+			name:    "basic",
+			dsTable: datasetTable{dataset: "my_dataset", table: "my_table"},
+			schema: bigquery.Schema{
+				{Name: "id", Type: bigquery.IntegerFieldType},
+				{Name: "name", Type: bigquery.StringFieldType},
+			},
 			snapshotStagingPath:   "gs://bucket/prefix",
 			sourceTableIdentifier: "my_dataset.my_table",
 			snapshotTime:          time.Date(2026, 8, 14, 12, 34, 56, 789000000, time.UTC),
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/prefix/my_dataset.my_table/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `id`, `name` FROM `my_dataset`.`my_table` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:34:56.789 UTC')",
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/prefix/my_dataset.my_table/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\t" +
+				"compression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `id`, `name` FROM `my_dataset`.`my_table` " +
+				"FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:34:56.789 UTC')",
 		},
 		{
 			name:                  "non-UTC snapshot time is converted to UTC",
@@ -34,7 +39,8 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket",
 			sourceTableIdentifier: "tbl",
 			snapshotTime:          time.Date(2026, 8, 14, 10, 0, 0, 0, time.FixedZone("UTC-5", -5*60*60)), // == 2026-08-14 15:00:00 UTC
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 15:00:00 UTC')",
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\t" +
+				"overwrite=true\n\t\t) AS\n\t\tSELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 15:00:00 UTC')",
 		},
 		{
 			name:                  "no fractional seconds are dropped from the literal",
@@ -43,11 +49,12 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket",
 			sourceTableIdentifier: "tbl",
 			snapshotTime:          time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC),
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 00:00:00 UTC')",
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\t" +
+				"overwrite=true\n\t\t) AS\n\t\tSELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 00:00:00 UTC')",
 		},
 		{
-			name:                  "JSON, Geography, and DateTime columns are cast for Parquet export",
-			dsTable:               datasetTable{dataset: "ds", table: "tbl"},
+			name:    "JSON, Geography, and DateTime columns are cast for Parquet export",
+			dsTable: datasetTable{dataset: "ds", table: "tbl"},
 			schema: bigquery.Schema{
 				{Name: "plain", Type: bigquery.StringFieldType},
 				{Name: "payload", Type: bigquery.JSONFieldType},
@@ -57,7 +64,9 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket",
 			sourceTableIdentifier: "tbl",
 			snapshotTime:          time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC),
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, CAST(`ts` AS TIMESTAMP) AS `ts` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:00:00 UTC')",
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\t" +
+				"overwrite=true\n\t\t) AS\n\t\tSELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, " +
+				"CAST(`ts` AS TIMESTAMP) AS `ts` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:00:00 UTC')",
 		},
 	}
 

--- a/flow/connectors/bigquery/qrep_object_pull_test.go
+++ b/flow/connectors/bigquery/qrep_object_pull_test.go
@@ -1,89 +1,70 @@
 package connbigquery
 
 import (
-	"strings"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildBigQueryExportSQL_ForSystemTimeAsOf(t *testing.T) {
-	dsTable := datasetTable{dataset: "my_dataset", table: "my_table"}
-	schema := bigquery.Schema{
-		{Name: "id", Type: bigquery.IntegerFieldType},
-		{Name: "name", Type: bigquery.StringFieldType},
+func TestBuildBigQueryExportSQL(t *testing.T) {
+	tests := []struct {
+		name                  string
+		dsTable               datasetTable
+		schema                bigquery.Schema
+		snapshotStagingPath   string
+		sourceTableIdentifier string
+		snapshotTime          time.Time
+		expected              string
+	}{
+		{
+			name:                  "basic",
+			dsTable:               datasetTable{dataset: "my_dataset", table: "my_table"},
+			schema:                bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}, {Name: "name", Type: bigquery.StringFieldType}},
+			snapshotStagingPath:   "gs://bucket/prefix",
+			sourceTableIdentifier: "my_dataset.my_table",
+			snapshotTime:          time.Date(2026, 8, 14, 12, 34, 56, 789000000, time.UTC),
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/prefix/my_dataset.my_table/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `id`, `name` FROM `my_dataset`.`my_table` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:34:56.789 UTC')",
+		},
+		{
+			name:                  "non-UTC snapshot time is converted to UTC",
+			dsTable:               datasetTable{dataset: "ds", table: "tbl"},
+			schema:                bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}},
+			snapshotStagingPath:   "gs://bucket",
+			sourceTableIdentifier: "tbl",
+			snapshotTime:          time.Date(2026, 8, 14, 10, 0, 0, 0, time.FixedZone("UTC-5", -5*60*60)), // == 2026-08-14 15:00:00 UTC
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 15:00:00 UTC')",
+		},
+		{
+			name:                  "no fractional seconds are dropped from the literal",
+			dsTable:               datasetTable{dataset: "ds", table: "tbl"},
+			schema:                bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}},
+			snapshotStagingPath:   "gs://bucket",
+			sourceTableIdentifier: "tbl",
+			snapshotTime:          time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC),
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 00:00:00 UTC')",
+		},
+		{
+			name:                  "JSON, Geography, and DateTime columns are cast for Parquet export",
+			dsTable:               datasetTable{dataset: "ds", table: "tbl"},
+			schema: bigquery.Schema{
+				{Name: "plain", Type: bigquery.StringFieldType},
+				{Name: "payload", Type: bigquery.JSONFieldType},
+				{Name: "geo", Type: bigquery.GeographyFieldType},
+				{Name: "ts", Type: bigquery.DateTimeFieldType},
+			},
+			snapshotStagingPath:   "gs://bucket",
+			sourceTableIdentifier: "tbl",
+			snapshotTime:          time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC),
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, CAST(`ts` AS TIMESTAMP) AS `ts` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:00:00 UTC')",
+		},
 	}
-	snapshotTime := time.Date(2026, 8, 14, 12, 34, 56, 789000000, time.UTC)
 
-	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket/prefix", "my_dataset.my_table", snapshotTime)
-
-	require.Contains(t, sql, "FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:34:56.789 UTC')")
-	require.Contains(t, sql, "FROM `my_dataset`.`my_table` FOR SYSTEM_TIME AS OF")
-	assert.Contains(t, sql, "uri='gs://bucket/prefix/my_dataset.my_table/*.parquet'")
-	assert.Contains(t, sql, "`id`")
-	assert.Contains(t, sql, "`name`")
-}
-
-func TestBuildBigQueryExportSQL_ConvertsNonUTCToUTC(t *testing.T) {
-	dsTable := datasetTable{dataset: "ds", table: "tbl"}
-	schema := bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}}
-
-	loc := time.FixedZone("UTC-5", -5*60*60)
-	// 2026-08-14 10:00:00 -05:00 == 2026-08-14 15:00:00 UTC
-	snapshotTime := time.Date(2026, 8, 14, 10, 0, 0, 0, loc)
-
-	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket", "tbl", snapshotTime)
-
-	require.Contains(t, sql, "FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 15:00:00 UTC')")
-}
-
-func TestBuildBigQueryExportSQL_NoFractionalSeconds(t *testing.T) {
-	dsTable := datasetTable{dataset: "ds", table: "tbl"}
-	schema := bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}}
-	snapshotTime := time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC)
-
-	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket", "tbl", snapshotTime)
-
-	// time.Format with ".999999" drops the fractional part entirely when it's zero.
-	require.Contains(t, sql, "FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 00:00:00 UTC')")
-}
-
-func TestBuildBigQueryExportSQL_ColumnCasts(t *testing.T) {
-	dsTable := datasetTable{dataset: "ds", table: "tbl"}
-	schema := bigquery.Schema{
-		{Name: "plain", Type: bigquery.StringFieldType},
-		{Name: "payload", Type: bigquery.JSONFieldType},
-		{Name: "geo", Type: bigquery.GeographyFieldType},
-		{Name: "ts", Type: bigquery.DateTimeFieldType},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql := buildBigQueryExportSQL(tt.dsTable, tt.schema, tt.snapshotStagingPath, tt.sourceTableIdentifier, tt.snapshotTime)
+			require.Equal(t, tt.expected, sql)
+		})
 	}
-	snapshotTime := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
-
-	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket", "tbl", snapshotTime)
-
-	assert.Contains(t, sql, "`plain`")
-	assert.Contains(t, sql, "TO_JSON_STRING(`payload`) AS `payload`")
-	assert.Contains(t, sql, "ST_AsText(`geo`) AS `geo`")
-	assert.Contains(t, sql, "CAST(`ts` AS TIMESTAMP) AS `ts`")
-
-	// Sanity check on the column order/joining.
-	selectClause := sql[strings.Index(sql, "SELECT "):strings.Index(sql, " FROM ")]
-	assert.Equal(t,
-		"SELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, CAST(`ts` AS TIMESTAMP) AS `ts`",
-		selectClause,
-	)
-}
-
-func TestBuildBigQueryExportSQL_ExportOptions(t *testing.T) {
-	dsTable := datasetTable{dataset: "ds", table: "tbl"}
-	schema := bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}}
-	snapshotTime := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
-
-	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket/prefix", "ds.tbl", snapshotTime)
-
-	assert.Contains(t, sql, "format='PARQUET'")
-	assert.Contains(t, sql, "compression='GZIP'")
-	assert.Contains(t, sql, "overwrite=true")
 }

--- a/flow/connectors/bigquery/qrep_object_pull_test.go
+++ b/flow/connectors/bigquery/qrep_object_pull_test.go
@@ -39,8 +39,9 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket",
 			sourceTableIdentifier: "tbl",
 			snapshotTime:          time.Date(2026, 8, 14, 10, 0, 0, 0, time.FixedZone("UTC-5", -5*60*60)), // == 2026-08-14 15:00:00 UTC
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\t" +
-				"overwrite=true\n\t\t) AS\n\t\tSELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 15:00:00 UTC')",
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET'," +
+				"\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\t" +
+				"SELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 15:00:00 UTC')",
 		},
 		{
 			name:                  "no fractional seconds are dropped from the literal",
@@ -49,8 +50,9 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket",
 			sourceTableIdentifier: "tbl",
 			snapshotTime:          time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC),
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\t" +
-				"overwrite=true\n\t\t) AS\n\t\tSELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 00:00:00 UTC')",
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET'," +
+				"\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\t" +
+				"SELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 00:00:00 UTC')",
 		},
 		{
 			name:    "JSON, Geography, and DateTime columns are cast for Parquet export",
@@ -64,8 +66,9 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket",
 			sourceTableIdentifier: "tbl",
 			snapshotTime:          time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC),
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\tcompression='GZIP',\n\t\t\t" +
-				"overwrite=true\n\t\t) AS\n\t\tSELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, " +
+			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET'," +
+				"\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\t" +
+				"SELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, " +
 				"CAST(`ts` AS TIMESTAMP) AS `ts` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:00:00 UTC')",
 		},
 	}

--- a/flow/connectors/bigquery/qrep_object_pull_test.go
+++ b/flow/connectors/bigquery/qrep_object_pull_test.go
@@ -1,0 +1,89 @@
+package connbigquery
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildBigQueryExportSQL_ForSystemTimeAsOf(t *testing.T) {
+	dsTable := datasetTable{dataset: "my_dataset", table: "my_table"}
+	schema := bigquery.Schema{
+		{Name: "id", Type: bigquery.IntegerFieldType},
+		{Name: "name", Type: bigquery.StringFieldType},
+	}
+	snapshotTime := time.Date(2026, 8, 14, 12, 34, 56, 789000000, time.UTC)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket/prefix", "my_dataset.my_table", snapshotTime)
+
+	require.Contains(t, sql, "FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:34:56.789 UTC')")
+	require.Contains(t, sql, "FROM `my_dataset`.`my_table` FOR SYSTEM_TIME AS OF")
+	assert.Contains(t, sql, "uri='gs://bucket/prefix/my_dataset.my_table/*.parquet'")
+	assert.Contains(t, sql, "`id`")
+	assert.Contains(t, sql, "`name`")
+}
+
+func TestBuildBigQueryExportSQL_ConvertsNonUTCToUTC(t *testing.T) {
+	dsTable := datasetTable{dataset: "ds", table: "tbl"}
+	schema := bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}}
+
+	loc := time.FixedZone("UTC-5", -5*60*60)
+	// 2026-08-14 10:00:00 -05:00 == 2026-08-14 15:00:00 UTC
+	snapshotTime := time.Date(2026, 8, 14, 10, 0, 0, 0, loc)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket", "tbl", snapshotTime)
+
+	require.Contains(t, sql, "FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 15:00:00 UTC')")
+}
+
+func TestBuildBigQueryExportSQL_NoFractionalSeconds(t *testing.T) {
+	dsTable := datasetTable{dataset: "ds", table: "tbl"}
+	schema := bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}}
+	snapshotTime := time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket", "tbl", snapshotTime)
+
+	// time.Format with ".999999" drops the fractional part entirely when it's zero.
+	require.Contains(t, sql, "FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 00:00:00 UTC')")
+}
+
+func TestBuildBigQueryExportSQL_ColumnCasts(t *testing.T) {
+	dsTable := datasetTable{dataset: "ds", table: "tbl"}
+	schema := bigquery.Schema{
+		{Name: "plain", Type: bigquery.StringFieldType},
+		{Name: "payload", Type: bigquery.JSONFieldType},
+		{Name: "geo", Type: bigquery.GeographyFieldType},
+		{Name: "ts", Type: bigquery.DateTimeFieldType},
+	}
+	snapshotTime := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket", "tbl", snapshotTime)
+
+	assert.Contains(t, sql, "`plain`")
+	assert.Contains(t, sql, "TO_JSON_STRING(`payload`) AS `payload`")
+	assert.Contains(t, sql, "ST_AsText(`geo`) AS `geo`")
+	assert.Contains(t, sql, "CAST(`ts` AS TIMESTAMP) AS `ts`")
+
+	// Sanity check on the column order/joining.
+	selectClause := sql[strings.Index(sql, "SELECT "):strings.Index(sql, " FROM ")]
+	assert.Equal(t,
+		"SELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, CAST(`ts` AS TIMESTAMP) AS `ts`",
+		selectClause,
+	)
+}
+
+func TestBuildBigQueryExportSQL_ExportOptions(t *testing.T) {
+	dsTable := datasetTable{dataset: "ds", table: "tbl"}
+	schema := bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}}
+	snapshotTime := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket/prefix", "ds.tbl", snapshotTime)
+
+	assert.Contains(t, sql, "format='PARQUET'")
+	assert.Contains(t, sql, "compression='GZIP'")
+	assert.Contains(t, sql, "overwrite=true")
+}

--- a/flow/connectors/bigquery/qrep_object_pull_test.go
+++ b/flow/connectors/bigquery/qrep_object_pull_test.go
@@ -28,8 +28,8 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket/prefix",
 			sourceTableIdentifier: "my_dataset.my_table",
 			snapshotTime:          time.Date(2026, 8, 14, 12, 34, 56, 789000000, time.UTC),
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/prefix/my_dataset.my_table/*.parquet',\n\t\t\tformat='PARQUET',\n\t\t\t" +
-				"compression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\tSELECT `id`, `name` FROM `my_dataset`.`my_table` " +
+			expected: "EXPORT DATA OPTIONS(uri='gs://bucket/prefix/my_dataset.my_table/*.parquet', format='PARQUET', " +
+				"compression='GZIP', overwrite=true) AS SELECT `id`, `name` FROM `my_dataset`.`my_table` " +
 				"FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:34:56.789 UTC')",
 		},
 		{
@@ -39,8 +39,8 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket",
 			sourceTableIdentifier: "tbl",
 			snapshotTime:          time.Date(2026, 8, 14, 10, 0, 0, 0, time.FixedZone("UTC-5", -5*60*60)), // == 2026-08-14 15:00:00 UTC
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET'," +
-				"\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\t" +
+			expected: "EXPORT DATA OPTIONS(uri='gs://bucket/tbl/*.parquet', format='PARQUET', " +
+				"compression='GZIP', overwrite=true) AS " +
 				"SELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 15:00:00 UTC')",
 		},
 		{
@@ -50,8 +50,8 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket",
 			sourceTableIdentifier: "tbl",
 			snapshotTime:          time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC),
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET'," +
-				"\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\t" +
+			expected: "EXPORT DATA OPTIONS(uri='gs://bucket/tbl/*.parquet', format='PARQUET', " +
+				"compression='GZIP', overwrite=true) AS " +
 				"SELECT `id` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 00:00:00 UTC')",
 		},
 		{
@@ -66,8 +66,8 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 			snapshotStagingPath:   "gs://bucket",
 			sourceTableIdentifier: "tbl",
 			snapshotTime:          time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC),
-			expected: "EXPORT DATA OPTIONS(\n\t\t\turi='gs://bucket/tbl/*.parquet',\n\t\t\tformat='PARQUET'," +
-				"\n\t\t\tcompression='GZIP',\n\t\t\toverwrite=true\n\t\t) AS\n\t\t" +
+			expected: "EXPORT DATA OPTIONS(uri='gs://bucket/tbl/*.parquet', format='PARQUET', " +
+				"compression='GZIP', overwrite=true) AS " +
 				"SELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, " +
 				"CAST(`ts` AS TIMESTAMP) AS `ts` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:00:00 UTC')",
 		},


### PR DESCRIPTION
The first PR from BigQuery CDC series. The next ones will be stacked on top of this one.
- Capture T (BigQuery's own CURRENT_TIMESTAMP(), not local wall-clock) and append FOR SYSTEM_TIME AS OF TIMESTAMP('<T> UTC') to every table's EXPORT DATA statement, so all tables in a snapshot read a consistent point in time.
- Trigger export from `SetupReplication` as well,  explanation in the code comments
- Persist T as the initial CDC checkpoint via SetLastOffset from `SetupReplication`.

Resolves: DBI-1035