### PR TITLE
classify wal segment short error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -746,6 +746,13 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			// Fall through for other internal errors
 			return ErrorOther, pgErrorInfo
 
+		case pgerrcode.DataCorrupted:
+			// Observed transient error on Aurora during a failover (evident by a subsequent transient error on retry:
+			// "ERROR: replication slots cannot be used on RO (Read Only) node (SQLSTATE 55000)" that auto-recovered)
+			if pgErr.Routine == "WALReadRaiseError" && strings.Contains(pgErr.Message, "could not read from log segment") {
+				return ErrorRetryRecoverable, pgErrorInfo
+			}
+			return ErrorOther, pgErrorInfo
 		case pgerrcode.ObjectNotInPrerequisiteState:
 			// the GUC names in this message are unquoted on PG16, quoted from PG17 on, and renamed to
 			// "effective_wal_level" on PG19, so only the prefix is stable across versions

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -304,6 +304,22 @@ func TestAuroraInternalWALErrorShouldBeRecoverable(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestPostgresWalRaiseErrorShouldBeRecoverable(t *testing.T) {
+	err := &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     pgerrcode.DataCorrupted,
+		Message:  "could not read from log segment 0000000100000EA000000039, offset 35536896: read 0 of 8192",
+		Routine:  "WALReadRaiseError",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("error starting replication at startLsn - 16084218300273: %w", err))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   pgerrcode.DataCorrupted,
+	}, errInfo)
+}
+
 func TestNeonProjectQuotaExceededErrorShouldBeConnectivity(t *testing.T) {
 	// Simulate a Neon project quota exceeded error
 	err := &pgconn.PgError{


### PR DESCRIPTION
> Postgres WAL error: received error response, message: &{Severity:ERROR SeverityUnlocalized:ERROR Code:XX001 Message:could not read from log segment 0000000100000EA000000039, offset 35536896: read 0 of 8192 Detail: Hint: Position:0 InternalPosition:0 InternalQuery: Where: SchemaName: TableName: ColumnName: DataTypeName: ConstraintName: File:xlogutils.c Line:1253 Routine:WALReadRaiseError UnknownFields:map[]}

Observed as transient error on Aurora during a failover, evident by a subsequent transient error on retry that auto-recovered:

> ERROR: replication slots cannot be used on RO (Read Only) node (SQLSTATE 55000)

Fixes:  DBI-1042