### PR TITLE
fix(cmd): don't panic on CLI app error, exit(1) instead

### DIFF
--- a/flow/main.go
+++ b/flow/main.go
@@ -316,6 +316,7 @@ func main() {
 	if err := app.Run(appCtx, os.Args); err != nil {
 		log.Printf("error running app: %+v", err)
 		appClose()
+		//nolint:gocritic
 		os.Exit(1)
 	}
 }

--- a/flow/main.go
+++ b/flow/main.go
@@ -315,6 +315,6 @@ func main() {
 
 	if err := app.Run(appCtx, os.Args); err != nil {
 		log.Printf("error running app: %+v", err)
-		panic(err)
+		os.Exit(1)
 	}
 }

--- a/flow/main.go
+++ b/flow/main.go
@@ -315,6 +315,7 @@ func main() {
 
 	if err := app.Run(appCtx, os.Args); err != nil {
 		log.Printf("error running app: %+v", err)
+		appClose()
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary
- `flow/main.go` turned any `app.Run` error into `panic(err)`, so normal CLI failures (e.g. `StartMaintenanceWorkflow` getting terminated) surfaced as Go panics/stack traces instead of a clean non-zero exit.
- Replaced `panic(err)` with `os.Exit(1)` — still fails the process for k8s/job detection, without the panic noise.