### PR TITLE
feat(bigquery): add watermark column cdc mode for bigquery source connector

### DIFF
--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
@@ -205,6 +206,12 @@ func (c *BigQueryConnector) PullRecords(
 	if err != nil {
 		return fmt.Errorf("failed to get current BigQuery timestamp: %w", err)
 	}
+
+	checkpoint, err := parseBigQueryCDCCheckpoint(req.LastOffset.Text, sourceTables, now)
+	if err != nil {
+		return err
+	}
+
 	if wait := checkpoint.nextPollWait(now, req.IdleTimeout); wait > 0 {
 		if err := waitForNextPoll(ctx, wait); err != nil {
 			return err
@@ -213,11 +220,6 @@ func (c *BigQueryConnector) PullRecords(
 		if err != nil {
 			return fmt.Errorf("failed to refresh current BigQuery timestamp after poll wait: %w", err)
 		}
-	}
-
-	checkpoint, err := parseBigQueryCDCCheckpoint(req.LastOffset.Text, sourceTables, now)
-	if err != nil {
-		return err
 	}
 
 	safetyLag, err := internal.PeerDBBigQueryCDCSafetyLag(ctx, req.Env)
@@ -243,9 +245,12 @@ func (c *BigQueryConnector) PullRecords(
 	if parallelism <= 0 {
 		parallelism = -1 // errgroup treats a negative limit as unlimited
 	}
+	queryMode := cfg.GetBigqueryCdcConfig().GetReplicationMode() == protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY
 	eventsFunctionByTable := make(map[string]protos.BigqueryCdcEventsFunction, len(cfg.TableMappings))
+	watermarkColumnByTable := make(map[string]string, len(cfg.TableMappings))
 	for _, tableMapping := range cfg.TableMappings {
 		eventsFunctionByTable[tableMapping.SourceTableIdentifier] = tableMapping.GetBigqueryCdcEventsFunction()
+		watermarkColumnByTable[tableMapping.SourceTableIdentifier] = tableMapping.GetWatermarkColumn()
 	}
 
 	var streamMu sync.Mutex
@@ -298,7 +303,16 @@ func (c *BigQueryConnector) PullRecords(
 		}
 
 		pull := c.pullTableAppends
-		if eventsFunctionByTable[sourceTableIdentifier] == protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES {
+		switch {
+		case queryMode:
+			watermarkColumn := watermarkColumnByTable[sourceTableIdentifier]
+			pull = func(
+				ctx context.Context, sourceTableIdentifier string, nameAndExclude model.NameAndExclude, start, end time.Time,
+				addRecord func(context.Context, model.Record[model.RecordItems]) error,
+			) (int64, error) {
+				return c.pullTableQuery(ctx, watermarkColumn, sourceTableIdentifier, nameAndExclude, start, end, addRecord)
+			}
+		case eventsFunctionByTable[sourceTableIdentifier] == protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES:
 			pull = c.pullTableChanges
 		}
 		plans = append(plans, tablePollPlan{start: start, upper: upper, table: sourceTableIdentifier, pull: pull})
@@ -394,8 +408,10 @@ func (c *BigQueryConnector) pullTableAppends(
 	}
 
 	var bytesTransferred atomic.Int64
-	it, err := c.runPullQuery(withByteCounter(ctx, &bytesTransferred), "APPENDS", dsTable.stringQuoted(),
-		sourceTableIdentifier, nameAndExclude.Exclude, "", start, end)
+	it, err := c.runPullQuery(withByteCounter(ctx, &bytesTransferred), sourceTableIdentifier, nameAndExclude.Exclude, start, end,
+		func(exclude map[string]struct{}) string {
+			return buildPullQuery("APPENDS", dsTable.stringQuoted(), exclude, "")
+		})
 	if err != nil {
 		return 0, fmt.Errorf("failed to run APPENDS query for table %s: %w", sourceTableIdentifier, err)
 	}
@@ -464,6 +480,14 @@ func buildPullQuery(fn string, dsTable string, exclude map[string]struct{}, orde
 	return q
 }
 
+// buildQueryModePullQuery renders "SELECT * [EXCEPT (...)] FROM dsTable WHERE
+// TIMESTAMP(watermarkColumn) > @start AND TIMESTAMP(watermarkColumn) <= @end ORDER
+func buildQueryModePullQuery(dsTable string, watermarkColumn string, exclude map[string]struct{}) string {
+	col := quotedIdentifier(watermarkColumn)
+	return fmt.Sprintf("SELECT *%s FROM %s WHERE TIMESTAMP(%s) > @start AND TIMESTAMP(%s) <= @end ORDER BY %s",
+		exceptClause(exclude), dsTable, col, col, col)
+}
+
 // exceptClause renders a "SELECT * EXCEPT (...)" suffix for the given excluded
 // column names, or "" if there are none.
 func exceptClause(exclude map[string]struct{}) string {
@@ -478,17 +502,18 @@ func exceptClause(exclude map[string]struct{}) string {
 	return fmt.Sprintf(" EXCEPT (%s)", strings.Join(quoted, ", "))
 }
 
-// runPullQuery runs the APPENDS()/CHANGES() query for sourceTableIdentifier,
-// retrying with a shrunk EXCEPT clause if BigQuery rejects a column that no longer
-// exists on the source table (BigQuery reports one such column per error, so this
-// may loop more than once).
+// runPullQuery runs a CDC pull query for sourceTableIdentifier, retrying with a
+// shrunk EXCEPT clause if BigQuery rejects a column that no longer exists on the
+// source table (BigQuery reports one such column per error, so this may loop more
+// than once). build renders the query text for a given (possibly narrowed) exclude
+// set; start/end are bound as the query's @start/@end parameters.
 func (c *BigQueryConnector) runPullQuery(
-	ctx context.Context, fn string, dsTable string, sourceTableIdentifier string,
-	exclude map[string]struct{}, orderBy string, start, end time.Time,
+	ctx context.Context, sourceTableIdentifier string, exclude map[string]struct{}, start, end time.Time,
+	buildQuery func(exclude map[string]struct{}) string,
 ) (*bigquery.RowIterator, error) {
 	effective := c.effectiveExclude(sourceTableIdentifier, exclude)
 	for {
-		q := c.client.Query(buildPullQuery(fn, dsTable, effective, orderBy))
+		q := c.client.Query(buildQuery(effective))
 		q.Parameters = []bigquery.QueryParameter{
 			{Name: "start", Value: start},
 			{Name: "end", Value: end},
@@ -639,10 +664,10 @@ func (c *BigQueryConnector) pullTableChanges(
 	}
 
 	var bytesTransferred atomic.Int64
-	it, err := c.runPullQuery(
-		withByteCounter(ctx, &bytesTransferred), "CHANGES", dsTable.stringQuoted(), sourceTableIdentifier, nameAndExclude.Exclude,
-		quotedIdentifier(bigQueryChangeTimestampColumn), start, end,
-	)
+	it, err := c.runPullQuery(withByteCounter(ctx, &bytesTransferred), sourceTableIdentifier, nameAndExclude.Exclude, start, end,
+		func(exclude map[string]struct{}) string {
+			return buildPullQuery("CHANGES", dsTable.stringQuoted(), exclude, quotedIdentifier(bigQueryChangeTimestampColumn))
+		})
 	if err != nil {
 		return 0, fmt.Errorf("failed to run CHANGES query for table %s: %w", sourceTableIdentifier, err)
 	}
@@ -717,4 +742,89 @@ func (c *BigQueryConnector) pullTableChanges(
 			return 0, err
 		}
 	}
+}
+
+// pullTableQuery runs SELECT * FROM <table> WHERE watermarkColumn > @start AND
+// watermarkColumn <= @end ORDER BY watermarkColumn for one source table
+// Returns the HTTP response body bytes consumed by BigQuery for this table's
+// query
+func (c *BigQueryConnector) pullTableQuery(
+	ctx context.Context,
+	watermarkColumn string,
+	sourceTableIdentifier string,
+	nameAndExclude model.NameAndExclude,
+	start, end time.Time,
+	addRecord func(context.Context, model.Record[model.RecordItems]) error,
+) (int64, error) {
+	dsTable, err := c.convertToDatasetTable(sourceTableIdentifier)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse table identifier %s: %w", sourceTableIdentifier, err)
+	}
+
+	var bytesTransferred atomic.Int64
+	it, err := c.runPullQuery(withByteCounter(ctx, &bytesTransferred), sourceTableIdentifier, nameAndExclude.Exclude, start, end,
+		func(exclude map[string]struct{}) string {
+			return buildQueryModePullQuery(dsTable.stringQuoted(), watermarkColumn, exclude)
+		})
+	if err != nil {
+		return 0, fmt.Errorf("failed to run watermark query for table %s: %w", sourceTableIdentifier, err)
+	}
+
+	var qfields []types.QField
+	watermarkColIdx := -1
+	for {
+		var row []bigquery.Value
+		if err := it.Next(&row); err != nil {
+			if errors.Is(err, iterator.Done) {
+				return bytesTransferred.Load(), nil
+			}
+			return 0, fmt.Errorf("failed to read row for table %s: %w", sourceTableIdentifier, err)
+		}
+
+		// it.Schema is only guaranteed populated after the first Next() call
+		if qfields == nil {
+			qfields = make([]types.QField, len(it.Schema))
+			for i, field := range it.Schema {
+				qfields[i] = BigQueryFieldToQField(field)
+			}
+			watermarkColIdx = locateColumnIndex(it.Schema, watermarkColumn)
+		}
+
+		// The watermark column is this row's own commit-time signal, used as
+		// CommitTimeNano. Falls back to the poll window's end if, unexpectedly, the
+		// column isn't present.
+		commitTimeNano := end.UnixNano()
+		if watermarkColIdx >= 0 {
+			switch v := row[watermarkColIdx].(type) {
+			case time.Time:
+				commitTimeNano = v.UnixNano()
+			case civil.Date:
+				commitTimeNano = v.In(time.UTC).UnixNano()
+			}
+		}
+
+		items, err := bigQueryRowToRecordItems(it.Schema, qfields, row)
+		if err != nil {
+			return 0, fmt.Errorf("failed to convert row for table %s: %w", sourceTableIdentifier, err)
+		}
+
+		if err := addRecord(ctx, &model.InsertRecord[model.RecordItems]{
+			BaseRecord:           model.BaseRecord{CommitTimeNano: commitTimeNano},
+			Items:                items,
+			SourceTableName:      sourceTableIdentifier,
+			DestinationTableName: nameAndExclude.Name,
+		}); err != nil {
+			return 0, err
+		}
+	}
+}
+
+// locateColumnIndex returns the index of name in schema, or -1 if absent.
+func locateColumnIndex(schema bigquery.Schema, name string) int {
+	for i, field := range schema {
+		if field.Name == name {
+			return i
+		}
+	}
+	return -1
 }

--- a/flow/connectors/bigquery/cdc_checkpoint.go
+++ b/flow/connectors/bigquery/cdc_checkpoint.go
@@ -63,6 +63,14 @@ func newBigQueryCDCCheckpoint(syncedThrough time.Time, sourceTables []string) *b
 	return &bigQueryCDCCheckpoint{Version: bigQueryCDCCheckpointVersion, Tables: tables}
 }
 
+func newBigQueryCDCCheckpointPerTable(syncedThrough map[string]time.Time) *bigQueryCDCCheckpoint {
+	tables := make(map[string]bigQueryCDCTableProgress, len(syncedThrough))
+	for table, t := range syncedThrough {
+		tables[table] = bigQueryCDCTableProgress{SyncedThrough: t, Target: t}
+	}
+	return &bigQueryCDCCheckpoint{Version: bigQueryCDCCheckpointVersion, Tables: tables}
+}
+
 func parseBigQueryCDCCheckpoint(raw string, sourceTables []string, now time.Time) (*bigQueryCDCCheckpoint, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {

--- a/flow/connectors/bigquery/cdc_test.go
+++ b/flow/connectors/bigquery/cdc_test.go
@@ -204,7 +204,7 @@ func TestBigQueryCDCCheckpointPollScheduleSurvivesReload(t *testing.T) {
 
 	encoded, err := cp.Marshal()
 	require.NoError(t, err)
-	reloaded, err := parseBigQueryCDCCheckpoint(encoded, []string{"a", "b"})
+	reloaded, err := parseBigQueryCDCCheckpoint(encoded, []string{"a", "b"}, now)
 	require.NoError(t, err)
 
 	assert.Zero(t, reloaded.nextPollWait(now, time.Hour), "table b is already due")
@@ -231,7 +231,7 @@ func TestBigQueryCDCCheckpointNextPollWait(t *testing.T) {
 			"tables": {
 				"a": {"synced_through": "2026-08-01T10:00:00Z", "target": "2026-08-01T10:00:00Z"}
 			}
-		}`, []string{"a"})
+		}`, []string{"a"}, now)
 		require.NoError(t, err)
 		assert.Zero(t, cp.nextPollWait(now, time.Hour))
 	})
@@ -360,6 +360,18 @@ func TestBuildPullQuery(t *testing.T) {
 	assert.Equal(t,
 		"SELECT * EXCEPT (`secret`) FROM CHANGES(TABLE `ds`.`tbl`, @start, @end) ORDER BY `_CHANGE_TIMESTAMP`",
 		buildPullQuery("CHANGES", "`ds`.`tbl`", map[string]struct{}{"secret": {}}, "`_CHANGE_TIMESTAMP`"),
+	)
+}
+
+func TestBuildQueryModePullQuery(t *testing.T) {
+	assert.Equal(t,
+		"SELECT * FROM `ds`.`tbl` WHERE TIMESTAMP(`updated_at`) > @start AND TIMESTAMP(`updated_at`) <= @end ORDER BY `updated_at`",
+		buildQueryModePullQuery("`ds`.`tbl`", "updated_at", nil),
+	)
+	assert.Equal(t,
+		"SELECT * EXCEPT (`secret`) FROM `ds`.`tbl` WHERE TIMESTAMP(`updated_at`) > @start AND "+
+			"TIMESTAMP(`updated_at`) <= @end ORDER BY `updated_at`",
+		buildQueryModePullQuery("`ds`.`tbl`", "updated_at", map[string]struct{}{"secret": {}}),
 	)
 }
 

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -356,9 +356,37 @@ func (c *BigQueryConnector) exportTablesAsOf(
 	stagingPath string,
 	snapshotTime time.Time,
 ) error {
+	return c.runTableExports(ctx, flowName, tableMappings, func(tm *protos.TableMapping) (string, error) {
+		return c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, "", stagingPath, snapshotTime)
+	})
+}
+
+// exportTablesAsOfWatermarks exports each table up to its own watermark-column
+// bound, for BIGQUERY_REPLICATION_MODE_QUERY -- unlike exportTablesAsOf, there is
+// no single BigQuery-clock instant every table is read as of, since each table's
+// watermark column advances independently.
+func (c *BigQueryConnector) exportTablesAsOfWatermarks(
+	ctx context.Context,
+	flowName string,
+	tableMappings []*protos.TableMapping,
+	stagingPath string,
+	boundByTable map[string]time.Time,
+) error {
+	return c.runTableExports(ctx, flowName, tableMappings, func(tm *protos.TableMapping) (string, error) {
+		return c.bigQueryExportQueryStatement(
+			ctx, tm.SourceTableIdentifier, tm.GetWatermarkColumn(), stagingPath, boundByTable[tm.SourceTableIdentifier])
+	})
+}
+
+func (c *BigQueryConnector) runTableExports(
+	ctx context.Context,
+	flowName string,
+	tableMappings []*protos.TableMapping,
+	buildExportSQL func(tm *protos.TableMapping) (string, error),
+) error {
 	jobs := make(map[string]*bigquery.Job, len(tableMappings))
 	for _, tm := range tableMappings {
-		exportSQL, err := c.bigQueryExportQueryStatement(ctx, tm.SourceTableIdentifier, stagingPath, snapshotTime)
+		exportSQL, err := buildExportSQL(tm)
 		if err != nil {
 			return fmt.Errorf("failed to build export SQL for table %s: %w", tm.SourceTableIdentifier, err)
 		}
@@ -392,6 +420,34 @@ func (c *BigQueryConnector) exportTablesAsOf(
 	return nil
 }
 
+// maxWatermarkValue returns the current maximum value of watermarkColumn on
+// sourceTableIdentifier, or the current BigQuery-clock time if the table has no
+// rows -- there is nothing to snapshot, so CDC just starts capturing from now.
+func (c *BigQueryConnector) maxWatermarkValue(
+	ctx context.Context, sourceTableIdentifier, watermarkColumn string,
+) (time.Time, error) {
+	dsTable, err := c.convertToDatasetTable(sourceTableIdentifier)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse table identifier %s: %w", sourceTableIdentifier, err)
+	}
+
+	it, err := c.client.Query(fmt.Sprintf("SELECT MAX(TIMESTAMP(%s)) AS wm FROM %s",
+		quotedIdentifier(watermarkColumn), dsTable.stringQuoted())).Read(ctx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to query max watermark for table %s: %w", sourceTableIdentifier, err)
+	}
+	var row struct {
+		Wm bigquery.NullTimestamp `bigquery:"wm"`
+	}
+	if err := it.Next(&row); err != nil {
+		return time.Time{}, fmt.Errorf("failed to read max watermark for table %s: %w", sourceTableIdentifier, err)
+	}
+	if !row.Wm.Valid {
+		return c.currentBigQueryTimestamp(ctx)
+	}
+	return row.Wm.Timestamp, nil
+}
+
 // currentBigQueryTimestamp queries BigQuery's own clock (rather than local wall-clock) so the
 // returned timestamp is consistent with BigQuery's FOR SYSTEM_TIME AS OF time-travel semantics.
 func (c *BigQueryConnector) currentBigQueryTimestamp(ctx context.Context) (time.Time, error) {
@@ -415,8 +471,8 @@ func (c *BigQueryConnector) currentBigQueryTimestamp(ctx context.Context) (time.
 // See: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/export-statements#syntax
 func (c *BigQueryConnector) bigQueryExportQueryStatement(
 	ctx context.Context,
-	sourceTableIdentifier, snapshotStagingPath string,
-	snapshotTime time.Time,
+	sourceTableIdentifier, watermarkColumn, snapshotStagingPath string,
+	bound time.Time,
 ) (string, error) {
 	dsTable, err := c.convertToDatasetTable(sourceTableIdentifier)
 	if err != nil {
@@ -429,15 +485,20 @@ func (c *BigQueryConnector) bigQueryExportQueryStatement(
 		return "", fmt.Errorf("failed to get table metadata for %s: %w", sourceTableIdentifier, err)
 	}
 
-	return buildBigQueryExportSQL(dsTable, metadata.Schema, snapshotStagingPath, sourceTableIdentifier, snapshotTime), nil
+	return buildBigQueryExportSQL(dsTable, metadata.Schema, snapshotStagingPath, sourceTableIdentifier, bound, watermarkColumn), nil
 }
 
-// buildBigQueryExportSQL builds the EXPORT DATA SQL string
+// buildBigQueryExportSQL builds the EXPORT DATA SQL string. With watermarkColumn
+// empty, tables are read consistently as of bound via FOR SYSTEM_TIME AS OF
+// (EVENTS mode's shared BigQuery-clock snapshot). With watermarkColumn set
+// (BIGQUERY_REPLICATION_MODE_QUERY), tables are instead filtered to
+// watermarkColumn <= bound, matching that table's own watermark progress.
 func buildBigQueryExportSQL(
 	dsTable datasetTable,
 	schema bigquery.Schema,
 	snapshotStagingPath, sourceTableIdentifier string,
-	snapshotTime time.Time,
+	bound time.Time,
+	watermarkColumn string,
 ) string {
 	columnSelects := make([]string, 0, len(schema))
 	for _, field := range schema {
@@ -460,15 +521,19 @@ func buildBigQueryExportSQL(
 	}
 
 	uri := fmt.Sprintf("%s/%s/*.parquet", snapshotStagingPath, url.PathEscape(sourceTableIdentifier))
-	snapshotLiteral := snapshotTime.UTC().Format("2006-01-02 15:04:05.999999")
+	boundLiteral := bound.UTC().Format("2006-01-02 15:04:05.999999")
+
+	from := fmt.Sprintf("%s FOR SYSTEM_TIME AS OF TIMESTAMP('%s UTC')", dsTable.stringQuoted(), boundLiteral)
+	if watermarkColumn != "" {
+		from = fmt.Sprintf("%s WHERE TIMESTAMP(%s) <= TIMESTAMP('%s UTC')",
+			dsTable.stringQuoted(), quotedIdentifier(watermarkColumn), boundLiteral)
+	}
 
 	return fmt.Sprintf(
-		"EXPORT DATA OPTIONS(uri='%s', format='PARQUET', compression='GZIP', overwrite=true)"+
-			" AS SELECT %s FROM %s FOR SYSTEM_TIME AS OF TIMESTAMP('%s UTC')",
+		"EXPORT DATA OPTIONS(uri='%s', format='PARQUET', compression='GZIP', overwrite=true) AS SELECT %s FROM %s",
 		uri,
 		strings.Join(columnSelects, ", "),
-		dsTable.stringQuoted(),
-		snapshotLiteral,
+		from,
 	)
 }
 
@@ -549,6 +614,10 @@ func (c *BigQueryConnector) SetupReplication(
 		return model.SetupReplicationResult{}, fmt.Errorf("failed to fetch flow config from db: %w", err)
 	}
 
+	if cfg.GetBigqueryCdcConfig().GetReplicationMode() == protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY {
+		return c.setupQueryModeReplication(ctx, req, cfg)
+	}
+
 	snapshotTime, err := c.currentBigQueryTimestamp(ctx)
 	if err != nil {
 		return model.SetupReplicationResult{}, fmt.Errorf("failed to get current BigQuery timestamp: %w", err)
@@ -577,6 +646,50 @@ func (c *BigQueryConnector) SetupReplication(
 	}
 	checkpoint := model.CdcCheckpoint{Text: checkpointText}
 	if err := c.SetLastOffset(ctx, req.FlowJobName, checkpoint); err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to persist initial CDC checkpoint: %w", err)
+	}
+
+	return model.SetupReplicationResult{}, nil
+}
+
+// setupQueryModeReplication is SetupReplication's BIGQUERY_REPLICATION_MODE_QUERY
+// path. There is no single BigQuery-clock instant to snapshot from: each table's
+// watermark column advances on its own, so each table gets its own starting
+// checkpoint -- the current MAX(watermark_column) on that table, queried directly
+// (this mode's initial load can read the live table, unlike EVENTS mode's
+// GCS/Parquet export, so it needs no FOR SYSTEM_TIME AS OF consistency point).
+// The exported snapshot and the first CDC checkpoint use that same value, so CDC's
+// first poll (watermark_column > checkpoint) picks up exactly where the snapshot
+// (watermark_column <= checkpoint) left off.
+func (c *BigQueryConnector) setupQueryModeReplication(
+	ctx context.Context,
+	req *protos.SetupReplicationInput,
+	cfg *protos.FlowConnectionConfigsCore,
+) (model.SetupReplicationResult, error) {
+	checkpointByTable := make(map[string]time.Time, len(cfg.TableMappings))
+	for _, tableMapping := range cfg.TableMappings {
+		watermark, err := c.maxWatermarkValue(ctx, tableMapping.SourceTableIdentifier, tableMapping.GetWatermarkColumn())
+		if err != nil {
+			return model.SetupReplicationResult{}, fmt.Errorf(
+				"failed to get max watermark for table %s: %w", tableMapping.SourceTableIdentifier, err)
+		}
+		checkpointByTable[tableMapping.SourceTableIdentifier] = watermark
+	}
+
+	if req.DoInitialSnapshot {
+		_ = c.LogFlowInfo(ctx, req.FlowJobName, "Starting initial-load BigQuery export to GCS staging bucket")
+		if err := c.exportTablesAsOfWatermarks(
+			ctx, req.FlowJobName, cfg.TableMappings, cfg.SnapshotStagingPath, checkpointByTable,
+		); err != nil {
+			return model.SetupReplicationResult{}, err
+		}
+	}
+
+	checkpointText, err := newBigQueryCDCCheckpointPerTable(checkpointByTable).Marshal()
+	if err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to encode initial CDC checkpoint: %w", err)
+	}
+	if err := c.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{Text: checkpointText}); err != nil {
 		return model.SetupReplicationResult{}, fmt.Errorf("failed to persist initial CDC checkpoint: %w", err)
 	}
 

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -361,20 +361,6 @@ func (c *BigQueryConnector) exportTablesAsOf(
 	})
 }
 
-// exportTablesAsOfWatermarks exports each table up to its own watermark-column bound
-func (c *BigQueryConnector) exportTablesAsOfWatermarks(
-	ctx context.Context,
-	flowName string,
-	tableMappings []*protos.TableMapping,
-	stagingPath string,
-	boundByTable map[string]time.Time,
-) error {
-	return c.runTableExports(ctx, flowName, tableMappings, func(tm *protos.TableMapping) (string, error) {
-		return c.bigQueryExportQueryStatement(
-			ctx, tm.SourceTableIdentifier, tm.GetWatermarkColumn(), stagingPath, boundByTable[tm.SourceTableIdentifier])
-	})
-}
-
 func (c *BigQueryConnector) runTableExports(
 	ctx context.Context,
 	flowName string,
@@ -685,9 +671,11 @@ func (c *BigQueryConnector) setupQueryModeReplication(
 
 	if req.DoInitialSnapshot {
 		_ = c.LogFlowInfo(ctx, req.FlowJobName, "Starting initial-load BigQuery export to GCS staging bucket")
-		if err := c.exportTablesAsOfWatermarks(
-			ctx, req.FlowJobName, cfg.TableMappings, cfg.SnapshotStagingPath, checkpointByTable,
-		); err != nil {
+		err := c.runTableExports(ctx, req.FlowJobName, cfg.TableMappings, func(tm *protos.TableMapping) (string, error) {
+			return c.bigQueryExportQueryStatement(
+				ctx, tm.SourceTableIdentifier, tm.GetWatermarkColumn(), cfg.SnapshotStagingPath, checkpointByTable[tm.SourceTableIdentifier])
+		})
+		if err != nil {
 			return "", err
 		}
 	}

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -361,10 +361,7 @@ func (c *BigQueryConnector) exportTablesAsOf(
 	})
 }
 
-// exportTablesAsOfWatermarks exports each table up to its own watermark-column
-// bound, for BIGQUERY_REPLICATION_MODE_QUERY -- unlike exportTablesAsOf, there is
-// no single BigQuery-clock instant every table is read as of, since each table's
-// watermark column advances independently.
+// exportTablesAsOfWatermarks exports each table up to its own watermark-column bound
 func (c *BigQueryConnector) exportTablesAsOfWatermarks(
 	ctx context.Context,
 	flowName string,
@@ -599,7 +596,8 @@ func (c *BigQueryConnector) FinishExport(v any) error {
 
 // SetupReplication is BigQuery's equivalent of capturing a starting replication position
 // (like MySQL's GTID/file-position capture): it has no replication slot to open, so it just
-// captures a BigQuery-clock timestamp T and persists it as the initial CDC checkpoint. Unlike
+// captures a BigQuery-clock timestamp T OR max(watermark_column)
+// and persists it as the initial CDC checkpoint. Unlike
 // MySQL/Postgres, BigQuery's initial load can't query the live table at pull time - QRep
 // pulls read pre-exported Parquet from GCS - so when the mirror wants an initial load
 // (req.DoInitialSnapshot), this also runs that export as of the same T, the same way
@@ -614,19 +612,39 @@ func (c *BigQueryConnector) SetupReplication(
 		return model.SetupReplicationResult{}, fmt.Errorf("failed to fetch flow config from db: %w", err)
 	}
 
+	var checkpointText string
 	if cfg.GetBigqueryCdcConfig().GetReplicationMode() == protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY {
-		return c.setupQueryModeReplication(ctx, req, cfg)
+		checkpointText, err = c.setupQueryModeReplication(ctx, req, cfg)
+	} else {
+		checkpointText, err = c.setupEventsModeReplication(ctx, req, cfg)
+	}
+	if err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to setup replication: %w", err)
 	}
 
+	if err := c.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{Text: checkpointText}); err != nil {
+		return model.SetupReplicationResult{}, fmt.Errorf("failed to persist initial CDC checkpoint: %w", err)
+	}
+
+	return model.SetupReplicationResult{}, nil
+}
+
+// setupEventsModeReplication captures a single BigQuery-clock timestamp T as the initial CDC checkpoint
+// uses EXPORT DATA ... FOR SYSTEM_TIME AS OF T to export the initial snapshot
+func (c *BigQueryConnector) setupEventsModeReplication(
+	ctx context.Context,
+	req *protos.SetupReplicationInput,
+	cfg *protos.FlowConnectionConfigsCore,
+) (string, error) {
 	snapshotTime, err := c.currentBigQueryTimestamp(ctx)
 	if err != nil {
-		return model.SetupReplicationResult{}, fmt.Errorf("failed to get current BigQuery timestamp: %w", err)
+		return "", fmt.Errorf("failed to get current BigQuery timestamp: %w", err)
 	}
 
 	if req.DoInitialSnapshot {
 		_ = c.LogFlowInfo(ctx, req.FlowJobName, "Starting initial-load BigQuery export to GCS staging bucket")
 		if err := c.exportTablesAsOf(ctx, req.FlowJobName, cfg.TableMappings, cfg.SnapshotStagingPath, snapshotTime); err != nil {
-			return model.SetupReplicationResult{}, err
+			return "", err
 		}
 	}
 
@@ -642,35 +660,24 @@ func (c *BigQueryConnector) SetupReplication(
 	}
 	checkpointText, err := newBigQueryCDCCheckpoint(checkpointTime, sourceTables).Marshal()
 	if err != nil {
-		return model.SetupReplicationResult{}, fmt.Errorf("failed to encode initial CDC checkpoint: %w", err)
-	}
-	checkpoint := model.CdcCheckpoint{Text: checkpointText}
-	if err := c.SetLastOffset(ctx, req.FlowJobName, checkpoint); err != nil {
-		return model.SetupReplicationResult{}, fmt.Errorf("failed to persist initial CDC checkpoint: %w", err)
+		return "", fmt.Errorf("failed to encode initial CDC checkpoint: %w", err)
 	}
 
-	return model.SetupReplicationResult{}, nil
+	return checkpointText, nil
 }
 
-// setupQueryModeReplication is SetupReplication's BIGQUERY_REPLICATION_MODE_QUERY
-// path. There is no single BigQuery-clock instant to snapshot from: each table's
-// watermark column advances on its own, so each table gets its own starting
-// checkpoint -- the current MAX(watermark_column) on that table, queried directly
-// (this mode's initial load can read the live table, unlike EVENTS mode's
-// GCS/Parquet export, so it needs no FOR SYSTEM_TIME AS OF consistency point).
-// The exported snapshot and the first CDC checkpoint use that same value, so CDC's
-// first poll (watermark_column > checkpoint) picks up exactly where the snapshot
-// (watermark_column <= checkpoint) left off.
+// setupQueryModeReplication fetches max(watermark_column) for each table and uses those as the initial CDC checkpoint
+// uses plain SELECT ... FROM ... WHERE watermark_column <= max(watermark_column) for each table to export the initial snapshot
 func (c *BigQueryConnector) setupQueryModeReplication(
 	ctx context.Context,
 	req *protos.SetupReplicationInput,
 	cfg *protos.FlowConnectionConfigsCore,
-) (model.SetupReplicationResult, error) {
+) (string, error) {
 	checkpointByTable := make(map[string]time.Time, len(cfg.TableMappings))
 	for _, tableMapping := range cfg.TableMappings {
 		watermark, err := c.maxWatermarkValue(ctx, tableMapping.SourceTableIdentifier, tableMapping.GetWatermarkColumn())
 		if err != nil {
-			return model.SetupReplicationResult{}, fmt.Errorf(
+			return "", fmt.Errorf(
 				"failed to get max watermark for table %s: %w", tableMapping.SourceTableIdentifier, err)
 		}
 		checkpointByTable[tableMapping.SourceTableIdentifier] = watermark
@@ -681,17 +688,14 @@ func (c *BigQueryConnector) setupQueryModeReplication(
 		if err := c.exportTablesAsOfWatermarks(
 			ctx, req.FlowJobName, cfg.TableMappings, cfg.SnapshotStagingPath, checkpointByTable,
 		); err != nil {
-			return model.SetupReplicationResult{}, err
+			return "", err
 		}
 	}
 
 	checkpointText, err := newBigQueryCDCCheckpointPerTable(checkpointByTable).Marshal()
 	if err != nil {
-		return model.SetupReplicationResult{}, fmt.Errorf("failed to encode initial CDC checkpoint: %w", err)
-	}
-	if err := c.SetLastOffset(ctx, req.FlowJobName, model.CdcCheckpoint{Text: checkpointText}); err != nil {
-		return model.SetupReplicationResult{}, fmt.Errorf("failed to persist initial CDC checkpoint: %w", err)
+		return "", fmt.Errorf("failed to encode initial CDC checkpoint: %w", err)
 	}
 
-	return model.SetupReplicationResult{}, nil
+	return checkpointText, nil
 }

--- a/flow/connectors/bigquery/qrep_object_pull_test.go
+++ b/flow/connectors/bigquery/qrep_object_pull_test.go
@@ -16,6 +16,7 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 		snapshotStagingPath   string
 		sourceTableIdentifier string
 		snapshotTime          time.Time
+		watermarkColumn       string
 		expected              string
 	}{
 		{
@@ -71,11 +72,27 @@ func TestBuildBigQueryExportSQL(t *testing.T) {
 				"SELECT `plain`, TO_JSON_STRING(`payload`) AS `payload`, ST_AsText(`geo`) AS `geo`, " +
 				"CAST(`ts` AS TIMESTAMP) AS `ts` FROM `ds`.`tbl` FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:00:00 UTC')",
 		},
+		{
+			name:    "watermark column filters instead of FOR SYSTEM_TIME AS OF",
+			dsTable: datasetTable{dataset: "ds", table: "tbl"},
+			schema: bigquery.Schema{
+				{Name: "id", Type: bigquery.IntegerFieldType},
+				{Name: "updated_at", Type: bigquery.TimestampFieldType},
+			},
+			snapshotStagingPath:   "gs://bucket",
+			sourceTableIdentifier: "tbl",
+			snapshotTime:          time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC),
+			watermarkColumn:       "updated_at",
+			expected: "EXPORT DATA OPTIONS(uri='gs://bucket/tbl/*.parquet', format='PARQUET', " +
+				"compression='GZIP', overwrite=true) AS " +
+				"SELECT `id`, `updated_at` FROM `ds`.`tbl` WHERE TIMESTAMP(`updated_at`) <= TIMESTAMP('2026-08-14 12:00:00 UTC')",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sql := buildBigQueryExportSQL(tt.dsTable, tt.schema, tt.snapshotStagingPath, tt.sourceTableIdentifier, tt.snapshotTime)
+			sql := buildBigQueryExportSQL(
+				tt.dsTable, tt.schema, tt.snapshotStagingPath, tt.sourceTableIdentifier, tt.snapshotTime, tt.watermarkColumn)
 			require.Equal(t, tt.expected, sql)
 		})
 	}

--- a/flow/connectors/bigquery/source.go
+++ b/flow/connectors/bigquery/source.go
@@ -72,7 +72,7 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 			watermarkColumn := tableMapping.GetWatermarkColumn()
 			if watermarkColumn == "" {
 				return fmt.Errorf("table %s has no watermark_column configured; QUERY replication mode requires "+
-					"one TIMESTAMP or DATE column per table to incrementally scan", dstDatasetTable.string())
+					"one TIMESTAMP column per table to incrementally scan", dstDatasetTable.string())
 			}
 
 			table := c.client.DatasetInProject(c.projectID, dstDatasetTable.dataset).Table(dstDatasetTable.table)
@@ -85,8 +85,8 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 			if field == nil {
 				return fmt.Errorf("watermark column %s does not exist on table %s", watermarkColumn, dstDatasetTable.string())
 			}
-			if field.Type != bigquery.TimestampFieldType && field.Type != bigquery.DateFieldType {
-				return fmt.Errorf("watermark column %s on table %s must be TIMESTAMP or DATE, got %s",
+			if field.Type != bigquery.TimestampFieldType {
+				return fmt.Errorf("watermark column %s on table %s must be TIMESTAMP, got %s",
 					watermarkColumn, dstDatasetTable.string(), field.Type)
 			}
 		}

--- a/flow/connectors/bigquery/source.go
+++ b/flow/connectors/bigquery/source.go
@@ -67,7 +67,30 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 
 	replicationMode := cfg.GetBigqueryCdcConfig().GetReplicationMode()
 	if replicationMode == protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY {
-		return fmt.Errorf("BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY is not yet supported")
+		for _, tableMapping := range cfg.TableMappings {
+			dstDatasetTable := dstDatasetTables[tableMapping.SourceTableIdentifier]
+			watermarkColumn := tableMapping.GetWatermarkColumn()
+			if watermarkColumn == "" {
+				return fmt.Errorf("table %s has no watermark_column configured; QUERY replication mode requires "+
+					"one TIMESTAMP or DATE column per table to incrementally scan", dstDatasetTable.string())
+			}
+
+			table := c.client.DatasetInProject(c.projectID, dstDatasetTable.dataset).Table(dstDatasetTable.table)
+			metadata, err := table.Metadata(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get metadata for table %s: %w", tableMapping.SourceTableIdentifier, err)
+			}
+
+			field := bigQueryFieldByName(metadata.Schema, watermarkColumn)
+			if field == nil {
+				return fmt.Errorf("watermark column %s does not exist on table %s", watermarkColumn, dstDatasetTable.string())
+			}
+			if field.Type != bigquery.TimestampFieldType && field.Type != bigquery.DateFieldType {
+				return fmt.Errorf("watermark column %s on table %s must be TIMESTAMP or DATE, got %s",
+					watermarkColumn, dstDatasetTable.string(), field.Type)
+			}
+		}
+		return nil
 	}
 
 	needsChangeHistory := false
@@ -127,6 +150,16 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 		}
 	}
 
+	return nil
+}
+
+// bigQueryFieldByName returns the schema field named name, or nil if absent.
+func bigQueryFieldByName(schema bigquery.Schema, name string) *bigquery.FieldSchema {
+	for _, field := range schema {
+		if field.Name == name {
+			return field
+		}
+	}
 	return nil
 }
 

--- a/flow/e2e/bigquery_cdc_test.go
+++ b/flow/e2e/bigquery_cdc_test.go
@@ -32,6 +32,7 @@ func createBigQueryCdcSourceTable(
 		Schema: bigquery.Schema{
 			{Name: "id", Type: bigquery.IntegerFieldType, Required: true},
 			{Name: "val", Type: bigquery.StringFieldType, Required: false},
+			{Name: "updated_at", Type: bigquery.TimestampFieldType, Required: true, DefaultValueExpression: "CURRENT_TIMESTAMP"},
 		},
 		TableConstraints: &bigquery.TableConstraints{
 			PrimaryKey: &bigquery.PrimaryKey{Columns: []string{"id"}},
@@ -139,8 +140,14 @@ func quoteBigQueryTableFQN(fqn string) string {
 	return "`" + strings.ReplaceAll(fqn, "`", "\\`") + "`"
 }
 
+type bqCdcFlowParams struct {
+	eventsFunction  protos.BigqueryCdcEventsFunction
+	replicationMode protos.BigQueryReplicationMode
+	watermarkColumn string
+}
+
 func bqCdcFlowConnectionConfig(
-	s BigQueryClickhouseSuite, srcTable, dstTable string, eventsFunction protos.BigqueryCdcEventsFunction,
+	s BigQueryClickhouseSuite, srcTable, dstTable string, params bqCdcFlowParams,
 ) *protos.FlowConnectionConfigs {
 	source := s.Source().(*bigQuerySource)
 	connectionGen := FlowConnectionGenerationConfig{
@@ -149,7 +156,8 @@ func bqCdcFlowConnectionConfig(
 			{
 				SourceTableIdentifier:      fmt.Sprintf("%s.%s", source.config.DatasetId, srcTable),
 				DestinationTableIdentifier: s.DestinationTable(dstTable),
-				BigqueryCdcEventsFunction:  eventsFunction,
+				BigqueryCdcEventsFunction:  params.eventsFunction,
+				WatermarkColumn:            params.watermarkColumn,
 			},
 		},
 		Destination: s.Peer().Name,
@@ -160,7 +168,7 @@ func bqCdcFlowConnectionConfig(
 	flowConnConfig.SnapshotStagingPath = bigQueryTestStagingPath(s, srcTable)
 	flowConnConfig.SourceConnectorConfig = &protos.FlowConnectionConfigs_BigqueryCdcConfig{
 		BigqueryCdcConfig: &protos.BigqueryCdcConfig{
-			ReplicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+			ReplicationMode: params.replicationMode,
 		},
 	}
 	flowConnConfig.IdleTimeoutSeconds = 5
@@ -180,7 +188,10 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Snapshot_To_CDC_Handoff() {
 	// present before the mirror exists - must land via the initial snapshot.
 	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "pre-snapshot-1"}, {ID: 2, Val: "pre-snapshot-2"}})
 
-	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS)
+	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
+		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+	})
 
 	tc := NewTemporalClient(t)
 	env := ExecutePeerflow(t, tc, flowConnConfig)
@@ -217,7 +228,10 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Appends_Insert_Only() {
 
 	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "initial-1"}})
 
