### PR TITLE
fix(clickhouse): treat CANNOT_ASSIGN_ALTER (517) as retryable

### DIFF
--- a/flow/pkg/clickhouse/query_retry.go
+++ b/flow/pkg/clickhouse/query_retry.go
@@ -34,6 +34,7 @@ var retryableExceptions = map[chproto.Error]struct{}{
 	chproto.ErrUnknownStatusOfInsert:      {},
 	425:                                   {}, // SYSTEM_ERROR
 	chproto.ErrKeeperException:            {},
+	chproto.ErrCannotAssignAlter:          {}, // "Metadata on replica is not up to date ... You can retry this error"
 }
 
 var retryableExceptionSubstrings = map[chproto.Error][]string{


### PR DESCRIPTION
## Summary

Add ClickHouse error code **517 (`CANNOT_ASSIGN_ALTER`)** to `retryableExceptions` in `flow/pkg/clickhouse/query_retry.go`, so schema-delta `ALTER TABLE ... ADD COLUMN` statements retry with the existing backoff instead of failing the whole sync batch.

## The bug

When the destination table is a `Replicated*MergeTree` (self-hosted CH with Keeper), `ReplayTableSchemaDeltas` issues one `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...` per added column, sequentially on one connection, with ~1 ms between statements. On the ClickHouse side each ALTER commits a metadata-version bump to Keeper, but the replica applies it **asynchronously** (typically tens of ms). The next ALTER's assignment check then finds the replica behind and fails:

```
code: 517, message: Metadata on replica is not up to date with common metadata in Zookeeper.
It means that this replica still not applied some of previous alters.
Probably too many alters executing concurrently (highly not recommended). You can retry this error.
```

Because 517 is not in `retryableExceptions`, the error propagates out of `ReplayTableSchemaDeltas` and fails the entire sync batch.

Worse, the failure is **self-sustaining**: when Temporal retries the batch, the first `ADD COLUMN IF NOT EXISTS` is now a no-op (its column already exists) — but a no-op ALTER on a Replicated table *still bumps the shared metadata version* (observed on ClickHouse 26.7.3: the znode version incremented once per retry cycle), so the second column's ALTER hits the same race on **every** replay. We observed a production mirror (MySQL/MariaDB → self-hosted CH, 23 tables) livelock this way for 46 hours — 280 consecutive identical failures at the Temporal retry cadence, CDC fully stopped — after a 4-column source migration. Nothing self-heals; the replica is fully caught up between cycles, and the race re-arms each time.

## The fix

One line: `chproto.ErrCannotAssignAlter` added to `retryableExceptions`. The existing `Exec` backoff (1 s on first retry) is orders of magnitude longer than the replica's metadata apply latency, so the retried ALTER succeeds. We ran this patch on the affected deployment: the wedged batch completed on its first retry and a ~970k-row backlog drained immediately. ClickHouse's own error text explicitly marks the condition retryable.

## Related observation (not changed here)

`flow/connectors/clickhouse/clickhouse.go` sets `"alter_sync": uint64(3)` with the comment "synchronous wait for ALTER commands; skip replicas that are down". In ClickHouse OSS, `alter_sync` valid values are 0/1/2 (26.7.3 treats other values as "do not wait"), which is what leaves the ~1 ms race window in the first place. If 3 is intentional for ClickHouse Cloud, a version/dialect-aware value might be worth considering — happy to file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mr6Ur67uzqbJSgLyME5ZXL
