### PR TITLE
 WIP feat(bigquery): implement CHANGES-mode CDC pull

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -52,8 +52,13 @@ func NewBigQueryServiceAccount(bqConfig *protos.BigqueryConfig) (*utils.GcpServi
 }
 
 type BigQueryConnector struct {
+	// lastPollAt is the wall-clock time PullRecords last actually queried
+	// BigQuery. It's a plain field, not mutex-guarded, because SyncFlow's outer
+	// loop (flow/activities/flowable.go) calls PullRecords sequentially, never
+	// concurrently, for a given connector instance. See cdc.go's waitForNextPoll.
+	lastPollAt time.Time
+	logger     log.Logger
 	*metadataStore.PostgresMetadata
-	logger        log.Logger
 	bqConfig      *protos.BigqueryConfig
 	credentials   *auth.Credentials
 	client        *bigquery.Client

--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -14,6 +16,7 @@ import (
 	"google.golang.org/api/iterator"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -33,11 +36,18 @@ const (
 	// same rationale as safetyLag.
 	queryWindow = 24 * time.Hour
 
-	// Pseudo-columns APPENDS() (and, later, CHANGES()) add on top of the base
-	// table's real columns. These are metadata, not data columns, and must not be
-	// copied into the record.
-	bigQueryChangeTypeColumn      = "_CHANGE_TYPE"
-	bigQueryChangeTimestampColumn = "_CHANGE_TIMESTAMP"
+	// Pseudo-columns APPENDS()/CHANGES() add on top of the base table's real
+	// columns. These are metadata, not data columns, and must not be copied into
+	// the record. _CHANGE_IS_FOR_UPDATE is CHANGES()-only: it marks whether a
+	// delete/insert row is one half of an update pair rather than a standalone
+	// change.
+	bigQueryChangeTypeColumn        = "_CHANGE_TYPE"
+	bigQueryChangeTimestampColumn   = "_CHANGE_TIMESTAMP"
+	bigQueryChangeIsForUpdateColumn = "_CHANGE_IS_FOR_UPDATE"
+
+	// _CHANGE_TYPE values.
+	bigQueryChangeTypeInsert = "INSERT"
+	bigQueryChangeTypeDelete = "DELETE"
 )
 
 // SetupReplConn is a no-op for BigQuery. c.client is a single long-lived connection
@@ -114,15 +124,21 @@ func (c *BigQueryConnector) waitForNextPoll(ctx context.Context, idleTimeout tim
 	return nil
 }
 
-// PullRecords polls APPENDS() for every mapped table over one window,
-// (checkpoint, upper], and pushes the resulting rows onto the stream as
-// InsertRecords -- there's no delete/insert pairing here, that's CHANGES mode
-// (chunk 5), so every row is a plain insert.
+// PullRecords polls every mapped table over one window, (checkpoint, upper], and
+// pushes the resulting records onto the stream. The mirror's cdc_mode
+// (BigqueryCdcConfig.CdcMode, read once per call -- mode is a per-mirror setting,
+// shared by every table in this poll cycle, not a per-table one) picks which of
+// APPENDS() or CHANGES() every table in this poll uses: APPENDS() emits plain
+// InsertRecords, CHANGES() additionally pairs up delete+insert rows that represent
+// one logical UPDATE into UpdateRecords (see pullTableChanges).
 //
 // Known open item, deliberately not resolved here (see the series plan): whether
-// APPENDS()'s window bounds are inclusive/exclusive on either end is undocumented.
-// This uses (checkpoint, upper] as the straightforward reading and defers empirical
-// verification against a live instance to chunk 5.
+// APPENDS()'s/CHANGES()'s window bounds are inclusive/exclusive on either end is
+// undocumented, and empirically verifying it against a live BigQuery instance is out
+// of reach in this sandboxed dev environment (no chunk in this series has run a real
+// query yet). This uses (checkpoint, upper] as the straightforward reading for both
+// functions; if that turns out wrong, a lower-bound nudge (e.g. +1us on checkpoint)
+// is the likely fix, applied uniformly since both share pollWindow's window math.
 func (c *BigQueryConnector) PullRecords(
 	ctx context.Context,
 	catalogPool shared.CatalogPool,
@@ -157,6 +173,15 @@ func (c *BigQueryConnector) PullRecords(
 		return nil
 	}
 
+	cfg, err := internal.FetchConfigFromDB(ctx, catalogPool, req.FlowJobName)
+	if err != nil {
+		return fmt.Errorf("failed to fetch flow config from db: %w", err)
+	}
+	pullTable := c.pullTableAppends
+	if cfg.GetBigqueryCdcConfig().GetCdcMode() == protos.BigqueryCdcMode_BIGQUERY_CDC_MODE_CHANGES {
+		pullTable = c.pullTableChanges
+	}
+
 	var recordCount int
 	addRecord := func(ctx context.Context, record model.Record[model.RecordItems]) error {
 		if recordCount == 0 {
@@ -176,7 +201,7 @@ func (c *BigQueryConnector) PullRecords(
 	slices.Sort(sourceTables)
 
 	for _, sourceTableIdentifier := range sourceTables {
-		if err := c.pullTableAppends(
+		if err := pullTable(
 			ctx, sourceTableIdentifier, req.TableNameMapping[sourceTableIdentifier], checkpoint, upper, addRecord,
 		); err != nil {
 			return err
@@ -191,7 +216,7 @@ func (c *BigQueryConnector) PullRecords(
 	req.RecordStream.UpdateLatestCheckpointText(upper.Format(time.RFC3339Nano))
 
 	trace.SpanFromContext(ctx).SetAttributes(attribute.Int64(otel_metrics.RowsInBatchKey, int64(recordCount)))
-	c.logger.Info("[bigquery] PullRecords polled APPENDS window",
+	c.logger.Info("[bigquery] PullRecords polled window",
 		slog.Time("start", checkpoint), slog.Time("end", upper), slog.Int("records", recordCount))
 
 	return nil
@@ -224,9 +249,10 @@ func (c *BigQueryConnector) pullTableAppends(
 
 	// it.Schema is only guaranteed populated after the first Next() call (the Go
 	// SDK may run the query via a fast path that defers schema resolution until
-	// the first page is fetched), so qfields is built lazily off the first row
-	// rather than right after Read().
+	// the first page is fetched), so qfields/changeCols are built lazily off the
+	// first row rather than right after Read().
 	var qfields []types.QField
+	var changeCols bigQueryChangeColumns
 	for {
 		var row []bigquery.Value
 		if err := it.Next(&row); err != nil {
@@ -241,32 +267,22 @@ func (c *BigQueryConnector) pullTableAppends(
 			for i, field := range it.Schema {
 				qfields[i] = BigQueryFieldToQField(field)
 			}
+			changeCols = locateBigQueryChangeColumns(it.Schema)
 		}
 
 		// _CHANGE_TIMESTAMP is APPENDS()'s own commit-time signal for the row;
 		// used as this record's CommitTimeNano. Falls back to the poll window's
 		// end if, unexpectedly, the column isn't present.
 		commitTimeNano := end.UnixNano()
-		items := model.NewRecordItems(len(row))
-		for i, field := range it.Schema {
-			switch field.Name {
-			case bigQueryChangeTypeColumn:
-				continue
-			case bigQueryChangeTimestampColumn:
-				if ts, ok := row[i].(time.Time); ok {
-					commitTimeNano = ts.UnixNano()
-				}
-				continue
+		if changeCols.changeTimestamp >= 0 {
+			if ts, ok := row[changeCols.changeTimestamp].(time.Time); ok {
+				commitTimeNano = ts.UnixNano()
 			}
-			if _, excluded := nameAndExclude.Exclude[field.Name]; excluded {
-				continue
-			}
+		}
 
-			qval, err := qvalueFromBigQueryValue(qfields[i], row[i])
-			if err != nil {
-				return fmt.Errorf("failed to convert column %s for table %s: %w", field.Name, sourceTableIdentifier, err)
-			}
-			items.AddColumn(field.Name, qval)
+		items, err := bigQueryRowToRecordItems(it.Schema, qfields, row, nameAndExclude.Exclude)
+		if err != nil {
+			return fmt.Errorf("failed to convert row for table %s: %w", sourceTableIdentifier, err)
 		}
 
 		if err := addRecord(ctx, &model.InsertRecord[model.RecordItems]{
@@ -278,4 +294,335 @@ func (c *BigQueryConnector) pullTableAppends(
 			return err
 		}
 	}
+}
+
+// bigQueryChangePseudoColumns are the metadata columns APPENDS()/CHANGES() add on top
+// of the base table's real columns -- never copied into the record.
+var bigQueryChangePseudoColumns = map[string]struct{}{
+	bigQueryChangeTypeColumn:        {},
+	bigQueryChangeTimestampColumn:   {},
+	bigQueryChangeIsForUpdateColumn: {},
+}
+
+// bigQueryRowToRecordItems converts one query-result row's non-pseudo, non-excluded
+// columns into RecordItems. Shared between APPENDS()'s and CHANGES()'s row
+// processing -- the underlying per-value conversion (qvalueFromBigQueryValue) is
+// mode-agnostic, only which columns to skip differs, and that's handled once here via
+// bigQueryChangePseudoColumns.
+func bigQueryRowToRecordItems(
+	schema bigquery.Schema, qfields []types.QField, row []bigquery.Value, exclude map[string]struct{},
+) (model.RecordItems, error) {
+	items := model.NewRecordItems(len(row))
+	for i, field := range schema {
+		if _, isPseudo := bigQueryChangePseudoColumns[field.Name]; isPseudo {
+			continue
+		}
+		if _, excluded := exclude[field.Name]; excluded {
+			continue
+		}
+
+		qval, err := qvalueFromBigQueryValue(qfields[i], row[i])
+		if err != nil {
+			return model.RecordItems{}, fmt.Errorf("failed to convert column %s: %w", field.Name, err)
+		}
+		items.AddColumn(field.Name, qval)
+	}
+	return items, nil
+}
+
+// bigQueryChangeColumns locates APPENDS()'/CHANGES()'s pseudo-columns within a query
+// result schema by index, once per query, so per-row processing doesn't need to
+// compare column names on every row. -1 means the column wasn't found (e.g.
+// isForUpdate is always -1 for APPENDS(), which doesn't have it).
+type bigQueryChangeColumns struct {
+	changeType      int
+	changeTimestamp int
+	isForUpdate     int
+}
+
+func locateBigQueryChangeColumns(schema bigquery.Schema) bigQueryChangeColumns {
+	cols := bigQueryChangeColumns{changeType: -1, changeTimestamp: -1, isForUpdate: -1}
+	for i, field := range schema {
+		switch field.Name {
+		case bigQueryChangeTypeColumn:
+			cols.changeType = i
+		case bigQueryChangeTimestampColumn:
+			cols.changeTimestamp = i
+		case bigQueryChangeIsForUpdateColumn:
+			cols.isForUpdate = i
+		}
+	}
+	return cols
+}
+
+// pullTableChanges runs
+// SELECT * FROM CHANGES(TABLE <table>, @start, @end)
+//
+//	ORDER BY _CHANGE_TIMESTAMP, _CHANGE_IS_FOR_UPDATE DESC, <pk columns>
+//
+// for one source table over (start, end], pairs up delete+insert rows that CHANGES()
+// represents as one logical UPDATE (see pairBigQueryChanges), and pushes the
+// resulting Insert/Update/DeleteRecords via addRecord.
+//
+// Unlike pullTableAppends' single-pass streaming, this buffers one window's full,
+// already-ordered result set into memory before emitting anything: pairing a delete
+// with the insert that immediately follows it needs one row of lookahead, and reading
+// the whole result into a slice is the simplest correct way to get that (see
+// pairBigQueryChanges' doc comment for why it's structured as a pure function over a
+// slice). Poll windows are capped at queryWindow, so this is bounded, not unbounded,
+// per-table memory.
+func (c *BigQueryConnector) pullTableChanges(
+	ctx context.Context,
+	sourceTableIdentifier string,
+	nameAndExclude model.NameAndExclude,
+	start, end time.Time,
+	addRecord func(context.Context, model.Record[model.RecordItems]) error,
+) error {
+	dsTable, err := c.convertToDatasetTable(sourceTableIdentifier)
+	if err != nil {
+		return fmt.Errorf("failed to parse table identifier %s: %w", sourceTableIdentifier, err)
+	}
+
+	// Re-checked here, not just trusted from mirror-creation-time validation
+	// (source.go's ValidateMirrorSource, which already requires this): PullRecords
+	// runs long after validation, on every poll, and the table's PK constraint
+	// could have been dropped since. Metadata() is also how the PK column names for
+	// the ORDER BY/pairing below are obtained -- no separate lookup to keep in sync
+	// with source.go's tableHasPrimaryKey, this calls that same helper.
+	metadata, err := c.client.DatasetInProject(c.projectID, dsTable.dataset).Table(dsTable.table).Metadata(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get metadata for table %s: %w", sourceTableIdentifier, err)
+	}
+	if !tableHasPrimaryKey(metadata) {
+		return fmt.Errorf("table %s has no primary key constraint configured on BigQuery; "+
+			"CHANGES mode requires one", sourceTableIdentifier)
+	}
+	pkColumns := metadata.TableConstraints.PrimaryKey.Columns
+
+	orderBy := make([]string, 0, len(pkColumns)+2)
+	orderBy = append(orderBy,
+		quotedIdentifier(bigQueryChangeTimestampColumn),
+		quotedIdentifier(bigQueryChangeIsForUpdateColumn)+" DESC")
+	for _, col := range pkColumns {
+		orderBy = append(orderBy, quotedIdentifier(col))
+	}
+
+	q := c.client.Query(fmt.Sprintf(
+		"SELECT * FROM CHANGES(TABLE %s, @start, @end) ORDER BY %s",
+		dsTable.stringQuoted(), strings.Join(orderBy, ", "),
+	))
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "start", Value: start},
+		{Name: "end", Value: end},
+	}
+
+	it, err := q.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to run CHANGES query for table %s: %w", sourceTableIdentifier, err)
+	}
+
+	var qfields []types.QField
+	var changeCols bigQueryChangeColumns
+	var pkIdx []int
+	var rows [][]bigquery.Value
+	var changeRows []bigQueryChangeRow
+	for {
+		var row []bigquery.Value
+		if err := it.Next(&row); err != nil {
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			return fmt.Errorf("failed to read CHANGES row for table %s: %w", sourceTableIdentifier, err)
+		}
+
+		if qfields == nil {
+			qfields = make([]types.QField, len(it.Schema))
+			for i, field := range it.Schema {
+				qfields[i] = BigQueryFieldToQField(field)
+			}
+			changeCols = locateBigQueryChangeColumns(it.Schema)
+			pkIdx = make([]int, len(pkColumns))
+			for i, col := range pkColumns {
+				idx := slices.IndexFunc(it.Schema, func(f *bigquery.FieldSchema) bool { return f.Name == col })
+				if idx < 0 {
+					return fmt.Errorf("primary key column %s not found in CHANGES result for table %s", col, sourceTableIdentifier)
+				}
+				pkIdx[i] = idx
+			}
+		}
+
+		changeRow := bigQueryChangeRow{pk: make([]bigquery.Value, len(pkIdx))}
+		if changeCols.changeType >= 0 {
+			changeRow.changeType, _ = row[changeCols.changeType].(string)
+		}
+		if changeCols.changeTimestamp >= 0 {
+			changeRow.changeTime, _ = row[changeCols.changeTimestamp].(time.Time)
+		}
+		if changeCols.isForUpdate >= 0 {
+			changeRow.isForUpdate, _ = row[changeCols.isForUpdate].(bool)
+		}
+		for i, idx := range pkIdx {
+			changeRow.pk[i] = row[idx]
+		}
+
+		rows = append(rows, row)
+		changeRows = append(changeRows, changeRow)
+	}
+
+	for _, change := range pairBigQueryChanges(changeRows) {
+		if err := c.emitBigQueryChange(
+			ctx, change, rows, changeRows, it.Schema, qfields, sourceTableIdentifier, nameAndExclude, addRecord,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitBigQueryChange converts one pairBigQueryChanges result into the corresponding
+// Insert/Update/DeleteRecord and pushes it via addRecord. rows and changeRows are the
+// same index-aligned, parallel slices pairBigQueryChanges was given.
+func (c *BigQueryConnector) emitBigQueryChange(
+	ctx context.Context,
+	change bigQueryPairedChange,
+	rows [][]bigquery.Value,
+	changeRows []bigQueryChangeRow,
+	schema bigquery.Schema,
+	qfields []types.QField,
+	sourceTableIdentifier string,
+	nameAndExclude model.NameAndExclude,
+	addRecord func(context.Context, model.Record[model.RecordItems]) error,
+) error {
+	switch change.kind {
+	case bigQueryChangeUpdate:
+		oldItems, err := bigQueryRowToRecordItems(schema, qfields, rows[change.deleteIdx], nameAndExclude.Exclude)
+		if err != nil {
+			return fmt.Errorf("failed to convert old row for table %s: %w", sourceTableIdentifier, err)
+		}
+		newItems, err := bigQueryRowToRecordItems(schema, qfields, rows[change.insertIdx], nameAndExclude.Exclude)
+		if err != nil {
+			return fmt.Errorf("failed to convert new row for table %s: %w", sourceTableIdentifier, err)
+		}
+		return addRecord(ctx, &model.UpdateRecord[model.RecordItems]{
+			BaseRecord:           model.BaseRecord{CommitTimeNano: changeRows[change.insertIdx].changeTime.UnixNano()},
+			OldItems:             oldItems,
+			NewItems:             newItems,
+			SourceTableName:      sourceTableIdentifier,
+			DestinationTableName: nameAndExclude.Name,
+			// UnchangedToastColumns is a Postgres TOAST concept (partial binlog/WAL
+			// row images) that BigQuery has no analogue for -- CHANGES() always
+			// returns full rows. Left nil/unset, the same convention MySQL's cdc.go
+			// follows when the binlog didn't skip any columns for a given row,
+			// even though MySQL has no TOAST either.
+		})
+	case bigQueryChangeInsert:
+		items, err := bigQueryRowToRecordItems(schema, qfields, rows[change.insertIdx], nameAndExclude.Exclude)
+		if err != nil {
+			return fmt.Errorf("failed to convert row for table %s: %w", sourceTableIdentifier, err)
+		}
+		return addRecord(ctx, &model.InsertRecord[model.RecordItems]{
+			BaseRecord:           model.BaseRecord{CommitTimeNano: changeRows[change.insertIdx].changeTime.UnixNano()},
+			Items:                items,
+			SourceTableName:      sourceTableIdentifier,
+			DestinationTableName: nameAndExclude.Name,
+		})
+	default: // bigQueryChangeDelete
+		items, err := bigQueryRowToRecordItems(schema, qfields, rows[change.deleteIdx], nameAndExclude.Exclude)
+		if err != nil {
+			return fmt.Errorf("failed to convert row for table %s: %w", sourceTableIdentifier, err)
+		}
+		return addRecord(ctx, &model.DeleteRecord[model.RecordItems]{
+			BaseRecord:           model.BaseRecord{CommitTimeNano: changeRows[change.deleteIdx].changeTime.UnixNano()},
+			Items:                items,
+			SourceTableName:      sourceTableIdentifier,
+			DestinationTableName: nameAndExclude.Name,
+		})
+	}
+}
+
+// bigQueryChangeRow holds one CHANGES() result row's pairing-relevant pseudo-columns.
+// Deliberately decoupled from bigquery.Schema and the row's full column data so
+// pairBigQueryChanges below can be exercised as a pure function over plain data,
+// without a live BigQuery client or iterator.
+type bigQueryChangeRow struct {
+	changeTime  time.Time
+	changeType  string
+	pk          []bigquery.Value
+	isForUpdate bool
+}
+
+type bigQueryChangeKind int
+
+const (
+	bigQueryChangeInsert bigQueryChangeKind = iota
+	bigQueryChangeDelete
+	bigQueryChangeUpdate
+)
+
+// bigQueryPairedChange is one pairing result, indexing into the rows slice
+// pairBigQueryChanges was given: a lone insert/delete leaves the other index at -1; a
+// matched update sets both.
+type bigQueryPairedChange struct {
+	kind      bigQueryChangeKind
+	deleteIdx int
+	insertIdx int
+}
+
+// pairBigQueryChanges scans rows -- expected in CHANGES()'s own
+// ORDER BY _CHANGE_TIMESTAMP, _CHANGE_IS_FOR_UPDATE DESC, <pk> order -- and pairs each
+// _CHANGE_IS_FOR_UPDATE delete with the insert immediately following it when they
+// share the same _CHANGE_TIMESTAMP and PK columns: that's CHANGES()'s own
+// representation of a single UPDATE as a delete+insert pair sharing the same PK and
+// timestamp. Any row not part of such a pair -- including a _CHANGE_IS_FOR_UPDATE
+// delete with no matching insert right after it, e.g. one whose pair fell in a
+// different poll window -- passes through as a lone insert/delete, exactly like a
+// genuine standalone insert/delete would.
+func pairBigQueryChanges(rows []bigQueryChangeRow) []bigQueryPairedChange {
+	changes := make([]bigQueryPairedChange, 0, len(rows))
+	for i := 0; i < len(rows); i++ {
+		row := rows[i]
+		if row.changeType == bigQueryChangeTypeDelete && row.isForUpdate && i+1 < len(rows) {
+			next := rows[i+1]
+			if next.changeType == bigQueryChangeTypeInsert && next.isForUpdate &&
+				next.changeTime.Equal(row.changeTime) && bigQueryPKEqual(row.pk, next.pk) {
+				changes = append(changes, bigQueryPairedChange{kind: bigQueryChangeUpdate, deleteIdx: i, insertIdx: i + 1})
+				i++
+				continue
+			}
+		}
+		switch row.changeType {
+		case bigQueryChangeTypeDelete:
+			changes = append(changes, bigQueryPairedChange{kind: bigQueryChangeDelete, deleteIdx: i, insertIdx: -1})
+		case bigQueryChangeTypeInsert:
+			changes = append(changes, bigQueryPairedChange{kind: bigQueryChangeInsert, deleteIdx: -1, insertIdx: i})
+		}
+	}
+	return changes
+}
+
+// bigQueryPKEqual compares two rows' primary key column values for
+// pairBigQueryChanges' match check. time.Time (a PK column could, in principle, be a
+// TIMESTAMP) uses Equal rather than reflect.DeepEqual, which can differ on
+// monotonic-clock representation for an otherwise-identical instant; every other
+// value type the BigQuery Go SDK returns (bool, int64, float64, string, []byte,
+// civil.Date, civil.Time, civil.DateTime, *big.Rat) is compared with
+// reflect.DeepEqual.
+func bigQueryPKEqual(a, b []bigquery.Value) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		at, aIsTime := a[i].(time.Time)
+		bt, bIsTime := b[i].(time.Time)
+		if aIsTime || bIsTime {
+			if !aIsTime || !bIsTime || !at.Equal(bt) {
+				return false
+			}
+			continue
+		}
+		if !reflect.DeepEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
 }

--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -1,0 +1,281 @@
+package connbigquery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/api/iterator"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/model"
+	"github.com/PeerDB-io/peerdb/flow/otel_metrics"
+	"github.com/PeerDB-io/peerdb/flow/shared"
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
+)
+
+const (
+	// safetyLag keeps a poll window's upper bound behind BigQuery's own clock.
+	// APPENDS()/CHANGES() consistency for writes in the last few seconds is
+	// undocumented, so staying safetyLag behind now() avoids querying right up to
+	// the instant of now() and risking rows that land just after the window closes.
+	// Hardcoded per the series' "Decisions locked in" -- not made configurable
+	// unless a customer actually needs it tuned.
+	safetyLag = 1 * time.Minute
+	// queryWindow caps how much time a single poll can cover, bounding one
+	// BigQuery job's row-scan cost even if a mirror falls far behind. Hardcoded,
+	// same rationale as safetyLag.
+	queryWindow = 24 * time.Hour
+
+	// Pseudo-columns APPENDS() (and, later, CHANGES()) add on top of the base
+	// table's real columns. These are metadata, not data columns, and must not be
+	// copied into the record.
+	bigQueryChangeTypeColumn      = "_CHANGE_TYPE"
+	bigQueryChangeTimestampColumn = "_CHANGE_TIMESTAMP"
+)
+
+// SetupReplConn is a no-op for BigQuery. c.client is a single long-lived connection
+// pool created once in NewBigQueryConnector and reused for every query -- unlike
+// Postgres, which re-derives a fresh RDS IAM token here per activity attempt,
+// BigQuery credential refresh is handled transparently underneath by
+// auth.Credentials, so there's no per-activity resource to (re)establish.
+func (c *BigQueryConnector) SetupReplConn(context.Context, map[string]string) error {
+	return nil
+}
+
+// UpdateReplStateLastOffset persists the checkpoint once a batch has been confirmed
+// synced to the destination. Thin wrapper over SetLastOffset, same shape as
+// MySQL's: the flow name travels via context rather than a parameter, per
+// CDCPullConnectorCore.UpdateReplStateLastOffset's signature.
+func (c *BigQueryConnector) UpdateReplStateLastOffset(ctx context.Context, lastOffset model.CdcCheckpoint) error {
+	flowName := ctx.Value(shared.FlowNameKey).(string)
+	return c.SetLastOffset(ctx, flowName, lastOffset)
+}
+
+// PullFlowCleanup is a no-op. BigQuery has no server-side replication resource
+// analogous to a Postgres replication slot/publication for this method to drop.
+// The persisted CDC checkpoint itself (the metadata_last_sync_state row keyed by
+// job name, backed by the embedded PostgresMetadata) is already cleaned up
+// centrally by FlowableActivity.RemoveFlowDetailsFromCatalog (which calls
+// connmetadata.SyncFlowCleanupInTx) regardless of source connector type, so
+// there's nothing left here for BigQuery specifically to do.
+func (c *BigQueryConnector) PullFlowCleanup(context.Context, string) error {
+	return nil
+}
+
+// EnsurePullability is a no-op. ValidateMirrorSource (source.go), run at
+// mirror-creation time, already confirms every mapped table exists and, for CDC
+// mirrors, satisfies its mode's requirements (a real PK constraint plus
+// enable_change_history for CHANGES; a safe destination engine choice when no PK
+// is present for APPENDS). There's nothing left for BigQuery to check at this
+// later setup_flow stage that creation-time validation didn't already gate.
+func (c *BigQueryConnector) EnsurePullability(
+	context.Context, *protos.EnsurePullabilityBatchInput,
+) (*protos.EnsurePullabilityBatchOutput, error) {
+	return nil, nil
+}
+
+// pollWindow computes the upper bound of the next APPENDS()/CHANGES() poll window
+// given the last-scanned checkpoint and BigQuery's current clock (now). upper is
+// capped at queryWindow past checkpoint (bounding one poll's row-scan cost) and at
+// safetyLag behind now (see safetyLag's doc comment). ok is false when upper
+// doesn't move past checkpoint -- e.g. the safety lag hasn't cleared yet -- meaning
+// there's nothing new to scan this cycle.
+func pollWindow(checkpoint, now time.Time) (time.Time, bool) {
+	upper := checkpoint.Add(queryWindow)
+	if safe := now.Add(-safetyLag); safe.Before(upper) {
+		upper = safe
+	}
+	return upper, upper.After(checkpoint)
+}
+
+// waitForNextPoll self-paces PullRecords. SyncFlow's outer loop
+// (flow/activities/flowable.go) calls PullRecords back-to-back with no pacing of
+// its own -- every other CDC connector blocks on a live stream instead of polling,
+// so the loop never needed one. Without this, BigQuery would issue a fresh, billed
+// query every loop iteration instead of respecting IdleTimeout.
+func (c *BigQueryConnector) waitForNextPoll(ctx context.Context, idleTimeout time.Duration) error {
+	// time.Since(zero-value lastPollAt) clamps to the max representable Duration,
+	// which is always >= idleTimeout, so the first-ever call naturally polls
+	// immediately without a separate IsZero check.
+	if wait := idleTimeout - time.Since(c.lastPollAt); wait > 0 {
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// PullRecords polls APPENDS() for every mapped table over one window,
+// (checkpoint, upper], and pushes the resulting rows onto the stream as
+// InsertRecords -- there's no delete/insert pairing here, that's CHANGES mode
+// (chunk 5), so every row is a plain insert.
+//
+// Known open item, deliberately not resolved here (see the series plan): whether
+// APPENDS()'s window bounds are inclusive/exclusive on either end is undocumented.
+// This uses (checkpoint, upper] as the straightforward reading and defers empirical
+// verification against a live instance to chunk 5.
+func (c *BigQueryConnector) PullRecords(
+	ctx context.Context,
+	catalogPool shared.CatalogPool,
+	otelManager *otel_metrics.OtelManager,
+	req *model.PullRecordsRequest[model.RecordItems],
+) error {
+	defer req.RecordStream.Close()
+	// Recorded regardless of how this call returns below (including the
+	// "nothing new to scan yet" early return) so pacing always advances.
+	defer func() { c.lastPollAt = time.Now() }()
+
+	if err := c.waitForNextPoll(ctx, req.IdleTimeout); err != nil {
+		return err
+	}
+
+	checkpoint, err := time.Parse(time.RFC3339Nano, req.LastOffset.Text)
+	if err != nil {
+		return fmt.Errorf("failed to parse BigQuery CDC checkpoint %q: %w", req.LastOffset.Text, err)
+	}
+
+	now, err := c.currentBigQueryTimestamp(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get current BigQuery timestamp: %w", err)
+	}
+
+	upper, ok := pollWindow(checkpoint, now)
+	if !ok {
+		// Nothing new to scan yet (e.g. the safety lag hasn't cleared). Don't
+		// advance the checkpoint: nothing was scanned to protect from a re-scan,
+		// and the same window is simply recomputed on the next poll.
+		req.RecordStream.SignalAsEmpty()
+		return nil
+	}
+
+	var recordCount int
+	addRecord := func(ctx context.Context, record model.Record[model.RecordItems]) error {
+		if recordCount == 0 {
+			req.RecordStream.SignalAsNotEmpty()
+		}
+		recordCount++
+		return req.RecordStream.AddRecord(ctx, record)
+	}
+
+	// Sequential per table, not concurrent, within this poll cycle -- bounds
+	// BigQuery job/slot usage (see the series' "Decisions locked in"). Sorted so
+	// polls process tables in a deterministic order (map iteration isn't).
+	sourceTables := make([]string, 0, len(req.TableNameMapping))
+	for sourceTableIdentifier := range req.TableNameMapping {
+		sourceTables = append(sourceTables, sourceTableIdentifier)
+	}
+	slices.Sort(sourceTables)
+
+	for _, sourceTableIdentifier := range sourceTables {
+		if err := c.pullTableAppends(
+			ctx, sourceTableIdentifier, req.TableNameMapping[sourceTableIdentifier], checkpoint, upper, addRecord,
+		); err != nil {
+			return err
+		}
+	}
+
+	if recordCount == 0 {
+		req.RecordStream.SignalAsEmpty()
+	}
+	// The window advances past what was scanned regardless of whether it
+	// contained changes, so the next poll doesn't re-scan it.
+	req.RecordStream.UpdateLatestCheckpointText(upper.Format(time.RFC3339Nano))
+
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Int64(otel_metrics.RowsInBatchKey, int64(recordCount)))
+	c.logger.Info("[bigquery] PullRecords polled APPENDS window",
+		slog.Time("start", checkpoint), slog.Time("end", upper), slog.Int("records", recordCount))
+
+	return nil
+}
+
+// pullTableAppends runs SELECT * FROM APPENDS(TABLE <table>, @start, @end) for one
+// source table over (start, end], converting and pushing each row via addRecord.
+func (c *BigQueryConnector) pullTableAppends(
+	ctx context.Context,
+	sourceTableIdentifier string,
+	nameAndExclude model.NameAndExclude,
+	start, end time.Time,
+	addRecord func(context.Context, model.Record[model.RecordItems]) error,
+) error {
+	dsTable, err := c.convertToDatasetTable(sourceTableIdentifier)
+	if err != nil {
+		return fmt.Errorf("failed to parse table identifier %s: %w", sourceTableIdentifier, err)
+	}
+
+	q := c.client.Query(fmt.Sprintf("SELECT * FROM APPENDS(TABLE %s, @start, @end)", dsTable.stringQuoted()))
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "start", Value: start},
+		{Name: "end", Value: end},
+	}
+
+	it, err := q.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to run APPENDS query for table %s: %w", sourceTableIdentifier, err)
+	}
+
+	// it.Schema is only guaranteed populated after the first Next() call (the Go
+	// SDK may run the query via a fast path that defers schema resolution until
+	// the first page is fetched), so qfields is built lazily off the first row
+	// rather than right after Read().
+	var qfields []types.QField
+	for {
+		var row []bigquery.Value
+		if err := it.Next(&row); err != nil {
+			if errors.Is(err, iterator.Done) {
+				return nil
+			}
+			return fmt.Errorf("failed to read APPENDS row for table %s: %w", sourceTableIdentifier, err)
+		}
+
+		if qfields == nil {
+			qfields = make([]types.QField, len(it.Schema))
+			for i, field := range it.Schema {
+				qfields[i] = BigQueryFieldToQField(field)
+			}
+		}
+
+		// _CHANGE_TIMESTAMP is APPENDS()'s own commit-time signal for the row;
+		// used as this record's CommitTimeNano. Falls back to the poll window's
+		// end if, unexpectedly, the column isn't present.
+		commitTimeNano := end.UnixNano()
+		items := model.NewRecordItems(len(row))
+		for i, field := range it.Schema {
+			switch field.Name {
+			case bigQueryChangeTypeColumn:
+				continue
+			case bigQueryChangeTimestampColumn:
+				if ts, ok := row[i].(time.Time); ok {
+					commitTimeNano = ts.UnixNano()
+				}
+				continue
+			}
+			if _, excluded := nameAndExclude.Exclude[field.Name]; excluded {
+				continue
+			}
+
+			qval, err := qvalueFromBigQueryValue(qfields[i], row[i])
+			if err != nil {
+				return fmt.Errorf("failed to convert column %s for table %s: %w", field.Name, sourceTableIdentifier, err)
+			}
+			items.AddColumn(field.Name, qval)
+		}
+
+		if err := addRecord(ctx, &model.InsertRecord[model.RecordItems]{
+			BaseRecord:           model.BaseRecord{CommitTimeNano: commitTimeNano},
+			Items:                items,
+			SourceTableName:      sourceTableIdentifier,
+			DestinationTableName: nameAndExclude.Name,
+		}); err != nil {
+			return err
+		}
+	}
+}

--- a/flow/connectors/bigquery/cdc_test.go
+++ b/flow/connectors/bigquery/cdc_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
 func TestPollWindow(t *testing.T) {
@@ -83,4 +86,171 @@ func TestWaitForNextPoll(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 		assert.Less(t, time.Since(start), time.Second)
 	})
+}
+
+func changeRow(changeType string, isForUpdate bool, t time.Time, pk ...bigquery.Value) bigQueryChangeRow {
+	return bigQueryChangeRow{changeType: changeType, changeTime: t, isForUpdate: isForUpdate, pk: pk}
+}
+
+func TestPairBigQueryChanges(t *testing.T) {
+	t1 := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Second)
+
+	t.Run("delete+insert pair with matching timestamp and pk becomes one update", func(t *testing.T) {
+		rows := []bigQueryChangeRow{
+			changeRow(bigQueryChangeTypeDelete, true, t1, int64(1)),
+			changeRow(bigQueryChangeTypeInsert, true, t1, int64(1)),
+		}
+		got := pairBigQueryChanges(rows)
+		require.Len(t, got, 1)
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeUpdate, deleteIdx: 0, insertIdx: 1}, got[0])
+	})
+
+	t.Run("standalone insert (not flagged for update) passes through", func(t *testing.T) {
+		rows := []bigQueryChangeRow{
+			changeRow(bigQueryChangeTypeInsert, false, t1, int64(2)),
+		}
+		got := pairBigQueryChanges(rows)
+		require.Len(t, got, 1)
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeInsert, deleteIdx: -1, insertIdx: 0}, got[0])
+	})
+
+	t.Run("standalone delete (not flagged for update) passes through", func(t *testing.T) {
+		rows := []bigQueryChangeRow{
+			changeRow(bigQueryChangeTypeDelete, false, t1, int64(3)),
+		}
+		got := pairBigQueryChanges(rows)
+		require.Len(t, got, 1)
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeDelete, deleteIdx: 0, insertIdx: -1}, got[0])
+	})
+
+	t.Run("flagged delete followed by insert with a different timestamp does not pair", func(t *testing.T) {
+		rows := []bigQueryChangeRow{
+			changeRow(bigQueryChangeTypeDelete, true, t1, int64(1)),
+			changeRow(bigQueryChangeTypeInsert, true, t2, int64(1)),
+		}
+		got := pairBigQueryChanges(rows)
+		require.Len(t, got, 2)
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeDelete, deleteIdx: 0, insertIdx: -1}, got[0])
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeInsert, deleteIdx: -1, insertIdx: 1}, got[1])
+	})
+
+	t.Run("flagged delete followed by insert with a different pk does not pair", func(t *testing.T) {
+		rows := []bigQueryChangeRow{
+			changeRow(bigQueryChangeTypeDelete, true, t1, int64(1)),
+			changeRow(bigQueryChangeTypeInsert, true, t1, int64(2)),
+		}
+		got := pairBigQueryChanges(rows)
+		require.Len(t, got, 2)
+		assert.Equal(t, bigQueryChangeDelete, got[0].kind)
+		assert.Equal(t, bigQueryChangeInsert, got[1].kind)
+	})
+
+	t.Run("flagged delete followed by an insert that isn't flagged for update does not pair", func(t *testing.T) {
+		rows := []bigQueryChangeRow{
+			changeRow(bigQueryChangeTypeDelete, true, t1, int64(1)),
+			changeRow(bigQueryChangeTypeInsert, false, t1, int64(1)),
+		}
+		got := pairBigQueryChanges(rows)
+		require.Len(t, got, 2)
+		assert.Equal(t, bigQueryChangeDelete, got[0].kind)
+		assert.Equal(t, bigQueryChangeInsert, got[1].kind)
+	})
+
+	t.Run("flagged delete with no following row (end of batch) passes through standalone", func(t *testing.T) {
+		rows := []bigQueryChangeRow{
+			changeRow(bigQueryChangeTypeInsert, false, t1, int64(9)),
+			changeRow(bigQueryChangeTypeDelete, true, t2, int64(1)),
+		}
+		got := pairBigQueryChanges(rows)
+		require.Len(t, got, 2)
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeInsert, deleteIdx: -1, insertIdx: 0}, got[0])
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeDelete, deleteIdx: 1, insertIdx: -1}, got[1])
+	})
+
+	t.Run("multiple pairs in sequence each pair up independently", func(t *testing.T) {
+		rows := []bigQueryChangeRow{
+			changeRow(bigQueryChangeTypeDelete, true, t1, int64(1)),
+			changeRow(bigQueryChangeTypeInsert, true, t1, int64(1)),
+			changeRow(bigQueryChangeTypeDelete, true, t2, int64(2)),
+			changeRow(bigQueryChangeTypeInsert, true, t2, int64(2)),
+		}
+		got := pairBigQueryChanges(rows)
+		require.Len(t, got, 2)
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeUpdate, deleteIdx: 0, insertIdx: 1}, got[0])
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeUpdate, deleteIdx: 2, insertIdx: 3}, got[1])
+	})
+
+	t.Run("a paired insert is consumed and not re-considered as its own entry", func(t *testing.T) {
+		// If the pairing consumed index 1 correctly, the loop resumes at index 2
+		// rather than re-examining the insert at index 1 as a standalone row.
+		rows := []bigQueryChangeRow{
+			changeRow(bigQueryChangeTypeDelete, true, t1, int64(1)),
+			changeRow(bigQueryChangeTypeInsert, true, t1, int64(1)),
+			changeRow(bigQueryChangeTypeInsert, false, t2, int64(5)),
+		}
+		got := pairBigQueryChanges(rows)
+		require.Len(t, got, 2)
+		assert.Equal(t, bigQueryChangeUpdate, got[0].kind)
+		assert.Equal(t, bigQueryPairedChange{kind: bigQueryChangeInsert, deleteIdx: -1, insertIdx: 2}, got[1])
+	})
+
+	t.Run("empty input yields no changes", func(t *testing.T) {
+		assert.Empty(t, pairBigQueryChanges(nil))
+	})
+}
+
+func TestBigQueryPKEqual(t *testing.T) {
+	t.Run("equal scalar values", func(t *testing.T) {
+		assert.True(t, bigQueryPKEqual([]bigquery.Value{int64(1), "a"}, []bigquery.Value{int64(1), "a"}))
+	})
+
+	t.Run("different scalar values", func(t *testing.T) {
+		assert.False(t, bigQueryPKEqual([]bigquery.Value{int64(1)}, []bigquery.Value{int64(2)}))
+	})
+
+	t.Run("different lengths", func(t *testing.T) {
+		assert.False(t, bigQueryPKEqual([]bigquery.Value{int64(1)}, []bigquery.Value{int64(1), "a"}))
+	})
+
+	t.Run("equal time.Time values compare via Equal, not reflect.DeepEqual", func(t *testing.T) {
+		base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+		// Same instant, different Location pointer/representation -- reflect.DeepEqual
+		// would consider these different even though they represent the same instant.
+		other := base.In(time.FixedZone("UTC", 0))
+		assert.True(t, bigQueryPKEqual([]bigquery.Value{base}, []bigquery.Value{other}))
+	})
+
+	t.Run("different time.Time values", func(t *testing.T) {
+		base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+		assert.False(t, bigQueryPKEqual([]bigquery.Value{base}, []bigquery.Value{base.Add(time.Second)}))
+	})
+}
+
+func TestBigQueryRowToRecordItems(t *testing.T) {
+	schema := bigquery.Schema{
+		{Name: "id", Type: bigquery.IntegerFieldType},
+		{Name: "name", Type: bigquery.StringFieldType},
+		{Name: "excluded_col", Type: bigquery.StringFieldType},
+		{Name: bigQueryChangeTypeColumn, Type: bigquery.StringFieldType},
+		{Name: bigQueryChangeTimestampColumn, Type: bigquery.TimestampFieldType},
+		{Name: bigQueryChangeIsForUpdateColumn, Type: bigquery.BooleanFieldType},
+	}
+	qfields := make([]types.QField, len(schema))
+	for i, f := range schema {
+		qfields[i] = BigQueryFieldToQField(f)
+	}
+	row := []bigquery.Value{
+		int64(1), "alice", "secret", bigQueryChangeTypeInsert, time.Now(), true,
+	}
+
+	items, err := bigQueryRowToRecordItems(schema, qfields, row, map[string]struct{}{"excluded_col": {}})
+	require.NoError(t, err)
+	assert.Equal(t, types.QValueInt64{Val: 1}, items.GetColumnValue("id"))
+	assert.Equal(t, types.QValueString{Val: "alice"}, items.GetColumnValue("name"))
+	assert.Nil(t, items.GetColumnValue("excluded_col"))
+	assert.Nil(t, items.GetColumnValue(bigQueryChangeTypeColumn))
+	assert.Nil(t, items.GetColumnValue(bigQueryChangeTimestampColumn))
+	assert.Nil(t, items.GetColumnValue(bigQueryChangeIsForUpdateColumn))
+	assert.Len(t, items.ColToVal, 2)
 }