-	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS)
+	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
+		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+	})
 
 	tc := NewTemporalClient(t)
 	env := ExecutePeerflow(t, tc, flowConnConfig)
@@ -252,6 +266,52 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Appends_Insert_Only() {
 	RequireEnvCanceled(t, env)
 }
 
+// Test_BigQuery_CDC_Query_Mode covers BIGQUERY_REPLICATION_MODE_QUERY: a plain
+// SELECT ... WHERE watermark_column > lower AND watermark_column <= upper scan,
+// rather than APPENDS()/CHANGES(). The initial snapshot is bounded by the
+// watermark column's max value at setup time instead of FOR SYSTEM_TIME AS OF.
+func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Query_Mode() {
+	t := s.T()
+	ctx := t.Context()
+
+	source := s.Source().(*bigQuerySource)
+	srcTable := AddSuffix(s, "cdc_query_mode")
+	dstTable := srcTable + "_dst"
+	tableFQN := createBigQueryCdcSourceTable(ctx, t, source, srcTable, false)
+
+	// present before the mirror exists - must land via the initial snapshot.
+	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "pre-snapshot-1"}})
+
+	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
+		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY,
+		watermarkColumn: "updated_at",
+	})
+
+	tc := NewTemporalClient(t)
+	env := ExecutePeerflow(t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(t, env, flowConnConfig)
+
+	EnvWaitForEqualTablesWithNames(env, s, "initial snapshot landed", srcTable, dstTable, "id,val")
+
+	// inserted strictly after the snapshot's watermark bound - must arrive via the
+	// watermark-column CDC poll, not the snapshot.
+	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 2, Val: "post-snapshot-1"}, {ID: 3, Val: "post-snapshot-2"}})
+
+	EnvWaitFor(t, env, 4*time.Minute, "post-snapshot insert picked up via watermark-column query", func() bool {
+		rows, err := s.GetRows(dstTable, "id,val")
+		if err != nil {
+			t.Log(err)
+			return false
+		}
+		return len(rows.Records) == 3
+	})
+	RequireEqualTablesWithNames(s, srcTable, dstTable, "id,val")
+
+	env.Cancel(ctx)
+	RequireEnvCanceled(t, env)
+}
+
 // Test_BigQuery_CDC_All_Types inserts its row only after replication setup, so
 // every value must travel through APPENDS(), qvalueFromBigQueryValue, and the CDC
 // destination path. This complements Test_Types, which exercises snapshot export.
