### PR TITLE
crdb stack/6 resolved buffering

### DIFF
--- a/flow/connectors/cockroachdb/cdc.go
+++ b/flow/connectors/cockroachdb/cdc.go
@@ -99,11 +99,18 @@ func (c *CockroachDBConnector) PullFlowCleanup(ctx context.Context, jobName stri
 // changefeedPullState carries the per-batch state shared between changefeed
 // sessions (a session being one sinkless changefeed query on one connection).
 //
-// A session reconnect replays every message since the last resolved timestamp,
-// so rows delivered before the failure point can be emitted again within one
-// PullRecords batch. Those duplicates are deliberately passed through: PeerDB
-// guarantees at-least-once delivery and destinations already absorb replays,
-// so deduplicating here would only duplicate that responsibility.
+// Converted records are buffered keyed by commit timestamp and row key, and
+// only handed to the record stream once a resolved timestamp at or beyond
+// their commit timestamp arrives; the checkpoint then advances to that same
+// resolved timestamp. Nothing emitted therefore ever lies past the persisted
+// checkpoint, so neither batch boundaries nor session reconnects re-deliver
+// records on the happy path (a reconnect's replays land on the same buffer
+// keys and collapse). Records still buffered when the batch ends are dropped,
+// not emitted: the next batch re-reads them from the cursor, trading a little
+// re-fetch work for exactly-once emission across batches. Delivery overall
+// stays at least once: a crash between emitting and persisting the checkpoint
+// replays, and force-emits under memory pressure (see
+// changefeedBufferSoftLimitBytes) intentionally emit past the checkpoint.
 //
 //nolint:govet // keeping related fields together over alignment
 type changefeedPullState struct {
@@ -112,6 +119,9 @@ type changefeedPullState struct {
 	sourceByEmitted  map[string]string
 	emittedSources   [][2]string
 	schemas          map[string]*changefeedTableSchema
+	buffer           map[string]*bufferedChangefeedRecord
+	bufferSeq        uint64
+	bufferedBytes    int64
 	cursor           crdbHLC
 	resolvedInterval time.Duration
 	recordCount      uint32
@@ -120,6 +130,35 @@ type changefeedPullState struct {
 	lastLagWarnAt    time.Time
 	deltaBytes       atomic.Int64
 	totalBytes       atomic.Int64
+}
+
+// bufferedChangefeedRecord is one converted record waiting for a resolved
+// timestamp to cover it. seq preserves arrival order among records sharing a
+// commit timestamp so emission stays deterministic.
+type bufferedChangefeedRecord struct {
+	record model.Record[model.RecordItems]
+	ts     crdbHLC
+	seq    uint64
+	bytes  int64
+}
+
+// stashRecord buffers a converted record under its commit timestamp and row
+// key. A replayed message (same timestamp, table and key) overwrites its
+// earlier copy instead of queueing a duplicate.
+func (state *changefeedPullState) stashRecord(
+	bufferKey string, record model.Record[model.RecordItems], ts crdbHLC, messageBytes int64,
+) {
+	if prior, ok := state.buffer[bufferKey]; ok {
+		state.bufferedBytes -= prior.bytes
+	}
+	state.bufferSeq++
+	state.buffer[bufferKey] = &bufferedChangefeedRecord{
+		record: record,
+		ts:     ts,
+		seq:    state.bufferSeq,
+		bytes:  messageBytes,
+	}
+	state.bufferedBytes += messageBytes
 }
 
 // indexSource registers a source table under the exact and quote-stripped
@@ -214,6 +253,7 @@ func (c *CockroachDBConnector) PullRecords(
 		tables:           make([]*common.QualifiedTable, 0, len(req.TableNameMapping)),
 		sourceByEmitted:  make(map[string]string, len(req.TableNameMapping)),
 		schemas:          make(map[string]*changefeedTableSchema, len(req.TableNameMapping)),
+		buffer:           make(map[string]*bufferedChangefeedRecord),
 		cursor:           cursor,
 		resolvedInterval: changefeedResolvedInterval,
 	}
@@ -258,6 +298,14 @@ func (c *CockroachDBConnector) PullRecords(
 			attribute.Int64(otel_metrics.RowsInBatchKey, int64(state.recordCount)),
 			attribute.Int64(otel_metrics.BytesPulledKey, state.totalBytes.Load()),
 		)
+		if len(state.buffer) > 0 {
+			// no data loss: nothing buffered was emitted, so the persisted
+			// cursor still precedes these records and the next batch re-reads
+			// them from the changefeed
+			c.logger.Debug("[cockroachdb] leaving records past the final resolved timestamp for the next batch",
+				slog.Int("bufferedRecords", len(state.buffer)),
+				slog.Int64("bufferedBytes", state.bufferedBytes))
+		}
 		c.logger.Info("[cockroachdb] PullRecords finished streaming",
 			slog.Uint64("records", uint64(state.recordCount)),
 			slog.Int64("bytes", state.totalBytes.Load()),
@@ -419,7 +467,7 @@ func (c *CockroachDBConnector) runChangefeedSession(
 				return done, err
 			}
 		} else if tableName.Valid {
-			if err := c.processChangefeedRow(ctx, otelManager, state, tableName.String, key, envelope); err != nil {
+			if err := c.processChangefeedRow(ctx, otelManager, state, tableName.String, key, envelope, messageBytes); err != nil {
 				return false, err
 			}
 		} else {
@@ -428,11 +476,26 @@ func (c *CockroachDBConnector) runChangefeedSession(
 
 		now := time.Now()
 		if !state.graceDeadline.IsZero() && !now.Before(state.graceDeadline) {
+			// the grace window closed without a covering resolved timestamp:
+			// hand over the buffer (emitting past the checkpoint, so it may
+			// replay) rather than cut an empty batch and re-read the same
+			// window next time
+			if err := c.emitBuffered(ctx, state, nil,
+				"batch filled but no covering resolved timestamp arrived within the grace window"); err != nil {
+				return false, err
+			}
 			return true, nil
 		}
-		if state.recordCount > 0 && !now.Before(state.batchDeadline.Add(2*state.resolvedInterval)) {
+		if (state.recordCount > 0 || len(state.buffer) > 0) &&
+			!now.Before(state.batchDeadline.Add(2*state.resolvedInterval)) {
 			// records are flowing but resolved timestamps stalled past the
-			// idle deadline: cut the batch with the last known checkpoint
+			// idle deadline: hand over whatever is buffered (emitting past the
+			// checkpoint, so it may replay) and cut the batch on the last
+			// known checkpoint rather than sit on the data indefinitely
+			if err := c.emitBuffered(ctx, state, nil,
+				"batch deadline passed without a covering resolved timestamp"); err != nil {
+				return false, err
+			}
 			return true, nil
 		}
 		watchdog.Reset(state.watchdogWindow())
@@ -464,8 +527,11 @@ func classifySessionEnd(ctx context.Context, queryCtx context.Context, rowsErr e
 	}
 }
 
-// handleResolved advances the checkpoint: resolved timestamps are the only
-// safe resume points, as row timestamps between them may arrive out of order.
+// handleResolved emits every buffered record the resolved timestamp covers,
+// then advances the checkpoint to it: resolved timestamps are the only safe
+// resume points, as row timestamps between them may arrive out of order, and
+// emitting first keeps everything handed to the stream at or before the
+// checkpoint that will be persisted for it.
 func (c *CockroachDBConnector) handleResolved(
 	ctx context.Context,
 	otelManager *otel_metrics.OtelManager,
@@ -477,6 +543,9 @@ func (c *CockroachDBConnector) handleResolved(
 		return false, err
 	}
 	otelManager.Metrics.CockroachDBResolvedLagGauge.Record(ctx, time.Since(time.Unix(0, ts.WallNanos)).Seconds())
+	if err := c.emitBuffered(ctx, state, &ts, ""); err != nil {
+		return false, err
+	}
 	state.cursor = ts
 	state.req.RecordStream.UpdateLatestCheckpointText(ts.String())
 	state.req.RecordStream.UpdateLatestCheckpointID(ts.WallNanos)
@@ -514,6 +583,7 @@ func (c *CockroachDBConnector) processChangefeedRow(
 	emittedTableName string,
 	key []byte,
 	envelope *changefeedEnvelope,
+	messageBytes int64,
 ) error {
 	source, ok := state.lookupSource(emittedTableName)
 	if !ok {
@@ -608,29 +678,91 @@ func (c *CockroachDBConnector) processChangefeedRow(
 		}
 	}
 
-	if err := state.req.RecordStream.AddRecord(ctx, record); err != nil {
-		return err
-	}
+	// the buffer key is the event's identity: a session reconnect replaying
+	// the same message lands on the same key and overwrites instead of queueing
+	// a duplicate
+	bufferKey := envelope.Updated + "\x00" + emittedTableName + "\x00" + string(key)
+	state.stashRecord(bufferKey, record, updatedTs, messageBytes)
 	otelManager.Metrics.CockroachDBRecordsReceivedCounter.Add(ctx, 1)
-	state.recordCount++
-	if state.recordCount == 1 {
-		state.req.RecordStream.SignalAsNotEmpty()
+	if state.batchDeadline.IsZero() {
 		state.batchDeadline = time.Now().Add(state.req.IdleTimeout)
 	}
-	if state.recordCount >= state.req.MaxBatchSize && state.graceDeadline.IsZero() {
+	if state.bufferedBytes >= changefeedBufferSoftLimitBytes {
+		if err := c.emitBuffered(ctx, state, nil, "buffer size limit reached"); err != nil {
+			return err
+		}
+	}
+	if state.recordCount+uint32(len(state.buffer)) >= state.req.MaxBatchSize && state.graceDeadline.IsZero() {
 		// full batch: allow a short grace period for a final resolved
 		// timestamp so the checkpoint covers the pulled records
 		state.graceDeadline = time.Now().Add(2 * state.resolvedInterval)
-	}
-	if state.recordCount%pullProgressLogInterval == 0 {
-		c.logger.Info("[cockroachdb] PullRecords streaming",
-			slog.Uint64("records", uint64(state.recordCount)),
-			slog.Int64("bytes", state.totalBytes.Load()))
 	}
 
 	commitTime := time.Unix(0, commitWallNanos)
 	otelManager.Metrics.LatestConsumedLogEventGauge.Record(ctx, commitTime.Unix())
 	otelManager.Metrics.SourceLagGauge.Record(ctx, time.Since(commitTime).Milliseconds())
+	return nil
+}
+
+// emitBuffered hands buffered records to the record stream in commit-timestamp
+// order. With upTo set, only records at or before it are emitted (the resolved
+// path, which keeps emissions covered by the checkpoint about to be recorded).
+// With upTo nil the whole buffer is force-emitted past the checkpoint, logged
+// with the reason: those records replay after a restart, which is the
+// pre-buffering behavior and the deliberate trade against unbounded memory.
+func (c *CockroachDBConnector) emitBuffered(
+	ctx context.Context,
+	state *changefeedPullState,
+	upTo *crdbHLC,
+	forceReason string,
+) error {
+	if len(state.buffer) == 0 {
+		return nil
+	}
+	eligible := make([]*bufferedChangefeedRecord, 0, len(state.buffer))
+	keys := make([]string, 0, len(state.buffer))
+	for key, entry := range state.buffer {
+		if upTo == nil || !entry.ts.After(*upTo) {
+			eligible = append(eligible, entry)
+			keys = append(keys, key)
+		}
+	}
+	if len(eligible) == 0 {
+		return nil
+	}
+	if upTo == nil {
+		c.logger.Warn("[cockroachdb] force-emitting buffered records past the checkpoint: "+forceReason,
+			slog.Int("records", len(eligible)),
+			slog.Int64("bufferedBytes", state.bufferedBytes),
+			slog.String("cursor", state.cursor.String()))
+	}
+	slices.SortFunc(eligible, func(a, b *bufferedChangefeedRecord) int {
+		if a.ts != b.ts {
+			if a.ts.After(b.ts) {
+				return 1
+			}
+			return -1
+		}
+		return int(a.seq - b.seq)
+	})
+	for _, entry := range eligible {
+		if err := state.req.RecordStream.AddRecord(ctx, entry.record); err != nil {
+			return err
+		}
+		state.recordCount++
+		if state.recordCount == 1 {
+			state.req.RecordStream.SignalAsNotEmpty()
+		}
+		if state.recordCount%pullProgressLogInterval == 0 {
+			c.logger.Info("[cockroachdb] PullRecords streaming",
+				slog.Uint64("records", uint64(state.recordCount)),
+				slog.Int64("bytes", state.totalBytes.Load()))
+		}
+	}
+	for _, key := range keys {
+		state.bufferedBytes -= state.buffer[key].bytes
+		delete(state.buffer, key)
+	}
 	return nil
 }
 

--- a/flow/connectors/cockroachdb/changefeed.go
+++ b/flow/connectors/cockroachdb/changefeed.go
@@ -49,6 +49,16 @@ const (
 	changefeedManyTablesThreshold = 100
 )
 
+// changefeedBufferSoftLimitBytes caps how much converted-record payload may
+// wait for a resolved timestamp before the buffer is force-emitted. Sized in
+// bytes of raw changefeed message payload rather than record count because a
+// single event can be arbitrarily large. Crossing it trades the no-duplicate
+// guarantee for bounded memory: force-emitted records sit past the persisted
+// checkpoint until the next resolved timestamp covers them, exactly like every
+// record did before buffering existed. A var, not a const, so tests can lower
+// it to exercise the force-emit path.
+var changefeedBufferSoftLimitBytes = int64(128 << 20)
+
 // After reports whether ts is strictly newer than other.
 func (ts crdbHLC) After(other crdbHLC) bool {
 	return ts.WallNanos > other.WallNanos ||

--- a/flow/connectors/cockroachdb/changefeed_test.go
+++ b/flow/connectors/cockroachdb/changefeed_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"strconv"
 	"testing"
 	"time"
 
@@ -860,6 +861,7 @@ func newProcessRowTestState() *changefeedPullState {
 		},
 		sourceByEmitted: make(map[string]string),
 		schemas:         make(map[string]*changefeedTableSchema),
+		buffer:          make(map[string]*bufferedChangefeedRecord),
 	}
 	state.indexSource("defaultdb.public.users", "public.users")
 	state.finishIndexing()
@@ -881,23 +883,102 @@ func TestProcessChangefeedRowFailureThenReplay(t *testing.T) {
 		After:   map[string]json.RawMessage{"id": json.RawMessage(`"not an int"`)},
 		Updated: updated,
 	}
-	err := c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), poisoned)
+	err := c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), poisoned, 10)
 	require.Error(t, err)
 	require.True(t, isPermanentChangefeedError(err), "conversion failures recur on replay and must be permanent")
 	require.Zero(t, state.recordCount)
+	require.Empty(t, state.buffer)
 
-	// the replay delivers a processable version: it must go through
+	// the replay delivers a processable version: it must be buffered
 	valid := &changefeedEnvelope{
 		After:   map[string]json.RawMessage{"id": json.RawMessage(`1`)},
 		Updated: updated,
 	}
-	require.NoError(t, c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), valid))
-	require.Equal(t, uint32(1), state.recordCount)
+	require.NoError(t, c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), valid, 10))
+	require.Zero(t, state.recordCount, "records wait in the buffer until a resolved timestamp covers them")
+	require.Len(t, state.buffer, 1)
 
-	// a replay of an already processed message is passed through again:
-	// PeerDB delivers at least once and the destination absorbs duplicates
-	require.NoError(t, c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), valid))
-	require.Equal(t, uint32(2), state.recordCount)
+	// a replay of an already buffered message overwrites its buffer slot
+	// instead of queueing a duplicate
+	require.NoError(t, c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), valid, 10))
+	require.Len(t, state.buffer, 1)
+	require.Equal(t, int64(10), state.bufferedBytes, "overwrites must not double-count buffered bytes")
+
+	// a resolved timestamp past the row's commit timestamp flushes exactly one
+	// record and advances the cursor
+	resolved := fmt.Sprintf("%d.0000000000", time.Now().UnixNano())
+	done, err := c.handleResolved(ctx, om, state, resolved)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, uint32(1), state.recordCount)
+	require.Empty(t, state.buffer)
+	require.Zero(t, state.bufferedBytes)
+}
+
+func TestChangefeedBufferHoldsRecordsPastResolved(t *testing.T) {
+	ctx := t.Context()
+	om, _ := newMetricsTestOtelManager(t)
+	c := &CockroachDBConnector{logger: log.NewStructuredLogger(slog.Default())}
+	state := newProcessRowTestState()
+
+	base := time.Now().UnixNano()
+	early := &changefeedEnvelope{
+		After:   map[string]json.RawMessage{"id": json.RawMessage(`1`)},
+		Updated: fmt.Sprintf("%d.0000000000", base),
+	}
+	late := &changefeedEnvelope{
+		After:   map[string]json.RawMessage{"id": json.RawMessage(`2`)},
+		Updated: fmt.Sprintf("%d.0000000000", base+2_000_000_000),
+	}
+	require.NoError(t, c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), early, 10))
+	require.NoError(t, c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[2]"), late, 10))
+
+	// a resolved between the two rows emits only the covered one; the other
+	// stays buffered for the next resolved (or gets re-read next batch)
+	resolved := fmt.Sprintf("%d.0000000000", base+1_000_000_000)
+	done, err := c.handleResolved(ctx, om, state, resolved)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, uint32(1), state.recordCount)
+	require.Len(t, state.buffer, 1)
+
+	record := <-state.req.RecordStream.GetRecords()
+	id, err := record.GetItems().GetValueByColName("id")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, id.Value(), "the record at or before the resolved timestamp is the one emitted")
+}
+
+func TestChangefeedBufferForceEmitAtSizeLimit(t *testing.T) {
+	ctx := t.Context()
+	om, _ := newMetricsTestOtelManager(t)
+	c := &CockroachDBConnector{logger: log.NewStructuredLogger(slog.Default())}
+	state := newProcessRowTestState()
+
+	priorLimit := changefeedBufferSoftLimitBytes
+	changefeedBufferSoftLimitBytes = 25
+	t.Cleanup(func() { changefeedBufferSoftLimitBytes = priorLimit })
+
+	base := time.Now().UnixNano()
+	for i := range 3 {
+		envelope := &changefeedEnvelope{
+			After:   map[string]json.RawMessage{"id": json.RawMessage(strconv.Itoa(i + 1))},
+			Updated: fmt.Sprintf("%d.0000000000", base+int64(i)),
+		}
+		require.NoError(t, c.processChangefeedRow(ctx, om, state,
+			"defaultdb.public.users", fmt.Appendf(nil, "[%d]", i+1), envelope, 10))
+	}
+
+	// the third stash crossed the 25-byte limit and force-emitted everything,
+	// past the checkpoint, in commit-timestamp order
+	require.Equal(t, uint32(3), state.recordCount)
+	require.Empty(t, state.buffer)
+	require.Zero(t, state.bufferedBytes)
+	for want := range int64(3) {
+		record := <-state.req.RecordStream.GetRecords()
+		id, err := record.GetItems().GetValueByColName("id")
+		require.NoError(t, err)
+		require.EqualValues(t, want+1, id.Value(), "force-emit must preserve commit-timestamp order")
+	}
 }
 
 func TestProcessChangefeedRowDropPathsFailLoudly(t *testing.T) {
@@ -912,7 +993,7 @@ func TestProcessChangefeedRowDropPathsFailLoudly(t *testing.T) {
 			After:   map[string]json.RawMessage{"id": json.RawMessage(`1`)},
 			Updated: updated,
 		}
-		err := c.processChangefeedRow(ctx, om, state, "defaultdb.public.renamed", []byte("[1]"), envelope)
+		err := c.processChangefeedRow(ctx, om, state, "defaultdb.public.renamed", []byte("[1]"), envelope, 10)
 		require.ErrorContains(t, err, "maps to no source table")
 		require.True(t, isPermanentChangefeedError(err))
 	})