--- a/flow/connectors/bigquery/cdc_test.go
+++ b/flow/connectors/bigquery/cdc_test.go
@@ -1,0 +1,86 @@
+package connbigquery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPollWindow(t *testing.T) {
+	checkpoint := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("caps at queryWindow past checkpoint when now is far ahead", func(t *testing.T) {
+		now := checkpoint.Add(queryWindow * 10)
+		upper, ok := pollWindow(checkpoint, now)
+		require.True(t, ok)
+		assert.True(t, upper.Equal(checkpoint.Add(queryWindow)))
+	})
+
+	t.Run("caps at safetyLag behind now when now is close", func(t *testing.T) {
+		now := checkpoint.Add(time.Hour)
+		upper, ok := pollWindow(checkpoint, now)
+		require.True(t, ok)
+		assert.True(t, upper.Equal(now.Add(-safetyLag)))
+	})
+
+	t.Run("nothing new to scan when safety lag hasn't cleared", func(t *testing.T) {
+		now := checkpoint.Add(safetyLag / 2)
+		upper, ok := pollWindow(checkpoint, now)
+		assert.False(t, ok)
+		// upper is still reported (as now-safetyLag), just not usable, since it
+		// doesn't move past checkpoint.
+		assert.True(t, upper.Equal(now.Add(-safetyLag)))
+		assert.False(t, upper.After(checkpoint))
+	})
+
+	t.Run("exactly at the boundary is not ok (upper must strictly move past checkpoint)", func(t *testing.T) {
+		now := checkpoint.Add(safetyLag)
+		upper, ok := pollWindow(checkpoint, now)
+		assert.False(t, ok)
+		assert.True(t, upper.Equal(checkpoint))
+	})
+}
+
+func TestWaitForNextPoll(t *testing.T) {
+	t.Run("first-ever call (zero lastPollAt) returns immediately", func(t *testing.T) {
+		c := &BigQueryConnector{}
+		start := time.Now()
+		err := c.waitForNextPoll(context.Background(), time.Hour)
+		require.NoError(t, err)
+		assert.Less(t, time.Since(start), 100*time.Millisecond)
+	})
+
+	t.Run("waits out the remainder of idleTimeout since lastPollAt", func(t *testing.T) {
+		c := &BigQueryConnector{lastPollAt: time.Now()}
+		idleTimeout := 50 * time.Millisecond
+		start := time.Now()
+		err := c.waitForNextPoll(context.Background(), idleTimeout)
+		require.NoError(t, err)
+		elapsed := time.Since(start)
+		assert.GreaterOrEqual(t, elapsed, idleTimeout-5*time.Millisecond)
+	})
+
+	t.Run("no wait once idleTimeout has already elapsed", func(t *testing.T) {
+		c := &BigQueryConnector{lastPollAt: time.Now().Add(-time.Hour)}
+		start := time.Now()
+		err := c.waitForNextPoll(context.Background(), time.Second)
+		require.NoError(t, err)
+		assert.Less(t, time.Since(start), 100*time.Millisecond)
+	})
+
+	t.Run("context cancellation interrupts the wait", func(t *testing.T) {
+		c := &BigQueryConnector{lastPollAt: time.Now()}
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}()
+		start := time.Now()
+		err := c.waitForNextPoll(ctx, time.Hour)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Less(t, time.Since(start), time.Second)
+	})
+}

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/url"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/storage"
@@ -341,9 +342,26 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 	runSnapshotStagingPath := basePath.JoinPath(activityInfo.WorkflowExecution.RunID).String()
 	c.logger.Info("Run snapshot staging path", slog.String("path", runSnapshotStagingPath))
 
