### PR TITLE
Preserve large CDC values for non-Snowflake destinations

### DIFF
--- a/ancillary-docker-compose.yml
+++ b/ancillary-docker-compose.yml
@@ -135,6 +135,7 @@ services:
     image: ${MYSQL_GTID_IMAGE}
     command:
       - "--binlog-row-metadata=FULL"
+      - "--max-allowed-packet=128M"
     restart: unless-stopped
     volumes:
       - mysql_gtid_data:/var/lib/mysql
@@ -153,7 +154,7 @@ services:
   mysql-pos:
     container_name: peerdb-mysql-pos
     image: ${MYSQL_POS_IMAGE}
-    command: ["--log_bin=mysql-bin", "--server-id=1", "--bind-address=::"]
+    command: ["--log_bin=mysql-bin", "--server-id=1", "--bind-address=::", "--max-allowed-packet=128M"]
     restart: unless-stopped
     volumes:
       - mysql_pos_data:/var/lib/mysql
@@ -176,6 +177,7 @@ services:
       - "--log-bin=maria"
       - "--binlog-format=ROW"
       - "--binlog-row-metadata=FULL"
+      - "--max-allowed-packet=128M"
     restart: unless-stopped
     volumes:
       - mariadb_data:/var/lib/mysql

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -531,7 +531,7 @@ func (c *MongoConnector) PullRecords(
 			continue
 		}
 