@@ -924,7 +1005,7 @@ func TestProcessChangefeedRowDropPathsFailLoudly(t *testing.T) {
 			After:   map[string]json.RawMessage{"id": json.RawMessage(`1`)},
 			Updated: updated,
 		}
-		err := c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), envelope)
+		err := c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), envelope, 10)
 		require.ErrorContains(t, err, "no cached schema")
 		require.True(t, isPermanentChangefeedError(err))
 	})
@@ -932,7 +1013,7 @@ func TestProcessChangefeedRowDropPathsFailLoudly(t *testing.T) {
 	t.Run("delete with unusable key", func(t *testing.T) {
 		state := newProcessRowTestState()
 		envelope := &changefeedEnvelope{Updated: updated}
-		err := c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte(`[1, 2]`), envelope)
+		err := c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte(`[1, 2]`), envelope, 10)
 		require.ErrorContains(t, err, "key is unusable")
 		require.True(t, isPermanentChangefeedError(err))
 	})
@@ -954,6 +1035,7 @@ func TestChangefeedMetricsRecording(t *testing.T) {
 		},
 		sourceByEmitted: make(map[string]string),
 		schemas:         make(map[string]*changefeedTableSchema),
+		buffer:          make(map[string]*bufferedChangefeedRecord),
 	}
 	state.indexSource("defaultdb.public.users", "public.users")
 	state.finishIndexing()
