### PR TITLE
feat(cloudsql): support GCP workload identity auth

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -2216,13 +2216,13 @@ func (a *FlowableActivity) RunPgDumpSchema(
 		return false, nil
 	}
 
-	// skip schema migration for non-password auth (e.g. IAM)
-	if srcPgConfig.PostgresConfig.AuthType != protos.PostgresAuthType_POSTGRES_PASSWORD {
-		logger.Info("skipping pg_dump schema migration: source peer uses non-password auth")
+	// Skip schema migration for auth modes that cannot provide pg_dump credentials.
+	if !pgDumpSchemaAuthSupported(srcPgConfig.PostgresConfig.AuthType) {
+		logger.Info("skipping pg_dump schema migration: source peer uses unsupported auth")
 		return false, nil
 	}
-	if dstPgConfig.PostgresConfig.AuthType != protos.PostgresAuthType_POSTGRES_PASSWORD {
-		logger.Info("skipping pg_dump schema migration: destination peer uses non-password auth")
+	if !pgDumpSchemaAuthSupported(dstPgConfig.PostgresConfig.AuthType) {
+		logger.Info("skipping pg_dump schema migration: destination peer uses unsupported auth")
 		return false, nil
 	}
 
@@ -2241,4 +2241,9 @@ func (a *FlowableActivity) RunPgDumpSchema(
 	a.Alerter.LogFlowInfo(ctx, input.FlowName,
 		fmt.Sprintf("pg_dump schema migration completed successfully in %s", elapsed))
 	return true, nil
+}
+
+func pgDumpSchemaAuthSupported(authType protos.PostgresAuthType) bool {
+	return authType == protos.PostgresAuthType_POSTGRES_PASSWORD ||
+		authType == protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH
 }

--- a/flow/activities/flowable_test.go
+++ b/flow/activities/flowable_test.go
@@ -1,0 +1,40 @@
+package activities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+)
+
+func TestPgDumpSchemaAuthSupported(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		authType  protos.PostgresAuthType
+		supported bool
+	}{
+		{
+			name:      "password reaches schema dump",
+			authType:  protos.PostgresAuthType_POSTGRES_PASSWORD,
+			supported: true,
+		},
+		{
+			name:      "Cloud SQL IAM reaches schema dump",
+			authType:  protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+			supported: true,
+		},
+		{
+			name:     "AWS IAM remains rejected",
+			authType: protos.PostgresAuthType_POSTGRES_IAM_AUTH,
+		},
+		{
+			name:     "unknown auth remains rejected",
+			authType: protos.PostgresAuthType(99),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.supported, pgDumpSchemaAuthSupported(test.authType))
+		})
+	}
+}

--- a/flow/connectors/bigquery/auth.go
+++ b/flow/connectors/bigquery/auth.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"os"
 	"strings"
 
-	"cloud.google.com/go/auth/credentials"
+	"cloud.google.com/go/auth"
 	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/compute/metadata"
+	"cloud.google.com/go/storage"
 
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 )
 
@@ -20,52 +19,12 @@ const (
 	BigQueryAuthTypeServiceAccount = "service_account"
 	// BigQueryAuthTypeServiceAccountWorkloadIdentity selects deployment-scoped workload identity credentials.
 	BigQueryAuthTypeServiceAccountWorkloadIdentity = "service_account_workload_identity"
-
-	workloadIdentityServiceAccountEnv = "PEERDB_GCP_WORKLOAD_IDENTITY_TARGET_SERVICE_ACCOUNT"
-	//nolint:gosec // Environment variable name, not a credential.
-	workloadIdentityTokenFileEnv       = "PEERDB_GCP_WORKLOAD_IDENTITY_TOKEN_FILE"
-	workloadIdentityProjectIDEnv       = "PEERDB_GCP_PROJECT_ID"
-	workloadIdentityClusterLocationEnv = "PEERDB_GCP_CLUSTER_LOCATION"
-	workloadIdentityClusterNameEnv     = "PEERDB_GCP_CLUSTER_NAME"
-
-	//nolint:gosec // Fixed public Google authentication endpoints, not credentials.
-	googleSTSTokenURL = "https://sts.googleapis.com/v1/token"
-	//nolint:gosec // Fixed public Google authentication endpoints, not credentials.
-	googleIAMCredentialsURL = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
-	//nolint:gosec // OAuth subject-token type identifier, not a credential.
-	jwtSubjectTokenType = "urn:ietf:params:oauth:token-type:jwt"
 )
 
 type bigQueryCredentialConfig struct {
-	credentialType  credentials.CredType
+	authCredentials *auth.Credentials
 	clientProjectID string
 	credentialsJSON []byte
-}
-
-type workloadIdentityDeploymentConfig struct {
-	targetServiceAccount string
-	tokenFile            string
-	projectID            string
-	clusterLocation      string
-	clusterName          string
-}
-
-type externalAccountCredentials struct {
-	Type                           string                          `json:"type"`
-	Audience                       string                          `json:"audience"`
-	SubjectTokenType               string                          `json:"subject_token_type"`
-	TokenURL                       string                          `json:"token_url"`
-	ServiceAccountImpersonationURL string                          `json:"service_account_impersonation_url"`
-	CredentialSource               externalAccountCredentialSource `json:"credential_source"`
-}
-
-type externalAccountCredentialSource struct {
-	File   string                                `json:"file"`
-	Format externalAccountCredentialSourceFormat `json:"format"`
-}
-
-type externalAccountCredentialSourceFormat struct {
-	Type string `json:"type"`
 }
 
 func resolveBigQueryResource(config *protos.BigqueryConfig) (string, string, error) {
@@ -111,7 +70,6 @@ func newBigQueryCredentialConfig(
 		}
 		return &bigQueryCredentialConfig{
 			credentialsJSON: serviceAccountJSON,
-			credentialType:  credentials.ServiceAccount,
 			clientProjectID: bigquery.DetectProjectID,
 		}, nil
 	}
@@ -120,129 +78,15 @@ func newBigQueryCredentialConfig(
 		return nil, fmt.Errorf("BigQuery project ID must be set in the peer when workload identity is selected")
 	}
 
-	deploymentConfig, err := resolveWorkloadIdentityDeploymentConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
-	credentialsJSON, err := deploymentConfig.credentialsJSON()
+	authCredentials, err := utils.NewGCPWorkloadIdentityCredentials(ctx, []string{
+		bigquery.Scope,
+		storage.ScopeFullControl,
+	})
 	if err != nil {
 		return nil, err
 	}
 	return &bigQueryCredentialConfig{
-		credentialsJSON: credentialsJSON,
-		credentialType:  credentials.ExternalAccount,
+		authCredentials: authCredentials,
 		clientProjectID: resourceProjectID,
 	}, nil
-}
-
-func resolveWorkloadIdentityDeploymentConfig(ctx context.Context) (*workloadIdentityDeploymentConfig, error) {
-	targetServiceAccount := envValue(workloadIdentityServiceAccountEnv)
-	if targetServiceAccount == "" {
-		return nil, fmt.Errorf(
-			"BigQuery workload identity requires deployment environment variable %s",
-			workloadIdentityServiceAccountEnv,
-		)
-	}
-	tokenFile := envValue(workloadIdentityTokenFileEnv)
-	if tokenFile == "" {
-		return nil, fmt.Errorf(
-			"BigQuery workload identity requires deployment environment variable %s",
-			workloadIdentityTokenFileEnv,
-		)
-	}
-
-	projectID, err := envOrMetadata(
-		ctx,
-		workloadIdentityProjectIDEnv,
-		"project/project-id",
-	)
-	if err != nil {
-		return nil, err
-	}
-	clusterLocation, err := envOrMetadata(
-		ctx,
-		workloadIdentityClusterLocationEnv,
-		"instance/attributes/cluster-location",
-	)
-	if err != nil {
-		return nil, err
-	}
-	clusterName, err := envOrMetadata(
-		ctx,
-		workloadIdentityClusterNameEnv,
-		"instance/attributes/cluster-name",
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &workloadIdentityDeploymentConfig{
-		targetServiceAccount: targetServiceAccount,
-		tokenFile:            tokenFile,
-		projectID:            projectID,
-		clusterLocation:      clusterLocation,
-		clusterName:          clusterName,
-	}, nil
-}
-
-func envValue(name string) string {
-	value, _ := os.LookupEnv(name)
-	return strings.TrimSpace(value)
-}
-
-func envOrMetadata(
-	ctx context.Context,
-	envName string,
-	metadataPath string,
-) (string, error) {
-	if value := envValue(envName); value != "" {
-		return value, nil
-	}
-	value, err := metadata.GetWithContext(ctx, metadataPath)
-	if err != nil {
-		return "", fmt.Errorf(
-			"BigQuery workload identity requires %s or the corresponding GKE metadata: %w",
-			envName,
-			err,
-		)
-	}
-	if strings.TrimSpace(value) == "" {
-		return "", fmt.Errorf(
-			"BigQuery workload identity requires %s or non-empty corresponding GKE metadata",
-			envName,
-		)
-	}
-	return strings.TrimSpace(value), nil
-}
-
-func (config *workloadIdentityDeploymentConfig) credentialsJSON() ([]byte, error) {
-	pool := config.projectID + ".svc.id.goog"
-	audience := fmt.Sprintf(
-		"identitynamespace:%s:https://container.googleapis.com/v1/projects/%s/locations/%s/clusters/%s",
-		pool,
-		config.projectID,
-		config.clusterLocation,
-		config.clusterName,
-	)
-	credentialConfig := externalAccountCredentials{
-		Type:             "external_account",
-		Audience:         audience,
-		SubjectTokenType: jwtSubjectTokenType,
-		TokenURL:         googleSTSTokenURL,
-		ServiceAccountImpersonationURL: googleIAMCredentialsURL +
-			url.PathEscape(config.targetServiceAccount) + ":generateAccessToken",
-		CredentialSource: externalAccountCredentialSource{
-			// The cloud auth file provider reopens this path for every token exchange,
-			// allowing Kubernetes to rotate the projected token in place.
-			File: config.tokenFile,
-			Format: externalAccountCredentialSourceFormat{
-				Type: "text",
-			},
-		},
-	}
-	credentialsJSON, err := json.Marshal(credentialConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal BigQuery workload identity credentials: %w", err)
-	}
-	return credentialsJSON, nil
 }

--- a/flow/connectors/bigquery/auth_test.go
+++ b/flow/connectors/bigquery/auth_test.go
@@ -1,27 +1,27 @@
 package connbigquery
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
-	"cloud.google.com/go/auth/credentials"
 	"cloud.google.com/go/bigquery"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+)
