### PR TITLE
SyncFlow graceful termination handling

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -350,10 +350,30 @@ func (a *FlowableActivity) SyncFlow(
 	})
 	defer shutdown()
 
+	ctx, cancelCtx := context.WithCancel(ctx)
+	defer cancelCtx()
+
 	ctx = context.WithValue(ctx, shared.FlowNameKey, config.FlowJobName)
 	// This is kept here and not deeper as we can have errors during SetupReplConn
 	ctx = internal.WithOperationContext(ctx, protos.FlowOperation_FLOW_OPERATION_SYNC)
 	logger := internal.LoggerFromCtx(ctx)
+
+	var shutDown atomic.Bool
+	if workerStopChan := activity.GetWorkerStopChannel(ctx); workerStopChan != nil {
+		go func() {
+			select {
+			case <-workerStopChan:
+				logger.Info("worker is stopping, shutting down SyncFlow")
+				shutDown.Store(true)
+				// when worker begins to shut down, worker stop channel is closed immediately,
+				// but it does not cancel the activity context until after WorkerStopTimeout.
+				// so we explicitly call cancelCtx() to gracefully terminate sync and normalize
+				cancelCtx()
+			case <-ctx.Done():
+				// exit guard to prevent goroutine leak
+			}
+		}()
+	}
 
 	destinationType, err := connectors.LoadPeerType(ctx, a.CatalogPool, config.DestinationName)
 	if err != nil {
@@ -450,6 +470,10 @@ func (a *FlowableActivity) SyncFlow(
 	normResponses.Close()
 	<-normDone
 
+	if shutDown.Load() {
+		logger.Info("SyncFlow shutdown")
+		return nil
+	}
 	if ctx.Err() != nil {
 		logger.Info("SyncFlow canceled", slog.Any("error", ctx.Err()))
 		return ctx.Err()

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -841,21 +841,18 @@ func (a *FlowableActivity) normalizeLoop(
 			normalizingBatchID.Store(reqBatchID)
 			if err := a.startNormalize(ctx, config, reqBatchID, normalizeResponses); err != nil {
 				_ = a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
-				for {
-					// update req to latest normalize request & retry
-					select {
-					case <-syncDone:
-						logger.Info("[normalize-loop] syncDone closed before retry")
-						return
-					case <-ctx.Done():
-						logger.Info("[normalize-loop] context closed before retry")
-						return
-					default:
-						time.Sleep(retryInterval)
-						retryInterval = min(retryInterval*2, 5*time.Minute)
-						reqBatchID = normalizeRequests.Load()
-						continue retryLoop
-					}
+				// update req to latest normalize request & retry
+				select {
+				case <-syncDone:
+					logger.Info("[normalize-loop] syncDone closed before retry")
+					return
+				case <-ctx.Done():
+					logger.Info("[normalize-loop] context closed before retry")
+					return
+				case <-time.After(retryInterval):
+					retryInterval = min(retryInterval*2, 5*time.Minute)
+					reqBatchID = normalizeRequests.Load()
+					continue retryLoop
 				}
 			}
 			break

--- a/flow/cmd/worker.go
+++ b/flow/cmd/worker.go
@@ -117,6 +117,9 @@ func WorkerSetup(ctx context.Context, opts *WorkerSetupOptions) (*WorkerSetupRes
 			slog.ErrorContext(ctx, "Peerflow Worker failed", slog.Any("error", err))
 		},
 		MaxHeartbeatThrottleInterval: 10 * time.Second,
+		// on shutdown, give in-flight activities time to drain (SyncFlow watches the
+		// worker stop channel) instead of immediate context cancellation.
+		WorkerStopTimeout: 30 * time.Second,
 	})
 	peerflow.RegisterFlowWorkerWorkflows(w)
 

--- a/flow/pkg/clickhouse/query_retry.go
+++ b/flow/pkg/clickhouse/query_retry.go
@@ -74,7 +74,11 @@ func Exec(ctx context.Context, logger log.Logger,
 		}
 		logger.Info("[exec] retryable error", slog.Any("error", err), slog.Int64("retry", int64(i)))
 		if i < 4 {
-			time.Sleep(time.Second * time.Duration(i*5+1))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second * time.Duration(i*5+1)):
+			}
 		}
 	}
 	if ex, ok := errors.AsType[*clickhouse.Exception](err); ok {
@@ -101,7 +105,11 @@ func Query(ctx context.Context, logger log.Logger,
 		}
 		logger.Info("[query] retryable error", slog.Any("error", err), slog.Int64("retry", int64(i)))
 		if i < 4 {
-			time.Sleep(time.Second * time.Duration(i*5+1))
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Second * time.Duration(i*5+1)):
+			}
 		}
 	}
 	return rows, err
