### PR TITLE
add exclude_snapshot_status to MirrorStatusRequest

### DIFF
--- a/flow/cmd/mirror_status.go
+++ b/flow/cmd/mirror_status.go
@@ -178,12 +178,16 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 		return nil, err
 	}
 
-	initialLoadResponse, apiErr := h.InitialLoadSummary(ctx, &protos.InitialLoadSummaryRequest{
-		ParentMirrorName: req.FlowJobName,
-	})
-	if apiErr != nil {
-		slog.ErrorContext(ctx, "unable to query clone table summary", slog.Any("error", apiErr))
-		return nil, apiErr
+	var snapshotStatus *protos.SnapshotStatus
+	if !req.ExcludeSnapshotStatus {
+		initialLoadResponse, apiErr := h.InitialLoadSummary(ctx, &protos.InitialLoadSummaryRequest{
+			ParentMirrorName: req.FlowJobName,
+		})
+		if apiErr != nil {
+			slog.ErrorContext(ctx, "unable to query clone table summary", slog.Any("error", apiErr))
+			return nil, apiErr
+		}
+		snapshotStatus = &protos.SnapshotStatus{Clones: initialLoadResponse.TableSummaries}
 	}
 
 	var cdcBatches []*protos.CDCBatch
@@ -206,11 +210,9 @@ func (h *FlowRequestHandler) cdcFlowStatus(
 		Config:          config,
 		SourceType:      srcType,
 		DestinationType: dstType,
-		SnapshotStatus: &protos.SnapshotStatus{
-			Clones: initialLoadResponse.TableSummaries,
-		},
-		CdcBatches: cdcBatches,
-		RowsSynced: rowsSynced,
+		SnapshotStatus:  snapshotStatus,
+		CdcBatches:      cdcBatches,
+		RowsSynced:      rowsSynced,
 	}, nil
 }
 

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -2685,6 +2685,20 @@ func (s APITestSuite) TestTotalRowsSyncedByMirror() {
 	}
 	require.Equal(s.t, int64(2), initialLoadRowsSynced)
 
+	// exclusion params keep table mappings while dropping history
+	leanStatusResponse, err := s.MirrorStatus(s.t.Context(), &protos.MirrorStatusRequest{
+		FlowJobName:           flowConnConfig.FlowJobName,
+		IncludeFlowInfo:       true,
+		ExcludeBatches:        true,
+		ExcludeSnapshotStatus: true,
+	})
+	require.NoError(s.t, err)
+	leanCdcStatus := leanStatusResponse.GetCdcStatus()
+	require.NotNil(s.t, leanCdcStatus)
+	require.Nil(s.t, leanCdcStatus.SnapshotStatus)
+	require.Empty(s.t, leanCdcStatus.CdcBatches)
+	require.Len(s.t, leanCdcStatus.Config.TableMappings, 2)
+
 	// check table stats cdc
 	tableStats, err := s.CDCTableTotalCounts(s.t.Context(), &protos.CDCTableTotalCountsRequest{
 		FlowJobName: flowConnConfig.FlowJobName,

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -104,6 +104,7 @@ message MirrorStatusRequest {
   string flow_job_name = 1;
   bool include_flow_info = 2;
   bool exclude_batches = 3;
+  bool exclude_snapshot_status = 4;
 }
 
 message PartitionStatus {

--- a/ui/app/mirrors/[mirrorId]/edit/page.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/page.tsx
@@ -13,6 +13,7 @@ async function getMirrorState(
       flow_job_name: flowJobName,
       include_flow_info: true,
       exclude_batches: true,
+      exclude_snapshot_status: true,
     }),
   });
   if (!res.ok) throw new Error('Mirror not found');

--- a/ui/app/mirrors/[mirrorId]/handlers.ts
+++ b/ui/app/mirrors/[mirrorId]/handlers.ts
@@ -13,6 +13,7 @@ export async function getMirrorState(
       flow_job_name,
       include_flow_info: true,
       exclude_batches: true,
+      exclude_snapshot_status: true,
     }),
   });
   if (!res.ok) throw res.json();


### PR DESCRIPTION
snapshot status grows too much in workloads with frequent add/remove table