+	// snapshotTime (T) anchors every table's export below via FOR SYSTEM_TIME AS OF, so all
+	// tables are read as of the same consistent point in time. It's queried from BigQuery's
+	// own clock rather than local wall-clock so it lines up with BigQuery's time-travel
+	// semantics. When the mirror continues into CDC, T also becomes the initial poll
+	// checkpoint (see below) so a later PullRecords resumes from exactly where this snapshot
+	// left off.
+	//
+	// Known limitation: T must stay within BigQuery's time-travel window (7 days by default)
+	// for the entire snapshot duration across all tables, or later tables' exports will fail.
+	// Not addressed here -- no retry/adjustment logic; a snapshot that runs long enough to
+	// walk outside the window needs a shorter export or a larger table-level time-travel
+	// setting.
+	snapshotTime, err := c.currentBigQueryTimestamp(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get current BigQuery timestamp for snapshot: %w", err)
+	}
+
 	jobs := make(map[string]*bigquery.Job)
 	for _, tm := range cfg.TableMappings {
-		exportSQL, err := c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, runSnapshotStagingPath)
+		exportSQL, err := c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, runSnapshotStagingPath, snapshotTime)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to build export SQL for table %s: %w", tm.SourceTableIdentifier, err)
 		}
@@ -375,7 +393,41 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 		_ = c.LogFlowInfo(ctx, flowName, "Exported snapshot data to GCS for table "+sourceTableIdentifier)
 	}
 
