### PR TITLE
fix(clickhouse): accept cloud_mode_engine modes 3 and 4 in SMT validation

### DIFF
--- a/flow/pkg/clickhouse/validation.go
+++ b/flow/pkg/clickhouse/validation.go
@@ -57,10 +57,11 @@ func validateDatabaseEngine(ctx context.Context, logger log.Logger, conn clickho
 func CheckIfClickHouseCloudHasSharedMergeTreeEnabled(ctx context.Context, logger log.Logger,
 	conn clickhouse.Conn,
 ) error {
-	// this is to indicate ClickHouse Cloud service is now creating tables with Shared* by default
+	// cloud_mode_engine 2, 3 and 4 all create tables with Shared* engines by default (3/4 only add
+	// carve-outs for explicit remote disks / Distributed); accept any of them as SMT-enabled
 	var cloudModeEngine bool
 	if err := QueryRow(ctx, logger, conn,
-		"SELECT value='2' AND changed='1' AND readonly='1' FROM system.settings WHERE name = 'cloud_mode_engine'").
+		"SELECT value IN ('2','3','4') AND changed='1' AND readonly='1' FROM system.settings WHERE name = 'cloud_mode_engine'").
 		Scan(&cloudModeEngine); err != nil {
 		return fmt.Errorf("failed to validate cloud_mode_engine setting: %w", err)
 	}

--- a/flow/pkg/clickhouse/validation_test.go
+++ b/flow/pkg/clickhouse/validation_test.go
@@ -158,6 +158,90 @@ func TestCheckIfTablesEmptyAndEngine(t *testing.T) {
 	}
 }
 
+func TestCheckIfClickHouseCloudHasSharedMergeTreeEnabled(t *testing.T) {
+	ctx := t.Context()
+	addr := fmt.Sprintf("%s:%d", testutil.ClickHouseTestHost(), testutil.ClickHouseTestPort())
+	adminConn, err := clickhouse.Open(&clickhouse.Options{Addr: []string{addr}})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, adminConn.Close())
+	})
+	require.NoError(t, adminConn.Ping(ctx))
+
+	tests := []struct {
+		name            string
+		profileSettings string
+		wantErr         string
+	}{
+		{
+			name:            "cloud_mode_engine 2 accepted",
+			profileSettings: "cloud_mode_engine = 2 READONLY",
+		},
+		{
+			name:            "cloud_mode_engine 3 accepted",
+			profileSettings: "cloud_mode_engine = 3 READONLY",
+		},
+		{
+			name:            "cloud_mode_engine 4 accepted",
+			profileSettings: "cloud_mode_engine = 4 READONLY",
+		},
+		{
+			name:            "cloud_mode_engine 1 rejected",
+			profileSettings: "cloud_mode_engine = 1 READONLY",
+			wantErr:         "not migrated to use SharedMergeTree",
+		},
+		{
+			name:            "non-readonly cloud_mode_engine rejected",
+			profileSettings: "cloud_mode_engine = 2",
+			wantErr:         "not migrated to use SharedMergeTree",
+		},
+		{
+			name:    "default cloud_mode_engine rejected",
+			wantErr: "not migrated to use SharedMergeTree",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			username := "smt_user_" + strings.ToLower(common.RandomString(8))
+			require.NoError(t, adminConn.Exec(ctx,
+				fmt.Sprintf("CREATE USER %s IDENTIFIED BY 'testpassword'", username)))
+			t.Cleanup(func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				require.NoError(t, adminConn.Exec(cleanupCtx, "DROP USER IF EXISTS "+username))
+			})
+			if tt.profileSettings != "" {
+				profile := username + "_profile"
+				require.NoError(t, adminConn.Exec(ctx,
+					fmt.Sprintf("CREATE SETTINGS PROFILE %s SETTINGS %s TO %s", profile, tt.profileSettings, username)))
+				t.Cleanup(func() {
+					cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					defer cancel()
+					require.NoError(t, adminConn.Exec(cleanupCtx, "DROP SETTINGS PROFILE IF EXISTS "+profile))
+				})
+			}
+
+			conn, err := clickhouse.Open(&clickhouse.Options{
+				Addr: []string{addr},
+				Auth: clickhouse.Auth{Username: username, Password: "testpassword"},
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, conn.Close())
+			})
+			require.NoError(t, conn.Ping(ctx))
+
+			err = CheckIfClickHouseCloudHasSharedMergeTreeEnabled(t.Context(), nopLogger{}, conn)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateClickHouseHost(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Problem

Creating a CDC mirror to a ClickHouse Cloud service can fail destination validation with:

> ClickHouse service is not migrated to use SharedMergeTree tables, please contact support

on services configured with `cloud_mode_engine = 3`, even though those services create SharedMergeTree tables by default.

## Cause

`CheckIfClickHouseCloudHasSharedMergeTreeEnabled` requires `cloud_mode_engine` to be exactly `2`. The setting is a mode ladder, and modes 3 and 4 are supersets of 2 that still rewrite DDLs to SharedMergeTree:

- `2` — rewrite DDLs to use SharedMergeTree
- `3` — same as 2, except when an explicitly passed remote disk is specified
- `4` — same as 3, plus use Alias instead of Distributed

ClickHouse Cloud has begun rolling out mode 3, so the exact-match check now rejects healthy SMT services. Mirrors never specify a remote disk, so their tables are created as SharedMergeTree under all three modes.

## Fix

Accept values `2`, `3` and `4`. The `changed`/`readonly` requirements are unchanged.

## Test

New test `TestCheckIfClickHouseCloudHasSharedMergeTreeEnabled` drives the check through per-user settings profiles (`CREATE SETTINGS PROFILE ... SETTINGS cloud_mode_engine = N READONLY`), which matches how Cloud pins the setting. It covers: modes 2/3/4 accepted, mode 1 rejected, non-readonly value rejected, and default (unchanged) value rejected. The mode 3/4 cases fail against the previous validation logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