@@ -119,7 +127,11 @@ func QueryRow(ctx context.Context, logger log.Logger,
 		}
 		logger.Info("[queryRow] retryable error", slog.Any("error", err), slog.Int64("retry", int64(i)))
 		if i < 4 {
-			time.Sleep(time.Second * time.Duration(i*5+1))
+			select {
+			case <-ctx.Done():
+				return row
+			case <-time.After(time.Second * time.Duration(i*5+1)):
+			}
 		}
 	}
 	return row

--- a/flow/pkg/clickhouse/query_retry_test.go
+++ b/flow/pkg/clickhouse/query_retry_test.go
@@ -1,0 +1,56 @@
+package clickhouse
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/require"
+)
+
+// retryableErrConn always fails Exec/Query with a retryable ClickHouse exception, triggering retry loop.
+type retryableErrConn struct {
+	driver.Conn
+}
+
+func (retryableErrConn) Exec(context.Context, string, ...any) error {
+	return &clickhouse.Exception{Code: int32(chproto.ErrTooManyParts)}
+}
+
+func (retryableErrConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	return nil, &clickhouse.Exception{Code: int32(chproto.ErrTooManyParts)}
+}
+
+func TestExecRetryBackoffPreemptedByContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := Exec(ctx, nopLogger{}, retryableErrConn{}, "INSERT INTO t VALUES (1)")
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, elapsed, time.Second, "cancellation should preempt the retry backoff")
+}
+
+func TestQueryRetryBackoffPreemptedByContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	rows, err := Query(ctx, nopLogger{}, retryableErrConn{}, "SELECT 1")
+	elapsed := time.Since(start)
+
+	require.Nil(t, rows)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, elapsed, time.Second, "cancellation should preempt the retry backoff")
+}

--- a/flow/workflows/cdc_flow_replay_fixtures_test.go
+++ b/flow/workflows/cdc_flow_replay_fixtures_test.go
@@ -2,6 +2,7 @@ package peerflow
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +73,7 @@ func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
 	t.Run("parked_resume", func(t *testing.T) {
 		wfID, firstRunID := startParkedFlow(ctx, t, c, "parked-resume")
 		require.NoError(t, c.SignalWorkflow(ctx, wfID, firstRunID, model.FlowSignal.Name, model.NoopSignal))
-		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID, time.Minute)
 		exportHistory(ctx, t, c, wfID, firstRunID, "parked_resume")
 		terminateWorkflow(ctx, t, c, wfID)
 	})
@@ -81,7 +82,7 @@ func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
 		wfID, firstRunID := startParkedFlow(ctx, t, c, "parked-config-update")
 		update := &protos.CDCFlowConfigUpdate{BatchSize: 250, IdleTimeout: 33}
 		require.NoError(t, c.SignalWorkflow(ctx, wfID, firstRunID, model.CDCDynamicPropertiesSignal.Name, update))
-		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID, time.Minute)
 		exportHistory(ctx, t, c, wfID, firstRunID, "parked_config_update")
 		terminateWorkflow(ctx, t, c, wfID)
 	})