+	// Persist T as the initial CDC checkpoint only when this mirror will keep polling for
+	// changes after the snapshot. Pure-snapshot flows (InitialSnapshotOnly) have no CDC
+	// follow-up, so there's nothing to resume and no checkpoint should be written.
+	//
+	// This is done here, in ExportTxSnapshot, rather than in SetupReplication (as
+	// CDCPullConnectorCore's other implementations do for their equivalent offsets): for
+	// BigQuery, SetupReplication and ExportTxSnapshot are called from disjoint branches of
+	// SnapshotFlowWorkflow depending on InitialSnapshotOnly, so T (captured above, specific to
+	// this export) is never in scope inside SetupReplication. See the workflow branching in
+	// flow/workflows/snapshot_flow.go: SetupReplication runs only when InitialSnapshotOnly is
+	// false, i.e. exactly when ExportTxSnapshot does *not* run.
+	if !cfg.InitialSnapshotOnly {
+		checkpoint := model.CdcCheckpoint{Text: snapshotTime.Format(time.RFC3339Nano)}
+		if err := c.SetLastOffset(ctx, flowName, checkpoint); err != nil {
+			return nil, nil, fmt.Errorf("failed to persist snapshot checkpoint: %w", err)
+		}
+	}
+
 	return &protos.ExportTxSnapshotOutput{SnapshotStagingPath: runSnapshotStagingPath}, runSnapshotStagingPath, nil
