### PR TITLE
fix(pg-pg): classify pgdump extension missing

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -219,15 +219,13 @@ var (
 	ErrorNotifyConstraintViolation = ErrorClass{
 		Class: "NOTIFY_CONSTRAINT_VIOLATION", action: NotifyUser,
 	}
-<<<<<<< HEAD
-	ErrorNotifyGeneratedAlwaysColumn = ErrorClass{
-		Class: "NOTIFY_GENERATED_ALWAYS_COLUMN", action: NotifyUser,
-=======
 	// The pg_dump automated schema migration failed because the destination is missing an extension
 	// that the source schema depends on; the user must install it on the destination.
 	ErrorNotifyPostgresExtensionNotAvailable = ErrorClass{
 		Class: "NOTIFY_POSTGRES_EXTENSION_NOT_AVAILABLE", action: NotifyUser,
->>>>>>> abf467b05 (fix(pg-pg): classify pgdump extension missing)
+	}
+	ErrorNotifyGeneratedAlwaysColumn = ErrorClass{
+		Class: "NOTIFY_GENERATED_ALWAYS_COLUMN", action: NotifyUser,
 	}
 	ErrorNotifyInvalidSynchronizedStandbySlots = ErrorClass{
 		Class: "NOTIFY_INVALID_SYNCHRONIZED_STANDBY_SLOTS", action: NotifyUser,

--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -82,8 +82,13 @@ var (
 	// e.g. could not open file "pg_logical/snapshots/2-8B023150.snap.8007.tmp": No such file or directory
 	PostgresCouldNotOpenSnapshotRe = regexp.MustCompile(`could not open file ".*\.snap\..*\.tmp"`)
 	PostgresNeonDonorWalLaggingRe  = regexp.MustCompile(`requested WAL up to [0-9A-F]+/[0-9A-F]+, but current donor \S+ has only up to`)
-	MySqlRdsBinlogFileNotFoundRe   = regexp.MustCompile(`File '/rdsdbdata/log/binlog/mysql-bin-changelog.\d+' not found`)
-	MongoPoolClearedErrorRe        = regexp.MustCompile(`connection pool for .+ was cleared because another operation failed with`)
+	// pg_dump automated schema migration failing because the destination lacks an extension the source uses,
+	// e.g. `extension "vector" is not available` or `could not open extension control file ".../vector.control"`.
+	PostgresExtensionNotAvailableRe = regexp.MustCompile(
+		`extension ".*?" is not available|could not open extension control file`,
+	)
+	MySqlRdsBinlogFileNotFoundRe = regexp.MustCompile(`File '/rdsdbdata/log/binlog/mysql-bin-changelog.\d+' not found`)
+	MongoPoolClearedErrorRe      = regexp.MustCompile(`connection pool for .+ was cleared because another operation failed with`)
 )
 
 func (e ErrorAction) String() string {
@@ -214,8 +219,15 @@ var (
 	ErrorNotifyConstraintViolation = ErrorClass{
 		Class: "NOTIFY_CONSTRAINT_VIOLATION", action: NotifyUser,
 	}
+<<<<<<< HEAD
 	ErrorNotifyGeneratedAlwaysColumn = ErrorClass{
 		Class: "NOTIFY_GENERATED_ALWAYS_COLUMN", action: NotifyUser,
+=======
+	// The pg_dump automated schema migration failed because the destination is missing an extension
+	// that the source schema depends on; the user must install it on the destination.
+	ErrorNotifyPostgresExtensionNotAvailable = ErrorClass{
+		Class: "NOTIFY_POSTGRES_EXTENSION_NOT_AVAILABLE", action: NotifyUser,
+>>>>>>> abf467b05 (fix(pg-pg): classify pgdump extension missing)
 	}
 	ErrorNotifyInvalidSynchronizedStandbySlots = ErrorClass{
 		Class: "NOTIFY_INVALID_SYNCHRONIZED_STANDBY_SLOTS", action: NotifyUser,
@@ -1446,6 +1458,15 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			AdditionalAttributes: map[AdditionalErrorAttributeKey]string{
 				ErrorAttributeKeyTable: mongoInvalidIdValueError.Table,
 			},
+		}
+	}
+
+	// pg_dump automated schema migration pipes into psql, so a missing destination extension surfaces
+	// as plain stderr text rather than a *pgconn.PgError.
+	if PostgresExtensionNotAvailableRe.MatchString(err.Error()) {
+		return ErrorNotifyPostgresExtensionNotAvailable, ErrorInfo{
+			Source: ErrorSourcePostgres,
+			Code:   "EXTENSION_NOT_AVAILABLE",
 		}
 	}
 

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -731,6 +731,7 @@ func TestPostgresUniqueViolationOnNormalize(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+<<<<<<< HEAD
 func TestPostgresGeneratedAlwaysColumnOnNormalize(t *testing.T) {
 	err := &pgconn.PgError{
 		Severity: "ERROR",
@@ -744,6 +745,27 @@ func TestPostgresGeneratedAlwaysColumnOnNormalize(t *testing.T) {
 		Source: ErrorSourcePostgres,
 		Code:   pgerrcode.GeneratedAlways,
 	}, errInfo, "Unexpected error info")
+=======
+func TestPostgresExtensionNotAvailableOnSchemaDump(t *testing.T) {
+	for name, message := range map[string]string{
+		"not available": `psql failed: exit status 3
+stderr:
+psql:<stdin>:42: ERROR:  extension "vector" is not available`,
+		"missing control file": `psql failed: exit status 3
+stderr:
+psql:<stdin>:42: ERROR:  could not open extension control file "/usr/share/postgresql/16/extension/vector.control": No such file or directory`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := fmt.Errorf("pg_dump schema migration failed: %s", message)
+			errorClass, errInfo := GetErrorClass(t.Context(), err)
+			assert.Equal(t, ErrorNotifyPostgresExtensionNotAvailable, errorClass, "Unexpected error class")
+			assert.Equal(t, ErrorInfo{
+				Source: ErrorSourcePostgres,
+				Code:   "EXTENSION_NOT_AVAILABLE",
+			}, errInfo, "Unexpected error info")
+		})
+	}
+>>>>>>> abf467b05 (fix(pg-pg): classify pgdump extension missing)
 }
 
 func TestPostgresLogicalDecodingNotSupportedOnStandby(t *testing.T) {

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -731,21 +731,6 @@ func TestPostgresUniqueViolationOnNormalize(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
-<<<<<<< HEAD
-func TestPostgresGeneratedAlwaysColumnOnNormalize(t *testing.T) {
-	err := &pgconn.PgError{
-		Severity: "ERROR",
-		Code:     pgerrcode.GeneratedAlways,
-		Message:  `cannot insert a non-DEFAULT value into column "id"`,
-	}
-	errorClass, errInfo := GetErrorClass(t.Context(),
-		fmt.Errorf("failed to normalize records: error executing normalize statement for table public.products: %w", err))
-	assert.Equal(t, ErrorNotifyGeneratedAlwaysColumn, errorClass, "Unexpected error class")
-	assert.Equal(t, ErrorInfo{
-		Source: ErrorSourcePostgres,
-		Code:   pgerrcode.GeneratedAlways,
-	}, errInfo, "Unexpected error info")
-=======
 func TestPostgresExtensionNotAvailableOnSchemaDump(t *testing.T) {
 	for name, message := range map[string]string{
 		"not available": `psql failed: exit status 3
@@ -765,7 +750,21 @@ psql:<stdin>:42: ERROR:  could not open extension control file "/usr/share/postg
 			}, errInfo, "Unexpected error info")
 		})
 	}
->>>>>>> abf467b05 (fix(pg-pg): classify pgdump extension missing)
+}
+
+func TestPostgresGeneratedAlwaysColumnOnNormalize(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.GeneratedAlways,
+		Message:  `cannot insert a non-DEFAULT value into column "id"`,
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("failed to normalize records: error executing normalize statement for table public.products: %w", err))
+	assert.Equal(t, ErrorNotifyGeneratedAlwaysColumn, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.GeneratedAlways,
+	}, errInfo, "Unexpected error info")
 }
 
 func TestPostgresLogicalDecodingNotSupportedOnStandby(t *testing.T) {


### PR DESCRIPTION
If the target Postgres does not have a custom extension installed which is installed on source, the user must switch to manual schema dump instead. 
This PR wires the notification for this case