+
+const (
+	testWorkloadIdentityServiceAccountEnv = "PEERDB_GCP_WORKLOAD_IDENTITY_TARGET_SERVICE_ACCOUNT"
+	//nolint:gosec // Environment variable name, not a credential.
+	testWorkloadIdentityTokenFileEnv       = "PEERDB_GCP_WORKLOAD_IDENTITY_TOKEN_FILE"
+	testWorkloadIdentityProjectIDEnv       = "PEERDB_GCP_PROJECT_ID"
+	testWorkloadIdentityClusterLocationEnv = "PEERDB_GCP_CLUSTER_LOCATION"
+	testWorkloadIdentityClusterNameEnv     = "PEERDB_GCP_CLUSTER_NAME"
 )
 
 func TestBigQueryServiceAccountAuthTypeRemainsLegacy(t *testing.T) {
@@ -43,7 +43,7 @@ func TestBigQueryServiceAccountAuthTypeRemainsLegacy(t *testing.T) {
 
 	credentialConfig, err := newBigQueryCredentialConfig(t.Context(), &config, config.ProjectId)
 	require.NoError(t, err)
-	require.Equal(t, credentials.ServiceAccount, credentialConfig.credentialType)
+	require.Nil(t, credentialConfig.authCredentials)
 	require.Equal(t, bigquery.DetectProjectID, credentialConfig.clientProjectID)
 
 	var credentialsDocument map[string]any
@@ -121,203 +121,8 @@ func TestResolveBigQueryResource(t *testing.T) {
 	}
 }
 
-func TestWorkloadIdentityCredentialsJSON(t *testing.T) {
-	config := workloadIdentityDeploymentConfig{ //nolint:gosec // Test-only fake account and token path.
-		targetServiceAccount: "tenant@tenant-project.iam.gserviceaccount.com",
-		tokenFile:            "/var/run/secrets/peerdb/gcp-token",
-		projectID:            "platform-project",
-		clusterLocation:      "us-central1",
-		clusterName:          "clickpipes",
-	}
-
-	credentialsJSON, err := config.credentialsJSON()
-	require.NoError(t, err)
-
-	var document externalAccountCredentials
-	require.NoError(t, json.Unmarshal(credentialsJSON, &document))
-	require.Equal(t, "external_account", document.Type)
-	require.Equal(t,
-		"identitynamespace:platform-project.svc.id.goog:"+
-			"https://container.googleapis.com/v1/projects/platform-project/locations/us-central1/clusters/clickpipes",
-		document.Audience,
-	)
-	require.Equal(t, jwtSubjectTokenType, document.SubjectTokenType)
-	require.Equal(t, googleSTSTokenURL, document.TokenURL)
-	require.Equal(t,
-		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"+
-			"tenant@tenant-project.iam.gserviceaccount.com:generateAccessToken",
-		document.ServiceAccountImpersonationURL,
-	)
-	require.Equal(t, "/var/run/secrets/peerdb/gcp-token", document.CredentialSource.File)
-	require.Equal(t, "text", document.CredentialSource.Format.Type)
-
-	_, err = credentials.NewCredentialsFromJSON(credentials.ExternalAccount, credentialsJSON, &credentials.DetectOptions{
-		Scopes: []string{bigquery.Scope},
-	})
-	require.NoError(t, err)
-}
-
-func TestWorkloadIdentityCredentialsReloadProjectedToken(t *testing.T) {
-	tokenFile := filepath.Join(t.TempDir(), "projected-token")
-	require.NoError(t, os.WriteFile(tokenFile, []byte("projected-token-one"), 0o600))
-
-	config := workloadIdentityDeploymentConfig{
-		targetServiceAccount: "tenant@tenant-project.iam.gserviceaccount.com",
-		tokenFile:            tokenFile,
-		projectID:            "platform-project",
-		clusterLocation:      "us-central1",
-		clusterName:          "clickpipes",
-	}
-	credentialsJSON, err := config.credentialsJSON()
-	require.NoError(t, err)
-
-	var stsSubjectTokens []string
-	var iamAuthorizationHeaders []string
-	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
-		require.Equal(t, "https", request.URL.Scheme)
-		switch request.URL.Host {
-		case "sts.googleapis.com":
-			require.Equal(t, http.MethodPost, request.Method)
-			require.Equal(t, "/v1/token", request.URL.Path)
-			body, err := io.ReadAll(request.Body)
-			require.NoError(t, err)
-			form, err := url.ParseQuery(string(body))
-			require.NoError(t, err)
-			stsSubjectTokens = append(stsSubjectTokens, form.Get("subject_token"))
-			//nolint:gosec // Test-only fake STS response values.
-			return jsonResponse(t, request, map[string]any{
-				"access_token":      fmt.Sprintf("sts-access-token-%d", len(stsSubjectTokens)),
-				"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
-				"token_type":        "Bearer",
-				"expires_in":        1,
-			}), nil
-		case "iamcredentials.googleapis.com":
-			require.Equal(t, http.MethodPost, request.Method)
-			require.Equal(t,
-				"/v1/projects/-/serviceAccounts/tenant@tenant-project.iam.gserviceaccount.com:generateAccessToken",
-				request.URL.Path,
-			)
-			iamAuthorizationHeaders = append(iamAuthorizationHeaders, request.Header.Get("Authorization"))
-			return jsonResponse(t, request, map[string]any{
-				"accessToken": fmt.Sprintf("tenant-access-token-%d", len(iamAuthorizationHeaders)),
-				"expireTime":  time.Now().Add(time.Second).UTC().Format(time.RFC3339),
-			}), nil
-		default:
-			return nil, fmt.Errorf("unexpected request URL %s", request.URL)
-		}
-	})
-
-	creds, err := credentials.NewCredentialsFromJSON(
-		credentials.ExternalAccount,
-		credentialsJSON,
-		&credentials.DetectOptions{
-			Scopes: []string{bigquery.Scope},
-			Client: &http.Client{Transport: transport},
-		},
-	)
-	require.NoError(t, err)
-
-	firstToken, err := creds.Token(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, "tenant-access-token-1", firstToken.Value)
-	require.Equal(t, []string{"projected-token-one"}, stsSubjectTokens)
-	require.Equal(t, []string{"Bearer sts-access-token-1"}, iamAuthorizationHeaders)
-
-	require.NoError(t, os.WriteFile(tokenFile, []byte("projected-token-two"), 0o600))
-	time.Sleep(time.Until(firstToken.Expiry) + time.Second)
-
-	secondToken, err := creds.Token(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, "tenant-access-token-2", secondToken.Value)
-	require.Equal(t, []string{"projected-token-one", "projected-token-two"}, stsSubjectTokens)
-	require.Equal(t,
-		[]string{"Bearer sts-access-token-1", "Bearer sts-access-token-2"},
-		iamAuthorizationHeaders,
-	)
-}
-
-func TestResolveWorkloadIdentityDeploymentConfig(t *testing.T) {
-	t.Setenv(workloadIdentityServiceAccountEnv, "tenant@tenant-project.iam.gserviceaccount.com")
-	t.Setenv(workloadIdentityTokenFileEnv, "/token")
-	t.Setenv(workloadIdentityProjectIDEnv, "")
-	t.Setenv(workloadIdentityClusterLocationEnv, "")
-	t.Setenv(workloadIdentityClusterNameEnv, "")
-
-	metadataValues := map[string]string{
-		"/computeMetadata/v1/project/project-id":                   "metadata-project",
-		"/computeMetadata/v1/instance/attributes/cluster-location": "metadata-location",
-		"/computeMetadata/v1/instance/attributes/cluster-name":     "metadata-cluster",
-	}
-	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		assert.Equal(t, "Google", request.Header.Get("Metadata-Flavor"))
-		value, ok := metadataValues[request.URL.Path]
-		assert.True(t, ok, "unexpected metadata path %s", request.URL.Path)
-		_, _ = response.Write([]byte(value))
-	}))
-	defer server.Close()
-	t.Setenv("GCE_METADATA_HOST", strings.TrimPrefix(server.URL, "http://"))
-
-	config, err := resolveWorkloadIdentityDeploymentConfig(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, "metadata-project", config.projectID)
-	require.Equal(t, "metadata-location", config.clusterLocation)
-	require.Equal(t, "metadata-cluster", config.clusterName)
-}
-
-func TestResolveWorkloadIdentityDeploymentConfigMissing(t *testing.T) {
-	tests := []struct {
-		name        string
-		environment map[string]string
-		wantError   string
-	}{
-		{
-			name:      "target service account",
-			wantError: workloadIdentityServiceAccountEnv,
-		},
-		{
-			name: "token file",
-			environment: map[string]string{
-				workloadIdentityServiceAccountEnv: "tenant@tenant-project.iam.gserviceaccount.com",
-			},
-			wantError: workloadIdentityTokenFileEnv,
-		},
-		{
-			name: "project context",
-			environment: map[string]string{
-				workloadIdentityServiceAccountEnv: "tenant@tenant-project.iam.gserviceaccount.com",
-				workloadIdentityTokenFileEnv:      "/token",
-			},
-			wantError: workloadIdentityProjectIDEnv,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			for _, name := range []string{
-				workloadIdentityServiceAccountEnv,
-				workloadIdentityTokenFileEnv,
-				workloadIdentityProjectIDEnv,
-				workloadIdentityClusterLocationEnv,
-				workloadIdentityClusterNameEnv,
-			} {
-				t.Setenv(name, test.environment[name])
-			}
-			server := httptest.NewServer(http.NotFoundHandler())
-			defer server.Close()
-			t.Setenv("GCE_METADATA_HOST", strings.TrimPrefix(server.URL, "http://"))
-
-			_, err := resolveWorkloadIdentityDeploymentConfig(t.Context())
-			require.ErrorContains(t, err, test.wantError)
-		})
-	}
-}
-
 func TestWorkloadIdentityUsesExplicitResourceProject(t *testing.T) {
-	t.Setenv(workloadIdentityServiceAccountEnv, "tenant@tenant-project.iam.gserviceaccount.com")
-	t.Setenv(workloadIdentityTokenFileEnv, "/token")
-	t.Setenv(workloadIdentityProjectIDEnv, "platform-project")
-	t.Setenv(workloadIdentityClusterLocationEnv, "us-central1")
-	t.Setenv(workloadIdentityClusterNameEnv, "clickpipes")
+	setBigQueryWorkloadIdentityEnv(t)
 
 	config := &protos.BigqueryConfig{
 		ProjectId: "resource-project",
@@ -330,8 +135,8 @@ func TestWorkloadIdentityUsesExplicitResourceProject(t *testing.T) {
 
 	credentialConfig, err := newBigQueryCredentialConfig(t.Context(), config, projectID)
 	require.NoError(t, err)
-	require.Equal(t, credentials.ExternalAccount, credentialConfig.credentialType)
 	require.Equal(t, "resource-project", credentialConfig.clientProjectID)
+	require.NotNil(t, credentialConfig.authCredentials)
 }
 
 func TestValidateBigQueryConnectionWithoutDefaultDataset(t *testing.T) {
@@ -384,36 +189,25 @@ func TestWorkloadIdentityRequiresPeerProject(t *testing.T) {
 }
 
 func TestWorkloadIdentityCredentialConfigReportsMissingDeploymentConfig(t *testing.T) {
-	t.Setenv(workloadIdentityServiceAccountEnv, "")
-	t.Setenv(workloadIdentityTokenFileEnv, "")
-	t.Setenv(workloadIdentityProjectIDEnv, "")
-	t.Setenv(workloadIdentityClusterLocationEnv, "")
-	t.Setenv(workloadIdentityClusterNameEnv, "")
+	t.Setenv(testWorkloadIdentityServiceAccountEnv, "")
+	t.Setenv(testWorkloadIdentityTokenFileEnv, "")
+	t.Setenv(testWorkloadIdentityProjectIDEnv, "")
+	t.Setenv(testWorkloadIdentityClusterLocationEnv, "")
+	t.Setenv(testWorkloadIdentityClusterNameEnv, "")
 
 	config := &protos.BigqueryConfig{
 		ProjectId: "resource-project",
 		AuthType:  BigQueryAuthTypeServiceAccountWorkloadIdentity,
 	}
 	_, err := newBigQueryCredentialConfig(t.Context(), config, config.ProjectId)
-	require.ErrorContains(t, err, workloadIdentityServiceAccountEnv)
+	require.ErrorContains(t, err, testWorkloadIdentityServiceAccountEnv)
 }
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
-	return fn(request)
-}
-
-func jsonResponse(t *testing.T, request *http.Request, value any) *http.Response {
+func setBigQueryWorkloadIdentityEnv(t *testing.T) {
 	t.Helper()
-	body, err := json.Marshal(value)
-	require.NoError(t, err)
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Header: http.Header{
-			"Content-Type": []string{"application/json"},
-		},
-		Body:    io.NopCloser(bytes.NewReader(body)),
-		Request: request,
-	}
+	t.Setenv(testWorkloadIdentityServiceAccountEnv, "tenant@tenant-project.iam.gserviceaccount.com")
+	t.Setenv(testWorkloadIdentityTokenFileEnv, "/token")
+	t.Setenv(testWorkloadIdentityProjectIDEnv, "platform-project")
+	t.Setenv(testWorkloadIdentityClusterLocationEnv, "us-central1")
+	t.Setenv(testWorkloadIdentityClusterNameEnv, "clickpipes")
 }

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -83,12 +83,8 @@ func NewBigQueryConnector(ctx context.Context, config *protos.BigqueryConfig) (*
 		},
 	}
 	var creds *auth.Credentials
-	if credentialConfig.credentialType == credentials.ExternalAccount {
-		creds, err = credentials.NewCredentialsFromJSON(
-			credentials.ExternalAccount,
-			credentialConfig.credentialsJSON,
-			detectOptions,
-		)
+	if credentialConfig.authCredentials != nil {
+		creds = credentialConfig.authCredentials
 	} else {
 		// Keep the legacy service-account-key path unchanged.
 		detectOptions.CredentialsJSON = credentialConfig.credentialsJSON //nolint:staticcheck // Preserve legacy service-account-key behavior.

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"cmp"
 	"context"
-	"crypto/tls"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -396,16 +395,9 @@ func (c *MySqlConnector) buildBinlogSyncerConfig(
 	ctx context.Context,
 	env map[string]string,
 ) (replication.BinlogSyncerConfig, error) {
-	var tlsConfig *tls.Config
-	if !c.config.DisableTls {
-		var err error
-		tlsConfig, err = common.CreateTlsConfig(
-			tls.VersionTLS12, c.config.RootCa, c.config.Host, c.config.TlsHost, c.config.SkipCertVerification,
-			nil,
-		)
-		if err != nil {
-			return replication.BinlogSyncerConfig{}, err
-		}
+	tlsConfig, err := mySQLTLSConfig(c.config)
+	if err != nil {
+		return replication.BinlogSyncerConfig{}, err
 	}
 	config, err := c.configWithAuthToken(ctx, true)
 	if err != nil {

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -30,9 +30,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/text/encoding"
-	"google.golang.org/protobuf/proto"
 
-	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
 	"github.com/PeerDB-io/peerdb/flow/connectors/utils/monitoring"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
@@ -387,6 +385,17 @@ func (c *MySqlConnector) SetupReplConn(context.Context, map[string]string) error
 }
 
 func (c *MySqlConnector) startSyncer(ctx context.Context, env map[string]string) (*replication.BinlogSyncer, error) {
+	config, err := c.buildBinlogSyncerConfig(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	return replication.NewBinlogSyncer(config), nil
+}
+
+func (c *MySqlConnector) buildBinlogSyncerConfig(
+	ctx context.Context,
+	env map[string]string,
+) (replication.BinlogSyncerConfig, error) {
 	var tlsConfig *tls.Config
 	if !c.config.DisableTls {
 		var err error
@@ -395,31 +404,17 @@ func (c *MySqlConnector) startSyncer(ctx context.Context, env map[string]string)
 			nil,
 		)
 		if err != nil {
-			return nil, err
+			return replication.BinlogSyncerConfig{}, err
 		}
 	}
-	config := c.config
-	if c.rdsAuth != nil {
-		c.logger.Info("Setting up IAM auth for MySQL replication")
-		host := c.config.Host
-		if c.config.TlsHost != "" {
-			host = c.config.TlsHost
-		}
-		token, err := utils.GetRDSToken(ctx, utils.RDSConnectionConfig{
-			Host: host,
-			Port: config.Port,
-			User: config.User,
-		}, c.rdsAuth, "MYSQL")
-		if err != nil {
-			return nil, err
-		}
-		config = proto.CloneOf(config)
-		config.Password = token
+	config, err := c.configWithAuthToken(ctx, true)
+	if err != nil {
+		return replication.BinlogSyncerConfig{}, err
 	}
 
 	eventCacheCount, err := internal.PeerDBMySQLEventCacheCount(ctx, env)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get event cache count: %w", err)
+		return replication.BinlogSyncerConfig{}, fmt.Errorf("failed to get event cache count: %w", err)
 	}
 
 	var serverId uint32
@@ -432,7 +427,7 @@ func (c *MySqlConnector) startSyncer(ctx context.Context, env map[string]string)
 		serverId = 1000 + rand.Uint32()%(math.MaxUint32-1000) //nolint:gosec // G404: server_id does not require cryptographic randomness
 	}
 
-	return replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+	return replication.BinlogSyncerConfig{
 		ServerID:              serverId,
 		Flavor:                c.Flavor(),
 		Host:                  config.Host,
@@ -450,7 +445,7 @@ func (c *MySqlConnector) startSyncer(ctx context.Context, env map[string]string)
 		HeartbeatPeriod:       c.binlogHeartbeatPeriod,
 		EventCacheCount:       eventCacheCount,
 		RowsEventDecodeFunc:   decodeRowsEvent,
-	}), nil
+	}, nil
 }
 
 func (c *MySqlConnector) startStreaming(

--- a/flow/connectors/mysql/cloudsql_test.go
+++ b/flow/connectors/mysql/cloudsql_test.go
@@ -1,0 +1,172 @@
+package connmysql
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/auth"
+	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
+)
+
+func TestMySQLCloudSQLAuthModeAndTLSValidation(t *testing.T) {
+	for name, authType := range map[string]protos.MySqlAuthType{
+		"password": protos.MySqlAuthType_MYSQL_PASSWORD,
+		"AWS IAM":  protos.MySqlAuthType_MYSQL_IAM_AUTH,
+	} {
+		t.Run(name+" remains unchanged", func(t *testing.T) {
+			provider, err := newMySQLCloudSQLTokenProviderWithFactory(
+				t.Context(),
+				&protos.MySqlConfig{AuthType: authType},
+				unexpectedMySQLCredentialsFactory,
+			)
+			require.NoError(t, err)
+			require.Nil(t, provider)
+		})
+	}
+
+	provider, err := newMySQLCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		&protos.MySqlConfig{
+			AuthType:   protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+			DisableTls: true,
+		},
+		unexpectedMySQLCredentialsFactory,
+	)
+	require.Nil(t, provider)
+	require.ErrorContains(t, err, "requires TLS")
+	_, err = NewMySqlConnector(t.Context(), &protos.MySqlConfig{
+		AuthType:   protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+		DisableTls: true,
+	})
+	require.ErrorContains(t, err, "requires TLS")
+
+	provider, err = newMySQLCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		&protos.MySqlConfig{
+			AuthType:             protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+			SkipCertVerification: true,
+		},
+		unexpectedMySQLCredentialsFactory,
+	)
+	require.Nil(t, provider)
+	require.ErrorContains(t, err, "requires certificate verification")
+	_, err = NewMySqlConnector(t.Context(), &protos.MySqlConfig{
+		AuthType:             protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+		SkipCertVerification: true,
+	})
+	require.ErrorContains(t, err, "requires certificate verification")
+
+	config := &protos.MySqlConfig{
+		User:     "configured-db-user",
+		AuthType: protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+	}
+	var scopes []string
+	provider, err = newMySQLCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		config,
+		func(_ context.Context, requestedScopes []string) (auth.TokenProvider, error) {
+			scopes = requestedScopes
+			return &mysqlSequenceTokenProvider{values: []string{"token"}}, nil
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	require.Equal(t, []string{utils.GCPCloudSQLLoginScope}, scopes)
+	require.Equal(t, "configured-db-user", config.User)
+}
+
+func TestMySQLCloudSQLEmptyTokenRejected(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		token *auth.Token
+	}{
+		{name: "nil token"},
+		{name: "empty token", token: &auth.Token{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := &protos.MySqlConfig{
+				User:     "configured-db-user",
+				Password: "persisted-password",
+			}
+			connector := &MySqlConnector{
+				config:       config,
+				cloudSQLAuth: mysqlTokenResultProvider{token: test.token},
+			}
+
+			prepared, err := connector.configWithAuthToken(t.Context(), false)
+			require.Nil(t, prepared)
+			require.ErrorContains(t, err, "token is empty")
+			require.Equal(t, "configured-db-user", config.User)
+			require.Equal(t, "persisted-password", config.Password)
+		})
+	}
+}
+
+func TestMySQLCloudSQLTokenAppliedToOrdinaryAndBinlogConfigs(t *testing.T) {
+	provider := &mysqlSequenceTokenProvider{values: []string{"ordinary-token", "binlog-token"}}
+	config := &protos.MySqlConfig{
+		Host:       "db.example.com",
+		Port:       3306,
+		User:       "configured-db-user",
+		Password:   "persisted-password",
+		Flavor:     protos.MySqlFlavor_MYSQL_MYSQL,
+		DisableTls: false,
+	}
+	connector := &MySqlConnector{
+		logger:       internal.LoggerFromCtx(t.Context()),
+		config:       config,
+		cloudSQLAuth: provider,
+	}
+
+	ordinaryConfig, err := connector.configWithAuthToken(t.Context(), false)
+	require.NoError(t, err)
+	binlogConfig, err := connector.buildBinlogSyncerConfig(t.Context(), map[string]string{
+		"PEERDB_MYSQL_EVENT_CACHE_COUNT": "10240",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "configured-db-user", ordinaryConfig.User)
+	require.Equal(t, "ordinary-token", ordinaryConfig.Password)
+	require.Equal(t, "configured-db-user", binlogConfig.User)
+	require.Equal(t, "binlog-token", binlogConfig.Password)
+	require.Equal(t, 2, provider.calls)
+	require.Equal(t, "persisted-password", config.Password)
+}
+
+func TestMySQLPasswordConfigRemainsUnchanged(t *testing.T) {
+	config := &protos.MySqlConfig{User: "configured-db-user", Password: "password"}
+	connector := &MySqlConnector{config: config}
+
+	prepared, err := connector.configWithAuthToken(t.Context(), false)
+	require.NoError(t, err)
+	require.Same(t, config, prepared)
+	require.Equal(t, "configured-db-user", prepared.User)
+	require.Equal(t, "password", prepared.Password)
+}
+
+type mysqlSequenceTokenProvider struct {
+	values []string
+	calls  int
+}
+
+func (provider *mysqlSequenceTokenProvider) Token(context.Context) (*auth.Token, error) {
+	value := provider.values[provider.calls]
+	provider.calls++
+	return &auth.Token{Value: value}, nil
+}
+
+type mysqlTokenResultProvider struct {
+	token *auth.Token
+}
+
+func (provider mysqlTokenResultProvider) Token(context.Context) (*auth.Token, error) {
+	return provider.token, nil
+}
+
+func unexpectedMySQLCredentialsFactory(context.Context, []string) (auth.TokenProvider, error) {
+	panic("credentials factory should not be called")
+}

--- a/flow/connectors/mysql/cloudsql_test.go
+++ b/flow/connectors/mysql/cloudsql_test.go
@@ -2,7 +2,15 @@ package connmysql
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/auth"
 	"github.com/stretchr/testify/require"
@@ -60,9 +68,33 @@ func TestMySQLCloudSQLAuthModeAndTLSValidation(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "requires certificate verification")
 
+	provider, err = newMySQLCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		&protos.MySqlConfig{AuthType: protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH},
+		unexpectedMySQLCredentialsFactory,
+	)
+	require.Nil(t, provider)
+	require.ErrorContains(t, err, "without tls_host requires a non-empty root CA")
+	_, err = NewMySqlConnector(t.Context(), &protos.MySqlConfig{
+		AuthType: protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+	})
+	require.ErrorContains(t, err, "without tls_host requires a non-empty root CA")
+	emptyRootCA := ""
+	provider, err = newMySQLCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		&protos.MySqlConfig{
+			AuthType: protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+			RootCa:   &emptyRootCA,
+		},
+		unexpectedMySQLCredentialsFactory,
+	)
+	require.Nil(t, provider)
+	require.ErrorContains(t, err, "requires a non-empty root CA")
+
 	config := &protos.MySqlConfig{
 		User:     "configured-db-user",
 		AuthType: protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+		TlsHost:  "cloudsql.google.internal",
 	}
 	var scopes []string
 	provider, err = newMySQLCloudSQLTokenProviderWithFactory(
@@ -77,6 +109,35 @@ func TestMySQLCloudSQLAuthModeAndTLSValidation(t *testing.T) {
 	require.NotNil(t, provider)
 	require.Equal(t, []string{utils.GCPCloudSQLLoginScope}, scopes)
 	require.Equal(t, "configured-db-user", config.User)
+}
+
+func TestMySQLCloudSQLTLSIdentityPolicy(t *testing.T) {
+	_, err := mySQLTLSConfig(&protos.MySqlConfig{
+		Host:     "synthetic-rpe-alias.internal",
+		AuthType: protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+	})
+	require.ErrorContains(t, err, "requires a non-empty root CA")
+
+	rootCA := generateMySQLRootCA(t)
+	chainOnlyConfig, err := mySQLTLSConfig(&protos.MySqlConfig{
+		Host:     "synthetic-rpe-alias.internal",
+		AuthType: protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+		RootCa:   &rootCA,
+	})
+	require.NoError(t, err)
+	require.True(t, chainOnlyConfig.InsecureSkipVerify)
+	require.NotNil(t, chainOnlyConfig.VerifyConnection)
+	require.Empty(t, chainOnlyConfig.ServerName)
+
+	tlsHostConfig, err := mySQLTLSConfig(&protos.MySqlConfig{
+		Host:     "synthetic-rpe-alias.internal",
+		AuthType: protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH,
+		TlsHost:  "cloudsql.google.internal",
+	})
+	require.NoError(t, err)
+	require.False(t, tlsHostConfig.InsecureSkipVerify)
+	require.Nil(t, tlsHostConfig.VerifyConnection)
+	require.Equal(t, "cloudsql.google.internal", tlsHostConfig.ServerName)
 }
 
 func TestMySQLCloudSQLEmptyTokenRejected(t *testing.T) {
@@ -169,4 +230,22 @@ func (provider mysqlTokenResultProvider) Token(context.Context) (*auth.Token, er
 
 func unexpectedMySQLCredentialsFactory(context.Context, []string) (auth.TokenProvider, error) {
 	panic("credentials factory should not be called")
+}
+
+func generateMySQLRootCA(t *testing.T) string {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	certificate, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate}))
 }

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -152,6 +152,10 @@ func newMySQLCloudSQLTokenProviderWithFactory(
 	if config.SkipCertVerification {
 		return nil, fmt.Errorf("MySQL Cloud SQL IAM authentication requires certificate verification")
 	}
+	if strings.TrimSpace(config.TlsHost) == "" &&
+		(config.RootCa == nil || strings.TrimSpace(config.GetRootCa()) == "") {
+		return nil, fmt.Errorf("MySQL Cloud SQL IAM authentication without tls_host requires a non-empty root CA")
+	}
 	credentials, err := credentialsFactory(ctx, []string{utils.GCPCloudSQLLoginScope})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MySQL Cloud SQL IAM credentials: %w", err)
@@ -229,15 +233,12 @@ func (c *MySqlConnector) connect(ctx context.Context) (*client.Conn, error) {
 					return err
 				}
 			}
