### PR TITLE
feat(pg-pg): classify generated pkey

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -209,6 +209,9 @@ var (
 	ErrorNotifyConstraintViolation = ErrorClass{
 		Class: "NOTIFY_CONSTRAINT_VIOLATION", action: NotifyUser,
 	}
+	ErrorNotifyGeneratedAlwaysColumn = ErrorClass{
+		Class: "NOTIFY_GENERATED_ALWAYS_COLUMN", action: NotifyUser,
+	}
 	ErrorNotifyInvalidSynchronizedStandbySlots = ErrorClass{
 		Class: "NOTIFY_INVALID_SYNCHRONIZED_STANDBY_SLOTS", action: NotifyUser,
 	}
@@ -797,6 +800,11 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 
 		case pgerrcode.CheckViolation, pgerrcode.UniqueViolation:
 			return ErrorNotifyConstraintViolation, pgErrorInfo
+
+		case pgerrcode.GeneratedAlways:
+			// Destination has a GENERATED ALWAYS column, so an explicit value from the source is rejected
+			// e.g. `cannot insert a non-DEFAULT value into column "id"`
+			return ErrorNotifyGeneratedAlwaysColumn, pgErrorInfo
 
 		case pgerrcode.TooManyConnections, // Maybe we can return something else?
 			pgerrcode.ConnectionException,

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -654,6 +654,21 @@ func TestPostgresUniqueViolationOnNormalize(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresGeneratedAlwaysColumnOnNormalize(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.GeneratedAlways,
+		Message:  `cannot insert a non-DEFAULT value into column "id"`,
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("failed to normalize records: error executing normalize statement for table public.products: %w", err))
+	assert.Equal(t, ErrorNotifyGeneratedAlwaysColumn, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.GeneratedAlways,
+	}, errInfo, "Unexpected error info")
+}
+
 func TestPostgresLogicalDecodingNotSupportedOnStandby(t *testing.T) {
 	err := &pgconn.PgError{
 		Severity: "ERROR",


### PR DESCRIPTION
For tables where the primary key is generated always by identity, non-default values we get in logical replication cannot be inserted.
The user needs to change it to generated by default or serial etc.

This PR wires the notification to the user for this scenario