+}
+
+// currentBigQueryTimestamp queries BigQuery's own clock (rather than local wall-clock) so the
+// returned timestamp is consistent with BigQuery's FOR SYSTEM_TIME AS OF time-travel semantics.
+func (c *BigQueryConnector) currentBigQueryTimestamp(ctx context.Context) (time.Time, error) {
+	it, err := c.client.Query("SELECT CURRENT_TIMESTAMP() AS ts").Read(ctx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to query current BigQuery timestamp: %w", err)
+	}
+	var row struct {
+		Ts time.Time `bigquery:"ts"`
+	}
+	if err := it.Next(&row); err != nil {
+		return time.Time{}, fmt.Errorf("failed to read current BigQuery timestamp: %w", err)
+	}
+	return row.Ts, nil
 }
 
 // bigQueryExportQueryStatement builds the EXPORT DATA SQL statement for exporting data from BigQuery to GCS in Parquet format.
@@ -386,6 +438,7 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 func (c *BigQueryConnector) bigQueryExportQueryStatement(
 	ctx context.Context,
 	sourceTableIdentifier, snapshotStagingPath string,
+	snapshotTime time.Time,
 ) (string, error) {
 	dsTable, err := c.convertToDatasetTable(sourceTableIdentifier)
 	if err != nil {
@@ -398,8 +451,20 @@ func (c *BigQueryConnector) bigQueryExportQueryStatement(
 		return "", fmt.Errorf("failed to get table metadata for %s: %w", sourceTableIdentifier, err)
 	}
 
-	columnSelects := make([]string, 0, len(metadata.Schema))
-	for _, field := range metadata.Schema {
+	return buildBigQueryExportSQL(dsTable, metadata.Schema, snapshotStagingPath, sourceTableIdentifier, snapshotTime), nil
+}
+
+// buildBigQueryExportSQL builds the EXPORT DATA SQL string given an already-resolved schema, so
+// it can be unit tested without a live BigQuery client. See bigQueryExportQueryStatement, which
+// resolves the schema and delegates here.
+func buildBigQueryExportSQL(
+	dsTable datasetTable,
+	schema bigquery.Schema,
+	snapshotStagingPath, sourceTableIdentifier string,
+	snapshotTime time.Time,
+) string {
+	columnSelects := make([]string, 0, len(schema))
+	for _, field := range schema {
 		quotedName := quotedIdentifier(field.Name)
 		columnSelect := quotedName
 		switch field.Type {
@@ -419,20 +484,22 @@ func (c *BigQueryConnector) bigQueryExportQueryStatement(
 	}
 
 	uri := fmt.Sprintf("%s/%s/*.parquet", snapshotStagingPath, url.PathEscape(sourceTableIdentifier))
+	// BigQuery's TIMESTAMP literal format; matches the precision/format validated against a
+	// live instance (see the FOR SYSTEM_TIME AS OF syntax docs referenced above).
+	snapshotLiteral := snapshotTime.UTC().Format("2006-01-02 15:04:05.999999")
 
-	exportSQL := fmt.Sprintf(`EXPORT DATA OPTIONS(
+	return fmt.Sprintf(`EXPORT DATA OPTIONS(
 			uri='%s',
 			format='PARQUET',
 			compression='GZIP',
 			overwrite=true
 		) AS
-		SELECT %s FROM %s`,
+		SELECT %s FROM %s FOR SYSTEM_TIME AS OF TIMESTAMP('%s UTC')`,
 		uri,
 		strings.Join(columnSelects, ", "),
 		dsTable.stringQuoted(),
+		snapshotLiteral,
 	)
-
-	return exportSQL, nil
 }
 
 func (c *BigQueryConnector) FinishExport(v any) error {

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -345,9 +345,7 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 	// snapshotTime (T) anchors every table's export below via FOR SYSTEM_TIME AS OF, so all
 	// tables are read as of the same consistent point in time. It's queried from BigQuery's
 	// own clock rather than local wall-clock so it lines up with BigQuery's time-travel
-	// semantics. When the mirror continues into CDC, T also becomes the initial poll
-	// checkpoint (see below) so a later PullRecords resumes from exactly where this snapshot
-	// left off.
+	// semantics.
 	//
 	// Known limitation: T must stay within BigQuery's time-travel window (7 days by default)
 	// for the entire snapshot duration across all tables, or later tables' exports will fail.
@@ -359,11 +357,28 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 		return nil, nil, fmt.Errorf("failed to get current BigQuery timestamp for snapshot: %w", err)
 	}
 
-	jobs := make(map[string]*bigquery.Job)
-	for _, tm := range cfg.TableMappings {
-		exportSQL, err := c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, runSnapshotStagingPath, snapshotTime)
+	if err := c.exportTablesAsOf(ctx, flowName, cfg.TableMappings, runSnapshotStagingPath, snapshotTime); err != nil {
+		return nil, nil, err
+	}
+
+	return &protos.ExportTxSnapshotOutput{SnapshotStagingPath: runSnapshotStagingPath}, runSnapshotStagingPath, nil
+}
+
+// exportTablesAsOf runs EXPORT DATA for every table in tableMappings, each read as of
+// snapshotTime, writing Parquet to stagingPath. Shared by ExportTxSnapshot (pure
+// snapshot-only flows) and SetupReplication (initial load for flows that continue into CDC).
+func (c *BigQueryConnector) exportTablesAsOf(
+	ctx context.Context,
+	flowName string,
+	tableMappings []*protos.TableMapping,
+	stagingPath string,
+	snapshotTime time.Time,
+) error {
+	jobs := make(map[string]*bigquery.Job, len(tableMappings))
+	for _, tm := range tableMappings {
+		exportSQL, err := c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, stagingPath, snapshotTime)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to build export SQL for table %s: %w", tm.SourceTableIdentifier, err)
+			return fmt.Errorf("failed to build export SQL for table %s: %w", tm.SourceTableIdentifier, err)
 		}
 
 		q := c.client.Query(exportSQL)
@@ -379,39 +394,20 @@ func (c *BigQueryConnector) ExportTxSnapshot(
 				}
 			}
 
-			return nil, nil, fmt.Errorf("failed to start export job for table %s: %w", tm.SourceTableIdentifier, err)
+			return fmt.Errorf("failed to start export job for table %s: %w", tm.SourceTableIdentifier, err)
 		}
 		jobs[tm.SourceTableIdentifier] = job
 	}
 	for sourceTableIdentifier, job := range jobs {
 		if status, err := job.Wait(ctx); err != nil {
-			return nil, nil, fmt.Errorf("error waiting for export job to complete: %w", err)
+			return fmt.Errorf("error waiting for export job to complete: %w", err)
 		} else if err := status.Err(); err != nil {
-			return nil, nil, fmt.Errorf("export job completed with error: %w", err)
+			return fmt.Errorf("export job completed with error: %w", err)
 		}
 
 		_ = c.LogFlowInfo(ctx, flowName, "Exported snapshot data to GCS for table "+sourceTableIdentifier)
 	}