-			if !c.config.DisableTls {
-				config, err := common.CreateTlsConfig(
-					tls.VersionTLS12, c.config.RootCa, c.config.Host, c.config.TlsHost, c.config.SkipCertVerification,
-					nil,
-				)
-				if err != nil {
-					return err
-				}
-				conn.SetTLSConfig(config)
+			tlsConfig, err := mySQLTLSConfig(c.config)
+			if err != nil {
+				return err
+			}
+			if tlsConfig != nil {
+				conn.SetTLSConfig(tlsConfig)
 			}
 			return nil
 		}}
@@ -260,6 +261,26 @@ func (c *MySqlConnector) connect(ctx context.Context) (*client.Conn, error) {
 		}
 	}
 	return conn, nil
+}
+
+func mySQLTLSConfig(config *protos.MySqlConfig) (*tls.Config, error) {
+	if config.DisableTls {
+		return nil, nil
+	}
+	var tlsOptions []common.TLSConfigOption
+	if config.AuthType == protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH &&
+		strings.TrimSpace(config.TlsHost) == "" {
+		tlsOptions = append(tlsOptions, common.WithCertificateChainOnlyVerification())
+	}
+	return common.CreateTlsConfig(
+		tls.VersionTLS12,
+		config.RootCa,
+		config.Host,
+		config.TlsHost,
+		config.SkipCertVerification,
+		nil,
+		tlsOptions...,
+	)
 }
 
 func (c *MySqlConnector) configWithAuthToken(

--- a/flow/connectors/mysql/mysql.go
+++ b/flow/connectors/mysql/mysql.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"cloud.google.com/go/auth"
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"go.temporal.io/sdk/log"
@@ -37,6 +38,7 @@ type MySqlConnector struct {
 	contexts             atomic.Pointer[chan context.Context]
 	ssh                  *utils.SSHTunnel
 	rdsAuth              *utils.RDSAuth
+	cloudSQLAuth         auth.TokenProvider
 	config               *protos.MySqlConfig
 	*metadataStore.PostgresMetadata
 	warnedUnsupportedEventTypes sync.Map
@@ -51,6 +53,10 @@ type MySqlConnector struct {
 }
 
 func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlConnector, error) {
+	cloudSQLAuth, err := newMySQLCloudSQLTokenProvider(ctx, config)
+	if err != nil {
+		return nil, err
+	}
 	pgMetadata, err := metadataStore.NewPostgresMetadata(ctx)
 	if err != nil {
 		return nil, err
@@ -78,6 +84,7 @@ func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlC
 		conn:                  atomic.Pointer[client.Conn]{},
 		logger:                logger,
 		rdsAuth:               rdsAuth,
+		cloudSQLAuth:          cloudSQLAuth,
 		binlogHeartbeatPeriod: defaultBinlogHeartbeatPeriod,
 	}
 	c.contexts.Store(&contexts)
@@ -117,6 +124,39 @@ func NewMySqlConnector(ctx context.Context, config *protos.MySqlConfig) (*MySqlC
 	}()
 
 	return c, nil
+}
+
+func newMySQLCloudSQLTokenProvider(
+	ctx context.Context,
+	config *protos.MySqlConfig,
+) (auth.TokenProvider, error) {
+	return newMySQLCloudSQLTokenProviderWithFactory(ctx, config, func(
+		ctx context.Context,
+		scopes []string,
+	) (auth.TokenProvider, error) {
+		return utils.NewGCPWorkloadIdentityCredentials(ctx, scopes)
+	})
+}
+
+func newMySQLCloudSQLTokenProviderWithFactory(
+	ctx context.Context,
+	config *protos.MySqlConfig,
+	credentialsFactory func(context.Context, []string) (auth.TokenProvider, error),
+) (auth.TokenProvider, error) {
+	if config.AuthType != protos.MySqlAuthType_MYSQL_GCP_CLOUD_SQL_IAM_AUTH {
+		return nil, nil
+	}
+	if config.DisableTls {
+		return nil, fmt.Errorf("MySQL Cloud SQL IAM authentication requires TLS")
+	}
+	if config.SkipCertVerification {
+		return nil, fmt.Errorf("MySQL Cloud SQL IAM authentication requires certificate verification")
+	}
+	credentials, err := credentialsFactory(ctx, []string{utils.GCPCloudSQLLoginScope})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MySQL Cloud SQL IAM credentials: %w", err)
+	}
+	return credentials, nil
 }
 
 func (c *MySqlConnector) watchCtx(ctx context.Context) func() {
@@ -201,25 +241,10 @@ func (c *MySqlConnector) connect(ctx context.Context) (*client.Conn, error) {
 			}
 			return nil
 		}}
