### PR TITLE
Track CDC event size distribution as a histogram

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -500,6 +500,7 @@ func (c *MongoConnector) PullRecords(
 		changeEventSize := int64(len(current))
 		deltaBytesProcessed.Add(changeEventSize)
 		cumulativeBytesProcessed.Add(changeEventSize)
+		otelManager.Metrics.FetchedEventSizeHistogram.Record(ctx, changeEventSize)
 
 		var changeEvent ChangeEvent
 		if err := decodeEvent(current, &changeEvent); err != nil {

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -500,7 +500,6 @@ func (c *MongoConnector) PullRecords(
 		changeEventSize := int64(len(current))
 		deltaBytesProcessed.Add(changeEventSize)
 		cumulativeBytesProcessed.Add(changeEventSize)
-		otelManager.Metrics.FetchedEventSizeHistogram.Record(ctx, changeEventSize)
 
 		var changeEvent ChangeEvent
 		if err := decodeEvent(current, &changeEvent); err != nil {
@@ -578,6 +577,7 @@ func (c *MongoConnector) PullRecords(
 				changeEvent.OperationType, changeEvent.Ns.Db, changeEvent.Ns.Coll))
 			continue
 		}
+		otelManager.Metrics.FetchedEventSizeHistogram.Record(ctx, changeEventSize)
 		checkpoint()
 	}
 

--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -847,8 +847,10 @@ func (c *MySqlConnector) PullRecords(
 					c.logger.Error(e.Error())
 					return e
 				}
-				fetchedBytes.Add(int64(len(event.RawData)))
-				totalFetchedBytes.Add(int64(len(event.RawData)))
+				eventSize := int64(len(event.RawData))
+				fetchedBytes.Add(eventSize)
+				totalFetchedBytes.Add(eventSize)
+				otelManager.Metrics.FetchedEventSizeHistogram.Record(ctx, eventSize)
 				inTx = true
 				enumMap := ev.Table.EnumStrValueMap()
 				setMap := ev.Table.SetStrValueMap()

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -840,8 +840,10 @@ func PullCdcRecords[Items model.Items](
 				}
 
 				if rec != nil {
-					fetchedBytes.Add(int64(len(msg.Data)))
-					totalFetchedBytes.Add(int64(len(msg.Data)))
+					eventSize := int64(len(msg.Data))
+					fetchedBytes.Add(eventSize)
+					totalFetchedBytes.Add(eventSize)
+					p.otelManager.Metrics.FetchedEventSizeHistogram.Record(ctx, eventSize)
 					tableName := rec.GetDestinationTableName()
 					switch r := rec.(type) {
 					case *model.UpdateRecord[Items]:

--- a/flow/connectors/postgres/cdc.go
+++ b/flow/connectors/postgres/cdc.go
@@ -843,7 +843,10 @@ func PullCdcRecords[Items model.Items](
 					eventSize := int64(len(msg.Data))
 					fetchedBytes.Add(eventSize)
 					totalFetchedBytes.Add(eventSize)
-					p.otelManager.Metrics.FetchedEventSizeHistogram.Record(ctx, eventSize)
+					switch rec.(type) {
+					case *model.InsertRecord[Items], *model.UpdateRecord[Items], *model.DeleteRecord[Items]:
+						p.otelManager.Metrics.FetchedEventSizeHistogram.Record(ctx, eventSize)
+					}
 					tableName := rec.GetDestinationTableName()
 					switch r := rec.(type) {
 					case *model.UpdateRecord[Items]:

--- a/flow/otel_metrics/observables.go
+++ b/flow/otel_metrics/observables.go
@@ -210,6 +210,16 @@ func (a *ContextAwareInt64Counter) Add(ctx context.Context, value int64, options
 	a.Int64Counter.Add(ctx, value, newOptions...)
 }
 
+type ContextAwareInt64Histogram struct {
+	metric.Int64Histogram
+	attrsCache contextAttributesCache
+}
+
+func (a *ContextAwareInt64Histogram) Record(ctx context.Context, value int64, options ...metric.RecordOption) {
+	newOptions := append([]metric.RecordOption{a.attrsCache.forContext(ctx)}, options...)
+	a.Int64Histogram.Record(ctx, value, newOptions...)
+}
+
 func Int64Gauge(meter metric.Meter, name string, opts ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
 	gaugeConfig := metric.NewInt64GaugeConfig(opts...)
 	return NewInt64SyncGauge(meter, name,
@@ -253,4 +263,22 @@ func NewContextAwareInt64Counter(meter metric.Meter, name string, opts ...metric
 	}
 
 	return &ContextAwareInt64Counter{Int64Counter: counter}, nil
+}
+
+func NewContextAwareInt64Histogram(
+	meter metric.Meter,
+	name string,
+	opts ...metric.Int64HistogramOption,
+) (metric.Int64Histogram, error) {
+	histogramConfig := metric.NewInt64HistogramConfig(opts...)
+	histogram, err := meter.Int64Histogram(name,
+		metric.WithDescription(histogramConfig.Description()),
+		metric.WithUnit(histogramConfig.Unit()),
+		metric.WithExplicitBucketBoundaries(histogramConfig.ExplicitBucketBoundaries()...),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ContextAwareInt64Histogram{Int64Histogram: histogram}, nil
 }

--- a/flow/otel_metrics/observables_test.go
+++ b/flow/otel_metrics/observables_test.go
@@ -9,6 +9,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
@@ -59,6 +61,36 @@ func TestContextAwareInt64SyncGaugeRecordsContextualAttributes(t *testing.T) {
 	require.Equal(t, "src", attrValue(t, inner.attrs[0], SourcePeerName))
 	require.Equal(t, protos.FlowOperation_FLOW_OPERATION_SYNC.String(),
 		attrValue(t, inner.attrs[0], FlowOperationKey))
+}
+
+func TestContextAwareInt64Histogram(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	histogram, err := NewContextAwareInt64Histogram(
+		provider.Meter("test"),
+		"test_event_size",
+		metric.WithUnit("By"),
+		metric.WithExplicitBucketBoundaries(100, 200, 500),
+	)
+	require.NoError(t, err)
+	histogram.Record(flowContext("test-flow"), 200)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	require.Len(t, rm.ScopeMetrics, 1)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+
+	got := rm.ScopeMetrics[0].Metrics[0]
+	require.Equal(t, "test_event_size", got.Name)
+	require.Equal(t, "By", got.Unit)
+	data, ok := got.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, data.DataPoints, 1)
+	require.Equal(t, []float64{100, 200, 500}, data.DataPoints[0].Bounds)
+	require.Equal(t, uint64(1), data.DataPoints[0].Count)
+	require.Equal(t, "test-flow", attrValue(t, data.DataPoints[0].Attributes, FlowNameKey))
 }
 
 func TestContextAttributesCache(t *testing.T) {

--- a/flow/otel_metrics/otel_manager.go
+++ b/flow/otel_metrics/otel_manager.go
@@ -56,6 +56,7 @@ const (
 	IntervalSinceLastNormalizeGaugeName  = "interval_since_last_normalize"
 	AllFetchedBytesCounterName           = "all_fetched_bytes"
 	FetchedBytesCounterName              = "fetched_bytes"
+	FetchedEventSizeHistogramName        = "fetched_event_size"
 	SourceLagGaugeName                   = "source_lag"
 	DestinationLagGaugeName              = "destination_lag"
 	E2ELagGaugeName                      = "e2e_lag"
@@ -121,6 +122,7 @@ type Metrics struct {
 	IntervalSinceLastNormalizeGauge   metric.Float64Gauge
 	AllFetchedBytesCounter            metric.Int64Counter
 	FetchedBytesCounter               metric.Int64Counter
+	FetchedEventSizeHistogram         metric.Int64Histogram
 	SourceLagGauge                    metric.Int64Gauge
 	DestinationLagGauge               metric.Int64Gauge
 	E2ELagGauge                       metric.Int64Gauge
@@ -189,14 +191,15 @@ func BuildMetricName(baseName string) string {
 }
 
 type OtelManager struct {
-	Metrics            Metrics
-	MetricsProvider    metric.MeterProvider
-	Meter              metric.Meter
-	Tracer             trace.Tracer
-	Float64GaugesCache map[string]metric.Float64Gauge
-	Int64GaugesCache   map[string]metric.Int64Gauge
-	Int64CountersCache map[string]metric.Int64Counter
-	Enabled            bool
+	Metrics              Metrics
+	MetricsProvider      metric.MeterProvider
+	Meter                metric.Meter
+	Tracer               trace.Tracer
+	Float64GaugesCache   map[string]metric.Float64Gauge
+	Int64GaugesCache     map[string]metric.Int64Gauge
+	Int64CountersCache   map[string]metric.Int64Counter
+	Int64HistogramsCache map[string]metric.Int64Histogram
+	Enabled              bool
 }
 
 func NewOtelManager(ctx context.Context, serviceName string, enabled bool) (*OtelManager, error) {
@@ -206,13 +209,14 @@ func NewOtelManager(ctx context.Context, serviceName string, enabled bool) (*Ote
 	}
 
 	otelManager := OtelManager{
-		Enabled:            enabled,
-		MetricsProvider:    metricsProvider,
-		Meter:              metricsProvider.Meter("io.peerdb." + serviceName),
-		Tracer:             Tracer(),
-		Float64GaugesCache: make(map[string]metric.Float64Gauge),
-		Int64GaugesCache:   make(map[string]metric.Int64Gauge),
-		Int64CountersCache: make(map[string]metric.Int64Counter),
+		Enabled:              enabled,
+		MetricsProvider:      metricsProvider,
+		Meter:                metricsProvider.Meter("io.peerdb." + serviceName),
+		Tracer:               Tracer(),
+		Float64GaugesCache:   make(map[string]metric.Float64Gauge),
+		Int64GaugesCache:     make(map[string]metric.Int64Gauge),
+		Int64CountersCache:   make(map[string]metric.Int64Counter),
+		Int64HistogramsCache: make(map[string]metric.Int64Histogram),
 	}
 	if err := otelManager.setupMetrics(ctx); err != nil {
 		return nil, err
@@ -259,6 +263,13 @@ func (om *OtelManager) GetOrInitFloat64Gauge(name string, opts ...metric.Float64
 
 func (om *OtelManager) GetOrInitInt64Counter(name string, opts ...metric.Int64CounterOption) (metric.Int64Counter, error) {
 	return getOrInitMetric(NewContextAwareInt64Counter, om.Meter, om.Int64CountersCache, name, opts...)
+}
+
+func (om *OtelManager) GetOrInitInt64Histogram(
+	name string,
+	opts ...metric.Int64HistogramOption,
+) (metric.Int64Histogram, error) {
+	return getOrInitMetric(NewContextAwareInt64Histogram, om.Meter, om.Int64HistogramsCache, name, opts...)
 }
 
 // CodeNotificationCounter is a global counter for emitting notifications for one-off things we want to know about with the least effort.
@@ -447,6 +458,25 @@ func (om *OtelManager) setupMetrics(ctx context.Context) error {
 	if om.Metrics.FetchedBytesCounter, err = om.GetOrInitInt64Counter(BuildMetricName(FetchedBytesCounterName),
 		metric.WithUnit("By"),
 		metric.WithDescription("Bytes received of CopyData over replication protocol for mapped tables only"),
+	); err != nil {
+		return err
+	}
+
+	if om.Metrics.FetchedEventSizeHistogram, err = om.GetOrInitInt64Histogram(
+		BuildMetricName(FetchedEventSizeHistogramName),
+		metric.WithUnit("By"),
+		metric.WithDescription("Size of each fetched CDC event for mapped tables"),
+		metric.WithExplicitBucketBoundaries(
+			10, 20, 50,
+			100, 200, 500,
+			1_000, 2_000, 5_000,
+			10_000, 20_000, 50_000,
+			100_000, 200_000, 500_000,
+			1_000_000, 2_000_000, 5_000_000,
+			10_000_000, 20_000_000, 50_000_000,
+			100_000_000, 200_000_000, 500_000_000,
+			1_000_000_000,
+		),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
Add a histogram for the size of individual CDC events.

The existing `fetched_bytes` counter reports total volume, logs expose delta between timer fires but with enough events can't distinguish 10000 * 50KB from 10000 * 40KB + 100MB. This histogram gives a sense of which sizes are present.

The Postgres path uses an explicit type switch so that keepalive, relation, and transaction-boundary messages are excluded and the distribution reflects row changes only.

## Testing

Deployed to ClickPipes service `378ddc9b-b2e7-49a5-89f2-375ec23f82a6` and exercised with generated load spanning log-scale value sizes from empty to 100 MB.