-
-	// Persist T as the initial CDC checkpoint only when this mirror will keep polling for
-	// changes after the snapshot. Pure-snapshot flows (InitialSnapshotOnly) have no CDC
-	// follow-up, so there's nothing to resume and no checkpoint should be written.
-	//
-	// This is done here, in ExportTxSnapshot, rather than in SetupReplication (as
-	// CDCPullConnectorCore's other implementations do for their equivalent offsets): for
-	// BigQuery, SetupReplication and ExportTxSnapshot are called from disjoint branches of
-	// SnapshotFlowWorkflow depending on InitialSnapshotOnly, so T (captured above, specific to
-	// this export) is never in scope inside SetupReplication. See the workflow branching in
-	// flow/workflows/snapshot_flow.go: SetupReplication runs only when InitialSnapshotOnly is
-	// false, i.e. exactly when ExportTxSnapshot does *not* run.
-	if !cfg.InitialSnapshotOnly {
-		checkpoint := model.CdcCheckpoint{Text: snapshotTime.Format(time.RFC3339Nano)}
-		if err := c.SetLastOffset(ctx, flowName, checkpoint); err != nil {
-			return nil, nil, fmt.Errorf("failed to persist snapshot checkpoint: %w", err)
-		}
-	}
-
-	return &protos.ExportTxSnapshotOutput{SnapshotStagingPath: runSnapshotStagingPath}, runSnapshotStagingPath, nil
+	return nil
 }
 
 // currentBigQueryTimestamp queries BigQuery's own clock (rather than local wall-clock) so the
@@ -574,9 +570,42 @@ func (c *BigQueryConnector) PullFlowCleanup(context.Context, string) error {
 	return nil
 }
 
+// SetupReplication is BigQuery's equivalent of capturing a starting replication position
+// (like MySQL's GTID/file-position capture): it has no replication slot to open, so it just
+// captures a BigQuery-clock timestamp T and persists it as the initial CDC checkpoint. Unlike
+// MySQL/Postgres, BigQuery's initial load can't query the live table at pull time - QRep
+// pulls read pre-exported Parquet from GCS - so when the mirror wants an initial load
+// (req.DoInitialSnapshot), this also runs that export as of the same T, the same way
+// ExportTxSnapshot does for pure snapshot-only flows. It returns a zero-value
+// model.SetupReplicationResult (no slot/snapshot name), matching MySQL: cloneTablesWithSlot
+// falls back to the mirror's configured SnapshotStagingPath when no override is given, which
+// is exactly where this export writes.
 func (c *BigQueryConnector) SetupReplication(
-	context.Context, shared.CatalogPool,
-	*protos.SetupReplicationInput,
+	ctx context.Context,
+	catalogPool shared.CatalogPool,
+	req *protos.SetupReplicationInput,
 ) (model.SetupReplicationResult, error) {
+	cfg, err := internal.FetchConfigFromDB(ctx, catalogPool, req.FlowJobName)
+	if err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to fetch flow config from db: %w", err)
+	}
+
+	snapshotTime, err := c.currentBigQueryTimestamp(ctx)
+	if err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to get current BigQuery timestamp: %w", err)
+	}
+
+	if req.DoInitialSnapshot {
+		_ = c.LogFlowInfo(ctx, req.FlowJobName, "Starting initial-load BigQuery export to GCS staging bucket")
+		if err := c.exportTablesAsOf(ctx, req.FlowJobName, cfg.TableMappings, cfg.SnapshotStagingPath, snapshotTime); err != nil {
+			return model.SetupReplicationResult{}, err
+		}
+	}
+
+	checkpoint := model.CdcCheckpoint{Text: snapshotTime.Format(time.RFC3339Nano)}
+	if err := c.SetLastOffset(ctx, req.FlowJobName, checkpoint); err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to persist initial CDC checkpoint: %w", err)
+	}
+
 	return model.SetupReplicationResult{}, nil
 }

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -314,13 +314,6 @@ func bigQuerySchemaToQRecordSchema(schema bigquery.Schema) (types.QRecordSchema,
 	return types.NewQRecordSchema(fields), nil
 }
 
-func (c *BigQueryConnector) EnsurePullability(
-	ctx context.Context,
-	req *protos.EnsurePullabilityBatchInput,
-) (*protos.EnsurePullabilityBatchOutput, error) {
-	return nil, nil
-}
-
 func (c *BigQueryConnector) ExportTxSnapshot(
 	ctx context.Context,
 	flowName string,
@@ -555,18 +548,6 @@ func (c *BigQueryConnector) FinishExport(v any) error {
 	c.logger.Info("GCS cleanup completed after export",
 		slog.Int("deletedObjects", deletedCount))
 
-	return nil
-}
-
-func (c *BigQueryConnector) SetupReplConn(context.Context, map[string]string) error {
-	return nil
-}
-
-func (c *BigQueryConnector) UpdateReplStateLastOffset(context.Context, model.CdcCheckpoint) error {
-	return nil
-}
-
-func (c *BigQueryConnector) PullFlowCleanup(context.Context, string) error {
 	return nil
 }
 

--- a/flow/connectors/bigquery/qrep_object_pull_test.go
+++ b/flow/connectors/bigquery/qrep_object_pull_test.go
@@ -1,0 +1,89 @@
+package connbigquery
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildBigQueryExportSQL_ForSystemTimeAsOf(t *testing.T) {
+	dsTable := datasetTable{dataset: "my_dataset", table: "my_table"}
+	schema := bigquery.Schema{
+		{Name: "id", Type: bigquery.IntegerFieldType},
+		{Name: "name", Type: bigquery.StringFieldType},
+	}
+	snapshotTime := time.Date(2026, 8, 14, 12, 34, 56, 789000000, time.UTC)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket/prefix", "my_dataset.my_table", snapshotTime)
+
+	require.Contains(t, sql, "FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:34:56.789 UTC')")
+	require.Contains(t, sql, "FROM `my_dataset`.`my_table` FOR SYSTEM_TIME AS OF")
+	assert.Contains(t, sql, "uri='gs://bucket/prefix/my_dataset.my_table/*.parquet'")
+	assert.Contains(t, sql, "`id`")
+	assert.Contains(t, sql, "`name`")
+}
+
+func TestBuildBigQueryExportSQL_ConvertsNonUTCToUTC(t *testing.T) {
+	dsTable := datasetTable{dataset: "ds", table: "tbl"}
+	schema := bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}}
+
+	loc := time.FixedZone("UTC-5", -5*60*60)
+	// 2026-08-14 10:00:00 -05:00 == 2026-08-14 15:00:00 UTC
+	snapshotTime := time.Date(2026, 8, 14, 10, 0, 0, 0, loc)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket", "tbl", snapshotTime)
+
+	require.Contains(t, sql, "FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 15:00:00 UTC')")
+}
+
+func TestBuildBigQueryExportSQL_NoFractionalSeconds(t *testing.T) {
+	dsTable := datasetTable{dataset: "ds", table: "tbl"}
+	schema := bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}}
+	snapshotTime := time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket", "tbl", snapshotTime)
+
+	// time.Format with ".999999" drops the fractional part entirely when it's zero.
+	require.Contains(t, sql, "FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 00:00:00 UTC')")
+}
+
+func TestBuildBigQueryExportSQL_ColumnCasts(t *testing.T) {
+	dsTable := datasetTable{dataset: "ds", table: "tbl"}
+	schema := bigquery.Schema{
+		{Name: "plain", Type: bigquery.StringFieldType},
+		{Name: "payload", Type: bigquery.JSONFieldType},
+		{Name: "geo", Type: bigquery.GeographyFieldType},
+		{Name: "ts", Type: bigquery.DateTimeFieldType},
+	}
+	snapshotTime := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket", "tbl", snapshotTime)
+
+	assert.Contains(t, sql, "`plain`")
+	assert.Contains(t, sql, "TO_JSON_STRING(`payload`) AS `payload`")
+	assert.Contains(t, sql, "ST_AsText(`geo`) AS `geo`")
+	assert.Contains(t, sql, "CAST(`ts` AS TIMESTAMP) AS `ts`")
+
+	// Sanity check on the column order/joining.
+	selectClause := sql[strings.Index(sql, "SELECT "):strings.Index(sql, " FROM ")]
+	assert.Equal(t,
+		"SELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, CAST(`ts` AS TIMESTAMP) AS `ts`",
+		selectClause,
+	)
+}
+
+func TestBuildBigQueryExportSQL_ExportOptions(t *testing.T) {
+	dsTable := datasetTable{dataset: "ds", table: "tbl"}
+	schema := bigquery.Schema{{Name: "id", Type: bigquery.IntegerFieldType}}
+	snapshotTime := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+
+	sql := buildBigQueryExportSQL(dsTable, schema, "gs://bucket/prefix", "ds.tbl", snapshotTime)
+
+	assert.Contains(t, sql, "format='PARQUET'")
+	assert.Contains(t, sql, "compression='GZIP'")
+	assert.Contains(t, sql, "overwrite=true")
+}