-		config := c.config
-		if c.rdsAuth != nil {
-			c.logger.Info("Setting up IAM auth for MySQL")
-			host := c.config.Host
-			if c.config.TlsHost != "" {
-				host = c.config.TlsHost
-			}
-			token, err := utils.GetRDSToken(ctx, utils.RDSConnectionConfig{
-				Host: host,
-				Port: config.Port,
-				User: config.User,
-			}, c.rdsAuth, "MYSQL")
-			if err != nil {
-				return nil, err
-			}
-			config = proto.CloneOf(config)
-			config.Password = token
+		config, err := c.configWithAuthToken(ctx, false)
+		if err != nil {
+			return nil, err
 		}
-		var err error
 		conn, err = client.ConnectWithDialer(ctx, "", shared.JoinHostPort(config.Host, config.Port),
 			config.User, config.Password, config.Database, c.Dialer(), argF...)
 		if err != nil {
@@ -235,6 +260,46 @@ func (c *MySqlConnector) connect(ctx context.Context) (*client.Conn, error) {
 		}
 	}
 	return conn, nil
+}
+
+func (c *MySqlConnector) configWithAuthToken(
+	ctx context.Context,
+	replicationConnection bool,
+) (*protos.MySqlConfig, error) {
+	config := c.config
+	if c.rdsAuth != nil {
+		if replicationConnection {
+			c.logger.Info("Setting up IAM auth for MySQL replication")
+		} else {
+			c.logger.Info("Setting up IAM auth for MySQL")
+		}
+		host := config.Host
+		if config.TlsHost != "" {
+			host = config.TlsHost
+		}
+		token, err := utils.GetRDSToken(ctx, utils.RDSConnectionConfig{
+			Host: host,
+			Port: config.Port,
+			User: config.User,
+		}, c.rdsAuth, "MYSQL")
+		if err != nil {
+			return nil, err
+		}
+		config = proto.CloneOf(config)
+		config.Password = token
+	}
+	if c.cloudSQLAuth != nil {
+		token, err := c.cloudSQLAuth.Token(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get MySQL Cloud SQL IAM token: %w", err)
+		}
+		if token == nil || token.Value == "" {
+			return nil, fmt.Errorf("MySQL Cloud SQL IAM token is empty")
+		}
+		config = proto.CloneOf(config)
+		config.Password = token.Value
+	}
+	return config, nil
 }
 
 func (c *MySqlConnector) setSessionSettings() error {

--- a/flow/connectors/postgres/cloudsql_test.go
+++ b/flow/connectors/postgres/cloudsql_test.go
@@ -1,0 +1,163 @@
+package connpostgres
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/auth"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/connectors/utils"
+	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+)
+
+func TestPostgresCloudSQLAuthModeAndTLSValidation(t *testing.T) {
+	for name, authType := range map[string]protos.PostgresAuthType{
+		"password": protos.PostgresAuthType_POSTGRES_PASSWORD,
+		"AWS IAM":  protos.PostgresAuthType_POSTGRES_IAM_AUTH,
+	} {
+		t.Run(name+" remains unchanged", func(t *testing.T) {
+			provider, err := newPostgresCloudSQLTokenProviderWithFactory(
+				t.Context(),
+				&protos.PostgresConfig{AuthType: authType},
+				unexpectedPostgresCredentialsFactory,
+			)
+			require.NoError(t, err)
+			require.Nil(t, provider)
+		})
+	}
+
+	disableTLS := true
+	provider, err := newPostgresCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		&protos.PostgresConfig{
+			AuthType:   protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+			DisableTls: &disableTLS,
+		},
+		unexpectedPostgresCredentialsFactory,
+	)
+	require.Nil(t, provider)
+	require.ErrorContains(t, err, "requires TLS")
+	_, err = NewPostgresConnector(t.Context(), nil, &protos.PostgresConfig{
+		AuthType:   protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+		DisableTls: &disableTLS,
+	})
+	require.ErrorContains(t, err, "requires TLS")
+
+	provider, err = newPostgresCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		&protos.PostgresConfig{
+			AuthType:             protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+			SkipCertVerification: true,
+		},
+		unexpectedPostgresCredentialsFactory,
+	)
+	require.Nil(t, provider)
+	require.ErrorContains(t, err, "requires certificate verification")
+	_, err = NewPostgresConnector(t.Context(), nil, &protos.PostgresConfig{
+		AuthType:             protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+		SkipCertVerification: true,
+	})
+	require.ErrorContains(t, err, "requires certificate verification")
+
+	config := &protos.PostgresConfig{
+		User:     "configured-db-user",
+		AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+	}
+	var scopes []string
+	provider, err = newPostgresCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		config,
+		func(_ context.Context, requestedScopes []string) (auth.TokenProvider, error) {
+			scopes = requestedScopes
+			return &sequenceTokenProvider{values: []string{"token"}}, nil
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	require.Equal(t, []string{utils.GCPCloudSQLLoginScope}, scopes)
+	require.Equal(t, "configured-db-user", config.User)
+}
+
+func TestPostgresCloudSQLEmptyTokenRejected(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		token *auth.Token
+	}{
+		{name: "nil token"},
+		{name: "empty token", token: &auth.Token{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config, err := pgx.ParseConfig("postgres://configured-db-user:persisted-password@localhost/database")
+			require.NoError(t, err)
+
+			prepared, err := preparePostgresConnConfig(
+				t.Context(),
+				config,
+				"",
+				nil,
+				tokenResultProvider{token: test.token},
+			)
+			require.Nil(t, prepared)
+			require.ErrorContains(t, err, "token is empty")
+			require.Equal(t, "configured-db-user", config.User)
+			require.Equal(t, "persisted-password", config.Password)
+		})
+	}
+}
+
+func TestPostgresCloudSQLTokenAppliedToEveryConnectionConfig(t *testing.T) {
+	provider := &sequenceTokenProvider{values: []string{"initial-token", "replication-token"}}
+	initial := &pgx.ConnConfig{Config: pgx.ConnConfig{}.Config}
+	initial.User = "configured-db-user"
+	initial.Password = "persisted-password"
+	replication := initial.Copy()
+	replication.RuntimeParams = map[string]string{"replication": "database"}
+
+	initialWithToken, err := preparePostgresConnConfig(t.Context(), initial, "", nil, provider)
+	require.NoError(t, err)
+	replicationWithToken, err := preparePostgresConnConfig(t.Context(), replication, "", nil, provider)
+	require.NoError(t, err)
+
+	require.Equal(t, "configured-db-user", initialWithToken.User)
+	require.Equal(t, "initial-token", initialWithToken.Password)
+	require.Equal(t, "configured-db-user", replicationWithToken.User)
+	require.Equal(t, "replication-token", replicationWithToken.Password)
+	require.Equal(t, 2, provider.calls)
+	require.Equal(t, "persisted-password", initial.Password)
+}
+
+func TestPostgresPasswordConfigRemainsUnchanged(t *testing.T) {
+	config, err := pgx.ParseConfig("postgres://configured-db-user:password@localhost/database")
+	require.NoError(t, err)
+
+	prepared, err := preparePostgresConnConfig(t.Context(), config, "", nil, nil)
+	require.NoError(t, err)
+	require.Same(t, config, prepared)
+	require.Equal(t, "configured-db-user", prepared.User)
+	require.Equal(t, "password", prepared.Password)
+}
+
+type sequenceTokenProvider struct {
+	values []string
+	calls  int
+}
+
+func (provider *sequenceTokenProvider) Token(context.Context) (*auth.Token, error) {
+	value := provider.values[provider.calls]
+	provider.calls++
+	return &auth.Token{Value: value}, nil
+}
+
+type tokenResultProvider struct {
+	token *auth.Token
+}
+
+func (provider tokenResultProvider) Token(context.Context) (*auth.Token, error) {
+	return provider.token, nil
+}
+
+func unexpectedPostgresCredentialsFactory(context.Context, []string) (auth.TokenProvider, error) {
+	panic("credentials factory should not be called")
+}