@@ -265,7 +325,10 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_All_Types() {
 	tableFQN := createBigQueryAllTypesCdcSourceTable(ctx, t, source, srcTable)
 
 	flowConnConfig := bqCdcFlowConnectionConfig(
-		s, srcTable, dstTable, protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		s, srcTable, dstTable, bqCdcFlowParams{
+			eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+			replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		},
 	)
 	flowConnConfig.DoInitialSnapshot = false
 
@@ -362,7 +425,10 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Changes_Insert_Update_Delete(
 		{ID: 3, Val: "initial-3"},
 	})
 
-	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES)
+	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
+		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES,
+		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+	})
 	flowConnConfig.Env = map[string]string{"PEERDB_BIGQUERY_CDC_SAFETY_LAG_SECONDS": "5"}
 
 	tc := NewTemporalClient(t)
@@ -424,7 +490,10 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Table_Failure_Does_Not_Block_
 	bqInsertRows(ctx, t, source, healthyFQN, []bqCdcRow{{ID: 1, Val: "healthy-initial"}})
 
 	appends := protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS
-	flowConnConfig := bqCdcFlowConnectionConfig(s, failedSrc, failedDst, appends)
+	flowConnConfig := bqCdcFlowConnectionConfig(s, failedSrc, failedDst, bqCdcFlowParams{
+		eventsFunction:  appends,
+		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+	})
 	flowConnConfig.TableMappings = append(flowConnConfig.TableMappings, &protos.TableMapping{
 		SourceTableIdentifier:      healthySourceID,
 		DestinationTableIdentifier: s.DestinationTable(healthyDst),
@@ -585,7 +654,10 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Restart_Mid_Window_Resume() {
 
 	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "initial-1"}})
 
