### PR TITLE
fix failure to abort multipart upload due to context cancellation

### DIFF
--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1857,3 +1857,20 @@ func TestMySQLStaleConnectionErrorJoinedShouldBeNotifyConnectivity(t *testing.T)
 		Code:   "CONNECTION_STALE",
 	}, errInfo, "Unexpected error info")
 }
+
+func TestS3MultipartUploadContextCancellationShouldBeIgnored(t *testing.T) {
+	t.Parallel()
+
+	sdkErr := errors.New(
+		"upload multipart failed, upload id: id, cause: failed to abort multipart upload " +
+			"(operation error S3: AbortMultipartUpload, context canceled), " +
+			"triggered after multipart upload failed: operation error S3: UploadPart, context canceled")
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf(
+		"failed to push records: failed to upload to staging: failed to upload file to S3: %w",
+		errors.Join(sdkErr, context.Canceled)))
+	assert.Equal(t, ErrorIgnoreContextCancelled, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceOther,
+		Code:   "CONTEXT_CANCELLED",
+	}, errInfo)
+}

--- a/flow/connectors/clickhouse/staging_s3.go
+++ b/flow/connectors/clickhouse/staging_s3.go
@@ -114,25 +114,19 @@ func (s *s3StagingStore) Upload(ctx context.Context, env map[string]string, key 
 		return fmt.Errorf("could not get s3 part size config: %w", err)
 	}
 
-	uploader := transfermanager.New(s3svc, func(o *transfermanager.Options) {
-		// GCS's S3 interop doesn't support aws-chunked trailing CRC32 checksums
-		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
-		if partSize > 0 {
-			o.PartSizeBytes = partSize
-			// match the old feature/s3/manager cutoff: objects under one part
-			// stay a single PutObject, keeping non-multipart ETags
-			o.MultipartUploadThreshold = partSize
-			if partSize > 256*1024*1024 {
-				o.Concurrency = 1
-			}
-		}
-	})
+	uploader := transfermanager.New(s3svc, utils.S3TransferOptions(partSize))
 
 	if _, err := uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 		Body:   body,
 	}); err != nil {
+		// transfermanager loses the context.Canceled unwrap chain when AbortMultipartUpload also
+		// fails on the canceled upload context; rejoin the cause so classifier sees the cancellation
+		// https://github.com/aws/aws-sdk-go-v2/blob/feature/s3/transfermanager/v0.3.10/feature/s3/transfermanager/api_op_UploadObject.go#L1204
+		if ctxErr := context.Cause(ctx); ctxErr != nil {
+			err = errors.Join(err, ctxErr)
+		}
 		s3Path := "s3://" + s.bucket + "/" + key
 		logger.Error("failed to upload file", slog.Any("error", err), slog.String("s3_path", s3Path))
 		return fmt.Errorf("failed to upload file to S3: %w", err)

--- a/flow/connectors/utils/avro_writer.go
+++ b/flow/connectors/utils/avro_writer.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -131,25 +132,19 @@ func (p *peerDBOCFWriter) WriteRecordsToS3(
 		return AvroFile{}, fmt.Errorf("could not get s3 part size config: %w", err)
 	}
 
-	uploader := transfermanager.New(s3svc, func(o *transfermanager.Options) {
-		// GCS's S3 interop doesn't support aws-chunked trailing CRC32 checksums
-		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
-		if partSize > 0 {
-			o.PartSizeBytes = partSize
-			// match the old feature/s3/manager cutoff: objects under one part
-			// stay a single PutObject, keeping non-multipart ETags
-			o.MultipartUploadThreshold = partSize
-			if partSize > 256*1024*1024 {
-				o.Concurrency = 1
-			}
-		}
-	})
+	uploader := transfermanager.New(s3svc, S3TransferOptions(partSize))
 
 	if _, err := uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(key),
 		Body:   r,
 	}); err != nil {
+		// transfermanager loses the context.Canceled unwrap chain when AbortMultipartUpload also
+		// fails on the canceled upload context; rejoin the cause so classifier sees the cancellation
+		// https://github.com/aws/aws-sdk-go-v2/blob/feature/s3/transfermanager/v0.3.10/feature/s3/transfermanager/api_op_UploadObject.go#L1204
+		if ctxErr := context.Cause(ctx); ctxErr != nil {
+			err = errors.Join(err, ctxErr)
+		}
 		s3Path := "s3://" + bucketName + "/" + key
 		logger.Error("failed to upload file", slog.Any("error", err), slog.String("s3_path", s3Path))
 		return AvroFile{}, fmt.Errorf("failed to upload file: %w", err)

--- a/flow/connectors/utils/aws.go
+++ b/flow/connectors/utils/aws.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithyendpoints "github.com/aws/smithy-go/endpoints"
@@ -409,6 +410,23 @@ func CreateS3Client(ctx context.Context, credsProvider AWSCredentialsProvider) (
 	}
 
 	return s3.New(options), nil
+}
+
+// S3TransferOptions returns the transfermanager options shared by all S3 uploads.
+func S3TransferOptions(partSize int64) func(*transfermanager.Options) {
+	return func(o *transfermanager.Options) {
+		// GCS's S3 interop doesn't support aws-chunked trailing CRC32 checksums
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		if partSize > 0 {
+			o.PartSizeBytes = partSize
+			// match the old feature/s3/manager cutoff: objects under one part
+			// stay a single PutObject, keeping non-multipart ETags
+			o.MultipartUploadThreshold = partSize
+			if partSize > 256*1024*1024 {
+				o.Concurrency = 1
+			}
+		}
+	}
 }
 
 // RecalculateV4Signature allow GCS over S3, removing Accept-Encoding header from sign


### PR DESCRIPTION
Error observed:
> failed to push records: failed to upload to staging: failed to upload file to S3: upload multipart failed, upload id: xxx, cause: failed to abort multipart upload (operation error S3: AbortMultipartUpload, context canceled), triggered after multipart upload failed: operation error S3: UploadPart, context canceled

transfermanager loses the context.Canceled unwrap chain when AbortMultipartUpload also fails on the canceled upload context; rejoin the cause so classifier sees the cancellation. 

Workaround for an upstream bug (double-checked even the latest version of transfermanager error is still using `%v` instead of `%w`): 
https://github.com/aws/aws-sdk-go-v2/blob/feature/s3/transfermanager/v0.3.10/feature/s3/transfermanager/api_op_UploadObject.go#L1204

Fixes: DBI-1058