--- a/flow/connectors/bigquery/qvalue_convert.go
+++ b/flow/connectors/bigquery/qvalue_convert.go
@@ -2,8 +2,12 @@ package connbigquery
 
 import (
 	"fmt"
+	"math/big"
+	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
+	"github.com/shopspring/decimal"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/shared/datatypes"
@@ -208,4 +212,140 @@ func BigQueryFieldToQField(bqField *bigquery.FieldSchema) types.QField {
 		Scale:     int16(bqField.Scale),
 		Nullable:  !bqField.Required,
 	}
+}
+
+// qvalueFromBigQueryValue converts one column of a query result row (e.g. from
+// APPENDS()/CHANGES()) into the QValue variant matching qfield.Type, as computed by
+// BigQueryFieldToQField from the same result schema. The Go SDK hands back an
+// already-typed value per BigQuery type (see cloud.google.com/go/bigquery's
+// convertBasicType): string, []byte, int64, float64, bool, time.Time (TIMESTAMP),
+// civil.Date (DATE), civil.Time (TIME), civil.DateTime (DATETIME), *big.Rat
+// (NUMERIC/BIGNUMERIC), or []bigquery.Value for a REPEATED column.
+//
+// RECORD/STRUCT columns aren't supported: their Go value is also []bigquery.Value,
+// which doesn't match any non-array qfield.Type, so they fail here with a clear
+// error rather than being silently misread.
+func qvalueFromBigQueryValue(qfield types.QField, value bigquery.Value) (types.QValue, error) {
+	if value == nil {
+		return types.QValueNull(qfield.Type), nil
+	}
+
+	switch qfield.Type {
+	case types.QValueKindArrayString, types.QValueKindArrayInt64, types.QValueKindArrayFloat64,
+		types.QValueKindArrayBoolean, types.QValueKindArrayTimestamp, types.QValueKindArrayDate,
+		types.QValueKindArrayNumeric:
+		values, ok := value.([]bigquery.Value)
+		if !ok {
+			return nil, fmt.Errorf("expected []bigquery.Value for repeated column %s, got %T", qfield.Name, value)
+		}
+		return qvalueArrayFromBigQueryValues(qfield, values)
+	}
+
+	switch v := value.(type) {
+	case bool:
+		return types.QValueBoolean{Val: v}, nil
+	case int64:
+		return types.QValueInt64{Val: v}, nil
+	case float64:
+		return types.QValueFloat64{Val: v}, nil
+	case []byte:
+		return types.QValueBytes{Val: v}, nil
+	case string:
+		switch qfield.Type {
+		case types.QValueKindJSON:
+			return types.QValueJSON{Val: v}, nil
+		case types.QValueKindGeography:
+			return types.QValueGeography{Val: v}, nil
+		default:
+			return types.QValueString{Val: v}, nil
+		}
+	case time.Time:
+		return types.QValueTimestamp{Val: v}, nil
+	case civil.Date:
+		return types.QValueDate{Val: v.In(time.UTC)}, nil
+	case civil.DateTime:
+		// BigQuery DATETIME is timezone-unaware; BigQueryTypeToQValueKind maps it
+		// to QValueKindTimestamp (same as TIMESTAMP -- see the snapshot-export
+		// path's CAST(... AS TIMESTAMP) treatment for the same reasoning), so it's
+		// carried as a UTC time.Time here too.
+		return types.QValueTimestamp{Val: v.In(time.UTC)}, nil
+	case civil.Time:
+		return types.QValueTime{Val: civilTimeToDuration(v)}, nil
+	case *big.Rat:
+		return types.QValueNumeric{
+			Val:       decimal.NewFromBigRat(v, int32(qfield.Scale)),
+			Precision: qfield.Precision,
+			Scale:     qfield.Scale,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported BigQuery value type %T for column %s", value, qfield.Name)
+	}
+}
+
+// qvalueArrayFromBigQueryValues converts a REPEATED column's value, which the Go
+// SDK returns as []bigquery.Value with one already-typed element per the field's
+// base (non-repeated) type.
+func qvalueArrayFromBigQueryValues(qfield types.QField, values []bigquery.Value) (types.QValue, error) {
+	switch qfield.Type {
+	case types.QValueKindArrayString:
+		arr, err := castBigQueryArray[string](qfield, values)
+		return types.QValueArrayString{Val: arr}, err
+	case types.QValueKindArrayInt64:
+		arr, err := castBigQueryArray[int64](qfield, values)
+		return types.QValueArrayInt64{Val: arr}, err
+	case types.QValueKindArrayFloat64:
+		arr, err := castBigQueryArray[float64](qfield, values)
+		return types.QValueArrayFloat64{Val: arr}, err
+	case types.QValueKindArrayBoolean:
+		arr, err := castBigQueryArray[bool](qfield, values)
+		return types.QValueArrayBoolean{Val: arr}, err
+	case types.QValueKindArrayTimestamp:
+		arr, err := castBigQueryArray[time.Time](qfield, values)
+		return types.QValueArrayTimestamp{Val: arr}, err
+	case types.QValueKindArrayDate:
+		dates, err := castBigQueryArray[civil.Date](qfield, values)
+		if err != nil {
+			return nil, err
+		}
+		arr := make([]time.Time, len(dates))
+		for i, d := range dates {
+			arr[i] = d.In(time.UTC)
+		}
+		return types.QValueArrayDate{Val: arr}, nil
+	case types.QValueKindArrayNumeric:
+		rats, err := castBigQueryArray[*big.Rat](qfield, values)
+		if err != nil {
+			return nil, err
+		}
+		arr := make([]decimal.Decimal, len(rats))
+		for i, r := range rats {
+			arr[i] = decimal.NewFromBigRat(r, int32(qfield.Scale))
+		}
+		return types.QValueArrayNumeric{Val: arr, Precision: qfield.Precision, Scale: qfield.Scale}, nil
+	default:
+		return nil, fmt.Errorf("unsupported repeated BigQuery column type for %s: %s", qfield.Name, qfield.Type)
+	}
+}
+
+// castBigQueryArray asserts every element of a REPEATED column's values to T,
+// mirroring the analogous helper in the cockroachdb connector's qvalue_convert.go.
+func castBigQueryArray[T any](qfield types.QField, values []bigquery.Value) ([]T, error) {
+	arr := make([]T, len(values))
+	for i, v := range values {
+		t, ok := v.(T)
+		if !ok {
+			return nil, fmt.Errorf("array column %s: element %d has unexpected type %T", qfield.Name, i, v)
+		}
+		arr[i] = t
+	}
+	return arr, nil
+}
+
+// civilTimeToDuration converts a civil.Time (BigQuery TIME) into the time.Duration
+// since midnight that types.QValueTime expects.
+func civilTimeToDuration(t civil.Time) time.Duration {
+	return time.Duration(t.Hour)*time.Hour +
+		time.Duration(t.Minute)*time.Minute +
+		time.Duration(t.Second)*time.Second +
+		time.Duration(t.Nanosecond)*time.Nanosecond
 }

--- a/flow/connectors/bigquery/qvalue_convert_test.go
+++ b/flow/connectors/bigquery/qvalue_convert_test.go
@@ -1,10 +1,15 @@
 package connbigquery
 
 import (
+	"math/big"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
@@ -298,4 +303,124 @@ func TestBigQueryTypeToQValueKind(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestQValueFromBigQueryValue(t *testing.T) {
+	qfield := func(bqType bigquery.FieldType, repeated bool, precision, scale int16) types.QField {
+		return BigQueryFieldToQField(&bigquery.FieldSchema{
+			Type: bqType, Repeated: repeated, Precision: int64(precision), Scale: int64(scale),
+		})
+	}
+
+	t.Run("null returns a kind-tagged QValueNull", func(t *testing.T) {
+		f := qfield(bigquery.IntegerFieldType, false, 0, 0)
+		v, err := qvalueFromBigQueryValue(f, nil)
+		require.NoError(t, err)
+		assert.Equal(t, types.QValueNull(types.QValueKindInt64), v)
+	})
+
+	t.Run("scalar types", func(t *testing.T) {
+		ts := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+		tests := []struct {
+			name     string
+			field    types.QField
+			value    bigquery.Value
+			expected types.QValue
+		}{
+			{"bool", qfield(bigquery.BooleanFieldType, false, 0, 0), true, types.QValueBoolean{Val: true}},
+			{"int64", qfield(bigquery.IntegerFieldType, false, 0, 0), int64(42), types.QValueInt64{Val: 42}},
+			{"float64", qfield(bigquery.FloatFieldType, false, 0, 0), 3.14, types.QValueFloat64{Val: 3.14}},
+			{"bytes", qfield(bigquery.BytesFieldType, false, 0, 0), []byte("hi"), types.QValueBytes{Val: []byte("hi")}},
+			{"string", qfield(bigquery.StringFieldType, false, 0, 0), "hello", types.QValueString{Val: "hello"}},
+			{"json", qfield(bigquery.JSONFieldType, false, 0, 0), `{"a":1}`, types.QValueJSON{Val: `{"a":1}`}},
+			{
+				"geography",
+				qfield(bigquery.GeographyFieldType, false, 0, 0),
+				"POINT(1 1)",
+				types.QValueGeography{Val: "POINT(1 1)"},
+			},
+			{"timestamp", qfield(bigquery.TimestampFieldType, false, 0, 0), ts, types.QValueTimestamp{Val: ts}},
+			{
+				"datetime carried as UTC timestamp",
+				qfield(bigquery.DateTimeFieldType, false, 0, 0),
+				civil.DateTimeOf(ts),
+				types.QValueTimestamp{Val: ts},
+			},
+			{
+				"date",
+				qfield(bigquery.DateFieldType, false, 0, 0),
+				civil.Date{Year: 2026, Month: 8, Day: 14},
+				types.QValueDate{Val: time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC)},
+			},
+			{
+				"time",
+				qfield(bigquery.TimeFieldType, false, 0, 0),
+				civil.Time{Hour: 1, Minute: 2, Second: 3, Nanosecond: 4000},
+				types.QValueTime{Val: time.Hour + 2*time.Minute + 3*time.Second + 4000*time.Nanosecond},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				v, err := qvalueFromBigQueryValue(tt.field, tt.value)
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, v)
+			})
+		}
+	})
+
+	t.Run("numeric converts *big.Rat honoring field scale", func(t *testing.T) {
+		f := qfield(bigquery.NumericFieldType, false, 10, 2)
+		v, err := qvalueFromBigQueryValue(f, big.NewRat(1, 4)) // 0.25
+		require.NoError(t, err)
+		numeric, ok := v.(types.QValueNumeric)
+		require.True(t, ok)
+		assert.True(t, decimal.NewFromFloat(0.25).Equal(numeric.Val))
+		assert.Equal(t, int16(10), numeric.Precision)
+		assert.Equal(t, int16(2), numeric.Scale)
+	})
+
+	t.Run("repeated columns", func(t *testing.T) {
+		t.Run("array string", func(t *testing.T) {
+			f := qfield(bigquery.StringFieldType, true, 0, 0)
+			v, err := qvalueFromBigQueryValue(f, []bigquery.Value{"a", "b"})
+			require.NoError(t, err)
+			assert.Equal(t, types.QValueArrayString{Val: []string{"a", "b"}}, v)
+		})
+
+		t.Run("array int64", func(t *testing.T) {
+			f := qfield(bigquery.IntegerFieldType, true, 0, 0)
+			v, err := qvalueFromBigQueryValue(f, []bigquery.Value{int64(1), int64(2)})
+			require.NoError(t, err)
+			assert.Equal(t, types.QValueArrayInt64{Val: []int64{1, 2}}, v)
+		})
+
+		t.Run("array numeric", func(t *testing.T) {
+			f := qfield(bigquery.NumericFieldType, true, 10, 2)
+			v, err := qvalueFromBigQueryValue(f, []bigquery.Value{big.NewRat(1, 2)})
+			require.NoError(t, err)
+			arr, ok := v.(types.QValueArrayNumeric)
+			require.True(t, ok)
+			require.Len(t, arr.Val, 1)
+			assert.True(t, decimal.NewFromFloat(0.5).Equal(arr.Val[0]))
+		})
+
+		t.Run("element type mismatch errors", func(t *testing.T) {
+			f := qfield(bigquery.IntegerFieldType, true, 0, 0)
+			_, err := qvalueFromBigQueryValue(f, []bigquery.Value{"not-an-int"})
+			require.Error(t, err)
+		})
+
+		t.Run("non-slice value for repeated column errors", func(t *testing.T) {
+			f := qfield(bigquery.IntegerFieldType, true, 0, 0)
+			_, err := qvalueFromBigQueryValue(f, int64(1))
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("unsupported Go value type errors instead of silently misconverting", func(t *testing.T) {
+		f := qfield(bigquery.IntegerFieldType, false, 0, 0)
+		// e.g. a RECORD column's nested []bigquery.Value landing on a non-array qfield.
+		_, err := qvalueFromBigQueryValue(f, []bigquery.Value{int64(1)})
+		require.Error(t, err)
+	})
 }

--- a/flow/connectors/bigquery/source.go
+++ b/flow/connectors/bigquery/source.go
@@ -95,8 +95,9 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 		case protos.BigqueryCdcMode_BIGQUERY_CDC_MODE_APPENDS:
 			if rejectKeylessReplacingMergeTree(hasPK, tableMapping.Engine) {
 				return fmt.Errorf("table %s has no primary key configured on BigQuery and the destination engine "+
-					"is ReplacingMergeTree (the default); ORDER BY tuple() on a keyless ReplacingMergeTree collapses "+
-					"the table on writes, so a PK-less table must use an explicit CH_ENGINE_MERGE_TREE engine instead",
+					"is a ReplacingMergeTree variant (the plain form is the default); ORDER BY tuple() on a keyless "+
+					"ReplacingMergeTree collapses the table on writes, so a PK-less table must use an explicit "+
+					"CH_ENGINE_MERGE_TREE engine instead",
 					dstDatasetTable.string())
 			}
 		}
@@ -117,8 +118,13 @@ func tableHasPrimaryKey(metadata *bigquery.TableMetadata) bool {
 // rejected: ORDER BY tuple() on a keyless ReplacingMergeTree collapses the table
 // on writes (errors on ClickHouse 25.12+, silently loses data before), so a
 // table with no PK to key off of must use an explicit MergeTree engine instead.
+// The replicated variant shares the same collapsing behavior (it's the same
+// dedup engine, just wrapped for replication - see the ClickHouse connector's
+// own normalize.go, which groups the two under one switch case) so it's
+// rejected too.
 func rejectKeylessReplacingMergeTree(hasPK bool, engine protos.TableEngine) bool {
-	return !hasPK && engine == protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE
+	return !hasPK && (engine == protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE ||
+		engine == protos.TableEngine_CH_ENGINE_REPLICATED_REPLACING_MERGE_TREE)
 }
 
 // tableHasChangeHistoryEnabled checks the enable_change_history table option via

--- a/flow/connectors/bigquery/source.go
+++ b/flow/connectors/bigquery/source.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
+	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
 
@@ -15,16 +17,14 @@ import (
 )
 
 func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *protos.FlowConnectionConfigsCore) error {
-	if !cfg.InitialSnapshotOnly || !cfg.DoInitialSnapshot {
-		return fmt.Errorf("BigQuery source connector only supports initial snapshot flows. CDC is not supported")
-	}
-
 	var missingTables []common.QualifiedTable
+	dstDatasetTables := make(map[string]datasetTable, len(cfg.TableMappings))
 	for _, tableMapping := range cfg.TableMappings {
 		dstDatasetTable, err := c.convertToDatasetTable(tableMapping.SourceTableIdentifier)
 		if err != nil {
 			return err
 		}
+		dstDatasetTables[tableMapping.SourceTableIdentifier] = dstDatasetTable
 
 		table := c.client.DatasetInProject(c.projectID, dstDatasetTable.dataset).Table(dstDatasetTable.table)
 
@@ -60,5 +60,95 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 		return fmt.Errorf("failed to access staging bucket: %w", exceptions.NewBigQueryError(err))
 	}
 
+	// snapshot-only mirrors never touch CDC, so no need to validate mode-specific requirements below
+	if cfg.DoInitialSnapshot && cfg.InitialSnapshotOnly {
+		return nil
+	}
+
+	cdcMode := cfg.GetBigqueryCdcConfig().GetCdcMode()
+	for _, tableMapping := range cfg.TableMappings {
+		dstDatasetTable := dstDatasetTables[tableMapping.SourceTableIdentifier]
+		table := c.client.DatasetInProject(c.projectID, dstDatasetTable.dataset).Table(dstDatasetTable.table)
+		metadata, err := table.Metadata(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get metadata for table %s: %w", tableMapping.SourceTableIdentifier, err)
+		}
+		hasPK := tableHasPrimaryKey(metadata)
+
+		switch cdcMode {
+		case protos.BigqueryCdcMode_BIGQUERY_CDC_MODE_CHANGES:
+			if !hasPK {
+				return fmt.Errorf("table %s has no primary key constraint configured on BigQuery; "+
+					"CHANGES mode requires a real (NOT ENFORCED) PK constraint on the source table",
+					dstDatasetTable.string())
+			}
+			hasChangeHistory, err := c.tableHasChangeHistoryEnabled(ctx, dstDatasetTable)
+			if err != nil {
+				return fmt.Errorf("failed to check enable_change_history option for table %s: %w",
+					dstDatasetTable.string(), exceptions.NewBigQueryError(err))
+			}
+			if !hasChangeHistory {
+				return fmt.Errorf("table %s does not have enable_change_history=TRUE set; "+
+					"CHANGES mode requires it (run ALTER TABLE ... SET OPTIONS(enable_change_history=true) on the source table)",
+					dstDatasetTable.string())
+			}
+		case protos.BigqueryCdcMode_BIGQUERY_CDC_MODE_APPENDS:
+			if rejectKeylessReplacingMergeTree(hasPK, tableMapping.Engine) {
+				return fmt.Errorf("table %s has no primary key configured on BigQuery and the destination engine "+
+					"is ReplacingMergeTree (the default); ORDER BY tuple() on a keyless ReplacingMergeTree collapses "+
+					"the table on writes, so a PK-less table must use an explicit CH_ENGINE_MERGE_TREE engine instead",
+					dstDatasetTable.string())
+			}
+		}
+	}
+
 	return nil
+}
+
+// tableHasPrimaryKey reports whether metadata carries a real (BigQuery PKs are
+// always NOT ENFORCED) primary key constraint.
+func tableHasPrimaryKey(metadata *bigquery.TableMetadata) bool {
+	return metadata.TableConstraints != nil &&
+		metadata.TableConstraints.PrimaryKey != nil &&
+		len(metadata.TableConstraints.PrimaryKey.Columns) > 0
+}
+
+// rejectKeylessReplacingMergeTree decides whether a keyless-table mirror must be
+// rejected: ORDER BY tuple() on a keyless ReplacingMergeTree collapses the table
+// on writes (errors on ClickHouse 25.12+, silently loses data before), so a
+// table with no PK to key off of must use an explicit MergeTree engine instead.
+func rejectKeylessReplacingMergeTree(hasPK bool, engine protos.TableEngine) bool {
+	return !hasPK && engine == protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE
+}
+
+// tableHasChangeHistoryEnabled checks the enable_change_history table option via
+// INFORMATION_SCHEMA.TABLE_OPTIONS. This option is not exposed as a typed field
+// on bigquery.TableMetadata, and PeerDB never sets it — only checks it.
+func (c *BigQueryConnector) tableHasChangeHistoryEnabled(ctx context.Context, dstDatasetTable datasetTable) (bool, error) {
+	q := c.client.Query(fmt.Sprintf(
+		"SELECT option_value FROM `%s`.INFORMATION_SCHEMA.TABLE_OPTIONS "+
+			"WHERE table_name = @table_name AND option_name = 'enable_change_history'",
+		dstDatasetTable.dataset))
+	q.Parameters = []bigquery.QueryParameter{{Name: "table_name", Value: dstDatasetTable.table}}
+	q.DefaultProjectID = c.projectID
+	q.DefaultDatasetID = dstDatasetTable.dataset
+
+	it, err := q.Read(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	var row []bigquery.Value
+	if err := it.Next(&row); err != nil {
+		if errors.Is(err, iterator.Done) {
+			return false, nil
+		}
+		return false, err
+	}
+	if len(row) == 0 {
+		return false, nil
+	}
+
+	optionValue, ok := row[0].(string)
+	return ok && strings.EqualFold(optionValue, "true"), nil
 }

--- a/flow/connectors/bigquery/source_test.go
+++ b/flow/connectors/bigquery/source_test.go
@@ -1,0 +1,95 @@
+package connbigquery
+
+import (
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+)
+
+func TestTableHasPrimaryKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *bigquery.TableMetadata
+		want     bool
+	}{
+		{
+			name:     "no constraints at all",
+			metadata: &bigquery.TableMetadata{},
+			want:     false,
+		},
+		{
+			name:     "constraints present but no primary key",
+			metadata: &bigquery.TableMetadata{TableConstraints: &bigquery.TableConstraints{}},
+			want:     false,
+		},
+		{
+			name: "primary key present but empty columns",
+			metadata: &bigquery.TableMetadata{
+				TableConstraints: &bigquery.TableConstraints{PrimaryKey: &bigquery.PrimaryKey{Columns: []string{}}},
+			},
+			want: false,
+		},
+		{
+			name: "real primary key",
+			metadata: &bigquery.TableMetadata{
+				TableConstraints: &bigquery.TableConstraints{PrimaryKey: &bigquery.PrimaryKey{Columns: []string{"id"}}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tableHasPrimaryKey(tt.metadata))
+		})
+	}
+}
+
+func TestRejectKeylessReplacingMergeTree(t *testing.T) {
+	tests := []struct {
+		name   string
+		hasPK  bool
+		engine protos.TableEngine
+		want   bool
+	}{
+		{
+			name:   "no PK, default engine (ReplacingMergeTree) - reject",
+			hasPK:  false,
+			engine: protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE,
+			want:   true,
+		},
+		{
+			name:   "no PK, explicit MergeTree - allowed",
+			hasPK:  false,
+			engine: protos.TableEngine_CH_ENGINE_MERGE_TREE,
+			want:   false,
+		},
+		{
+			name:   "has PK, ReplacingMergeTree - allowed",
+			hasPK:  true,
+			engine: protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE,
+			want:   false,
+		},
+		{
+			name:   "has PK, MergeTree - allowed",
+			hasPK:  true,
+			engine: protos.TableEngine_CH_ENGINE_MERGE_TREE,
+			want:   false,
+		},
+		{
+			name:   "no PK, replicated ReplacingMergeTree - allowed (only the plain RMT default is restricted)",
+			hasPK:  false,
+			engine: protos.TableEngine_CH_ENGINE_REPLICATED_REPLACING_MERGE_TREE,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rejectKeylessReplacingMergeTree(tt.hasPK, tt.engine))
+		})
+	}
+}