@@ -90,7 +91,7 @@ func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
 		wfID, firstRunID := startRunningFlow(ctx, t, c, "running-pause")
 		waitPendingActivity(ctx, t, c, wfID, firstRunID, "SyncFlow")
 		require.NoError(t, c.SignalWorkflow(ctx, wfID, firstRunID, model.FlowSignal.Name, model.PauseSignal))
-		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID, time.Minute)
 		exportHistory(ctx, t, c, wfID, firstRunID, "running_pause")
 		terminateWorkflow(ctx, t, c, wfID)
 	})
@@ -100,7 +101,7 @@ func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
 		waitPendingActivity(ctx, t, c, wfID, firstRunID, "SyncFlow")
 		req := &protos.FlowStateChangeRequest{RequestedFlowState: protos.FlowStatus_STATUS_TERMINATING}
 		require.NoError(t, c.SignalWorkflow(ctx, wfID, firstRunID, model.FlowSignalStateChange.Name, req))
-		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID, time.Minute)
 		exportHistory(ctx, t, c, wfID, firstRunID, "running_terminate")
 		terminateWorkflow(ctx, t, c, wfID)
 	})
@@ -109,8 +110,18 @@ func TestGenerateCDCFlowReplayFixtures(t *testing.T) {
 		// the fake SyncFlow returns promptly for this flow name, exercising the
 		// steady-state "sync finished -> ContinueAsNew" path
 		wfID, firstRunID := startRunningFlow(ctx, t, c, "running-sync-finish")
-		waitContinuedAsNew(ctx, t, c, wfID, firstRunID)
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID, time.Minute)
 		exportHistory(ctx, t, c, wfID, firstRunID, "running_sync_finish")
+		terminateWorkflow(ctx, t, c, wfID)
+	})
+
+	t.Run("running_sync_error", func(t *testing.T) {
+		// the fake SyncFlow fails for this flow name, exercising the error path:
+		// ActivityTaskFailed -> backoff timer -> timer fires -> ContinueAsNew.
+		wfID, firstRunID := startRunningFlow(ctx, t, c, "running-sync-error")
+		// give enough time for backoff timer to complete
+		waitContinuedAsNew(ctx, t, c, wfID, firstRunID, 3*time.Minute)
+		exportHistory(ctx, t, c, wfID, firstRunID, "running_sync_error")
 		terminateWorkflow(ctx, t, c, wfID)
 	})
 }