-		items := model.NewMongoRecordItems(2)
+		items := model.NewRecordItems(2)
 		switch operationType(changeEvent.OperationType) {
 		case operationTypeInsert:
 			if err := addRecordItems(changeEvent.DocumentKey, changeEvent.FullDocument, &items, sourceTableName); err != nil {

--- a/flow/connectors/utils/stream.go
+++ b/flow/connectors/utils/stream.go
@@ -10,6 +10,7 @@ import (
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	"github.com/PeerDB-io/peerdb/flow/model/qvalue"
+	"github.com/PeerDB-io/peerdb/flow/shared"
 	"github.com/PeerDB-io/peerdb/flow/shared/types"
 )
 
@@ -86,13 +87,14 @@ func recordToQRecordOrError(
 	numericTruncator model.StreamNumericTruncator,
 ) ([]types.QValue, error) {
 	var entries [8]types.QValue
+	jsonOpts := rawTableJSONOptions(targetDWH)
 	switch typedRecord := record.(type) {
 	case *model.InsertRecord[model.RecordItems]:
 		tableNumericTruncator := numericTruncator.Get(typedRecord.DestinationTableName)
 		preprocessedItems := truncateNumerics(
 			typedRecord.Items, targetDWH, unboundedNumericAsString, tableNumericTruncator,
 		)
-		itemsJSON, err := model.ItemsToJSON(preprocessedItems)
+		itemsJSON, err := preprocessedItems.ToJSONWithOptions(jsonOpts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize insert record items to JSON: %w", err)
 		}
@@ -106,11 +108,11 @@ func recordToQRecordOrError(
 		preprocessedItems := truncateNumerics(
 			typedRecord.NewItems, targetDWH, unboundedNumericAsString, tableNumericTruncator,
 		)
-		newItemsJSON, err := model.ItemsToJSON(preprocessedItems)
+		newItemsJSON, err := preprocessedItems.ToJSONWithOptions(jsonOpts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize update record new items to JSON: %w", err)
 		}
-		oldItemsJSON, err := model.ItemsToJSON(typedRecord.OldItems)
+		oldItemsJSON, err := typedRecord.OldItems.ToJSONWithOptions(jsonOpts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize update record old items to JSON: %w", err)
 		}
@@ -121,7 +123,7 @@ func recordToQRecordOrError(
 		entries[7] = types.QValueString{Val: KeysToString(typedRecord.UnchangedToastColumns)}
 
 	case *model.DeleteRecord[model.RecordItems]:
-		itemsJSON, err := model.ItemsToJSON(typedRecord.Items)
+		itemsJSON, err := typedRecord.Items.ToJSONWithOptions(jsonOpts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize delete record items to JSON: %w", err)
 		}
@@ -144,6 +146,14 @@ func recordToQRecordOrError(
 	entries[6] = types.QValueInt64{Val: batchID}
 
 	return entries[:], nil
+}
+
+func rawTableJSONOptions(target protos.DBType) model.ToJSONOptions {
+	opts := model.NewToJSONOptions(nil, true)
+	if target == protos.DBType_SNOWFLAKE {
+		opts.ClearValuesOverBytes = shared.SnowflakeClearValueThresholdBytes
+	}
+	return opts
 }
 
 func InitialiseTableRowsMap(tableMaps []*protos.TableMapping) map[string]*model.RecordTypeCounts {

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -106,8 +106,7 @@ func (s ClickHouseSuite) Test_Large_Text_CDC() {
 	largeTextBytes := 100 * 1024 * 1024
 	payloadType := "TEXT"
 	if _, ok := s.source.(*MySqlSource); ok {
-		// Stay just below MySQL's default 64 MiB max_allowed_packet without changing server settings.
-		largeTextBytes = 63 * 1024 * 1024
+		largeTextBytes = 32 * 1024 * 1024
 		payloadType = "LONGTEXT"
 	}
 

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -100,6 +100,61 @@ func (s ClickHouseSuite) attachSuffix(input string) string {
 	return fmt.Sprintf("%s_%s", input, s.suffix)
 }
 
+func (s ClickHouseSuite) Test_Large_Text_CDC() {
+	const srcTable = "test_large_text_cdc"
+	const dstTable = "test_large_text_cdc"
+	largeTextBytes := 100 * 1024 * 1024
+	payloadType := "TEXT"
+	if _, ok := s.source.(*MySqlSource); ok {
+		// Stay just below MySQL's default 64 MiB max_allowed_packet without changing server settings.
+		largeTextBytes = 63 * 1024 * 1024
+		payloadType = "LONGTEXT"
+	}
+
+	srcSchemaTable := s.attachSchemaSuffix(srcTable)
+	require.NoError(s.t, s.source.Exec(s.t.Context(), fmt.Sprintf(`
+		CREATE TABLE %s (
+			id INT PRIMARY KEY,
+			payload %s NOT NULL
+		)`, srcSchemaTable, payloadType)))
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("clickhouse_large_text_cdc"),
+		TableNameMapping: map[string]string{srcSchemaTable: dstTable},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.MaxBatchSize = 1
+	flowConnConfig.IdleTimeoutSeconds = 1
+
+	tc := NewTemporalClient(s.t)
+	env := ExecutePeerflow(s.t, tc, flowConnConfig)
+	defer func() {
+		env.Cancel(s.t.Context())
+		RequireEnvCanceled(s.t, env)
+	}()
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	EnvNoError(s.t, env, s.source.Exec(s.t.Context(), fmt.Sprintf(
+		"INSERT INTO %s (id, payload) VALUES (1, REPEAT('x', %d))", srcSchemaTable, largeTextBytes,
+	)))
+
+	var payloadLength any
+	EnvWaitFor(s.t, env, 2*time.Minute, "normalize large CDC string", func() bool {
+		rows, err := s.GetRows(dstTable, "id, length(payload) AS payload_length")
+		if err != nil {
+			s.t.Log(err)
+			return false
+		}
+		if len(rows.Records) != 1 {
+			return false
+		}
+		payloadLength = rows.Records[0][1].Value()
+		return true
+	})
+	require.EqualValues(s.t, largeTextBytes, payloadLength)
+}
+
 func (s ClickHouseSuite) Test_Addition_Removal() {
 	tc := NewTemporalClient(s.t)
 

--- a/flow/model/model.go
+++ b/flow/model/model.go
@@ -93,8 +93,9 @@ type PullRecordsRequest[T Items] struct {
 }
 
 type ToJSONOptions struct {
-	UnnestColumns map[string]struct{}
-	HStoreAsJSON  bool
+	UnnestColumns        map[string]struct{}
+	HStoreAsJSON         bool
+	ClearValuesOverBytes int // 0 means preserve values
 }
 
 func NewToJSONOptions(unnestCols []string, hstoreAsJSON bool) ToJSONOptions {

--- a/flow/model/qvalue/avro_converter.go
+++ b/flow/model/qvalue/avro_converter.go
@@ -259,7 +259,7 @@ func QValueToAvro(
 		types.QValueGeography, types.QValueGeometry, types.QValuePoint:
 		size := stringSize(v.Value().(string), sizeOpt)
 		if c.TargetDWH == protos.DBType_SNOWFLAKE && v.Value() != nil &&
-			(len(v.Value().(string)) > 15*1024*1024) {
+			(len(v.Value().(string)) > shared.SnowflakeClearValueThresholdBytes) {
 			slog.WarnContext(ctx, "Clearing TEXT value > 15MB for Snowflake!")
 			slog.WarnContext(ctx, "Check this issue for details: https://github.com/PeerDB-io/peerdb/issues/309")
 
@@ -577,7 +577,7 @@ func (c *QValueAvroConverter) processBytes(byteData []byte, so sizeOpt) (any, in
 
 func (c *QValueAvroConverter) processJSON(jsonString string) any {
 	if c.Nullable {
-		if c.TargetDWH == protos.DBType_SNOWFLAKE && len(jsonString) > 15*1024*1024 {
+		if c.TargetDWH == protos.DBType_SNOWFLAKE && len(jsonString) > shared.SnowflakeClearValueThresholdBytes {
 			c.logger.Warn("Clearing JSON value > 15MB for Snowflake!")
 			c.logger.Warn("Check this issue for details: https://github.com/PeerDB-io/peerdb/issues/309")
 			return nil
@@ -585,7 +585,7 @@ func (c *QValueAvroConverter) processJSON(jsonString string) any {
 		return &jsonString
 	}
 
-	if c.TargetDWH == protos.DBType_SNOWFLAKE && len(jsonString) > 15*1024*1024 {
+	if c.TargetDWH == protos.DBType_SNOWFLAKE && len(jsonString) > shared.SnowflakeClearValueThresholdBytes {
 		c.logger.Warn("Clearing JSON value > 15MB for Snowflake!")
 		c.logger.Warn("Check this issue for details: https://github.com/PeerDB-io/peerdb/issues/309")
 		return ""
@@ -650,7 +650,7 @@ func (c *QValueAvroConverter) processHStore(hstore string) (any, error) {
 	}
 
 	if c.Nullable {
-		if c.TargetDWH == protos.DBType_SNOWFLAKE && len(jsonString) > 15*1024*1024 {
+		if c.TargetDWH == protos.DBType_SNOWFLAKE && len(jsonString) > shared.SnowflakeClearValueThresholdBytes {
 			c.logger.Warn("Clearing HStore equivalent JSON value > 15MB for Snowflake!")
 			c.logger.Warn("Check this issue for details: https://github.com/PeerDB-io/peerdb/issues/309")
 			return nil, nil
@@ -658,7 +658,7 @@ func (c *QValueAvroConverter) processHStore(hstore string) (any, error) {
 		return &jsonString, nil
 	}
 
-	if c.TargetDWH == protos.DBType_SNOWFLAKE && len(jsonString) > 15*1024*1024 {
+	if c.TargetDWH == protos.DBType_SNOWFLAKE && len(jsonString) > shared.SnowflakeClearValueThresholdBytes {
 		c.logger.Warn("Clearing HStore equivalent JSON value > 15MB for Snowflake!")
 		c.logger.Warn("Check this issue for details: https://github.com/PeerDB-io/peerdb/issues/309")
 		return "", nil

--- a/flow/model/record_items.go
+++ b/flow/model/record_items.go
@@ -26,22 +26,12 @@ func ItemsToJSON(items Items) (string, error) {
 
 // encoding/gob cannot encode unexported fields
 type RecordItems struct {
-	ColToVal               map[string]types.QValue
-	TruncateThresholdBytes int
+	ColToVal map[string]types.QValue
 }
 
 func NewRecordItems(capacity int) RecordItems {
 	return RecordItems{
-		ColToVal:               make(map[string]types.QValue, capacity),
-		TruncateThresholdBytes: 15 * 1024 * 1024,
-	}
-}
-
-func NewMongoRecordItems(capacity int) RecordItems {
-	return RecordItems{
 		ColToVal: make(map[string]types.QValue, capacity),
-		// https://github.com/catfi/supercell/blob/fbea41792b1b6018886771289f1f1534376303ec/dep/linux/mongodb/mongo/bson/util/builder.h#L44
-		TruncateThresholdBytes: 16*1024*1024 + 16*1024,
 	}
 }
 
@@ -110,13 +100,13 @@ func (r RecordItems) toMap(opts ToJSONOptions) (map[string]any, error) {
 			jsonStruct[col] = string(v.Val)
 		case types.QValueString:
 			strVal := v.Val
-			if len(strVal) > r.TruncateThresholdBytes {
+			if opts.ClearValuesOverBytes > 0 && len(strVal) > opts.ClearValuesOverBytes {
 				jsonStruct[col] = ""
 			} else {
 				jsonStruct[col] = strVal
 			}
 		case types.QValueJSON:
-			if len(v.Val) > r.TruncateThresholdBytes {
+			if opts.ClearValuesOverBytes > 0 && len(v.Val) > opts.ClearValuesOverBytes {
 				jsonStruct[col] = "{}"
 			} else if _, ok := opts.UnnestColumns[col]; ok {
 				var unnestStruct map[string]any
@@ -138,7 +128,7 @@ func (r RecordItems) toMap(opts ToJSONOptions) (map[string]any, error) {
 				if err != nil {
 					return nil, fmt.Errorf("unable to convert hstore column %s to json for value %T: %w", col, v, err)
 				}
-				if len(jsonVal) > r.TruncateThresholdBytes {
+				if opts.ClearValuesOverBytes > 0 && len(jsonVal) > opts.ClearValuesOverBytes {
 					jsonStruct[col] = ""
 				} else {
 					jsonStruct[col] = jsonVal

--- a/flow/model/record_items_test.go
+++ b/flow/model/record_items_test.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/PeerDB-io/peerdb/flow/shared/types"
+)
+
+func TestRecordItemsClearValuesOverBytes(t *testing.T) {
+	items := NewRecordItems(4)
+	items.AddColumn("at_limit", types.QValueString{Val: "12345"})
+	items.AddColumn("over_limit", types.QValueString{Val: "123456"})
+	items.AddColumn("json", types.QValueJSON{Val: `{"key":"value"}`})
+	items.AddColumn("hstore", types.QValueHStore{Val: `"key"=>"value"`})
+
+	opts := NewToJSONOptions(nil, true)
+	opts.ClearValuesOverBytes = 5
+	got, err := items.toMap(opts)
+	require.NoError(t, err)
+	require.Equal(t, "12345", got["at_limit"])
+	require.Empty(t, got["over_limit"])
+	require.Equal(t, "{}", got["json"])
+	require.Empty(t, got["hstore"])
+}
+
+func TestRecordItemsPreserveValuesByDefault(t *testing.T) {
+	items := NewRecordItems(3)
+	items.AddColumn("string", types.QValueString{Val: "123456"})
+	items.AddColumn("json", types.QValueJSON{Val: `{"key":"value"}`})
+	items.AddColumn("hstore", types.QValueHStore{Val: `"key"=>"value"`})
+
+	got, err := items.toMap(NewToJSONOptions(nil, true))
+	require.NoError(t, err)
+	require.Equal(t, "123456", got["string"])
+	require.JSONEq(t, `{"key":"value"}`, got["json"].(string))
+	require.JSONEq(t, `{"key":"value"}`, got["hstore"].(string))
+}

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -84,6 +84,9 @@ const (
 	QRepChannelSize = 1024
 )
 
+// SnowflakeClearValueThresholdBytes leaves headroom below Snowflake's 16 MiB value limit.
+const SnowflakeClearValueThresholdBytes = 15 * 1024 * 1024
+
 func Val[T any](p *T) T {
 	if p == nil {
 		var zero T


### PR DESCRIPTION
## Problem

`RecordItems` carried a `TruncateThresholdBytes` field set by the source connector — 15 MiB everywhere, 16 MiB + 16 KiB for MongoDB. When a CDC record was serialized into the raw-table JSON, any `String`, `JSON`, or `HStore` value above that threshold was replaced with an empty value, for every destination.

That limit exists for Snowflake alone (#309), and it was applied everywhere. A 20 MiB text column replicated to ClickHouse landed as an empty string, with no error.

## Change

The threshold moves from the source-side record to a destination-aware serialization option, `ToJSONOptions.ClearValuesOverBytes` (0 preserves values). `rawTableJSONOptions` in `flow/connectors/utils/stream.go` sets it, and only for Snowflake.

| Destination | Values over 15 MiB (string / JSON / hstore) |
| --- | --- |
| Snowflake | cleared to `""` / `{}` — unchanged behavior |
| ClickHouse and all others | preserved |

Also in this PR:

- `shared.SnowflakeClearValueThresholdBytes` replaces the four hardcoded `15*1024*1024` literals in the Avro converter, so the raw-table path and the Avro path share one constant.
- `NewMongoRecordItems` is removed; MongoDB now uses `NewRecordItems`. Its 16 MiB + 16 KiB threshold is redundant because the MongoDB server caps documents at 16 MiB.

## Verification

New tests:

- `flow/model/record_items_test.go` — values are cleared at the configured limit and preserved when no limit is set.
- `ClickHouseSuite.Test_Large_Text_CDC` — CDC of a 100 MiB PostgreSQL `TEXT` and a 63 MiB MySQL `LONGTEXT` (just under MySQL's default 64 MiB `max_allowed_packet`), asserting the destination value length matches the source.

The e2e tests were validated to work: temporarily restoring the unconditional truncation made both ClickHouse cases fail with an empty destination value. As a stress check, PostgreSQL CDC of a 1023 MiB string also passed after temporarily raising the local ClickHouse server memory ceiling.
