### PR TITLE
mark bigquery.go as not deprecated

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,7 +42,6 @@ deprecated:
           # bigquery_source_test.go) are never auto-labeled as deprecated.
           # (A `!`-negation / `all-globs-to-all-files` block was tried first but
           # silently disables the whole labeler config in actions/labeler v5.)
-          - flow/connectors/bigquery/bigquery.go
           - flow/connectors/bigquery/merge_stmt_generator.go
           - flow/connectors/bigquery/qrep.go
           - flow/connectors/bigquery/qrep_avro_sync.go


### PR DESCRIPTION
bigquery.go needs to be updated for CDC implementation: https://github.com/PeerDB-io/peerdb/pull/4707
de-deprecate it