--- a/flow/connectors/bigquery/source_test.go
+++ b/flow/connectors/bigquery/source_test.go
@@ -80,8 +80,14 @@ func TestRejectKeylessReplacingMergeTree(t *testing.T) {
 			want:   false,
 		},
 		{
-			name:   "no PK, replicated ReplacingMergeTree - allowed (only the plain RMT default is restricted)",
+			name:   "no PK, replicated ReplacingMergeTree - reject (same collapsing dedup engine, just replicated)",
 			hasPK:  false,
+			engine: protos.TableEngine_CH_ENGINE_REPLICATED_REPLACING_MERGE_TREE,
+			want:   true,
+		},
+		{
+			name:   "has PK, replicated ReplacingMergeTree - allowed",
+			hasPK:  true,
 			engine: protos.TableEngine_CH_ENGINE_REPLICATED_REPLACING_MERGE_TREE,
 			want:   false,
 		},

--- a/flow/connectors/core.go
+++ b/flow/connectors/core.go
@@ -693,6 +693,7 @@ var (
 	_ CDCPullConnector = &connpostgres.PostgresConnector{}
 	_ CDCPullConnector = &connmysql.MySqlConnector{}
 	_ CDCPullConnector = &connmongo.MongoConnector{}
+	_ CDCPullConnector = &connbigquery.BigQueryConnector{}
 
 	_ CDCPullPgConnector = &connpostgres.PostgresConnector{}
 


### PR DESCRIPTION
CHANGES() reports an UPDATE as a delete+insert pair sharing the same PK
and _CHANGE_TIMESTAMP, so PullRecords needs to pair those back into one
UpdateRecord instead of emitting two records -- otherwise every update
on a CHANGES-mode mirror would be replicated as a delete followed by an
unrelated insert. Reads cdc_mode once per PullRecords call (it's a
per-mirror setting) to pick APPENDS or CHANGES per the "Decisions
locked in" plan.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>