### PR TITLE
support legacy 0-byte geometry data

### DIFF
--- a/flow/connectors/mysql/qvalue_convert.go
+++ b/flow/connectors/mysql/qvalue_convert.go
@@ -152,6 +152,12 @@ func QRecordSchemaFromMysqlFields(tableSchema *protos.TableSchema, fields []*mys
 // MySQL's internal geometry format is 4-byte SRID (little-endian) followed by standard WKB.
 // SRID is stripped because destinations like ClickHouse don't support EWKT (SRID=N;WKT).
 func processGeometryData(data []byte) (types.QValueGeometry, error) {
+	if len(data) == 0 {
+		// MariaDB and MySQL 5.X store a zero-length value when a NOT NULL geometry column is filled
+		// by an implicit default (e.g. non-strict INSERT, INSERT IGNORE), and such rows survive
+		// upgrades even though they can no longer be created. Map them to an empty string.
+		return types.QValueGeometry{}, nil
+	}
 	if len(data) <= 4 {
 		return types.QValueGeometry{}, fmt.Errorf("geometry data too short: %d bytes", len(data))
 	}

--- a/flow/connectors/mysql/qvalue_convert_test.go
+++ b/flow/connectors/mysql/qvalue_convert_test.go
@@ -159,3 +159,29 @@ func TestCompactMySQLJSON(t *testing.T) {
 	// Invalid JSON falls back to the original bytes rather than dropping the value.
 	require.Equal(t, `not json`, compactMySQLJSON([]byte(`not json`)))
 }
+
+func TestProcessGeometryData(t *testing.T) {
+	qv, err := processGeometryData(nil)
+	require.NoError(t, err)
+	require.Equal(t, types.QValueGeometry{}, qv)
+
+	qv, err = processGeometryData([]byte{})
+	require.NoError(t, err)
+	require.Equal(t, types.QValueGeometry{}, qv)
+
+	// 1-4 bytes cannot be a valid SRID+WKB payload and is still rejected
+	_, err = processGeometryData([]byte{0, 0, 0, 0})
+	require.ErrorContains(t, err, "geometry data too short")
+
+	// SRID prefix + WKB for POINT(1 2)
+	point := []byte{
+		0, 0, 0, 0, // SRID 0
+		1,          // little-endian
+		1, 0, 0, 0, // type: point
+		0, 0, 0, 0, 0, 0, 0xf0, 0x3f, // x = 1
+		0, 0, 0, 0, 0, 0, 0, 0x40, // y = 2
+	}
+	qv, err = processGeometryData(point)
+	require.NoError(t, err)
+	require.Equal(t, "POINT (1 2)", qv.Val)
+}


### PR DESCRIPTION
MySQL 5.7 (and MariaDB) can create zero-byte values for a NOT NULL GEOMETRY column when the column is omitted on insert:
```
mysql> CREATE TABLE `geo` (`id` int primary key, `g` geometry NOT NULL);
Query OK, 0 rows affected (0.02 sec)

mysql> insert into geo (id) values (1);
ERROR 1364 (HY000): Field 'g' doesn't have a default value

mysql> insert ignore into geo (id) values (1);
Query OK, 1 row affected, 1 warning (0.00 sec)

mysql> show warnings;
+---------+------+----------------------------------------+
| Level   | Code | Message                                |
+---------+------+----------------------------------------+
| Warning | 1364 | Field 'g' doesn't have a default value |
+---------+------+----------------------------------------+
1 row in set (0.00 sec)

mysql> select * from geo;
+----+---+
| id | g |
+----+---+
|  1 |   |
+----+---+

```

These values can persist after an upgrade to MySQL 8.x and cause snapshot failures when converting geometry.

Because geometry is propagated as a string in ClickHouse, we can be more lenient here and add support for this. Note that this doesn't fix other destination types where data is propagated as Geometry (e.g. MySQL-> PG, MySQL -> Snowflake), but it is already broken for those cases today so this is not introducing a regression. 

Testing: add unit test; locally test against a mysql 5.7 instance, repro-ed the error,  and after the fix was able to successfully snapshot and cdc into table with empty string in destination.

Fixes: DBI-1043