### PR TITLE
feat(bigquery): override bq http client to calculate fetched bytes

### DIFF
--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -104,10 +104,14 @@ func NewBigQueryConnector(ctx context.Context, config *protos.BigqueryConfig) (*
 		return nil, fmt.Errorf("failed to create credentials: %v", err)
 	}
 
+	meteredHTTPClient, err := newMeteredBigQueryHTTPClient(ctx, creds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metered BigQuery HTTP client: %v", err)
+	}
 	client, err := bigquery.NewClient(
 		ctx,
 		credentialConfig.clientProjectID,
-		option.WithAuthCredentials(creds),
+		option.WithHTTPClient(meteredHTTPClient),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create BigQuery client: %v", err)

--- a/flow/connectors/bigquery/bigquery.go
+++ b/flow/connectors/bigquery/bigquery.go
@@ -111,6 +111,7 @@ func NewBigQueryConnector(ctx context.Context, config *protos.BigqueryConfig) (*
 	client, err := bigquery.NewClient(
 		ctx,
 		credentialConfig.clientProjectID,
+		option.WithAuthCredentials(creds),
 		option.WithHTTPClient(meteredHTTPClient),
 	)
 	if err != nil {

--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -379,8 +379,8 @@ func (c *BigQueryConnector) PullRecords(
 
 // pullTableAppends runs SELECT * FROM APPENDS(TABLE <table>, @start, @end) for one
 // source table over [start, end), converting and pushing each row via addRecord.
-// Returns the HTTP response bytes BigQuery transferred for this table's query,
-// including pagination fetches (see withByteCounter).
+// Returns the HTTP response body bytes consumed by BigQuery for this table's
+// query, including pagination fetches (see withByteCounter).
 func (c *BigQueryConnector) pullTableAppends(
 	ctx context.Context,
 	sourceTableIdentifier string,
@@ -624,8 +624,8 @@ func locateBigQueryChangeColumns(schema bigquery.Schema) bigQueryChangeColumns {
 // carrying the new values. The old-values half is skipped -- OldItems isn't needed
 // downstream (see model.UpdateRecord usage), so there's nothing to pair it with; the
 // UPDATE row alone is forwarded as the UpdateRecord.
-// Returns the HTTP response bytes BigQuery transferred for this table's query,
-// including pagination fetches (see withByteCounter).
+// Returns the HTTP response body bytes consumed by BigQuery for this table's
+// query, including pagination fetches (see withByteCounter).
 func (c *BigQueryConnector) pullTableChanges(
 	ctx context.Context,
 	sourceTableIdentifier string,

--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/bigquery"
@@ -378,7 +379,8 @@ func (c *BigQueryConnector) PullRecords(
 
 // pullTableAppends runs SELECT * FROM APPENDS(TABLE <table>, @start, @end) for one
 // source table over [start, end), converting and pushing each row via addRecord.
-// Returns the approximate byte size of the RecordItems actually forwarded
+// Returns the HTTP response bytes BigQuery transferred for this table's query,
+// including pagination fetches (see withByteCounter).
 func (c *BigQueryConnector) pullTableAppends(
 	ctx context.Context,
 	sourceTableIdentifier string,
@@ -391,19 +393,20 @@ func (c *BigQueryConnector) pullTableAppends(
 		return 0, fmt.Errorf("failed to parse table identifier %s: %w", sourceTableIdentifier, err)
 	}
 
-	it, err := c.runPullQuery(ctx, "APPENDS", dsTable.stringQuoted(), sourceTableIdentifier, nameAndExclude.Exclude, "", start, end)
+	var bytesTransferred atomic.Int64
+	it, err := c.runPullQuery(withByteCounter(ctx, &bytesTransferred), "APPENDS", dsTable.stringQuoted(),
+		sourceTableIdentifier, nameAndExclude.Exclude, "", start, end)
 	if err != nil {
 		return 0, fmt.Errorf("failed to run APPENDS query for table %s: %w", sourceTableIdentifier, err)
 	}
 
 	var qfields []types.QField
 	var changeCols bigQueryChangeColumns
-	var bytesForwarded int64
 	for {
 		var row []bigquery.Value
 		if err := it.Next(&row); err != nil {
 			if errors.Is(err, iterator.Done) {
-				return bytesForwarded, nil
+				return bytesTransferred.Load(), nil
 			}
 			return 0, fmt.Errorf("failed to read APPENDS row for table %s: %w", sourceTableIdentifier, err)
 		}
@@ -432,12 +435,6 @@ func (c *BigQueryConnector) pullTableAppends(
 			return 0, fmt.Errorf("failed to convert row for table %s: %w", sourceTableIdentifier, err)
 		}
 
-		itemBytes, err := recordItemsApproxBytes(items)
-		if err != nil {
-			return 0, fmt.Errorf("failed to size row for table %s: %w", sourceTableIdentifier, err)
-		}
-		bytesForwarded += itemBytes
-
 		if err := addRecord(ctx, &model.InsertRecord[model.RecordItems]{
 			BaseRecord:           model.BaseRecord{CommitTimeNano: commitTimeNano},
 			Items:                items,
@@ -447,15 +444,6 @@ func (c *BigQueryConnector) pullTableAppends(
 			return 0, err
 		}
 	}
-}
-
-// recordItemsApproxBytes estimates the storage size of one converted row
-func recordItemsApproxBytes(items model.RecordItems) (int64, error) {
-	b, err := items.MarshalJSON()
-	if err != nil {
-		return 0, err
-	}
-	return int64(len(b)), nil
 }
 
 // bigQueryChangePseudoColumns are the metadata columns APPENDS()/CHANGES() add on top
@@ -636,7 +624,8 @@ func locateBigQueryChangeColumns(schema bigquery.Schema) bigQueryChangeColumns {
 // carrying the new values. The old-values half is skipped -- OldItems isn't needed
 // downstream (see model.UpdateRecord usage), so there's nothing to pair it with; the
 // UPDATE row alone is forwarded as the UpdateRecord.
-// Returns the approximate byte size of the RecordItems actually forwarded
+// Returns the HTTP response bytes BigQuery transferred for this table's query,
+// including pagination fetches (see withByteCounter).
 func (c *BigQueryConnector) pullTableChanges(
 	ctx context.Context,
 	sourceTableIdentifier string,
@@ -649,8 +638,9 @@ func (c *BigQueryConnector) pullTableChanges(
 		return 0, fmt.Errorf("failed to parse table identifier %s: %w", sourceTableIdentifier, err)
 	}
 
+	var bytesTransferred atomic.Int64
 	it, err := c.runPullQuery(
-		ctx, "CHANGES", dsTable.stringQuoted(), sourceTableIdentifier, nameAndExclude.Exclude,
+		withByteCounter(ctx, &bytesTransferred), "CHANGES", dsTable.stringQuoted(), sourceTableIdentifier, nameAndExclude.Exclude,
 		quotedIdentifier(bigQueryChangeTimestampColumn), start, end,
 	)
 	if err != nil {
@@ -659,12 +649,11 @@ func (c *BigQueryConnector) pullTableChanges(
 
 	var qfields []types.QField
 	var changeCols bigQueryChangeColumns
-	var bytesForwarded int64
 	for {
 		var row []bigquery.Value
 		if err := it.Next(&row); err != nil {
 			if errors.Is(err, iterator.Done) {
-				return bytesForwarded, nil
+				return bytesTransferred.Load(), nil
 			}
 			return 0, fmt.Errorf("failed to read CHANGES row for table %s: %w", sourceTableIdentifier, err)
 		}
@@ -704,11 +693,6 @@ func (c *BigQueryConnector) pullTableChanges(
 		if err != nil {
 			return 0, fmt.Errorf("failed to convert row for table %s: %w", sourceTableIdentifier, err)
 		}
-		itemBytes, err := recordItemsApproxBytes(items)
-		if err != nil {
-			return 0, fmt.Errorf("failed to size row for table %s: %w", sourceTableIdentifier, err)
-		}
-		bytesForwarded += itemBytes
 
 		baseRecord := model.BaseRecord{CommitTimeNano: commitTimeNano}
 		var record model.Record[model.RecordItems]

--- a/flow/connectors/bigquery/metered_http.go
+++ b/flow/connectors/bigquery/metered_http.go
@@ -1,0 +1,66 @@
+package connbigquery
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync/atomic"
+
+	"cloud.google.com/go/auth"
+	"google.golang.org/api/option"
+	htransport "google.golang.org/api/transport/http"
+)
+
+type byteCounterCtxKey struct{}
+
+// withByteCounter returns a context that meteredRoundTripper accumulates response
+// body bytes into, for HTTP calls made using that context (including paginated
+// follow-up requests, which BigQuery's RowIterator issues against the same ctx it
+// was created with).
+func withByteCounter(ctx context.Context, counter *atomic.Int64) context.Context {
+	return context.WithValue(ctx, byteCounterCtxKey{}, counter)
+}
+
+// meteredRoundTripper counts response body bytes actually read off the wire for
+// requests whose context carries a byte counter (see withByteCounter), so BigQuery
+// CDC pull can report real transferred bytes instead of an approximation of the
+// converted row size.
+type meteredRoundTripper struct {
+	base http.RoundTripper
+}
+
+func (t *meteredRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if resp == nil {
+		return nil, err
+	}
+	if counter, ok := req.Context().Value(byteCounterCtxKey{}).(*atomic.Int64); ok {
+		resp.Body = &countingReadCloser{ReadCloser: resp.Body, counter: counter}
+	}
+	return resp, err
+}
+
+// countingReadCloser adds each Read's returned byte count to counter as the
+// response body is consumed, since chunked/compressed responses have no reliable
+// Content-Length to read the size from up front.
+type countingReadCloser struct {
+	io.ReadCloser
+	counter *atomic.Int64
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.ReadCloser.Read(p)
+	c.counter.Add(int64(n))
+	return n, err
+}
+
+// newMeteredBigQueryHTTPClient builds an authenticated HTTP client for the
+// BigQuery client whose RoundTripper reports transferred bytes via withByteCounter.
+func newMeteredBigQueryHTTPClient(ctx context.Context, creds *auth.Credentials) (*http.Client, error) {
+	transport, err := htransport.NewTransport(ctx, &meteredRoundTripper{base: http.DefaultTransport},
+		option.WithAuthCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{Transport: transport}, nil
+}

--- a/flow/connectors/bigquery/metered_http.go
+++ b/flow/connectors/bigquery/metered_http.go
@@ -21,10 +21,11 @@ func withByteCounter(ctx context.Context, counter *atomic.Int64) context.Context
 	return context.WithValue(ctx, byteCounterCtxKey{}, counter)
 }
 
-// meteredRoundTripper counts response body bytes actually read off the wire for
-// requests whose context carries a byte counter (see withByteCounter), so BigQuery
-// CDC pull can report real transferred bytes instead of an approximation of the
-// converted row size.
+// meteredRoundTripper counts response body bytes consumed by the BigQuery client
+// for requests whose context carries a byte counter (see withByteCounter), so
+// BigQuery CDC pull can report bytes read instead of an approximation of the
+// converted row size. net/http may transparently decompress the body before it
+// reaches this wrapper.
 type meteredRoundTripper struct {
 	base http.RoundTripper
 }
@@ -41,8 +42,7 @@ func (t *meteredRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 }
 
 // countingReadCloser adds each Read's returned byte count to counter as the
-// response body is consumed, since chunked/compressed responses have no reliable
-// Content-Length to read the size from up front.
+// response body is consumed.
 type countingReadCloser struct {
 	io.ReadCloser
 	counter *atomic.Int64
@@ -55,7 +55,8 @@ func (c *countingReadCloser) Read(p []byte) (int, error) {
 }
 
 // newMeteredBigQueryHTTPClient builds an authenticated HTTP client for the
-// BigQuery client whose RoundTripper reports transferred bytes via withByteCounter.
+// BigQuery client whose RoundTripper reports consumed response body bytes via
+// withByteCounter.
 func newMeteredBigQueryHTTPClient(ctx context.Context, creds *auth.Credentials) (*http.Client, error) {
 	transport, err := htransport.NewTransport(ctx, &meteredRoundTripper{base: http.DefaultTransport},
 		option.WithAuthCredentials(creds))


### PR DESCRIPTION
Use custom http client to how many bytes cross tne network for BQ cdc


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>