--- a/flow/connectors/postgres/cloudsql_test.go
+++ b/flow/connectors/postgres/cloudsql_test.go
@@ -61,9 +61,37 @@ func TestPostgresCloudSQLAuthModeAndTLSValidation(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "requires certificate verification")
 
+	provider, err = newPostgresCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		&protos.PostgresConfig{AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH},
+		unexpectedPostgresCredentialsFactory,
+	)
+	require.Nil(t, provider)
+	require.ErrorContains(t, err, "without tls_host requires a non-empty root CA")
+	_, err = NewPostgresConnector(t.Context(), nil, &protos.PostgresConfig{
+		AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+	})
+	require.ErrorContains(t, err, "without tls_host requires a non-empty root CA")
+	_, err = postgresConfigForSchemaDump(t.Context(), &protos.PostgresConfig{
+		AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+	})
+	require.ErrorContains(t, err, "without tls_host requires a non-empty root CA")
+	emptyRootCA := ""
+	provider, err = newPostgresCloudSQLTokenProviderWithFactory(
+		t.Context(),
+		&protos.PostgresConfig{
+			AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+			RootCa:   &emptyRootCA,
+		},
+		unexpectedPostgresCredentialsFactory,
+	)
+	require.Nil(t, provider)
+	require.ErrorContains(t, err, "requires a non-empty root CA")
+
 	config := &protos.PostgresConfig{
 		User:     "configured-db-user",
 		AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+		TlsHost:  "cloudsql.google.internal",
 	}
 	var scopes []string
 	provider, err = newPostgresCloudSQLTokenProviderWithFactory(
@@ -108,7 +136,7 @@ func TestPostgresCloudSQLEmptyTokenRejected(t *testing.T) {
 }
 
 func TestPostgresCloudSQLTokenAppliedToEveryConnectionConfig(t *testing.T) {
-	provider := &sequenceTokenProvider{values: []string{"initial-token", "replication-token"}}
+	provider := &sequenceTokenProvider{values: []string{"initial-token", "replication-token", "schema-token"}}
 	initial := &pgx.ConnConfig{Config: pgx.ConnConfig{}.Config}
 	initial.User = "configured-db-user"
 	initial.Password = "persisted-password"
@@ -119,13 +147,19 @@ func TestPostgresCloudSQLTokenAppliedToEveryConnectionConfig(t *testing.T) {
 	require.NoError(t, err)
 	replicationWithToken, err := preparePostgresConnConfig(t.Context(), replication, "", nil, provider)
 	require.NoError(t, err)
+	schemaConfig := &protos.PostgresConfig{User: "configured-db-user", Password: "persisted-password"}
+	schemaWithToken, err := postgresConfigWithCloudSQLToken(t.Context(), schemaConfig, provider)
+	require.NoError(t, err)
 
 	require.Equal(t, "configured-db-user", initialWithToken.User)
 	require.Equal(t, "initial-token", initialWithToken.Password)
 	require.Equal(t, "configured-db-user", replicationWithToken.User)
 	require.Equal(t, "replication-token", replicationWithToken.Password)
-	require.Equal(t, 2, provider.calls)
+	require.Equal(t, "configured-db-user", schemaWithToken.User)
+	require.Equal(t, "schema-token", schemaWithToken.Password)
+	require.Equal(t, 3, provider.calls)
 	require.Equal(t, "persisted-password", initial.Password)
+	require.Equal(t, "persisted-password", schemaConfig.Password)
 }
 
 func TestPostgresPasswordConfigRemainsUnchanged(t *testing.T) {

--- a/flow/connectors/postgres/pgdump_schema.go
+++ b/flow/connectors/postgres/pgdump_schema.go
@@ -13,6 +13,10 @@ import (
 	"os/exec"
 	"regexp"
 	"strconv"
+	"strings"
+
+	"cloud.google.com/go/auth"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
@@ -32,6 +36,14 @@ var incompatibleLineRE = regexp.MustCompile(`^(SET\s+transaction_timeout\s*=|\\(
 // RunPgDumpSchema streams a schema-only pg_dump from source directly into psql
 // on the destination, piping stdout into stdin without intermediate files.
 func RunPgDumpSchema(ctx context.Context, srcConfig *protos.PostgresConfig, dstConfig *protos.PostgresConfig) error {
+	srcConfig, err := postgresConfigForSchemaDump(ctx, srcConfig)
+	if err != nil {
+		return fmt.Errorf("source: %w", err)
+	}
+	dstConfig, err = postgresConfigForSchemaDump(ctx, dstConfig)
+	if err != nil {
+		return fmt.Errorf("destination: %w", err)
+	}
 	srcAddr, err := resolvePgAddr(ctx, srcConfig)
 	if err != nil {
 		return fmt.Errorf("source: %w", err)
@@ -47,6 +59,34 @@ func RunPgDumpSchema(ctx context.Context, srcConfig *protos.PostgresConfig, dstC
 	}
 
 	return nil
+}
+
+func postgresConfigForSchemaDump(
+	ctx context.Context,
+	config *protos.PostgresConfig,
+) (*protos.PostgresConfig, error) {
+	provider, err := newPostgresCloudSQLTokenProvider(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return config, nil
+	}
+	return postgresConfigWithCloudSQLToken(ctx, config, provider)
+}
+
+func postgresConfigWithCloudSQLToken(
+	ctx context.Context,
+	config *protos.PostgresConfig,
+	provider auth.TokenProvider,
+) (*protos.PostgresConfig, error) {
+	token, err := postgresCloudSQLToken(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+	config = proto.CloneOf(config)
+	config.Password = token
+	return config, nil
 }
 
 // pipeCommand runs srcBinary with the given args, piping its stdout into psql on the destination.
@@ -360,10 +400,14 @@ func appendTLSEnv(ctx context.Context, cmd *exec.Cmd, config *protos.PostgresCon
 	// carry a matching IP SAN, so we only do name verification for hostnames.
 	_, ipErr := netip.ParseAddr(addr.host)
 	hostIsIP := ipErr == nil
+	cloudSQLChainOnly := config.AuthType == protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH &&
+		strings.TrimSpace(config.TlsHost) == ""
 
 	switch {
 	case config.SkipCertVerification:
 		cmd.Env = append(cmd.Env, "PGSSLMODE=require")
+	case cloudSQLChainOnly:
+		cmd.Env = append(cmd.Env, "PGSSLMODE=verify-ca")
 	case hasRootCA && hostIsIP:
 		cmd.Env = append(cmd.Env, "PGSSLMODE=verify-ca")
 	case hasRootCA:

--- a/flow/connectors/postgres/pgdump_schema_test.go
+++ b/flow/connectors/postgres/pgdump_schema_test.go
@@ -554,6 +554,33 @@ func TestAppendTLSEnv(t *testing.T) {
 			wantRootCert: "file",
 		},
 		{
+			name: "Cloud SQL IAM synthetic alias verifies CA without hostname",
+			config: &protos.PostgresConfig{
+				Host:     "synthetic-rpe-alias.internal",
+				Port:     5432,
+				Database: "d",
+				AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+				RootCa:   testCA,
+			},
+			addr:         pgAddr{host: "synthetic-rpe-alias.internal"},
+			wantSSLMode:  "verify-ca",
+			wantRootCert: "file",
+		},
+		{
+			name: "Cloud SQL IAM tls_host verifies hostname",
+			config: &protos.PostgresConfig{
+				Host:     "synthetic-rpe-alias.internal",
+				Port:     5432,
+				Database: "d",
+				AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+				TlsHost:  "cloudsql.google.internal",
+				RootCa:   testCA,
+			},
+			addr:         pgAddr{host: "cloudsql.google.internal", hostaddr: "192.0.2.10"},
+			wantSSLMode:  "verify-full",
+			wantRootCert: "file",
+		},
+		{
 			name: "provided CA alone verify-ca for IP identity",
 			config: &protos.PostgresConfig{
 				Host: "10.0.0.1", Port: 5432, Database: "d",

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -217,11 +218,26 @@ func newPostgresCloudSQLTokenProviderWithFactory(
 	if config.SkipCertVerification {
 		return nil, fmt.Errorf("PostgreSQL Cloud SQL IAM authentication requires certificate verification")
 	}
+	if strings.TrimSpace(config.TlsHost) == "" &&
+		(config.RootCa == nil || strings.TrimSpace(config.GetRootCa()) == "") {
+		return nil, fmt.Errorf("PostgreSQL Cloud SQL IAM authentication without tls_host requires a non-empty root CA")
+	}
 	credentials, err := credentialsFactory(ctx, []string{utils.GCPCloudSQLLoginScope})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PostgreSQL Cloud SQL IAM credentials: %w", err)
 	}
 	return credentials, nil
+}
+
+func postgresCloudSQLToken(ctx context.Context, provider auth.TokenProvider) (string, error) {
+	token, err := provider.Token(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get PostgreSQL Cloud SQL IAM token: %w", err)
+	}
+	if token == nil || token.Value == "" {
+		return "", fmt.Errorf("PostgreSQL Cloud SQL IAM token is empty")
+	}
+	return token.Value, nil
 }
 
 func ParseConfig(connectionString string, pgConfig *protos.PostgresConfig) (*pgx.ConnConfig, error) {
@@ -247,9 +263,14 @@ func ParseConfig(connectionString string, pgConfig *protos.PostgresConfig) (*pgx
 				return nil, err
 			}
 		}
+		var tlsOptions []common.TLSConfigOption
+		if pgConfig.AuthType == protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH &&
+			strings.TrimSpace(pgConfig.TlsHost) == "" {
+			tlsOptions = append(tlsOptions, common.WithCertificateChainOnlyVerification())
+		}
 		tlsConfig, err := common.CreateTlsConfig(
 			tls.VersionTLS12, pgConfig.RootCa, connConfig.Host, pgConfig.TlsHost, pgConfig.SkipCertVerification,
-			clientCert)
+			clientCert, tlsOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/flow/connectors/postgres/postgres.go
+++ b/flow/connectors/postgres/postgres.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"cloud.google.com/go/auth"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -37,6 +38,7 @@ type PostgresConnector struct {
 	clockOffsetUpdatedAt   time.Time
 	logger                 log.Logger
 	rdsAuth                *utils.RDSAuth
+	cloudSQLAuth           auth.TokenProvider
 	customTypeMapping      map[uint32]pkg_pg.CustomDataType
 	replConn               *pgx.Conn
 	replState              *ReplState
@@ -84,6 +86,10 @@ func newPostgresConnector(
 	ctx context.Context, env map[string]string, pgConfig *protos.PostgresConfig, destinationType protos.DBType,
 ) (*PostgresConnector, error) {
 	logger := internal.LoggerFromCtx(ctx)
+	cloudSQLAuth, err := newPostgresCloudSQLTokenProvider(ctx, pgConfig)
+	if err != nil {
+		return nil, err
+	}
 	flowNameInApplicationName, err := internal.PeerDBApplicationNamePerMirrorName(ctx, nil)
 	if err != nil {
 		logger.Error("Failed to get flow name from application name", slog.Any("error", err))
@@ -122,7 +128,7 @@ func newPostgresConnector(
 			return nil, fmt.Errorf("failed to verify auth config: %w", err)
 		}
 	}
-	conn, err := NewPostgresConnFromConfig(ctx, connConfig, pgConfig.TlsHost, rdsAuth, tunnel)
+	conn, err := NewPostgresConnFromConfig(ctx, connConfig, pgConfig.TlsHost, rdsAuth, cloudSQLAuth, tunnel)
 	if err != nil {
 		tunnel.Close()
 
@@ -171,6 +177,7 @@ func newPostgresConnector(
 		pgVersion:              0,
 		typeMap:                pgtype.NewMap(),
 		rdsAuth:                rdsAuth,
+		cloudSQLAuth:           cloudSQLAuth,
 		cdcStoreEnabled:        cdcStoreEnabled,
 	}
 
@@ -182,6 +189,39 @@ func newPostgresConnector(
 	})
 
 	return connector, nil
+}
+
+func newPostgresCloudSQLTokenProvider(
+	ctx context.Context,
+	config *protos.PostgresConfig,
+) (auth.TokenProvider, error) {
+	return newPostgresCloudSQLTokenProviderWithFactory(ctx, config, func(
+		ctx context.Context,
+		scopes []string,
+	) (auth.TokenProvider, error) {
+		return utils.NewGCPWorkloadIdentityCredentials(ctx, scopes)
+	})
+}
+
+func newPostgresCloudSQLTokenProviderWithFactory(
+	ctx context.Context,
+	config *protos.PostgresConfig,
+	credentialsFactory func(context.Context, []string) (auth.TokenProvider, error),
+) (auth.TokenProvider, error) {
+	if config.AuthType != protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH {
+		return nil, nil
+	}
+	if config.DisableTls != nil && config.GetDisableTls() {
+		return nil, fmt.Errorf("PostgreSQL Cloud SQL IAM authentication requires TLS")
+	}
+	if config.SkipCertVerification {
+		return nil, fmt.Errorf("PostgreSQL Cloud SQL IAM authentication requires certificate verification")
+	}
+	credentials, err := credentialsFactory(ctx, []string{utils.GCPCloudSQLLoginScope})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create PostgreSQL Cloud SQL IAM credentials: %w", err)
+	}
+	return credentials, nil
 }
 
 func ParseConfig(connectionString string, pgConfig *protos.PostgresConfig) (*pgx.ConnConfig, error) {

--- a/flow/connectors/postgres/postgres_source.go
+++ b/flow/connectors/postgres/postgres_source.go
@@ -105,7 +105,7 @@ func (c *PostgresConnector) CreateReplConn(ctx context.Context, env map[string]s
 		c.logger.Info("not setting wal_sender_timeout")
 	}
 
-	conn, err := NewPostgresConnFromConfig(ctx, replConfig, c.Config.TlsHost, c.rdsAuth, c.ssh)
+	conn, err := NewPostgresConnFromConfig(ctx, replConfig, c.Config.TlsHost, c.rdsAuth, c.cloudSQLAuth, c.ssh)
 	if err != nil {
 		internal.LoggerFromCtx(ctx).Error("failed to create replication connection", slog.Any("error", err))
 		return nil, walSenderTimeout{}, fmt.Errorf("failed to create replication connection: %w", err)

--- a/flow/connectors/postgres/postgres_tls_test.go
+++ b/flow/connectors/postgres/postgres_tls_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
+	"github.com/PeerDB-io/peerdb/flow/internal"
 )
 
 const testTLSConnString = "postgres://user@localhost:5432/testdb?sslmode=require"
@@ -124,4 +125,21 @@ func TestParseConfigClientTLS(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+}
+
+func TestParseConfigCloudSQLIAMEnablesTLSByDefault(t *testing.T) {
+	config := &protos.PostgresConfig{
+		Host:     "localhost",
+		Port:     5432,
+		User:     "configured-db-user",
+		Database: "testdb",
+		AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+	}
+	require.Nil(t, config.DisableTls)
+	connectionString := internal.GetPGConnectionString(config, "")
+	require.Contains(t, connectionString, "sslmode=require")
+	connConfig, err := ParseConfig(connectionString, config)
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.TLSConfig)
+	require.Equal(t, "configured-db-user", connConfig.User)
 }

--- a/flow/connectors/postgres/postgres_tls_test.go
+++ b/flow/connectors/postgres/postgres_tls_test.go
@@ -128,12 +128,14 @@ func TestParseConfigClientTLS(t *testing.T) {
 }
 
 func TestParseConfigCloudSQLIAMEnablesTLSByDefault(t *testing.T) {
+	rootCA, _ := generateClientCertKey(t, "test-root")
 	config := &protos.PostgresConfig{
 		Host:     "localhost",
 		Port:     5432,
 		User:     "configured-db-user",
 		Database: "testdb",
 		AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+		RootCa:   &rootCA,
 	}
 	require.Nil(t, config.DisableTls)
 	connectionString := internal.GetPGConnectionString(config, "")
@@ -141,5 +143,24 @@ func TestParseConfigCloudSQLIAMEnablesTLSByDefault(t *testing.T) {
 	connConfig, err := ParseConfig(connectionString, config)
 	require.NoError(t, err)
 	require.NotNil(t, connConfig.TLSConfig)
+	require.True(t, connConfig.TLSConfig.InsecureSkipVerify)
+	require.NotNil(t, connConfig.TLSConfig.VerifyConnection)
+	require.Empty(t, connConfig.TLSConfig.ServerName)
 	require.Equal(t, "configured-db-user", connConfig.User)
+}
+
+func TestParseConfigCloudSQLIAMUsesTLSHostIdentity(t *testing.T) {
+	config := &protos.PostgresConfig{
+		Host:     "synthetic-rpe-alias.internal",
+		Port:     5432,
+		User:     "configured-db-user",
+		Database: "testdb",
+		AuthType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+		TlsHost:  "cloudsql.google.internal",
+	}
+	connConfig, err := ParseConfig(internal.GetPGConnectionString(config, ""), config)
+	require.NoError(t, err)
+	require.False(t, connConfig.TLSConfig.InsecureSkipVerify)
+	require.Nil(t, connConfig.TLSConfig.VerifyConnection)
+	require.Equal(t, "cloudsql.google.internal", connConfig.TLSConfig.ServerName)
 }

--- a/flow/connectors/postgres/qrep_partition_test.go
+++ b/flow/connectors/postgres/qrep_partition_test.go
@@ -89,7 +89,7 @@ func setupTestSchema(t *testing.T) (string, *pgx.Conn, string) {
 	}
 	t.Cleanup(func() { tunnel.Close() })
 
-	conn, err := NewPostgresConnFromConfig(t.Context(), config, "", nil, tunnel)
+	conn, err := NewPostgresConnFromConfig(t.Context(), config, "", nil, nil, tunnel)
 	if err != nil {
 		t.Fatalf("Failed to create connection: %v", err)
 	}

--- a/flow/connectors/postgres/ssh_wrapped_conn.go
+++ b/flow/connectors/postgres/ssh_wrapped_conn.go
@@ -2,9 +2,11 @@ package connpostgres
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 
+	"cloud.google.com/go/auth"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgproto3"
 
@@ -17,6 +19,7 @@ func NewPostgresConnFromConfig(
 	connConfig *pgx.ConnConfig,
 	tlsHost string,
 	rdsAuth *utils.RDSAuth,
+	cloudSQLAuth auth.TokenProvider,
 	tunnel *utils.SSHTunnel,
 ) (*pgx.Conn, error) {
 	if tunnel.IsActive() {
@@ -27,24 +30,11 @@ func NewPostgresConnFromConfig(
 			return []string{host}, nil
 		}
 	}
-	logger := internal.LoggerFromCtx(ctx)
-	if rdsAuth != nil {
-		host := connConfig.Host
-		if tlsHost != "" {
-			host = tlsHost
-		}
-		logger.Info("Setting up IAM auth for Postgres")
-		token, err := utils.GetRDSToken(ctx, utils.RDSConnectionConfig{
-			Host: host,
-			Port: uint32(connConfig.Port),
-			User: connConfig.User,
-		}, rdsAuth, "POSTGRES")
-		if err != nil {
-			return nil, err
-		}
-		connConfig = connConfig.Copy()
-		connConfig.Password = token
+	connConfig, err := preparePostgresConnConfig(ctx, connConfig, tlsHost, rdsAuth, cloudSQLAuth)
+	if err != nil {
+		return nil, err
 	}
+	logger := internal.LoggerFromCtx(ctx)
 
 	// If the endpoint is misbehaved (e.g. a TCP tunnel started pointing at something new),
 	// the random initial sequence of bytes may be misinterpreted as a multi-GB message and
@@ -69,4 +59,43 @@ func NewPostgresConnFromConfig(
 	conn.PgConn().Frontend().SetMaxBodyLen(0)
 
 	return conn, nil
+}
+
+func preparePostgresConnConfig(
+	ctx context.Context,
+	connConfig *pgx.ConnConfig,
+	tlsHost string,
+	rdsAuth *utils.RDSAuth,
+	cloudSQLAuth auth.TokenProvider,
+) (*pgx.ConnConfig, error) {
+	logger := internal.LoggerFromCtx(ctx)
+	if rdsAuth != nil {
+		host := connConfig.Host
+		if tlsHost != "" {
+			host = tlsHost
+		}
+		logger.Info("Setting up IAM auth for Postgres")
+		token, err := utils.GetRDSToken(ctx, utils.RDSConnectionConfig{
+			Host: host,
+			Port: uint32(connConfig.Port),
+			User: connConfig.User,
+		}, rdsAuth, "POSTGRES")
+		if err != nil {
+			return nil, err
+		}
+		connConfig = connConfig.Copy()
+		connConfig.Password = token
+	}
+	if cloudSQLAuth != nil {
+		token, err := cloudSQLAuth.Token(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get PostgreSQL Cloud SQL IAM token: %w", err)
+		}
+		if token == nil || token.Value == "" {
+			return nil, fmt.Errorf("PostgreSQL Cloud SQL IAM token is empty")
+		}
+		connConfig = connConfig.Copy()
+		connConfig.Password = token.Value
+	}
+	return connConfig, nil
 }

--- a/flow/connectors/postgres/ssh_wrapped_conn.go
+++ b/flow/connectors/postgres/ssh_wrapped_conn.go
@@ -2,7 +2,6 @@ package connpostgres
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 
@@ -87,15 +86,12 @@ func preparePostgresConnConfig(
 		connConfig.Password = token
 	}
 	if cloudSQLAuth != nil {
-		token, err := cloudSQLAuth.Token(ctx)
+		token, err := postgresCloudSQLToken(ctx, cloudSQLAuth)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get PostgreSQL Cloud SQL IAM token: %w", err)
-		}
-		if token == nil || token.Value == "" {
-			return nil, fmt.Errorf("PostgreSQL Cloud SQL IAM token is empty")
+			return nil, err
 		}
 		connConfig = connConfig.Copy()
-		connConfig.Password = token.Value
+		connConfig.Password = token
 	}
 	return connConfig, nil
 }

--- a/flow/connectors/utils/gcp_workload_identity.go
+++ b/flow/connectors/utils/gcp_workload_identity.go
@@ -1,0 +1,188 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"cloud.google.com/go/auth"
+	"cloud.google.com/go/auth/credentials"
+	"cloud.google.com/go/compute/metadata"
+)
+
+const (
+	// GCPCloudSQLLoginScope authorizes IAM database logins to Cloud SQL.
+	GCPCloudSQLLoginScope = "https://www.googleapis.com/auth/sqlservice.login"
+
+	workloadIdentityServiceAccountEnv = "PEERDB_GCP_WORKLOAD_IDENTITY_TARGET_SERVICE_ACCOUNT"
+	//nolint:gosec // Environment variable name, not a credential.
+	workloadIdentityTokenFileEnv       = "PEERDB_GCP_WORKLOAD_IDENTITY_TOKEN_FILE"
+	workloadIdentityProjectIDEnv       = "PEERDB_GCP_PROJECT_ID"
+	workloadIdentityClusterLocationEnv = "PEERDB_GCP_CLUSTER_LOCATION"
+	workloadIdentityClusterNameEnv     = "PEERDB_GCP_CLUSTER_NAME"
+
+	//nolint:gosec // Fixed public Google authentication endpoints, not credentials.
+	googleSTSTokenURL = "https://sts.googleapis.com/v1/token"
+	//nolint:gosec // Fixed public Google authentication endpoints, not credentials.
+	googleIAMCredentialsURL = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
+	//nolint:gosec // OAuth subject-token type identifier, not a credential.
+	jwtSubjectTokenType = "urn:ietf:params:oauth:token-type:jwt"
+)
+
+type workloadIdentityDeploymentConfig struct {
+	targetServiceAccount string
+	tokenFile            string
+	projectID            string
+	clusterLocation      string
+	clusterName          string
+}
+
+type externalAccountCredentials struct {
+	Type                           string                          `json:"type"`
+	Audience                       string                          `json:"audience"`
+	SubjectTokenType               string                          `json:"subject_token_type"`
+	TokenURL                       string                          `json:"token_url"`
+	ServiceAccountImpersonationURL string                          `json:"service_account_impersonation_url"`
+	CredentialSource               externalAccountCredentialSource `json:"credential_source"`
+}
+
+type externalAccountCredentialSource struct {
+	File   string                                `json:"file"`
+	Format externalAccountCredentialSourceFormat `json:"format"`
+}
+
+type externalAccountCredentialSourceFormat struct {
+	Type string `json:"type"`
+}
+
+// NewGCPWorkloadIdentityCredentials creates deployment-scoped credentials for the requested scopes.
+func NewGCPWorkloadIdentityCredentials(ctx context.Context, scopes []string) (*auth.Credentials, error) {
+	return newGCPWorkloadIdentityCredentials(ctx, scopes, nil)
+}
+
+func newGCPWorkloadIdentityCredentials(
+	ctx context.Context,
+	scopes []string,
+	client *http.Client,
+) (*auth.Credentials, error) {
+	deploymentConfig, err := resolveWorkloadIdentityDeploymentConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	credentialsJSON, err := deploymentConfig.credentialsJSON()
+	if err != nil {
+		return nil, err
+	}
+	return credentials.NewCredentialsFromJSON(
+		credentials.ExternalAccount,
+		credentialsJSON,
+		&credentials.DetectOptions{Scopes: scopes, Client: client},
+	)
+}
+
+func resolveWorkloadIdentityDeploymentConfig(ctx context.Context) (*workloadIdentityDeploymentConfig, error) {
+	targetServiceAccount := envValue(workloadIdentityServiceAccountEnv)
+	if targetServiceAccount == "" {
+		return nil, fmt.Errorf(
+			"GCP workload identity requires deployment environment variable %s",
+			workloadIdentityServiceAccountEnv,
+		)
+	}
+	tokenFile := envValue(workloadIdentityTokenFileEnv)
+	if tokenFile == "" {
+		return nil, fmt.Errorf(
+			"GCP workload identity requires deployment environment variable %s",
+			workloadIdentityTokenFileEnv,
+		)
+	}
+
+	projectID, err := envOrMetadata(ctx, workloadIdentityProjectIDEnv, "project/project-id")
+	if err != nil {
+		return nil, err
+	}
+	clusterLocation, err := envOrMetadata(
+		ctx,
+		workloadIdentityClusterLocationEnv,
+		"instance/attributes/cluster-location",
+	)
+	if err != nil {
+		return nil, err
+	}
+	clusterName, err := envOrMetadata(
+		ctx,
+		workloadIdentityClusterNameEnv,
+		"instance/attributes/cluster-name",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workloadIdentityDeploymentConfig{
+		targetServiceAccount: targetServiceAccount,
+		tokenFile:            tokenFile,
+		projectID:            projectID,
+		clusterLocation:      clusterLocation,
+		clusterName:          clusterName,
+	}, nil
+}
+
+func envValue(name string) string {
+	value, _ := os.LookupEnv(name)
+	return strings.TrimSpace(value)
+}
+
+func envOrMetadata(ctx context.Context, envName string, metadataPath string) (string, error) {
+	if value := envValue(envName); value != "" {
+		return value, nil
+	}
+	value, err := metadata.GetWithContext(ctx, metadataPath)
+	if err != nil {
+		return "", fmt.Errorf(
+			"GCP workload identity requires %s or the corresponding GKE metadata: %w",
+			envName,
+			err,
+		)
+	}
+	if strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf(
+			"GCP workload identity requires %s or non-empty corresponding GKE metadata",
+			envName,
+		)
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func (config *workloadIdentityDeploymentConfig) credentialsJSON() ([]byte, error) {
+	pool := config.projectID + ".svc.id.goog"
+	audience := fmt.Sprintf(
+		"identitynamespace:%s:https://container.googleapis.com/v1/projects/%s/locations/%s/clusters/%s",
+		pool,
+		config.projectID,
+		config.clusterLocation,
+		config.clusterName,
+	)
+	credentialConfig := externalAccountCredentials{
+		Type:             "external_account",
+		Audience:         audience,
+		SubjectTokenType: jwtSubjectTokenType,
+		TokenURL:         googleSTSTokenURL,
+		ServiceAccountImpersonationURL: googleIAMCredentialsURL +
+			url.PathEscape(config.targetServiceAccount) + ":generateAccessToken",
+		CredentialSource: externalAccountCredentialSource{
+			// The auth library reopens this path for every token exchange so projected-token rotation is observed.
+			File: config.tokenFile,
+			Format: externalAccountCredentialSourceFormat{
+				Type: "text",
+			},
+		},
+	}
+	credentialsJSON, err := json.Marshal(credentialConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal GCP workload identity credentials: %w", err)
+	}
+	return credentialsJSON, nil
+}

--- a/flow/connectors/utils/gcp_workload_identity_test.go
+++ b/flow/connectors/utils/gcp_workload_identity_test.go
@@ -1,0 +1,216 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkloadIdentityCredentialsJSON(t *testing.T) {
+	config := workloadIdentityDeploymentConfig{ //nolint:gosec // Test-only fake account and token path.
+		targetServiceAccount: "tenant@tenant-project.iam.gserviceaccount.com",
+		tokenFile:            "/var/run/secrets/peerdb/gcp-token",
+		projectID:            "platform-project",
+		clusterLocation:      "us-central1",
+		clusterName:          "clickpipes",
+	}
+
+	credentialsJSON, err := config.credentialsJSON()
+	require.NoError(t, err)
+
+	var document externalAccountCredentials
+	require.NoError(t, json.Unmarshal(credentialsJSON, &document))
+	require.Equal(t, "external_account", document.Type)
+	require.Equal(t,
+		"identitynamespace:platform-project.svc.id.goog:"+
+			"https://container.googleapis.com/v1/projects/platform-project/locations/us-central1/clusters/clickpipes",
+		document.Audience,
+	)
+	require.Equal(t, jwtSubjectTokenType, document.SubjectTokenType)
+	require.Equal(t, googleSTSTokenURL, document.TokenURL)
+	require.Equal(t,
+		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"+
+			"tenant@tenant-project.iam.gserviceaccount.com:generateAccessToken",
+		document.ServiceAccountImpersonationURL,
+	)
+	require.Equal(t, "/var/run/secrets/peerdb/gcp-token", document.CredentialSource.File)
+	require.Equal(t, "text", document.CredentialSource.Format.Type)
+}
+
+func TestWorkloadIdentityCredentialsReloadProjectedToken(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "projected-token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("projected-token-one"), 0o600))
+	setWorkloadIdentityEnv(t, tokenFile)
+
+	var stsSubjectTokens []string
+	var iamAuthorizationHeaders []string
+	var iamScopes [][]string
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		require.Equal(t, "https", request.URL.Scheme)
+		switch request.URL.Host {
+		case "sts.googleapis.com":
+			body, err := io.ReadAll(request.Body)
+			require.NoError(t, err)
+			form, err := url.ParseQuery(string(body))
+			require.NoError(t, err)
+			stsSubjectTokens = append(stsSubjectTokens, form.Get("subject_token"))
+			return jsonResponse(t, request, map[string]any{ //nolint:gosec // Test-only fake token.
+				"access_token":      fmt.Sprintf("sts-access-token-%d", len(stsSubjectTokens)),
+				"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+				"token_type":        "Bearer",
+				"expires_in":        1,
+			}), nil
+		case "iamcredentials.googleapis.com":
+			iamAuthorizationHeaders = append(iamAuthorizationHeaders, request.Header.Get("Authorization"))
+			var body struct {
+				Scope []string `json:"scope"`
+			}
+			require.NoError(t, json.NewDecoder(request.Body).Decode(&body))
+			iamScopes = append(iamScopes, body.Scope)
+			return jsonResponse(t, request, map[string]any{
+				"accessToken": fmt.Sprintf("tenant-access-token-%d", len(iamAuthorizationHeaders)),
+				"expireTime":  time.Now().Add(time.Second).UTC().Format(time.RFC3339),
+			}), nil
+		default:
+			return nil, fmt.Errorf("unexpected request URL %s", request.URL)
+		}
+	})
+
+	creds, err := newGCPWorkloadIdentityCredentials(
+		t.Context(),
+		[]string{GCPCloudSQLLoginScope},
+		&http.Client{Transport: transport},
+	)
+	require.NoError(t, err)
+
+	firstToken, err := creds.Token(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "tenant-access-token-1", firstToken.Value)
+	require.Equal(t, []string{"projected-token-one"}, stsSubjectTokens)
+	require.Equal(t, []string{"Bearer sts-access-token-1"}, iamAuthorizationHeaders)
+	require.Equal(t, [][]string{{GCPCloudSQLLoginScope}}, iamScopes)
+
+	require.NoError(t, os.WriteFile(tokenFile, []byte("projected-token-two"), 0o600))
+	time.Sleep(time.Until(firstToken.Expiry) + time.Second)
+
+	secondToken, err := creds.Token(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "tenant-access-token-2", secondToken.Value)
+	require.Equal(t, []string{"projected-token-one", "projected-token-two"}, stsSubjectTokens)
+	require.Equal(t, []string{"Bearer sts-access-token-1", "Bearer sts-access-token-2"}, iamAuthorizationHeaders)
+	require.Equal(t, [][]string{{GCPCloudSQLLoginScope}, {GCPCloudSQLLoginScope}}, iamScopes)
+}
+
+func TestResolveWorkloadIdentityDeploymentConfig(t *testing.T) {
+	t.Setenv(workloadIdentityServiceAccountEnv, "tenant@tenant-project.iam.gserviceaccount.com")
+	t.Setenv(workloadIdentityTokenFileEnv, "/token")
+	t.Setenv(workloadIdentityProjectIDEnv, "")
+	t.Setenv(workloadIdentityClusterLocationEnv, "")
+	t.Setenv(workloadIdentityClusterNameEnv, "")
+
+	metadataValues := map[string]string{
+		"/computeMetadata/v1/project/project-id":                   "metadata-project",
+		"/computeMetadata/v1/instance/attributes/cluster-location": "metadata-location",
+		"/computeMetadata/v1/instance/attributes/cluster-name":     "metadata-cluster",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "Google", request.Header.Get("Metadata-Flavor"))
+		value, ok := metadataValues[request.URL.Path]
+		assert.True(t, ok, "unexpected metadata path %s", request.URL.Path)
+		_, _ = response.Write([]byte(value))
+	}))
+	defer server.Close()
+	t.Setenv("GCE_METADATA_HOST", strings.TrimPrefix(server.URL, "http://"))
+
+	config, err := resolveWorkloadIdentityDeploymentConfig(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "metadata-project", config.projectID)
+	require.Equal(t, "metadata-location", config.clusterLocation)
+	require.Equal(t, "metadata-cluster", config.clusterName)
+}
+
+func TestResolveWorkloadIdentityDeploymentConfigMissing(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment map[string]string
+		wantError   string
+	}{
+		{name: "target service account", wantError: workloadIdentityServiceAccountEnv},
+		{
+			name: "token file",
+			environment: map[string]string{
+				workloadIdentityServiceAccountEnv: "tenant@tenant-project.iam.gserviceaccount.com",
+			},
+			wantError: workloadIdentityTokenFileEnv,
+		},
+		{
+			name: "project context",
+			environment: map[string]string{
+				workloadIdentityServiceAccountEnv: "tenant@tenant-project.iam.gserviceaccount.com",
+				workloadIdentityTokenFileEnv:      "/token",
+			},
+			wantError: workloadIdentityProjectIDEnv,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, name := range []string{
+				workloadIdentityServiceAccountEnv,
+				workloadIdentityTokenFileEnv,
+				workloadIdentityProjectIDEnv,
+				workloadIdentityClusterLocationEnv,
+				workloadIdentityClusterNameEnv,
+			} {
+				t.Setenv(name, test.environment[name])
+			}
+			server := httptest.NewServer(http.NotFoundHandler())
+			defer server.Close()
+			t.Setenv("GCE_METADATA_HOST", strings.TrimPrefix(server.URL, "http://"))
+
+			_, err := resolveWorkloadIdentityDeploymentConfig(t.Context())
+			require.ErrorContains(t, err, test.wantError)
+		})
+	}
+}
+
+func setWorkloadIdentityEnv(t *testing.T, tokenFile string) {
+	t.Helper()
+	t.Setenv(workloadIdentityServiceAccountEnv, "tenant@tenant-project.iam.gserviceaccount.com")
+	t.Setenv(workloadIdentityTokenFileEnv, tokenFile)
+	t.Setenv(workloadIdentityProjectIDEnv, "platform-project")
+	t.Setenv(workloadIdentityClusterLocationEnv, "us-central1")
+	t.Setenv(workloadIdentityClusterNameEnv, "clickpipes")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func jsonResponse(t *testing.T, request *http.Request, value any) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(value)
+	require.NoError(t, err)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body:    io.NopCloser(bytes.NewReader(body)),
+		Request: request,
+	}
+}

--- a/flow/internal/postgres.go
+++ b/flow/internal/postgres.go
@@ -21,7 +21,9 @@ import (
 // 2. If TLS is not explicitly required, but DisableTls is explicitly set to false, then we also use TLS.
 // 3. Otherwise, we do not use TLS.
 func PGMustUseTlsConnection(pgConfig *protos.PostgresConfig) bool {
-	return pgConfig.RequireTls || (pgConfig.DisableTls != nil && !*pgConfig.DisableTls)
+	return pgConfig.RequireTls ||
+		pgConfig.AuthType == protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH ||
+		(pgConfig.DisableTls != nil && !*pgConfig.DisableTls)
 }
 
 // SanitizePGHost strips pasted connection-string junk (path/query suffixes,

--- a/flow/internal/postgres_test.go
+++ b/flow/internal/postgres_test.go
@@ -17,6 +17,7 @@ func TestPGMustUseTlsConnection(t *testing.T) {
 		disableTls *bool
 		name       string
 		requireTls bool
+		authType   protos.PostgresAuthType
 		expected   bool
 	}{
 		{
@@ -61,6 +62,11 @@ func TestPGMustUseTlsConnection(t *testing.T) {
 			disableTls: boolPtr(true),
 			expected:   true,
 		},
+		{
+			name:     "Cloud SQL IAM defaults to TLS",
+			authType: protos.PostgresAuthType_POSTGRES_GCP_CLOUD_SQL_IAM_AUTH,
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -68,6 +74,7 @@ func TestPGMustUseTlsConnection(t *testing.T) {
 			config := &protos.PostgresConfig{
 				RequireTls: tt.requireTls,
 				DisableTls: tt.disableTls,
+				AuthType:   tt.authType,
 			}
 			assert.Equal(t, tt.expected, PGMustUseTlsConnection(config))
 		})

--- a/flow/pkg/common/tls.go
+++ b/flow/pkg/common/tls.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 )
 
 // Modified from https://github.com/golang/go/blob/master/src/crypto/tls/example_test.go.
@@ -35,6 +36,21 @@ type ClientCertificate struct {
 	privateKey  string
 }
 
+type tlsConfigOptions struct {
+	verifyCertificateChainOnly bool
+}
+
+// TLSConfigOption customizes TLS verification without changing the default behavior.
+type TLSConfigOption func(*tlsConfigOptions)
+
+// WithCertificateChainOnlyVerification verifies the server chain against the provided root CA without hostname matching.
+// The caller-provided per-instance CA is the server identity anchor; broad or shared roots are not safe for this mode.
+func WithCertificateChainOnlyVerification() TLSConfigOption {
+	return func(options *tlsConfigOptions) {
+		options.verifyCertificateChainOnly = true
+	}
+}
+
 // NewClientCertificate requires both the certificate and private key to be non-empty.
 func NewClientCertificate(certificate string, privateKey string) (*ClientCertificate, error) {
 	if certificate == "" || privateKey == "" {
@@ -45,9 +61,22 @@ func NewClientCertificate(certificate string, privateKey string) (*ClientCertifi
 
 func CreateTlsConfig(
 	minVersion uint16, rootCAs *string, host string, tlsHost string, skipCertVerification bool,
-	clientCert *ClientCertificate,
+	clientCert *ClientCertificate, options ...TLSConfigOption,
 ) (*tls.Config, error) {
-	config := &tls.Config{MinVersion: minVersion}
+	configOptions := tlsConfigOptions{}
+	for _, option := range options {
+		option(&configOptions)
+	}
+	if configOptions.verifyCertificateChainOnly {
+		if skipCertVerification {
+			return nil, errors.New("certificate chain verification cannot be combined with skip certificate verification")
+		}
+		if rootCAs == nil || strings.TrimSpace(*rootCAs) == "" {
+			return nil, errors.New("certificate chain verification requires a non-empty root CA")
+		}
+	}
+
+	config := &tls.Config{MinVersion: minVersion} //nolint:gosec // Callers select TLS 1.2 or newer.
 	if rootCAs != nil {
 		caPool := x509.NewCertPool()
 		if !caPool.AppendCertsFromPEM([]byte(*rootCAs)) {
@@ -62,7 +91,10 @@ func CreateTlsConfig(
 		}
 		config.Certificates = []tls.Certificate{cert}
 	}
-	if skipCertVerification {
+	if configOptions.verifyCertificateChainOnly {
+		config.InsecureSkipVerify = true
+		config.VerifyConnection = verifyConnectionWithoutHostname(config.RootCAs)
+	} else if skipCertVerification {
 		// self-hosted instances may generate self-signed certs that can't be verified
 		// but can still be used for TLS — this must be explicitly requested by the user
 		config.InsecureSkipVerify = true

--- a/flow/pkg/common/tls.go
+++ b/flow/pkg/common/tls.go
@@ -76,7 +76,7 @@ func CreateTlsConfig(
 		}
 	}
 
-	config := &tls.Config{MinVersion: minVersion} //nolint:gosec // Callers select TLS 1.2 or newer.
+	config := &tls.Config{MinVersion: minVersion}
 	if rootCAs != nil {
 		caPool := x509.NewCertPool()
 		if !caPool.AppendCertsFromPEM([]byte(*rootCAs)) {

--- a/flow/pkg/common/tls_test.go
+++ b/flow/pkg/common/tls_test.go
@@ -90,3 +90,107 @@ func TestCreateTlsConfigClientCertificate(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestCreateTlsConfigCertificateChainOnlyVerification(t *testing.T) {
+	rootPEM, leaf, intermediate := generateServerCertificateChain(t, "cloudsql.google.internal")
+
+	config, err := CreateTlsConfig(
+		tls.VersionTLS12,
+		&rootPEM,
+		"synthetic-rpe-alias.internal",
+		"",
+		false,
+		nil,
+		WithCertificateChainOnlyVerification(),
+	)
+	require.NoError(t, err)
+	require.True(t, config.InsecureSkipVerify)
+	require.Empty(t, config.ServerName)
+	require.NotNil(t, config.VerifyConnection)
+	require.NoError(t, config.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{leaf, intermediate},
+	}))
+}
+
+func TestCreateTlsConfigCertificateChainOnlyVerificationRequiresRootCA(t *testing.T) {
+	_, err := CreateTlsConfig(
+		tls.VersionTLS12,
+		nil,
+		"synthetic-rpe-alias.internal",
+		"",
+		false,
+		nil,
+		WithCertificateChainOnlyVerification(),
+	)
+	require.ErrorContains(t, err, "requires a non-empty root CA")
+}
+
+func generateServerCertificateChain(
+	t *testing.T,
+	dnsName string,
+) (string, *x509.Certificate, *x509.Certificate) {
+	t.Helper()
+	now := time.Now()
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(10),
+		Subject:               pkix.Name{CommonName: "test root"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	root, err := x509.ParseCertificate(rootDER)
+	require.NoError(t, err)
+
+	intermediateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	intermediateTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(11),
+		Subject:               pkix.Name{CommonName: "test intermediate"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	intermediateDER, err := x509.CreateCertificate(
+		rand.Reader,
+		intermediateTemplate,
+		root,
+		&intermediateKey.PublicKey,
+		rootKey,
+	)
+	require.NoError(t, err)
+	intermediate, err := x509.ParseCertificate(intermediateDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(12),
+		Subject:      pkix.Name{CommonName: dnsName},
+		DNSNames:     []string{dnsName},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	leafDER, err := x509.CreateCertificate(
+		rand.Reader,
+		leafTemplate,
+		intermediate,
+		&leafKey.PublicKey,
+		intermediateKey,
+	)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+
+	rootPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
+	return string(rootPEM), leaf, intermediate
+}

--- a/protos/peers.proto
+++ b/protos/peers.proto
@@ -113,6 +113,7 @@ message AwsAuthenticationConfig {
 enum PostgresAuthType {
   POSTGRES_PASSWORD = 0;
   POSTGRES_IAM_AUTH = 1;
+  POSTGRES_GCP_CLOUD_SQL_IAM_AUTH = 2;
 }
 
 message ClientTlsConfig {
@@ -236,6 +237,7 @@ enum MySqlReplicationMechanism {
 enum MySqlAuthType {
   MYSQL_PASSWORD = 0;
   MYSQL_IAM_AUTH = 1;
+  MYSQL_GCP_CLOUD_SQL_IAM_AUTH = 2;
 }
 message MySqlConfig {
   string host = 1;


### PR DESCRIPTION
## Problem

Cloud SQL-backed PostgreSQL and MySQL peers currently require static database passwords. ClickPipes needs to authenticate with short-lived IAM database login tokens minted through the tenant GSA workload-identity chain.

Linear: https://linear.app/clickhouse/issue/CLP-959/cloud-sql-source-workload-identity-iam-auth

## Solution

- Add dedicated PostgreSQL and MySQL Cloud SQL IAM auth enum values.
- Extract the existing GCP workload-identity exchange and tenant-GSA impersonation into a shared utility.
- Mint a fresh `sqlservice.login` token for each ordinary, replication, and binlog connection.
- Preserve configured database usernames and existing SSH/RPE networking.
- Require TLS with certificate verification for Cloud SQL IAM auth.
- Keep tokens in memory only and reject nil or empty token responses.

## Testing

- Focused tests passed for `connectors/utils`, `connectors/bigquery`, `connectors/postgres`, `connectors/mysql`, and `internal`.
- Compile-only tests passed for affected packages.
- `golangci-lint` passed with 0 issues.
- `git diff --check` passed.

## Risks and follow-up

- Live Cloud SQL PostgreSQL logical-replication and MySQL binlog smoke tests are still required.
- The MySQL path relies on Cloud SQL requesting `mysql_clear_password` over verified TLS.
- After merge, publish a new `flow-api-client` version for the dependent clickpipes-platform PR.