-	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS)
+	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
+		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+	})
 
 	tc := NewTemporalClient(t)
 	env := ExecutePeerflow(t, tc, flowConnConfig)
@@ -680,7 +752,11 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_Source_CDC_Table_Removal_Drops_Ch
 	bqInsertRows(ctx, t, source, removedFQN, []bqCdcRow{{ID: 1, Val: "removed-snapshot"}})
 
 	appends := protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS
-	flowConnConfig := bqCdcFlowConnectionConfig(s, retainedSrc, retainedDst, appends)
+	flowConnConfig := bqCdcFlowConnectionConfig(s, retainedSrc, retainedDst, bqCdcFlowParams{
+		eventsFunction:  appends,
+		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		watermarkColumn: "",
+	})
 	retainedMapping := flowConnConfig.TableMappings[0]
 	removedMapping := &protos.TableMapping{
 		SourceTableIdentifier:      fmt.Sprintf("%s.%s", source.config.DatasetId, removedSrc),

--- a/flow/e2e/bigquery_source_test.go
+++ b/flow/e2e/bigquery_source_test.go
@@ -215,7 +215,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_Source_CDC_Validation() {
 			require.Contains(t, err.Error(), "watermark_column")
 		})
 
-		t.Run("rejects a non-timestamp/date watermark column", func(t *testing.T) {
+		t.Run("rejects a non-timestamp watermark column", func(t *testing.T) {
 			for _, tableMapping := range flowConfig.TableMappings {
 				tableMapping.WatermarkColumn = "trip_id" // INTEGER
 			}
@@ -226,27 +226,13 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_Source_CDC_Validation() {
 			}()
 
 			err := bqConn.ValidateMirrorSource(ctx, flowConfig)
-			require.Error(t, err, "QUERY mode should reject a watermark column that isn't TIMESTAMP or DATE")
-			require.Contains(t, err.Error(), "must be TIMESTAMP or DATE")
+			require.Error(t, err, "QUERY mode should reject a watermark column that isn't TIMESTAMP")
+			require.Contains(t, err.Error(), "must be TIMESTAMP")
 		})
 
 		t.Run("accepts a TIMESTAMP watermark column", func(t *testing.T) {
 			for _, tableMapping := range flowConfig.TableMappings {
 				tableMapping.WatermarkColumn = "pickup_datetime"
-			}
-			defer func() {
-				for _, tableMapping := range flowConfig.TableMappings {
-					tableMapping.WatermarkColumn = ""
-				}
-			}()
-
-			err := bqConn.ValidateMirrorSource(ctx, flowConfig)
-			require.NoError(t, err)
-		})
-
-		t.Run("accepts a DATE watermark column", func(t *testing.T) {
-			for _, tableMapping := range flowConfig.TableMappings {
-				tableMapping.WatermarkColumn = "pickup_date"
 			}
 			defer func() {
 				for _, tableMapping := range flowConfig.TableMappings {

--- a/flow/e2e/bigquery_source_test.go
+++ b/flow/e2e/bigquery_source_test.go
@@ -201,7 +201,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_Source_CDC_Validation() {
 		require.Contains(t, err.Error(), "enable_change_history")
 	})
 
-	t.Run("QUERY replication mode is rejected", func(t *testing.T) {
+	t.Run("QUERY replication mode", func(t *testing.T) {
 		flowConfig.SourceConnectorConfig = &protos.FlowConnectionConfigsCore_BigqueryCdcConfig{
 			BigqueryCdcConfig: &protos.BigqueryCdcConfig{
 				ReplicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY,
@@ -209,8 +209,54 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_Source_CDC_Validation() {
 		}
 		defer func() { flowConfig.SourceConnectorConfig = nil }()
 
-		err := bqConn.ValidateMirrorSource(ctx, flowConfig)
-		require.Error(t, err, "QUERY replication mode isn't implemented yet")
+		t.Run("requires a watermark column", func(t *testing.T) {
+			err := bqConn.ValidateMirrorSource(ctx, flowConfig)
+			require.Error(t, err, "QUERY mode should reject a table with no watermark_column set")
+			require.Contains(t, err.Error(), "watermark_column")
+		})
+
+		t.Run("rejects a non-timestamp/date watermark column", func(t *testing.T) {
+			for _, tableMapping := range flowConfig.TableMappings {
+				tableMapping.WatermarkColumn = "trip_id" // INTEGER
+			}
+			defer func() {
+				for _, tableMapping := range flowConfig.TableMappings {
+					tableMapping.WatermarkColumn = ""
+				}
+			}()
+
+			err := bqConn.ValidateMirrorSource(ctx, flowConfig)
+			require.Error(t, err, "QUERY mode should reject a watermark column that isn't TIMESTAMP or DATE")
+			require.Contains(t, err.Error(), "must be TIMESTAMP or DATE")
+		})
+
+		t.Run("accepts a TIMESTAMP watermark column", func(t *testing.T) {
+			for _, tableMapping := range flowConfig.TableMappings {
+				tableMapping.WatermarkColumn = "pickup_datetime"
+			}
+			defer func() {
+				for _, tableMapping := range flowConfig.TableMappings {
+					tableMapping.WatermarkColumn = ""
+				}
+			}()
+
+			err := bqConn.ValidateMirrorSource(ctx, flowConfig)
+			require.NoError(t, err)
+		})
+
+		t.Run("accepts a DATE watermark column", func(t *testing.T) {
+			for _, tableMapping := range flowConfig.TableMappings {
+				tableMapping.WatermarkColumn = "pickup_date"
+			}
+			defer func() {
+				for _, tableMapping := range flowConfig.TableMappings {
+					tableMapping.WatermarkColumn = ""
+				}
+			}()
+
+			err := bqConn.ValidateMirrorSource(ctx, flowConfig)
+			require.NoError(t, err)
+		})
 	})
 }
 

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -53,7 +53,7 @@ message TableMapping {
   // BIGQUERY_REPLICATION_MODE_EVENTS.
   BigqueryCdcEventsFunction bigquery_cdc_events_function = 10;
   // Only meaningful when the mirror's BigqueryCdcConfig.replication_mode is
-  // BIGQUERY_REPLICATION_MODE_QUERY. Names a TIMESTAMP or DATE column used to
+  // BIGQUERY_REPLICATION_MODE_QUERY. Names a TIMESTAMP column used to
   // incrementally scan this table: WHERE watermark_column > lower_bound AND
   // watermark_column <= upper_bound. Required in that mode.
   string watermark_column = 11;

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -52,6 +52,11 @@ message TableMapping {
   // Only meaningful when the mirror's BigqueryCdcConfig.replication_mode is
   // BIGQUERY_REPLICATION_MODE_EVENTS.
   BigqueryCdcEventsFunction bigquery_cdc_events_function = 10;
+  // Only meaningful when the mirror's BigqueryCdcConfig.replication_mode is
+  // BIGQUERY_REPLICATION_MODE_QUERY. Names a TIMESTAMP or DATE column used to
+  // incrementally scan this table: WHERE watermark_column > lower_bound AND
+  // watermark_column <= upper_bound. Required in that mode.
+  string watermark_column = 11;
 }
 
 message SetupInput {

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -195,6 +195,7 @@ function reformattedTableMapping(tableMapping: TableMapRow[]): TableMapping[] {
       partitionByExpr: row.partitionByExpr,
       bigqueryCdcEventsFunction:
         BigqueryCdcEventsFunction.BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+      watermarkColumn: row.watermarkColumn,
     }));
 }
 
@@ -232,6 +233,7 @@ export function changesToTablesMapping(
           shardingKey: row.shardingKey,
           policyName: row.policyName,
           partitionByExpr: row.partitionByExpr,
+          watermarkColumn: row.watermarkColumn,
         }) as TableMapping
     );
   return mapping;
@@ -458,6 +460,7 @@ export async function fetchTables(
         partitionByExpr: '',
         bigqueryCdcEventsFunction:
           BigqueryCdcEventsFunction.BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+        watermarkColumn: '',
         isReplicaIdentityFull: tableObject.isReplicaIdentityFull,
       });
     }


### PR DESCRIPTION
This PR implements watermark column BigQuery CDC mode. Essentially, it's the simplest mode that does the following on every PullRecords call: 
`SELECT ... FROM ... WHERE col > lower AND col <= upper ORDER BY col`

Initial snapshot in this mode uses watermark column to scan the data for the first time and then stores `SELECT max(col) FROM ...` as an initial checkpoint for CDC. (in contrast to APPENDS/CHANGES mode where we use `FOR SYSTEM_TIME AS OF TIMESTAMP('2026-08-14 12:34:56.789 UTC')`).

Resolves: DBI-1056

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>