### PR TITLE
feat(bigquery): apply CDC backpressure per table

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -408,6 +408,9 @@ func (a *FlowableActivity) SyncFlow(
 	normBufferSize := normBufferHours * 3600 / int64(idleTimeout.Seconds())
 	// Normalize is always 1 batch behind, allow 2 to still run in parallel with pull-sync
 	normBufferSize = max(normBufferSize, 2)
+	// ClickHouse persists normalization progress per destination table, and
+	// BigQuery can pause source tables independently.
+	tableLevelBackpressure := config.GetBigqueryCdcConfig() != nil && destinationType == protos.DBType_CLICKHOUSE
 
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {
@@ -425,7 +428,7 @@ func (a *FlowableActivity) SyncFlow(
 		var syncErr error
 		if config.System == protos.TypeSystem_Q {
 			syncResponse, syncErr = a.pullAndSync(groupCtx, config, options, srcConn.(connectors.CDCPullConnector),
-				normRequests, normResponses, normBufferSize, idleTimeout, &syncingBatchID, &syncState)
+				normRequests, normResponses, normBufferSize, tableLevelBackpressure, idleTimeout, &syncingBatchID, &syncState)
 		} else {
 			syncResponse, syncErr = a.pullAndSyncPg(groupCtx, config, options, srcConn.(connectors.CDCPullPgConnector),
 				normRequests, normResponses, normBufferSize, idleTimeout, &syncingBatchID, &syncState)
@@ -478,6 +481,7 @@ func (a *FlowableActivity) pullAndSync(
 	normRequests *concurrency.LastChan,
 	normResponses *concurrency.LastChan,
 	normBufferSize int64,
+	tableLevelBackpressure bool,
 	idleTimeout time.Duration,
 	syncingBatchID *atomic.Int64,
 	syncWaiting *atomic.Pointer[string],
@@ -512,7 +516,7 @@ func (a *FlowableActivity) pullAndSync(
 		}
 	}
 	return pullAndSyncCore(ctx, a, config, options, srcConn,
-		normRequests, normResponses, normBufferSize, idleTimeout,
+		normRequests, normResponses, normBufferSize, tableLevelBackpressure, idleTimeout,
 		syncingBatchID, syncWaiting, adaptStream,
 		connectors.CDCPullConnector.PullRecords,
 		connectors.CDCSyncConnector.SyncRecords)
@@ -531,7 +535,7 @@ func (a *FlowableActivity) pullAndSyncPg(
 	syncWaiting *atomic.Pointer[string],
 ) (*model.SyncResponse, error) {
 	return pullAndSyncCore(ctx, a, config, options, srcConn,
-		normRequests, normResponses, normBufferSize, idleTimeout,
+		normRequests, normResponses, normBufferSize, false, idleTimeout,
 		syncingBatchID, syncWaiting, nil,
 		connectors.CDCPullPgConnector.PullPg,
 		connectors.CDCSyncPgConnector.SyncPg)

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -127,6 +127,7 @@ func pullAndSyncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDC
 	normRequests *concurrency.LastChan,
 	normResponses *concurrency.LastChan,
 	normBufferSize int64,
+	tableLevelBackpressure bool,
 	idleTimeout time.Duration,
 	syncingBatchID *atomic.Int64,
 	syncState *atomic.Pointer[string],
@@ -226,6 +227,19 @@ func pullAndSyncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDC
 	startTime := time.Now()
 	syncState.Store(new("syncing"))
 	errGroup, errCtx := errgroup.WithContext(ctx)
+	var tableBackpressure *model.TableBackpressure
+	if tableLevelBackpressure {
+		pgMetadata := connmetadata.NewPostgresMetadataFromCatalog(logger, a.CatalogPool)
+		normalizeBatchIDs, err := pgMetadata.GetLastNormalizeBatchIDs(ctx, flowName)
+		if err != nil {
+			return nil, a.Alerter.LogFlowError(ctx, flowName, err)
+		}
+		tableBackpressure = &model.TableBackpressure{
+			NormalizedBatchIDs: normalizeBatchIDs.Tables,
+			GlobalNormalizedID: normalizeBatchIDs.Global,
+			BufferSize:         normBufferSize,
+		}
+	}
 	errGroup.Go(func() error {
 		pullCtx, pullSpan := a.OtelManager.Tracer.Start(errCtx, "cdc.pull", trace.WithAttributes(
 			attribute.String(otel_metrics.FlowNameKey, flowName),
@@ -247,6 +261,8 @@ func pullAndSyncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDC
 			RecordStream:                recordBatchPull,
 			Env:                         config.Env,
 			InternalVersion:             config.Version,
+			SyncBatchID:                 syncBatchID,
+			TableBackpressure:           tableBackpressure,
 		})
 		if err != nil {
 			pullSpan.RecordError(err)
@@ -414,7 +430,7 @@ func pullAndSyncCore[TPull connectors.CDCPullConnectorCore, TSync connectors.CDC
 		syncState.Store(new("normalizing"))
 		normRequests.Update(res.CurrentSyncBatchID)
 		normWaitThreshold := res.CurrentSyncBatchID - normBufferSize
-		if normResponses.Load() <= normWaitThreshold {
+		if !tableLevelBackpressure && normResponses.Load() <= normWaitThreshold {
 			logger.Warn("sync waiting on normalize backpressure",
 				slog.Int64("syncBatchID", res.CurrentSyncBatchID),
 				slog.Int64("normalizeBatchID", normResponses.Load()),

--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -167,6 +167,22 @@ func runTablePolls(
 	return results, nil
 }
 
+func tableIsBackpressured(
+	checkpoint *bigQueryCDCCheckpoint,
+	sourceTableIdentifier string,
+	destinationTableIdentifier string,
+	pressure *model.TableBackpressure,
+) bool {
+	if pressure == nil {
+		return false
+	}
+	normalizedBatchID := max(
+		pressure.GlobalNormalizedID,
+		pressure.NormalizedBatchIDs[destinationTableIdentifier],
+	)
+	return checkpoint.IsBackpressured(sourceTableIdentifier, normalizedBatchID, pressure.BufferSize)
+}
+
 // PullRecords polls every mapped table from its own synced-through checkpoint.
 // A table failure leaves only that table behind; successful siblings continue
 // and the resulting per-table checkpoint is confirmed with the shared stream.
@@ -247,6 +263,7 @@ func (c *BigQueryConnector) PullRecords(
 	}
 
 	healthyTables := 0
+	backpressuredTables := 0
 	plans := make([]tablePollPlan, 0, len(sourceTables))
 	attemptedTables := 0
 	for _, sourceTableIdentifier := range sourceTables {
@@ -261,6 +278,12 @@ func (c *BigQueryConnector) PullRecords(
 		checkpoint.RecordAttempt(sourceTableIdentifier, now)
 		attemptedTables++
 
+		destinationTable := req.TableNameMapping[sourceTableIdentifier].Name
+		if tableIsBackpressured(checkpoint, sourceTableIdentifier, destinationTable, req.TableBackpressure) {
+			backpressuredTables++
+			healthyTables++
+			continue
+		}
 		start, err := checkpoint.SyncedThrough(sourceTableIdentifier)
 		if err != nil {
 			return err
@@ -301,7 +324,7 @@ func (c *BigQueryConnector) PullRecords(
 				slog.String("table", plan.table), slog.Any("error", err))
 			continue
 		}
-		checkpoint.RecordSuccess(plan.table, plan.upper)
+		checkpoint.RecordSuccess(plan.table, plan.upper, req.SyncBatchID)
 		healthyTables++
 		bytesProcessed += results[i].bytesProcessed
 	}
@@ -347,6 +370,7 @@ func (c *BigQueryConnector) PullRecords(
 	)
 	c.logger.Info("[bigquery] PullRecords polled tables",
 		slog.Int("tables", attemptedTables), slog.Int("failedTables", len(tableErrors)),
+		slog.Int("backpressuredTables", backpressuredTables),
 		slog.Int("records", recordCount), slog.Int64("bytes", bytesProcessed))
 
 	return nil

--- a/flow/connectors/bigquery/cdc_checkpoint.go
+++ b/flow/connectors/bigquery/cdc_checkpoint.go
@@ -23,6 +23,9 @@ type bigQueryCDCTableProgress struct {
 	// started. PeerDB persists it with the checkpoint so worker restarts keep
 	// the configured poll interval. A zero value makes a new table due now.
 	LastAttemptAt time.Time `json:"last_attempt_at,omitzero"`
+	// SyncedBatchID is the latest raw batch assigned to a successful poll of
+	// this table. It stays fixed while this table is failed or backpressured.
+	SyncedBatchID int64 `json:"synced_batch_id"`
 }
 
 type bigQueryCDCCheckpoint struct {
@@ -144,11 +147,16 @@ func (c *bigQueryCDCCheckpoint) RecordAttempt(table string, attemptedAt time.Tim
 	c.Tables[table] = progress
 }
 
-func (c *bigQueryCDCCheckpoint) RecordSuccess(table string, target time.Time) {
+func (c *bigQueryCDCCheckpoint) RecordSuccess(table string, target time.Time, syncBatchID int64) {
 	progress := c.Tables[table]
 	progress.SyncedThrough = target
 	progress.Target = target
+	progress.SyncedBatchID = syncBatchID
 	c.Tables[table] = progress
+}
+
+func (c *bigQueryCDCCheckpoint) IsBackpressured(table string, normalizedBatchID, bufferSize int64) bool {
+	return c.Tables[table].SyncedBatchID-normalizedBatchID >= bufferSize
 }
 
 // RecordFailure keeps the last confirmed cursor and records the attempted

--- a/flow/connectors/bigquery/cdc_test.go
+++ b/flow/connectors/bigquery/cdc_test.go
@@ -67,8 +67,8 @@ func TestBigQueryCDCCheckpointInitialization(t *testing.T) {
 	assert.JSONEq(t, `{
 		"version": 1,
 		"tables": {
-			"project.dataset.a": {"synced_through": "2026-08-01T00:00:00Z", "target": "2026-08-01T00:00:00Z"},
-			"project.dataset.b": {"synced_through": "2026-08-01T00:00:00Z", "target": "2026-08-01T00:00:00Z"}
+			"project.dataset.a": {"synced_through": "2026-08-01T00:00:00Z", "target": "2026-08-01T00:00:00Z", "synced_batch_id": 0},
+			"project.dataset.b": {"synced_through": "2026-08-01T00:00:00Z", "target": "2026-08-01T00:00:00Z", "synced_batch_id": 0}
 		}
 	}`, encoded)
 }
@@ -79,7 +79,7 @@ func TestBigQueryCDCCheckpointRecordsIndependentTableOutcomes(t *testing.T) {
 	cp := newBigQueryCDCCheckpoint(start, []string{"a", "b"})
 
 	cp.RecordAttempt("a", target)
-	cp.RecordSuccess("a", target)
+	cp.RecordSuccess("a", target, 7)
 	cp.RecordAttempt("b", target)
 	assert.True(t, cp.RecordFailure("b", target), "first failure in an episode should be reported")
 	cp.RecordAttempt("b", target.Add(time.Hour))
@@ -92,8 +92,42 @@ func TestBigQueryCDCCheckpointRecordsIndependentTableOutcomes(t *testing.T) {
 	assert.Equal(t, target.Add(time.Hour), cp.Tables["b"].Target)
 	assert.Equal(t, target.Add(time.Hour), cp.Tables["b"].LastAttemptAt)
 
-	cp.RecordSuccess("b", target.Add(2*time.Hour))
+	cp.RecordSuccess("b", target.Add(2*time.Hour), 8)
 	assert.True(t, cp.RecordFailure("b", target.Add(3*time.Hour)), "failure after recovery starts a new episode")
+}
+
+func TestBigQueryCDCCheckpointTableBackpressure(t *testing.T) {
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	cp := newBigQueryCDCCheckpoint(start, []string{"a", "b"})
+	cp.RecordSuccess("a", start.Add(time.Hour), 10)
+	cp.RecordSuccess("b", start.Add(time.Hour), 20)
+
+	assert.False(t, cp.IsBackpressured("a", 9, 2))
+	assert.True(t, cp.IsBackpressured("a", 8, 2), "the exact buffer boundary applies pressure")
+	assert.True(t, cp.IsBackpressured("b", 18, 2))
+
+	before := cp.Tables["a"]
+	cp.RecordSuccess("b", start.Add(2*time.Hour), 21)
+	assert.Equal(t, before, cp.Tables["a"], "a skipped table retains its complete progress")
+}
+
+func TestTableIsBackpressuredUsesDestinationProgressAndGlobalFloor(t *testing.T) {
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	cp := newBigQueryCDCCheckpoint(start, []string{"source.a", "source.b"})
+	cp.RecordSuccess("source.a", start.Add(time.Hour), 10)
+	cp.RecordSuccess("source.b", start.Add(time.Hour), 10)
+	pressure := &model.TableBackpressure{
+		GlobalNormalizedID: 7,
+		NormalizedBatchIDs: map[string]int64{"destination.a": 8},
+		BufferSize:         2,
+	}
+
+	assert.True(t, tableIsBackpressured(cp, "source.a", "destination.a", pressure))
+	assert.True(t, tableIsBackpressured(cp, "source.b", "destination.b", pressure))
+	pressure.GlobalNormalizedID = 9
+	assert.False(t, tableIsBackpressured(cp, "source.b", "destination.b", pressure),
+		"the global frontier covers batches where a sparse table had no rows")
+	assert.False(t, tableIsBackpressured(cp, "source.a", "destination.a", nil))
 }
 
 func TestBigQueryCDCCheckpointDropsRemovedTables(t *testing.T) {
@@ -164,7 +198,7 @@ func TestBigQueryCDCCheckpointPollScheduleSurvivesReload(t *testing.T) {
 	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
 	cp := newBigQueryCDCCheckpoint(now.Add(-3*time.Hour), []string{"a", "b"})
 	cp.RecordAttempt("a", now)
-	cp.RecordSuccess("a", now.Add(-time.Hour))
+	cp.RecordSuccess("a", now.Add(-time.Hour), 7)
 	cp.RecordAttempt("b", now.Add(-2*time.Hour))
 	assert.True(t, cp.RecordFailure("b", now.Add(-time.Hour)))
 

--- a/flow/connectors/external_metadata/store.go
+++ b/flow/connectors/external_metadata/store.go
@@ -37,6 +37,11 @@ type PostgresMetadata struct {
 	logger log.Logger
 }
 
+type NormalizeBatchIDs struct {
+	Tables map[string]int64
+	Global int64
+}
+
 func NewPostgresMetadata(ctx context.Context) (*PostgresMetadata, error) {
 	pool, err := internal.GetCatalogConnectionPoolFromEnv(ctx)
 	if err != nil {
@@ -98,6 +103,28 @@ func (p *PostgresMetadata) GetLastNormalizedBatchIDForTable(ctx context.Context,
 	}
 
 	return lastSyncedBatchID, nil
+}
+
+// GetLastNormalizeBatchIDs reads the global and per-table normalization
+// frontiers from the same catalog snapshot.
+func (p *PostgresMetadata) GetLastNormalizeBatchIDs(ctx context.Context, jobName string) (NormalizeBatchIDs, error) {
+	var global pgtype.Int8
+	var tableBatchIDDataJSON string
+	if err := p.pool.QueryRow(ctx,
+		`SELECT normalize_batch_id, table_batch_id_data FROM `+lastSyncStateTableName+` WHERE job_name = $1`,
+		jobName,
+	).Scan(&global, &tableBatchIDDataJSON); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return NormalizeBatchIDs{Tables: make(map[string]int64)}, nil
+		}
+		return NormalizeBatchIDs{}, fmt.Errorf("failed to get normalize batch ids: %w", err)
+	}
+
+	tables := make(map[string]int64)
+	if err := json.Unmarshal([]byte(tableBatchIDDataJSON), &tables); err != nil {
+		return NormalizeBatchIDs{}, fmt.Errorf("failed to unmarshal table batch id data: %w", err)
+	}
+	return NormalizeBatchIDs{Global: global.Int64, Tables: tables}, nil
 }
 
 // SetLastNormalizedBatchIDForTable updates the last batch ID normalized for the given target table.

--- a/flow/e2e/bigquery_cdc_test.go
+++ b/flow/e2e/bigquery_cdc_test.go
@@ -886,6 +886,7 @@ func queryBigQueryCheckpointText(ctx context.Context, pool *pgxpool.Pool, flowJo
 type bigQueryCDCTestTableProgress struct {
 	SyncedThrough time.Time `json:"synced_through"`
 	Target        time.Time `json:"target"`
+	SyncedBatchID int64     `json:"synced_batch_id"`
 }
 
 type bigQueryCDCTestCheckpoint struct {

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -90,6 +90,18 @@ type PullRecordsRequest[T Items] struct {
 	InternalVersion uint32
 	// IdleTimeout is the timeout to wait for new records.
 	IdleTimeout time.Duration
+	// SyncBatchID is the batch that will contain records emitted by this pull.
+	SyncBatchID int64
+	// TableBackpressure is set only when the source can pause tables independently.
+	TableBackpressure *TableBackpressure
+}
+
+// TableBackpressure contains durable destination normalization progress for a
+// table-aware source pull.
+type TableBackpressure struct {
+	NormalizedBatchIDs map[string]int64
+	GlobalNormalizedID int64
+	BufferSize         int64
 }
 
 type ToJSONOptions struct {

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -64,36 +64,36 @@ func (r *RecordsToStreamRequest[T]) GetRecords() <-chan Record[T] {
 }
 
 type PullRecordsRequest[T Items] struct {
+	// overrides dynamic configuration
+	Env map[string]string
 	// record batch for pushing changes into
 	RecordStream *CDCStream[T]
-	// ConsumedOffset can be reported as committed to reduce slot size
-	ConsumedOffset *atomic.Int64
-	// FlowJobName is the name of the flow job.
-	FlowJobName string
+	// TableBackpressure is set only when the source can pause tables independently.
+	TableBackpressure *TableBackpressure
 	// relId to name Mapping
 	SrcTableIDNameMapping map[uint32]string
 	// source to destination table name mapping
 	TableNameMapping map[string]NameAndExclude
 	// tablename to schema mapping
 	TableNameSchemaMapping map[string]*protos.TableSchema
-	// overrides dynamic configuration
-	Env map[string]string
+	// ConsumedOffset can be reported as committed to reduce slot size
+	ConsumedOffset *atomic.Int64
 	// override publication name
 	OverridePublicationName string
 	// override replication slot name
 	OverrideReplicationSlotName string
+	// FlowJobName is the name of the flow job.
+	FlowJobName string
 	// LastOffset is the latest LSN that was synced.
 	LastOffset CdcCheckpoint
-	// MaxBatchSize is the max number of records to fetch.
-	MaxBatchSize uint32
-	// peerdb versioning to prevent breaking changes
-	InternalVersion uint32
 	// IdleTimeout is the timeout to wait for new records.
 	IdleTimeout time.Duration
 	// SyncBatchID is the batch that will contain records emitted by this pull.
 	SyncBatchID int64
-	// TableBackpressure is set only when the source can pause tables independently.
-	TableBackpressure *TableBackpressure
+	// MaxBatchSize is the max number of records to fetch.
+	MaxBatchSize uint32
+	// peerdb versioning to prevent breaking changes
+	InternalVersion uint32
 }
 
 // TableBackpressure contains durable destination normalization progress for a


### PR DESCRIPTION
## Summary

- store the latest assigned sync batch ID in each BigQuery source-table checkpoint
- compare that watermark with ClickHouse's global and per-table normalization progress
- pause only the source tables whose normalize gap reaches `PEERDB_NORMALIZE_BUFFER_HOURS`
- keep the existing global backpressure path for every other connector pair

## Backpressure workflow

```mermaid
flowchart TD
    A[Start BigQuery CDC pull] --> B[Read source checkpoint per table]
    B --> C[Read global and per-table normalize batch IDs]
    C --> D{For each table: synced batch minus max of global and table normalized batch reaches buffer?}

    D -->|Yes| E[Skip this table for the current pull]
    E --> F[Keep its cursor and synced batch ID unchanged]

    D -->|No| G[Poll this BigQuery table]
    G --> H[Sync records to ClickHouse raw storage]
    H --> I[Persist the table cursor and synced batch ID]
    I --> J[ClickHouse normalizes the table]
    J --> K[Persist table_batch_id_data for the destination table]
    K --> A

    F --> L[Other source tables continue through the same decision independently]
    L --> A
```

The global normalized batch ID acts as a floor. A sparse table does not appear behind when it had no rows in batches that the mirror already normalized globally.

If a table is backpressured, BigQuery leaves its complete checkpoint entry unchanged. The table remains part of the mirror and resumes after its normalization gap drops below the buffer.

## Scope

This PR isolates BigQuery polling and raw syncing from table-level normalize lag. ClickHouse still waits for all table queries in the current normalization group before it schedules a later group. Independent normalization scheduling can follow as a separate change.

## Tests

- `go test ./connectors/bigquery ./connectors/external_metadata ./activities -count=1`
- `go test ./e2e -run '^$' -count=1`
- `go test -count=1 -v -run '^TestBigQueryClickhouseSuite$/Test_Trips_Flow$' ./e2e/`

Resolves: DBI-1047