@@ -962,12 +1044,15 @@ func TestChangefeedMetricsRecording(t *testing.T) {
 		PrimaryKeyColumns: []string{"id"},
 	}, nil)
 
-	updated := fmt.Sprintf("%d.0000000000", time.Now().Add(-time.Minute).UnixNano())
+	// older than the resolved timestamp below so handleResolved flushes the
+	// buffered record (recordCount > 0) instead of taking the idle-mirror
+	// direct-persist path, which needs a real metadata store
+	updated := fmt.Sprintf("%d.0000000000", time.Now().Add(-2*time.Minute).UnixNano())
 	envelope := &changefeedEnvelope{
 		After:   map[string]json.RawMessage{"id": json.RawMessage("1")},
 		Updated: updated,
 	}
-	require.NoError(t, c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), envelope))
+	require.NoError(t, c.processChangefeedRow(ctx, om, state, "defaultdb.public.users", []byte("[1]"), envelope, 10))
 
 	recordsMetric, found := collectMetric(t, ctx, reader, otel_metrics.CockroachDBRecordsReceivedName)
 	require.True(t, found, "records received counter should be collected")

--- a/flow/e2e/cockroachdb_test.go
+++ b/flow/e2e/cockroachdb_test.go
@@ -786,6 +786,85 @@ func (s CockroachDBSuite) Test_CDC_Live_PullRecords() {
 	require.Greater(t, checkpoint2.ID, checkpoint.ID)
 }
 
