### PR TITLE
classify too many tables error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -1250,6 +1250,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				Code:                 chErrorInfo.Code,
 				AdditionalAttributes: additionalAttributes,
 			}
+		case chproto.ErrTooManyTables:
+			return ErrorNotifyClickHouseError, chErrorInfo
 		case chproto.ErrUnknownUser:
 			return ErrorNotifyClickHouseError, chErrorInfo
 		}

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1462,6 +1462,23 @@ func TestClickHouseTooManyPartsWithTableName(t *testing.T) {
 	}, errInfo)
 }
 
+func TestClickHouseTooManyTablesDuringTableCreationShouldNotifyUser(t *testing.T) {
+	t.Parallel()
+
+	chErr := &clickhouse.Exception{
+		Code: int32(chproto.ErrTooManyTables),
+		//nolint:lll
+		Message: "Too many tables. The limit (server configuration parameter `max_table_num_to_throw`) is set to 500, the current number is 500",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), exceptions.NewClickHouseNormalizedTableCreationError(
+		fmt.Errorf("[clickhouse] error while creating destination ClickHouse table: %w", chErr), "test"))
+	assert.Equal(t, ErrorNotifyClickHouseError, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceClickHouse,
+		Code:   strconv.Itoa(int(chproto.ErrTooManyTables)),
+	}, errInfo)
+}
+
 func TestClickHouseTooManyPartsWithoutTableName(t *testing.T) {
 	err := &clickhouse.Exception{
 		Code: int32(chproto.ErrTooManyParts),


### PR DESCRIPTION
Add missing clickhouse error code for classification.

Fixes: DBI-1019