### PR TITLE
feat(bigquery): poll CDC source tables in parallel

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/auth"
@@ -56,8 +57,9 @@ type BigQueryConnector struct {
 	lastPollAt time.Time
 	// droppedExcludeColumns remembers, per source table, excluded columns that
 	// BigQuery has reported as no longer existing, so later polls stop asking BigQuery
-	// to EXCEPT them.
-	droppedExcludeColumns map[string]map[string]struct{}
+	// to EXCEPT them. Parallel CDC table polls share it, so it maps a source table
+	// identifier to a map[string]struct{} that is replaced, never mutated in place.
+	droppedExcludeColumns sync.Map
 	logger                log.Logger
 	*metadataStore.PostgresMetadata
 	bqConfig      *protos.BigqueryConfig
@@ -129,16 +131,15 @@ func NewBigQueryConnector(ctx context.Context, config *protos.BigqueryConfig) (*
 	}
 
 	return &BigQueryConnector{
-		credentials:           creds,
-		bqConfig:              config,
-		client:                client,
-		datasetID:             datasetID,
-		projectID:             projectID,
-		PostgresMetadata:      metadataStore.NewPostgresMetadataFromCatalog(logger, catalogPool),
-		storageClient:         storageClient,
-		catalogPool:           catalogPool,
-		logger:                logger,
-		droppedExcludeColumns: make(map[string]map[string]struct{}),
+		credentials:      creds,
+		bqConfig:         config,
+		client:           client,
+		datasetID:        datasetID,
+		projectID:        projectID,
+		PostgresMetadata: metadataStore.NewPostgresMetadataFromCatalog(logger, catalogPool),
+		storageClient:    storageClient,
+		catalogPool:      catalogPool,
+		logger:           logger,
 	}, nil
 }
 

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -53,8 +53,6 @@ func NewBigQueryServiceAccount(bqConfig *protos.BigqueryConfig) (*utils.GcpServi
 }
 
 type BigQueryConnector struct {
-	// lastPollAt is the wall-clock time PullRecords last actually queried BigQuery.
-	lastPollAt time.Time
 	// droppedExcludeColumns remembers, per source table, excluded columns that
 	// BigQuery has reported as no longer existing, so later polls stop asking BigQuery
 	// to EXCEPT them. Parallel CDC table polls share it, so it maps a source table

--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -9,11 +9,13 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/bigquery"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 
@@ -90,6 +92,80 @@ func (c *BigQueryConnector) waitForNextPoll(ctx context.Context, idleTimeout tim
 	return nil
 }
 
+// tablePollPlan is one table's poll window for the current batch. Windows are
+// resolved from the checkpoint before any table runs, so concurrent polls never
+// touch the checkpoint.
+type tablePollPlan struct {
+	start time.Time
+	upper time.Time
+	pull  func(
+		ctx context.Context,
+		sourceTableIdentifier string,
+		nameAndExclude model.NameAndExclude,
+		start, end time.Time,
+		addRecord func(context.Context, model.Record[model.RecordItems]) error,
+	) (int64, error)
+	table string
+}
+
+type tablePollResult struct {
+	err            error
+	bytesProcessed int64
+}
+
+type tablePullError struct {
+	err   error
+	table string
+}
+
+// runTablePolls scans the planned windows with up to parallelism tables in flight,
+// returning one result per plan. A table that fails without emitting anything is
+// reported in its own result so siblings keep their progress; anything that makes
+// the whole pull unsafe -- context cancellation, or a failure after part of a
+// table's window already reached the stream -- is returned as the error and
+// abandons the remaining tables.
+func runTablePolls(
+	ctx context.Context,
+	plans []tablePollPlan,
+	parallelism int,
+	tableNameMapping map[string]model.NameAndExclude,
+	addRecord func(context.Context, model.Record[model.RecordItems]) error,
+) ([]tablePollResult, error) {
+	results := make([]tablePollResult, len(plans))
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(parallelism)
+	for i, plan := range plans {
+		group.Go(func() error {
+			emitted := false
+			tableBytesProcessed, err := plan.pull(
+				groupCtx, plan.table, tableNameMapping[plan.table], plan.start, plan.upper,
+				func(ctx context.Context, record model.Record[model.RecordItems]) error {
+					emitted = true
+					return addRecord(ctx, record)
+				},
+			)
+			if err != nil {
+				if groupCtx.Err() != nil {
+					return groupCtx.Err()
+				}
+				if emitted {
+					// Part of this table's window is already downstream, so leaving the
+					// table behind would let the batch confirm records it never finished.
+					return fmt.Errorf("BigQuery CDC table %s failed after emitting records: %w", plan.table, err)
+				}
+				results[i] = tablePollResult{err: err}
+				return nil
+			}
+			results[i] = tablePollResult{bytesProcessed: tableBytesProcessed}
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 // PullRecords polls every mapped table from its own synced-through checkpoint.
 // A table failure leaves only that table behind; successful siblings continue
 // and the resulting per-table checkpoint is confirmed with the shared stream.
@@ -132,18 +208,34 @@ func (c *BigQueryConnector) PullRecords(
 	if err != nil {
 		return fmt.Errorf("failed to get BigQuery CDC max query window: %w", err)
 	}
-
 	cfg, err := internal.FetchConfigFromDB(ctx, catalogPool, req.FlowJobName)
 	if err != nil {
 		return fmt.Errorf("failed to fetch flow config from db: %w", err)
+	}
+
+	parallelism := int(cfg.GetBigqueryCdcConfig().GetQueryCdcTablesParallelism())
+	if parallelism <= 0 {
+		parallelism, err = internal.PeerDBBigQueryCDCTableParallelism(ctx, req.Env)
+		if err != nil {
+			return fmt.Errorf("failed to get BigQuery CDC table parallelism: %w", err)
+		}
+	}
+	if parallelism <= 0 {
+		parallelism = -1 // errgroup treats a negative limit as unlimited
 	}
 	eventsFunctionByTable := make(map[string]protos.BigqueryCdcEventsFunction, len(cfg.TableMappings))
 	for _, tableMapping := range cfg.TableMappings {
 		eventsFunctionByTable[tableMapping.SourceTableIdentifier] = tableMapping.GetBigqueryCdcEventsFunction()
 	}
 
+	var streamMu sync.Mutex
 	var recordCount int
 	addRecord := func(ctx context.Context, record model.Record[model.RecordItems]) error {
+		// SignalAsNotEmpty closes the channel and can't be called in parallel
+		// as well as AddRecord, writing to the records channel is fine, but
+		// it also read-write needsNormalize in unsynchronized way
+		streamMu.Lock()
+		defer streamMu.Unlock()
 		if recordCount == 0 {
 			req.RecordStream.SignalAsNotEmpty()
 		}
@@ -151,14 +243,8 @@ func (c *BigQueryConnector) PullRecords(
 		return req.RecordStream.AddRecord(ctx, record)
 	}
 
-	var bytesProcessed int64
-	var tableErrors []error
-	type tablePullError struct {
-		err   error
-		table string
-	}
-	var customerVisibleTableErrors []tablePullError
 	healthyTables := 0
+	plans := make([]tablePollPlan, 0, len(sourceTables))
 	for _, sourceTableIdentifier := range sourceTables {
 		start, err := checkpoint.SyncedThrough(sourceTableIdentifier)
 		if err != nil {
@@ -172,35 +258,37 @@ func (c *BigQueryConnector) PullRecords(
 			continue
 		}
 
-		pullTable := c.pullTableAppends
+		pull := c.pullTableAppends
 		if eventsFunctionByTable[sourceTableIdentifier] == protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES {
-			pullTable = c.pullTableChanges
+			pull = c.pullTableChanges
 		}
-		recordCountBeforeTable := recordCount
-		tableBytesProcessed, err := pullTable(
-			ctx, sourceTableIdentifier, req.TableNameMapping[sourceTableIdentifier], start, upper, addRecord,
-		)
-		if err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			if recordCount > recordCountBeforeTable {
-				return fmt.Errorf("BigQuery CDC table %s failed after emitting records: %w", sourceTableIdentifier, err)
-			}
-			if checkpoint.RecordFailure(sourceTableIdentifier, upper) {
+		plans = append(plans, tablePollPlan{start: start, upper: upper, table: sourceTableIdentifier, pull: pull})
+	}
+
+	results, err := runTablePolls(ctx, plans, parallelism, req.TableNameMapping, addRecord)
+	if err != nil {
+		return err
+	}
+
+	var bytesProcessed int64
+	var tableErrors []error
+	var customerVisibleTableErrors []tablePullError
+	for i, plan := range plans {
+		if err := results[i].err; err != nil {
+			if checkpoint.RecordFailure(plan.table, plan.upper) {
 				customerVisibleTableErrors = append(customerVisibleTableErrors, tablePullError{
-					table: sourceTableIdentifier,
+					table: plan.table,
 					err:   err,
 				})
 			}
 			tableErrors = append(tableErrors, err)
 			c.logger.Error("[bigquery] CDC table poll failed; other tables will continue",
-				slog.String("table", sourceTableIdentifier), slog.Any("error", err))
+				slog.String("table", plan.table), slog.Any("error", err))
 			continue
 		}
-		checkpoint.RecordSuccess(sourceTableIdentifier, upper)
+		checkpoint.RecordSuccess(plan.table, plan.upper)
 		healthyTables++
-		bytesProcessed += tableBytesProcessed
+		bytesProcessed += results[i].bytesProcessed
 	}
 	if len(sourceTables) > 0 && healthyTables == 0 {
 		return errors.Join(tableErrors...)
@@ -390,15 +478,10 @@ func (c *BigQueryConnector) runPullQuery(
 		if len(missing) == 0 {
 			return nil, err
 		}
-		dropped := c.droppedExcludeColumns[sourceTableIdentifier]
-		if dropped == nil {
-			dropped = make(map[string]struct{}, len(missing))
-			c.droppedExcludeColumns[sourceTableIdentifier] = dropped
-		}
 		next := make(map[string]struct{}, len(effective))
 		for col := range effective {
 			if _, gone := missing[col]; gone {
-				dropped[col] = struct{}{}
+				c.markDroppedExcludeColumn(sourceTableIdentifier, col)
 				c.logger.Warn("[bigquery] excluded column no longer exists on source table, dropping from EXCEPT clause",
 					slog.String("table", sourceTableIdentifier), slog.String("column", col))
 				continue
@@ -409,10 +492,28 @@ func (c *BigQueryConnector) runPullQuery(
 	}
 }
 
+// markDroppedExcludeColumn remembers that col no longer exists on
+// sourceTableIdentifier, so later polls stop asking BigQuery to EXCEPT it.
+func (c *BigQueryConnector) markDroppedExcludeColumn(sourceTableIdentifier string, col string) {
+	dropped := c.droppedExcludeColumnsFor(sourceTableIdentifier)
+	next := make(map[string]struct{}, len(dropped)+1)
+	maps.Copy(next, dropped)
+	next[col] = struct{}{}
+	c.droppedExcludeColumns.Store(sourceTableIdentifier, next)
+}
+
+func (c *BigQueryConnector) droppedExcludeColumnsFor(sourceTableIdentifier string) map[string]struct{} {
+	stored, ok := c.droppedExcludeColumns.Load(sourceTableIdentifier)
+	if !ok {
+		return nil
+	}
+	return stored.(map[string]struct{})
+}
+
 // effectiveExclude returns exclude minus any columns already known (from a prior
 // runPullQuery retry) to no longer exist on sourceTableIdentifier.
 func (c *BigQueryConnector) effectiveExclude(sourceTableIdentifier string, exclude map[string]struct{}) map[string]struct{} {
-	dropped := c.droppedExcludeColumns[sourceTableIdentifier]
+	dropped := c.droppedExcludeColumnsFor(sourceTableIdentifier)
 	if len(dropped) == 0 {
 		return exclude
 	}

--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -79,17 +79,18 @@ func pollWindow(checkpoint, now time.Time, safetyLag, maxQueryWindow time.Durati
 	return upper, upper.After(checkpoint)
 }
 
-// waitForNextPoll self-paces PullRecords, park it until
-// time since the last poll hasn't crossed idleTimeout
-func (c *BigQueryConnector) waitForNextPoll(ctx context.Context, idleTimeout time.Duration) error {
-	if wait := idleTimeout - time.Since(c.lastPollAt); wait > 0 {
-		select {
-		case <-time.After(wait):
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+func waitForNextPoll(ctx context.Context, wait time.Duration) error {
+	if wait <= 0 {
+		return nil
 	}
-	return nil
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // tablePollPlan is one table's poll window for the current batch. Windows are
@@ -176,13 +177,6 @@ func (c *BigQueryConnector) PullRecords(
 	req *model.PullRecordsRequest[model.RecordItems],
 ) error {
 	defer req.RecordStream.Close()
-	// Recorded regardless of how this call returns below (including the
-	// "nothing new to scan yet" early return) so pacing always advances.
-	defer func() { c.lastPollAt = time.Now() }()
-
-	if err := c.waitForNextPoll(ctx, req.IdleTimeout); err != nil {
-		return err
-	}
 
 	sourceTables := make([]string, 0, len(req.TableNameMapping))
 	for sourceTableIdentifier := range req.TableNameMapping {
@@ -193,6 +187,15 @@ func (c *BigQueryConnector) PullRecords(
 	now, err := c.currentBigQueryTimestamp(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current BigQuery timestamp: %w", err)
+	}
+	if wait := checkpoint.nextPollWait(now, req.IdleTimeout); wait > 0 {
+		if err := waitForNextPoll(ctx, wait); err != nil {
+			return err
+		}
+		now, err = c.currentBigQueryTimestamp(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to refresh current BigQuery timestamp after poll wait: %w", err)
+		}
 	}
 
 	checkpoint, err := parseBigQueryCDCCheckpoint(req.LastOffset.Text, sourceTables, now)
@@ -245,7 +248,19 @@ func (c *BigQueryConnector) PullRecords(
 
 	healthyTables := 0
 	plans := make([]tablePollPlan, 0, len(sourceTables))
+	attemptedTables := 0
 	for _, sourceTableIdentifier := range sourceTables {
+		pollDue, err := checkpoint.pollDue(sourceTableIdentifier, now, req.IdleTimeout)
+		if err != nil {
+			return err
+		}
+		if !pollDue {
+			healthyTables++
+			continue
+		}
+		checkpoint.RecordAttempt(sourceTableIdentifier, now)
+		attemptedTables++
+
 		start, err := checkpoint.SyncedThrough(sourceTableIdentifier)
 		if err != nil {
 			return err
@@ -318,14 +333,12 @@ func (c *BigQueryConnector) PullRecords(
 
 	if recordCount == 0 {
 		c.logger.Info("[bigquery] PullRecords no new records")
+		req.RecordStream.SignalAsEmpty()
 		// still move the checkpoint forward
 		err = c.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{Text: checkpointText})
 		if err != nil {
-			c.logger.Error("[bigquery] PullRecords failed to persist checkpoint",
-				slog.String("checkpoint", checkpointText),
-				slog.Any("error", err))
+			return fmt.Errorf("failed to persist BigQuery CDC checkpoint: %w", err)
 		}
-		req.RecordStream.SignalAsEmpty()
 	}
 
 	trace.SpanFromContext(ctx).SetAttributes(
@@ -333,7 +346,7 @@ func (c *BigQueryConnector) PullRecords(
 		attribute.Int64(otel_metrics.BytesPulledKey, bytesProcessed),
 	)
 	c.logger.Info("[bigquery] PullRecords polled tables",
-		slog.Int("tables", len(sourceTables)), slog.Int("failedTables", len(tableErrors)),
+		slog.Int("tables", attemptedTables), slog.Int("failedTables", len(tableErrors)),
 		slog.Int("records", recordCount), slog.Int64("bytes", bytesProcessed))
 
 	return nil

--- a/flow/connectors/bigquery/cdc_checkpoint.go
+++ b/flow/connectors/bigquery/cdc_checkpoint.go
@@ -19,6 +19,10 @@ type bigQueryCDCTableProgress struct {
 	// SyncedThrough after success and remains ahead of it while a failed window
 	// is waiting to be retried.
 	Target time.Time `json:"target"`
+	// LastAttemptAt is the BigQuery clock time when the latest poll attempt
+	// started. PeerDB persists it with the checkpoint so worker restarts keep
+	// the configured poll interval. A zero value makes a new table due now.
+	LastAttemptAt time.Time `json:"last_attempt_at,omitzero"`
 }
 
 type bigQueryCDCCheckpoint struct {
@@ -106,8 +110,45 @@ func (c *bigQueryCDCCheckpoint) SyncedThrough(table string) (time.Time, error) {
 	return progress.SyncedThrough, nil
 }
 
+func (c *bigQueryCDCCheckpoint) nextPollWait(now time.Time, pollInterval time.Duration) time.Duration {
+	var earliest time.Time
+	for _, progress := range c.Tables {
+		if progress.LastAttemptAt.IsZero() {
+			return 0
+		}
+		nextPollAt := progress.LastAttemptAt.Add(pollInterval)
+		if !nextPollAt.After(now) {
+			return 0
+		}
+		if earliest.IsZero() || nextPollAt.Before(earliest) {
+			earliest = nextPollAt
+		}
+	}
+	if earliest.IsZero() {
+		return 0
+	}
+	return earliest.Sub(now)
+}
+
+func (c *bigQueryCDCCheckpoint) pollDue(table string, now time.Time, pollInterval time.Duration) (bool, error) {
+	progress, ok := c.Tables[table]
+	if !ok {
+		return false, fmt.Errorf("BigQuery CDC checkpoint is missing table %s", table)
+	}
+	return progress.LastAttemptAt.IsZero() || !progress.LastAttemptAt.Add(pollInterval).After(now), nil
+}
+
+func (c *bigQueryCDCCheckpoint) RecordAttempt(table string, attemptedAt time.Time) {
+	progress := c.Tables[table]
+	progress.LastAttemptAt = attemptedAt
+	c.Tables[table] = progress
+}
+
 func (c *bigQueryCDCCheckpoint) RecordSuccess(table string, target time.Time) {
-	c.Tables[table] = bigQueryCDCTableProgress{SyncedThrough: target, Target: target}
+	progress := c.Tables[table]
+	progress.SyncedThrough = target
+	progress.Target = target
+	c.Tables[table] = progress
 }
 
 // RecordFailure keeps the last confirmed cursor and records the attempted

--- a/flow/connectors/bigquery/cdc_test.go
+++ b/flow/connectors/bigquery/cdc_test.go
@@ -78,14 +78,19 @@ func TestBigQueryCDCCheckpointRecordsIndependentTableOutcomes(t *testing.T) {
 	target := start.Add(time.Hour)
 	cp := newBigQueryCDCCheckpoint(start, []string{"a", "b"})
 
+	cp.RecordAttempt("a", target)
 	cp.RecordSuccess("a", target)
+	cp.RecordAttempt("b", target)
 	assert.True(t, cp.RecordFailure("b", target), "first failure in an episode should be reported")
+	cp.RecordAttempt("b", target.Add(time.Hour))
 	assert.False(t, cp.RecordFailure("b", target.Add(time.Hour)), "repeated failure should not be reported again")
 
 	assert.Equal(t, target, cp.Tables["a"].SyncedThrough)
 	assert.Equal(t, target, cp.Tables["a"].Target)
+	assert.Equal(t, target, cp.Tables["a"].LastAttemptAt)
 	assert.Equal(t, start, cp.Tables["b"].SyncedThrough)
 	assert.Equal(t, target.Add(time.Hour), cp.Tables["b"].Target)
+	assert.Equal(t, target.Add(time.Hour), cp.Tables["b"].LastAttemptAt)
 
 	cp.RecordSuccess("b", target.Add(2*time.Hour))
 	assert.True(t, cp.RecordFailure("b", target.Add(3*time.Hour)), "failure after recovery starts a new episode")
@@ -155,42 +160,86 @@ func TestBigQueryCDCCheckpointRejectsUnknownVersion(t *testing.T) {
 	require.ErrorContains(t, err, "unsupported BigQuery CDC checkpoint version 2")
 }
 
+func TestBigQueryCDCCheckpointPollScheduleSurvivesReload(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	cp := newBigQueryCDCCheckpoint(now.Add(-3*time.Hour), []string{"a", "b"})
+	cp.RecordAttempt("a", now)
+	cp.RecordSuccess("a", now.Add(-time.Hour))
+	cp.RecordAttempt("b", now.Add(-2*time.Hour))
+	assert.True(t, cp.RecordFailure("b", now.Add(-time.Hour)))
+
+	encoded, err := cp.Marshal()
+	require.NoError(t, err)
+	reloaded, err := parseBigQueryCDCCheckpoint(encoded, []string{"a", "b"})
+	require.NoError(t, err)
+
+	assert.Zero(t, reloaded.nextPollWait(now, time.Hour), "table b is already due")
+	due, err := reloaded.pollDue("a", now, time.Hour)
+	require.NoError(t, err)
+	assert.False(t, due)
+	due, err = reloaded.pollDue("b", now, time.Hour)
+	require.NoError(t, err)
+	assert.True(t, due)
+	assert.Equal(t, now.Add(-3*time.Hour), reloaded.Tables["b"].SyncedThrough)
+}
+
+func TestBigQueryCDCCheckpointNextPollWait(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("new table is due immediately", func(t *testing.T) {
+		cp := newBigQueryCDCCheckpoint(now, []string{"a"})
+		assert.Zero(t, cp.nextPollWait(now, time.Hour))
+	})
+
+	t.Run("checkpoint from before durable scheduling is due immediately", func(t *testing.T) {
+		cp, err := parseBigQueryCDCCheckpoint(`{
+			"version": 1,
+			"tables": {
+				"a": {"synced_through": "2026-08-01T10:00:00Z", "target": "2026-08-01T10:00:00Z"}
+			}
+		}`, []string{"a"})
+		require.NoError(t, err)
+		assert.Zero(t, cp.nextPollWait(now, time.Hour))
+	})
+
+	t.Run("uses earliest per-table due time", func(t *testing.T) {
+		cp := newBigQueryCDCCheckpoint(now, []string{"a", "b"})
+		cp.RecordAttempt("a", now.Add(-15*time.Minute))
+		cp.RecordAttempt("b", now.Add(-45*time.Minute))
+		assert.Equal(t, 15*time.Minute, cp.nextPollWait(now, time.Hour))
+	})
+
+	t.Run("returns immediately once a table is due", func(t *testing.T) {
+		cp := newBigQueryCDCCheckpoint(now, []string{"a"})
+		cp.RecordAttempt("a", now.Add(-time.Hour))
+		assert.Zero(t, cp.nextPollWait(now, time.Hour))
+	})
+}
+
 func TestWaitForNextPoll(t *testing.T) {
-	t.Run("first-ever call (zero lastPollAt) returns immediately", func(t *testing.T) {
-		c := &BigQueryConnector{}
+	t.Run("non-positive wait returns immediately", func(t *testing.T) {
 		start := time.Now()
-		err := c.waitForNextPoll(context.Background(), time.Hour)
+		err := waitForNextPoll(context.Background(), 0)
 		require.NoError(t, err)
 		assert.Less(t, time.Since(start), 100*time.Millisecond)
 	})
 
-	t.Run("waits out the remainder of idleTimeout since lastPollAt", func(t *testing.T) {
-		c := &BigQueryConnector{lastPollAt: time.Now()}
-		idleTimeout := 50 * time.Millisecond
+	t.Run("waits for the requested duration", func(t *testing.T) {
+		wait := 50 * time.Millisecond
 		start := time.Now()
-		err := c.waitForNextPoll(context.Background(), idleTimeout)
+		err := waitForNextPoll(context.Background(), wait)
 		require.NoError(t, err)
-		elapsed := time.Since(start)
-		assert.GreaterOrEqual(t, elapsed, idleTimeout-5*time.Millisecond)
-	})
-
-	t.Run("no wait once idleTimeout has already elapsed", func(t *testing.T) {
-		c := &BigQueryConnector{lastPollAt: time.Now().Add(-time.Hour)}
-		start := time.Now()
-		err := c.waitForNextPoll(context.Background(), time.Second)
-		require.NoError(t, err)
-		assert.Less(t, time.Since(start), 100*time.Millisecond)
+		assert.GreaterOrEqual(t, time.Since(start), wait-5*time.Millisecond)
 	})
 
 	t.Run("context cancellation interrupts the wait", func(t *testing.T) {
-		c := &BigQueryConnector{lastPollAt: time.Now()}
 		ctx, cancel := context.WithCancel(context.Background())
 		go func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
 		}()
 		start := time.Now()
-		err := c.waitForNextPoll(ctx, time.Hour)
+		err := waitForNextPoll(ctx, time.Hour)
 		require.ErrorIs(t, err, context.Canceled)
 		assert.Less(t, time.Since(start), time.Second)
 	})

--- a/flow/connectors/bigquery/cdc_test.go
+++ b/flow/connectors/bigquery/cdc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/googleapi"
 
+	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
@@ -255,9 +257,8 @@ func TestMissingExceptColumns(t *testing.T) {
 }
 
 func TestEffectiveExclude(t *testing.T) {
-	c := &BigQueryConnector{droppedExcludeColumns: map[string]map[string]struct{}{
-		"ds.tbl": {"secret_column": {}},
-	}}
+	c := &BigQueryConnector{}
+	c.droppedExcludeColumns.Store("ds.tbl", map[string]struct{}{"secret_column": {}})
 	exclude := map[string]struct{}{"secret_column": {}, "large_payload": {}}
 
 	assert.Equal(t, map[string]struct{}{"large_payload": {}}, c.effectiveExclude("ds.tbl", exclude))
@@ -277,4 +278,106 @@ func TestBuildPullQuery(t *testing.T) {
 		"SELECT * EXCEPT (`secret`) FROM CHANGES(TABLE `ds`.`tbl`, @start, @end) ORDER BY `_CHANGE_TIMESTAMP`",
 		buildPullQuery("CHANGES", "`ds`.`tbl`", map[string]struct{}{"secret": {}}, "`_CHANGE_TIMESTAMP`"),
 	)
+}
+
+func testPollPlan(
+	table string,
+	pull func(context.Context, string, model.NameAndExclude, time.Time, time.Time,
+		func(context.Context, model.Record[model.RecordItems]) error) (int64, error),
+) tablePollPlan {
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	return tablePollPlan{start: start, upper: start.Add(time.Hour), table: table, pull: pull}
+}
+
+func TestRunTablePollsIsolatesFailures(t *testing.T) {
+	failure := errors.New("boom")
+	plans := []tablePollPlan{
+		testPollPlan("ds.ok", func(
+			context.Context, string, model.NameAndExclude, time.Time, time.Time,
+			func(context.Context, model.Record[model.RecordItems]) error,
+		) (int64, error) {
+			return 42, nil
+		}),
+		testPollPlan("ds.bad", func(
+			context.Context, string, model.NameAndExclude, time.Time, time.Time,
+			func(context.Context, model.Record[model.RecordItems]) error,
+		) (int64, error) {
+			return 0, failure
+		}),
+	}
+
+	results, err := runTablePolls(t.Context(), plans, 2, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.NoError(t, results[0].err)
+	assert.Equal(t, int64(42), results[0].bytesProcessed)
+	assert.ErrorIs(t, results[1].err, failure)
+}
+
+func TestRunTablePollsFailsBatchWhenTableAlreadyEmitted(t *testing.T) {
+	failure := errors.New("boom")
+	plans := []tablePollPlan{
+		testPollPlan("ds.bad", func(
+			ctx context.Context, _ string, _ model.NameAndExclude, _ time.Time, _ time.Time,
+			addRecord func(context.Context, model.Record[model.RecordItems]) error,
+		) (int64, error) {
+			if err := addRecord(ctx, &model.InsertRecord[model.RecordItems]{}); err != nil {
+				return 0, err
+			}
+			return 0, failure
+		}),
+	}
+
+	_, err := runTablePolls(t.Context(), plans, 1, nil, func(context.Context, model.Record[model.RecordItems]) error {
+		return nil
+	})
+	require.ErrorIs(t, err, failure)
+	assert.Contains(t, err.Error(), "ds.bad")
+}
+
+func TestRunTablePollsRespectsParallelism(t *testing.T) {
+	const parallelism = 2
+	var mu sync.Mutex
+	inFlight, maxInFlight := 0, 0
+
+	plans := make([]tablePollPlan, 0, 8)
+	for i := range 8 {
+		plans = append(plans, testPollPlan(fmt.Sprintf("ds.t%d", i), func(
+			context.Context, string, model.NameAndExclude, time.Time, time.Time,
+			func(context.Context, model.Record[model.RecordItems]) error,
+		) (int64, error) {
+			mu.Lock()
+			inFlight++
+			maxInFlight = max(maxInFlight, inFlight)
+			mu.Unlock()
+			time.Sleep(5 * time.Millisecond)
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+			return 0, nil
+		}))
+	}
+
+	_, err := runTablePolls(t.Context(), plans, parallelism, nil, nil)
+	require.NoError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.LessOrEqual(t, maxInFlight, parallelism)
+	assert.Greater(t, maxInFlight, 1, "tables should actually run concurrently")
+}
+
+func TestRunTablePollsReturnsContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	plans := []tablePollPlan{
+		testPollPlan("ds.tbl", func(
+			ctx context.Context, _ string, _ model.NameAndExclude, _ time.Time, _ time.Time,
+			_ func(context.Context, model.Record[model.RecordItems]) error,
+		) (int64, error) {
+			return 0, ctx.Err()
+		}),
+	}
+
+	_, err := runTablePolls(ctx, plans, 1, nil, nil)
+	assert.ErrorIs(t, err, context.Canceled)
 }

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -300,6 +300,15 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 	{
+		Name: "PEERDB_BIGQUERY_CDC_TABLE_PARALLELISM",
+		Description: "BigQuery CDC only: default for how many source tables one poll queries concurrently, " +
+			"used when a mirror does not set query_cdc_tables_parallelism; 0 or less removes the limit",
+		DefaultValue:     "10",
+		ValueType:        protos.DynconfValueType_INT,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_BIGQUERY,
+	},
+	{
 		Name:             "PEERDB_CLICKHOUSE_ENABLE_PRIMARY_UPDATE",
 		Description:      "Enable generating deletion records for updates in ClickHouse, avoids stale records when primary key updated",
 		DefaultValue:     "false",
@@ -718,6 +727,10 @@ func PeerDBBigQueryCDCMaxQueryWindow(ctx context.Context, env map[string]string)
 		return 0, err
 	}
 	return time.Duration(x) * time.Second, nil
+}
+
+func PeerDBBigQueryCDCTableParallelism(ctx context.Context, env map[string]string) (int, error) {
+	return dynamicConfSigned[int](ctx, env, "PEERDB_BIGQUERY_CDC_TABLE_PARALLELISM")
 }
 
 func PeerDBCDCChannelBufferSize(ctx context.Context, env map[string]string) (int, error) {

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -68,6 +68,10 @@ enum BigQueryReplicationMode {
 
 message BigqueryCdcConfig {
   BigQueryReplicationMode replication_mode = 1;
+  // How many source tables one CDC poll queries concurrently. BigQuery enforces a
+  // hard limit of 100 concurrent queries per project, shared by every mirror.
+  // Falls back to PEERDB_BIGQUERY_CDC_TABLE_PARALLELISM (default 10) when unset.
+  int32 query_cdc_tables_parallelism = 2;
 }
 
 // FlowConnectionConfigs is for external use by the API, maintaining backwards compatibility


### PR DESCRIPTION
Stacked on #4712.

## What

BigQuery CDC polled one source table at a time. A slow or large table blocked every table queued behind it in the same batch, so a single heavy table set the pace for the whole mirror. Table polls now run concurrently.

## How

PulLRecords spins up a goroutine per table with bounded parallelism controlled via mirror settings (or dynamic config as a fallback).
Error reporting behavior stays the same (one failing table doesn't block the others). When all tables have failed -> an error is returned from PullRecords.

Resolves: DBI-1046
