### PR TITLE
fix(alerting): notify user on ClickHouse fatal-shutdown aborts

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -1171,6 +1171,10 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				return ErrorRetryRecoverable, chErrorInfo
 			}
 		case chproto.ErrAborted:
+			// The destination server aborts in-flight queries while it restarts after a fatal error.
+			if strings.Contains(chException.Message, "The server is shutting down due to a fatal error") {
+				return ErrorNotifyClickHouseError, chErrorInfo
+			}
 			return ErrorInternalClickHouse, chErrorInfo
 		case chproto.ErrTooManySimultaneousQueries:
 			return ErrorIgnoreConnTemporary, chErrorInfo

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1952,3 +1952,31 @@ func TestS3MultipartUploadContextCancellationShouldBeIgnored(t *testing.T) {
 		Code:   "CONTEXT_CANCELLED",
 	}, errInfo)
 }
+
+func TestClickHouseFatalShutdownAbortShouldBeNotifyClickHouseError(t *testing.T) {
+	err := &clickhouse.Exception{
+		Code:    236,
+		Message: "The server is shutting down due to a fatal error",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		exceptions.NewNormalizationError(fmt.Errorf("failed to normalize records: %w", err)))
+	assert.Equal(t, ErrorNotifyClickHouseError, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceClickHouse,
+		Code:   "236",
+	}, errInfo, "Unexpected error info")
+}
+
+func TestClickHouseGenericAbortShouldBeInternalClickHouse(t *testing.T) {
+	err := &clickhouse.Exception{
+		Code:    236,
+		Message: "Query was cancelled",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(),
+		fmt.Errorf("failed to push records: %w", err))
+	assert.Equal(t, ErrorInternalClickHouse, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceClickHouse,
+		Code:   "236",
+	}, errInfo, "Unexpected error info")
+}


### PR DESCRIPTION
A repeatedly crashing CH makes the alert go to telemetry+recoverable route. Notify user instead

Closes DBI-1072