+// Test_CDC_Exactly_Once_Across_Batches pins the resolved-timestamp buffering
+// behavior: records are emitted only once a resolved timestamp covers them and
+// the checkpoint advances to that same value, so consecutive batches must not
+// re-deliver events on the happy path. A force-emit (buffer cap or a stalled
+// resolved stream) intentionally breaks this and logs a loud warning; if this
+// test ever flakes with a duplicate, check the pull logs for that warning
+// before suspecting the buffering logic.
+func (s CockroachDBSuite) Test_CDC_Exactly_Once_Across_Batches() {
+	t := s.t
+	ctx := t.Context()
+	schema := "e2e_test_" + s.suffix
+	flowName := "cdcexact_" + s.suffix
+	src := schema + ".cdc_exact"
+	require.NoError(t, s.source.Exec(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INT8 PRIMARY KEY, v TEXT)", src)))
+
+	cfConn := s.changefeedConnector(t)
+	_, err := cfConn.SetupReplication(ctx, shared.CatalogPool{}, &protos.SetupReplicationInput{
+		FlowJobName:      flowName,
+		TableNameMapping: map[string]string{src: "cdc_exact_dst"},
+	})
+	require.NoError(t, err)
+	lastOffset, err := cfConn.GetLastOffset(ctx, flowName)
+	require.NoError(t, err)
+
+	tableMappings := []*protos.TableMapping{
+		{SourceTableIdentifier: src, DestinationTableIdentifier: "cdc_exact_dst"},
+	}
+	schemas, err := cfConn.GetTableSchema(ctx, nil, shared.InternalVersion_Latest, protos.TypeSystem_Q, tableMappings)
+	require.NoError(t, err)
+	makeRequest := func(offset model.CdcCheckpoint) *model.PullRecordsRequest[model.RecordItems] {
+		return &model.PullRecordsRequest[model.RecordItems]{
+			FlowJobName:            flowName,
+			TableNameMapping:       map[string]model.NameAndExclude{src: model.NewNameAndExclude("cdc_exact_dst", nil)},
+			TableNameSchemaMapping: map[string]*protos.TableSchema{"cdc_exact_dst": schemas[src]},
+			LastOffset:             offset,
+			MaxBatchSize:           1000,
+			InternalVersion:        shared.InternalVersion_Latest,
+			IdleTimeout:            5 * time.Second,
+		}
+	}
+
+	require.NoError(t, s.source.Exec(ctx, fmt.Sprintf(
+		"INSERT INTO %s SELECT i, 'v' || i::TEXT FROM generate_series(1, 50) AS g(i)", src)))
+	require.NoError(t, s.source.Exec(ctx, fmt.Sprintf("UPDATE %s SET v = 'u2' WHERE id = 2", src)))
+	require.NoError(t, s.source.Exec(ctx, fmt.Sprintf("DELETE FROM %s WHERE id = 3", src)))
+
+	records1, checkpoint1, err := pullOneBatch(t, ctx, cfConn, makeRequest(lastOffset))
+	require.NoError(t, err)
+
+	require.NoError(t, s.source.Exec(ctx, fmt.Sprintf(
+		"INSERT INTO %s SELECT i, 'v' || i::TEXT FROM generate_series(51, 80) AS g(i)", src)))
+	records2, checkpoint2, err := pullOneBatch(t, ctx, cfConn, makeRequest(checkpoint1))
+	require.NoError(t, err)
+	require.Greater(t, checkpoint2.ID, checkpoint1.ID)
+
+	type cdcEvent struct {
+		id   int64
+		kind string
+	}
+	seen := map[cdcEvent]int{}
+	for _, record := range append(append([]model.Record[model.RecordItems]{}, records1...), records2...) {
+		switch typed := record.(type) {
+		case *model.InsertRecord[model.RecordItems]:
+			seen[cdcEvent{typed.Items.GetColumnValue("id").(types.QValueInt64).Val, "insert"}]++
+		case *model.UpdateRecord[model.RecordItems]:
+			seen[cdcEvent{typed.NewItems.GetColumnValue("id").(types.QValueInt64).Val, "update"}]++
+		case *model.DeleteRecord[model.RecordItems]:
+			seen[cdcEvent{typed.Items.GetColumnValue("id").(types.QValueInt64).Val, "delete"}]++
+		default:
+			t.Fatalf("unexpected record type %T", record)
+		}
+	}
+	require.Len(t, seen, 82, "80 inserts + 1 update + 1 delete, each as a distinct event")
+	for event, count := range seen {
+		require.Equal(t, 1, count, "event %v must be emitted exactly once across batches", event)
+	}
+}
+
 func (s CockroachDBSuite) Test_CDC_Schema_Delta_At_Event_Time() {
 	t := s.t
 	ctx := t.Context()


### PR DESCRIPTION
Follow-up to #4669, implementing the buffering discussed on the dedupe thread there and on Slack.

Changefeed events now wait in an in-memory buffer keyed by commit timestamp and row key. When a resolved timestamp arrives, everything it covers is emitted in commit order and the checkpoint advances to that same value, so nothing handed to the stream ever lies past the persisted checkpoint. Batch boundaries stop producing duplicates: records still buffered when a batch ends are dropped and re-read by the next batch from the cursor. Session reconnect replays land on the same buffer keys and collapse.

The buffer is bounded in bytes computed from the raw changefeed message sizes, not record count, since single events can be large. Crossing the cap (128 MiB) or a resolved stream that stalls past the batch deadline force-emits the buffer past the checkpoint with a warning, which is exactly the pre-existing at-least-once behavior, so the degraded mode is the previously reviewed semantics. Delivery overall remains at least once: a crash between emit and checkpoint persist still replays.

Validation: new unit tests for the replay-collapse, partial-emit-at-resolved and force-emit ordering paths, plus a new e2e test (Test_CDC_Exactly_Once_Across_Batches) asserting 82 events arrive exactly once across two consecutive pulls. Full suite run against a 5-node v26.2.5 cluster behind haproxy, 17/17 passing, and unit suites green.