@@ -155,15 +166,21 @@ func registerFakeActivities(w worker.Worker) {
 		activity.RegisterOptions{Name: "UpdateCDCConfigInCatalogActivity"},
 	)
 	w.RegisterActivityWithOptions(
+		// one registration serves all scenarios, so behavior is keyed on flow
+		// name: running-sync-finish needs SyncFlow to complete, running-sync-error
+		// needs SyncFlow to error, and running-pause/-terminate need it stuck in
+		// flight so the signal cancels an active sync
 		func(ctx context.Context, cfg *protos.FlowConnectionConfigsCore, opts *protos.SyncFlowOptions) error {
-			// one registration serves all scenarios, so behavior is keyed on flow
-			// name: running-sync-finish needs SyncFlow to complete (recording the
-			// sync-finished -> ContinueAsNew path), while running-pause/-terminate
-			// need it stuck in flight so the signal cancels an active sync
 			if cfg.FlowJobName == fixtureFlowName("running-sync-finish") {
 				time.Sleep(2 * time.Second)
 				return nil
 			}
+
+			if cfg.FlowJobName == fixtureFlowName("running-sync-error") {
+				time.Sleep(2 * time.Second)
+				return errors.New("simulated sync failure for replay fixture")
+			}
+
 			// block until canceled; heartbeats are required both by the 1-minute
 			// HeartbeatTimeout and to receive the cancellation from the server
 			for {
@@ -264,7 +281,7 @@ func waitPendingActivity(ctx context.Context, t *testing.T, c client.Client, wfI
 	}, time.Minute, 200*time.Millisecond, "activity %s never became pending", activityName)
 }
 
-func waitContinuedAsNew(ctx context.Context, t *testing.T, c client.Client, wfID, runID string) {
+func waitContinuedAsNew(ctx context.Context, t *testing.T, c client.Client, wfID, runID string, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
 		resp, err := c.DescribeWorkflowExecution(ctx, wfID, runID)
@@ -272,7 +289,7 @@ func waitContinuedAsNew(ctx context.Context, t *testing.T, c client.Client, wfID
 			return false
 		}
 		return resp.WorkflowExecutionInfo.Status == enums.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
-	}, time.Minute, 200*time.Millisecond, "run %s never continued-as-new", runID)
+	}, timeout, 200*time.Millisecond, "run %s never continued-as-new", runID)
 }
 
 func exportHistory(ctx context.Context, t *testing.T, c client.Client, wfID, runID, name string) {

--- a/flow/workflows/testdata/replay/running_sync_error.json
+++ b/flow/workflows/testdata/replay/running_sync_error.json
@@ -1,0 +1,489 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-08-26T22:21:34.810355Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048587",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "peer-flow-task-queue",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1lcnJvciIsInRhYmxlTWFwcGluZ3MiOlt7InNvdXJjZVRhYmxlSWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25UYWJsZUlkZW50aWZpZXIiOiJyZXBsYXlfZHN0In1dLCJtYXhCYXRjaFNpemUiOjEwMCwiaWRsZVRpbWVvdXRTZWNvbmRzIjoiMTAifQ=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiIsIkVycm9yQ291bnQiOjAsIkFjdGl2ZVNpZ25hbCI6MCwiQ3VycmVudEZsb3dTdGF0dXMiOjEsIlNuYXBzaG90TnVtUm93c1BlclBhcnRpdGlvbiI6MCwiU25hcHNob3ROdW1QYXJ0aXRpb25zT3ZlcnJpZGUiOjAsIlNuYXBzaG90TWF4UGFyYWxsZWxXb3JrZXJzIjowLCJTbmFwc2hvdE51bVRhYmxlc0luUGFyYWxsZWwiOjB9"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "01a0402a-14da-756a-99ff-ac67cb1de13b",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "firstExecutionRunId": "01a0402a-14da-756a-99ff-ac67cb1de13b",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "replay-fixture-running-sync-error"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-08-26T22:21:34.810395Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048588",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "peer-flow-task-queue",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-08-26T22:21:34.812479Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048593",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "requestId": "3ef9ab5d-ab36-4c50-b0bc-980ab78919be",
+        "historySizeBytes": "1050",
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-08-26T22:21:34.815380Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048597",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            3
+          ],
+          "sdkName": "temporal-go",
+          "sdkVersion": "1.47.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-08-26T22:21:34.815439Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048598",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "GetFlowMetadata"
+        },
+        "taskQueue": {
+          "name": "peer-flow-task-queue",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0NvbnRleHRNZXRhZGF0YUlucHV0"
+              },
+              "data": "eyJmbG93TmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1lcnJvciIsInN0YXR1cyI6IlNUQVRVU19SVU5OSU5HIn0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "60s"
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-08-26T22:21:34.817184Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048604",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "requestId": "140ab382-e511-4e9b-9c2b-3d0fbbb92e4e",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-08-26T22:21:34.820735Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048605",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0NvbnRleHRNZXRhZGF0YQ=="
+              },
+              "data": "eyJmbG93TmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1lcnJvciJ9"
+            }
+          ]
+        },
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "15106@MacBook-Pro-CH.local@"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-08-26T22:21:34.820738Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048606",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "MacBook-Pro-CH.local:8c5003ad-b869-4443-ba49-d9411a323972",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "peer-flow-task-queue"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-08-26T22:21:34.821523Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048610",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "requestId": "66324c13-dfbf-4ad5-8298-ed8a30e8d5ea",
+        "historySizeBytes": "2024",
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-08-26T22:21:34.826858Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048614",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-08-26T22:21:34.826885Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048615",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "11",
+        "activityType": {
+          "name": "SyncFlow"
+        },
+        "taskQueue": {
+          "name": "peer-flow-task-queue",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1lcnJvciIsInRhYmxlTWFwcGluZ3MiOlt7InNvdXJjZVRhYmxlSWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25UYWJsZUlkZW50aWZpZXIiOiJyZXBsYXlfZHN0In1dLCJtYXhCYXRjaFNpemUiOjEwMCwiaWRsZVRpbWVvdXRTZWNvbmRzIjoiMTAifQ=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuU3luY0Zsb3dPcHRpb25z"
+              },
+              "data": "eyJiYXRjaFNpemUiOjEwMCwiaWRsZVRpbWVvdXRTZWNvbmRzIjoiMTAiLCJ0YWJsZU1hcHBpbmdzIjpbeyJzb3VyY2VUYWJsZUlkZW50aWZpZXIiOiJwdWJsaWMucmVwbGF5X3NyYyIsImRlc3RpbmF0aW9uVGFibGVJZGVudGlmaWVyIjoicmVwbGF5X2RzdCJ9XX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "31536000s",
+        "heartbeatTimeout": "60s",
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s",
+          "maximumAttempts": 1
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-08-26T22:21:34.826920Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048616",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJBY3Rpdml0eUlEIjoiMSIsIkFjdGl2aXR5VHlwZSI6InVwZGF0ZUZsb3dTdGF0dXNJbkNhdGFsb2dBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDI2LTA4LTI2VDIyOjIxOjM0LjgyNTAyMjE2NloiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "MQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "10"
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-08-26T22:21:34.827570Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048621",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "requestId": "5b8e1226-4688-489f-b2c2-220e1f27ca9c",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        }
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-08-26T22:21:36.831447Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_FAILED",
+      "taskId": "1048622",
+      "activityTaskFailedEventAttributes": {
+        "failure": {
+          "message": "simulated sync failure for replay fixture",
+          "source": "GoSDK",
+          "applicationFailureInfo": {}
+        },
+        "scheduledEventId": "11",
+        "startedEventId": "13",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-08-26T22:21:36.831458Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048623",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "MacBook-Pro-CH.local:8c5003ad-b869-4443-ba49-d9411a323972",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "peer-flow-task-queue"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-08-26T22:21:36.834526Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048627",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "15",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "requestId": "6577b425-dfee-4f39-b528-5479be403db6",
+        "historySizeBytes": "3524",
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        }
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-08-26T22:21:36.838446Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048631",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "15",
+        "startedEventId": "16",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": "2026-08-26T22:21:36.838528Z",
+      "eventType": "EVENT_TYPE_TIMER_STARTED",
+      "taskId": "1048632",
+      "userMetadata": {
+        "summary": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg=="
+          },
+          "data": "IlNsZWVwIg=="
+        }
+      },
+      "timerStartedEventAttributes": {
+        "timerId": "18",
+        "startToFireTimeout": "60s",
+        "workflowTaskCompletedEventId": "17"
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": "2026-08-26T22:22:36.840243Z",
+      "eventType": "EVENT_TYPE_TIMER_FIRED",
+      "taskId": "1048635",
+      "timerFiredEventAttributes": {
+        "timerId": "18",
+        "startedEventId": "18"
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2026-08-26T22:22:36.840258Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048636",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "MacBook-Pro-CH.local:8c5003ad-b869-4443-ba49-d9411a323972",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "peer-flow-task-queue"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2026-08-26T22:22:36.843633Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048640",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "20",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "requestId": "174d750c-8bc2-4d21-af1b-7d69ea1aa5e8",
+        "historySizeBytes": "3983",
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        }
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": "2026-08-26T22:22:36.849025Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048644",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "20",
+        "startedEventId": "21",
+        "identity": "15106@MacBook-Pro-CH.local@",
+        "workerVersion": {
+          "buildId": "673700b4acefca0dab46ea43dc5d02c6"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": "2026-08-26T22:22:36.849572Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW",
+      "taskId": "1048645",
+      "workflowExecutionContinuedAsNewEventAttributes": {
+        "newExecutionRunId": "d098a2a7-170e-42e3-af99-ac728a822ecb",
+        "workflowType": {
+          "name": "CDCFlowWorkflow"
+        },
+        "taskQueue": {
+          "name": "peer-flow-task-queue",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wcm90b2J1Zg==",
+                "messageType": "cGVlcmRiX2Zsb3cuRmxvd0Nvbm5lY3Rpb25Db25maWdzQ29yZQ=="
+              },
+              "data": "eyJmbG93Sm9iTmFtZSI6InJlcGxheS1maXh0dXJlLXJ1bm5pbmctc3luYy1lcnJvciIsInRhYmxlTWFwcGluZ3MiOlt7InNvdXJjZVRhYmxlSWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25UYWJsZUlkZW50aWZpZXIiOiJyZXBsYXlfZHN0In1dLCJtYXhCYXRjaFNpemUiOjEwMCwiaWRsZVRpbWVvdXRTZWNvbmRzIjoiMTAifQ=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJGbG93Q29uZmlnVXBkYXRlIjpudWxsLCJTeW5jRmxvd09wdGlvbnMiOnsiYmF0Y2hfc2l6ZSI6MTAwLCJpZGxlX3RpbWVvdXRfc2Vjb25kcyI6MTAsInRhYmxlX21hcHBpbmdzIjpbeyJzb3VyY2VfdGFibGVfaWRlbnRpZmllciI6InB1YmxpYy5yZXBsYXlfc3JjIiwiZGVzdGluYXRpb25fdGFibGVfaWRlbnRpZmllciI6InJlcGxheV9kc3QifV19LCJEcm9wRmxvd0lucHV0IjpudWxsLCJMYXN0RXJyb3IiOiIyMDI2LTA4LTI2VDIyOjIxOjM2LjgzNDUyNloiLCJFcnJvckNvdW50IjoxLCJBY3RpdmVTaWduYWwiOjAsIkN1cnJlbnRGbG93U3RhdHVzIjoxLCJTbmFwc2hvdE51bVJvd3NQZXJQYXJ0aXRpb24iOjAsIlNuYXBzaG90TnVtUGFydGl0aW9uc092ZXJyaWRlIjowLCJTbmFwc2hvdE1heFBhcmFsbGVsV29ya2VycyI6MCwiU25hcHNob3ROdW1UYWJsZXNJblBhcmFsbGVsIjowfQ=="
+            }
+          ]
+        },
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "workflowTaskCompletedEventId": "22",
+        "header": {},
+        "inheritBuildId": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
PR can be reviewed commit-by-commit:

1. As part of introducing graceful termination during worker shutdown, we want to make sure that context cancellation are immediately processed and not delayed due to time.sleep pausing execution

2. Adding a Temporal replay test coverage to catch code changes that could lead to indeterminism error during graceful termination. We already have a test case for `running_sync_finish` which is the happy path; this `running_sync_error` is added specifically to address pipe that are `RUNNING` but SyncFlow is [erroring out](https://github.com/PeerDB-io/peerdb/blob/113ffc792a9457434f5792c811cf15d4b0206118/flow/workflows/cdc_flow.go#L865-L894).

3. adds a `WorkerStopTimeout` of 30s (so worker doesn't shutdown immediately on `SIGTERM`) and a goroutine in SyncFlow that watches worker stop channel for worker stopping and triggers context cancellation. With this change, worker with running pipes can shutdown gracefully; workflow that already processed the pause signal (today's case during upgrade) doesn't have running activities, so will shutdown immediately, effectively same behavior as not setting a `WorkerStopTimeout` today.

Fixes: DBI-1050

Testing: 
- test service upgrade without maintenance worker with this graceful termination code, observed logs for `worker stopping, draining sync flow` and `sync flow drained for worker shutdown`. 
- test service upgrade with start-/end-maintenance, observed `sync canceled` when StartMaintenance workflow paused the pipe, and the graceful termination path did not get triggered. 