### PR TITLE
fix(clickhouse): insert into local _shard on clustered replicated targets to avoid silent Distributed+quorum row loss

### DIFF
--- a/flow/connectors/clickhouse/avro_sync.go
+++ b/flow/connectors/clickhouse/avro_sync.go
@@ -49,8 +49,22 @@ func (s *ClickHouseAvroSyncMethod) CopyStageToDestination(ctx context.Context, a
 		return fmt.Errorf("failed to build staging table function: %w", err)
 	}
 
+	// On clustered replicated targets, route the INSERT directly to the local
+	// _shard ReplicatedMergeTree table (where insert_quorum is actually
+	// contracted). Inserting into the Distributed table with insert_quorum
+	// silently drops the part (ClickHouse #97557). Reads still go through the
+	// Distributed table.
+	insertTarget := s.config.DestinationTableIdentifier
+	if s.Config.Cluster != "" {
+		shardTable, err := s.getDistributedShardTable(ctx, s.config.DestinationTableIdentifier)
+		if err != nil {
+			return fmt.Errorf("failed to resolve shard table for %s: %w", s.config.DestinationTableIdentifier, err)
+		}
+		insertTarget = shardTable
+	}
+
 	query := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
-		peerdb_clickhouse.QuoteIdentifier(s.config.DestinationTableIdentifier), stagingTableFunction)
+		peerdb_clickhouse.QuoteIdentifier(insertTarget), stagingTableFunction)
 	return s.exec(ctx, query)
 }
 

--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -577,6 +577,20 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				continue
 			}
 
+			// On clustered replicated targets, route the physical INSERT
+			// directly to the local _shard ReplicatedMergeTree table (where
+			// insert_quorum is actually contracted). Empty => normalize writes
+			// to the Distributed table as before.
+			var insertTargetTable string
+			if c.Config.Cluster != "" {
+				insertTargetTable, err = c.getDistributedShardTable(ctx, tbl)
+				if err != nil {
+					c.logger.Error("[clickhouse] error while resolving shard table for INSERT target",
+						slog.String("table", tbl), slog.Any("error", err))
+					return fmt.Errorf("error while resolving shard table for %s: %w", tbl, err)
+				}
+			}
+
 			queryGenerator := NewNormalizeQueryGenerator(
 				tbl,
 				req.TableNameSchemaMapping,
@@ -592,6 +606,7 @@ func (c *ClickHouseConnector) NormalizeRecords(
 				req.SoftDeleteColName,
 				req.Version,
 				req.Flags,
+				insertTargetTable,
 			)
 			query, err := queryGenerator.BuildQuery(ctx)
 			if err != nil {

--- a/flow/connectors/clickhouse/normalize_query.go
+++ b/flow/connectors/clickhouse/normalize_query.go
@@ -24,7 +24,13 @@ type NormalizeQueryGenerator struct {
 	chVersion                       *chproto.Version
 	Query                           string
 	TableName                       string
-	rawTableName                    string
+	// insertTargetTable overrides the physical INSERT INTO target. When set
+	// (clustered targets), the INSERT goes directly to the local _shard
+	// ReplicatedMergeTree table where insert_quorum is actually contracted;
+	// empty falls back to TableName (the Distributed table). Metadata/raw
+	// filtering still keys off TableName, not this.
+	insertTargetTable string
+	rawTableName      string
 	isDeletedColName                string
 	tableMappings                   []*protos.TableMapping
 	lastNormBatchID                 int64
@@ -51,6 +57,7 @@ func NewNormalizeQueryGenerator(
 	configuredSoftDeleteColName string,
 	version uint32,
 	flags []string,
+	insertTargetTable string,
 ) *NormalizeQueryGenerator {
 	isDeletedColumn := defaultIsDeletedColName
 	if configuredSoftDeleteColName != "" {
@@ -71,6 +78,7 @@ func NewNormalizeQueryGenerator(
 		isDeletedColName:                isDeletedColumn,
 		version:                         version,
 		flags:                           flags,
+		insertTargetTable:               insertTargetTable,
 	}
 }
 
@@ -366,8 +374,16 @@ func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error
 		chSettings.Add(clickhouse.SettingJsonTypeEscapeDotsInKeys, "1")
 	}
 
+	// Physical INSERT target: on clustered replicated targets this is the
+	// resolved local _shard table (insert_quorum is contracted there);
+	// otherwise the Distributed table (== TableName). Reads still go through
+	// the Distributed table.
+	insertTarget := t.TableName
+	if t.insertTargetTable != "" {
+		insertTarget = t.insertTargetTable
+	}
 	insertIntoSelectQuery := fmt.Sprintf("INSERT INTO %s %s %s%s",
-		peerdb_clickhouse.QuoteIdentifier(t.TableName), colSelector.String(), selectQuery.String(), chSettings.String())
+		peerdb_clickhouse.QuoteIdentifier(insertTarget), colSelector.String(), selectQuery.String(), chSettings.String())
 
 	t.Query = insertIntoSelectQuery
 

--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -260,6 +260,7 @@ func TestBuildQuery_Basic(t *testing.T) {
 		"",
 		shared.InternalVersion_Latest,
 		nil,
+		"",
 	)
 
 	query, err := g.BuildQuery(ctx)
@@ -315,6 +316,7 @@ func TestBuildQuery_WithPrimaryUpdate(t *testing.T) {
 		"",
 		shared.InternalVersion_Latest,
 		nil,
+		"",
 	)
 
 	query, err := g.BuildQuery(ctx)
@@ -367,12 +369,72 @@ func TestBuildQuery_WithSourceSchemaAsDestinationColumn(t *testing.T) {
 		"",
 		shared.InternalVersion_Latest,
 		nil,
+		"",
 	)
 
 	query, err := g.BuildQuery(ctx)
 	require.NoError(t, err)
 	require.Contains(t, query, " AS `_peerdb_source_schema`")
 	require.Contains(t, query, "parallel_distributed_insert_select=0")
+}
+
+func TestBuildQuery_InsertTargetTableOverride(t *testing.T) {
+	ctx := t.Context()
+	tableName := "my_table"
+	rawTableName := "raw_my_table"
+	endBatchID := int64(10)
+	lastNormBatchID := int64(5)
+	env := map[string]string{}
+
+	tableSchema := &protos.TableSchema{
+		Columns: []*protos.FieldDescription{
+			{Name: "id", Type: string(types.QValueKindInt64)},
+		},
+		NullableEnabled: false,
+	}
+	tableNameSchemaMapping := map[string]*protos.TableSchema{
+		tableName: tableSchema,
+	}
+	tableMappings := []*protos.TableMapping{
+		{
+			SourceTableIdentifier:      "public.my_table",
+			DestinationTableIdentifier: tableName,
+		},
+	}
+
+	newGen := func(insertTargetTable string) *NormalizeQueryGenerator {
+		return NewNormalizeQueryGenerator(
+			tableName,
+			tableNameSchemaMapping,
+			tableMappings,
+			endBatchID,
+			lastNormBatchID,
+			false,
+			false,
+			env,
+			rawTableName,
+			nil,
+			false,
+			"",
+			shared.InternalVersion_Latest,
+			nil,
+			insertTargetTable,
+		)
+	}
+
+	// Override present: physical INSERT target is the shard table, but the
+	// metadata literal still references the logical (Distributed) table name.
+	query, err := newGen("my_table_shard").BuildQuery(ctx)
+	require.NoError(t, err)
+	require.Contains(t, query, "INSERT INTO `my_table_shard`")
+	require.NotContains(t, query, "INSERT INTO `my_table`")
+	require.Contains(t, query, "_peerdb_destination_table_name = 'my_table'")
+
+	// Empty override: falls back to TableName.
+	query, err = newGen("").BuildQuery(ctx)
+	require.NoError(t, err)
+	require.Contains(t, query, "INSERT INTO `my_table`")
+	require.Contains(t, query, "_peerdb_destination_table_name = 'my_table'")
 }
 
 func TestGetOrderedPartitionByColumns(t *testing.T) {

--- a/flow/connectors/clickhouse/table_function.go
+++ b/flow/connectors/clickhouse/table_function.go
@@ -157,7 +157,9 @@ func buildInsertFromTableFunctionQuery(
 	// On a clustered target, INSERT into the local _shard ReplicatedMergeTree rather than the
 	// Distributed front (CH #97557: Distributed + insert_quorum_parallel=0 silently drops the part).
 	targetTable := config.destinationTable
-	if config.connector != nil && config.connector.Config.Cluster != "" {
+	if config.connector.Config.Cluster != "" {
+		// Do NOT silently fall back to the Distributed target when clustered — that is the
+		// #97557 data-loss path. Resolve the shard name and hard-error if we cannot.
 		shardTable, err := config.connector.getDistributedShardTable(ctx, config.destinationTable)
 		if err != nil {
 			return "", err

--- a/flow/connectors/clickhouse/table_function.go
+++ b/flow/connectors/clickhouse/table_function.go
@@ -154,8 +154,19 @@ func buildInsertFromTableFunctionQuery(
 		settingsStr = chSettings.String()
 	}
 
+	// On a clustered target, INSERT into the local _shard ReplicatedMergeTree rather than the
+	// Distributed front (CH #97557: Distributed + insert_quorum_parallel=0 silently drops the part).
+	targetTable := config.destinationTable
+	if config.connector != nil && config.connector.Config.Cluster != "" {
+		shardTable, err := config.connector.getDistributedShardTable(ctx, config.destinationTable)
+		if err != nil {
+			return "", err
+		}
+		targetTable = shardTable
+	}
+
 	return fmt.Sprintf("INSERT INTO %s(%s) SELECT %s FROM %s%s",
-		peerdb_clickhouse.QuoteIdentifier(config.destinationTable), insertedStr, selectorStr, tableFunctionExpr, settingsStr), nil
+		peerdb_clickhouse.QuoteIdentifier(targetTable), insertedStr, selectorStr, tableFunctionExpr, settingsStr), nil
 }
 
 // buildInsertFromTableFunctionQueryWithPartitioning builds an INSERT query with hash-based partitioning

--- a/flow/connectors/clickhouse/table_function_test.go
+++ b/flow/connectors/clickhouse/table_function_test.go
@@ -26,6 +26,9 @@ func TestBuildInsertFromTableFunctionQuery(t *testing.T) {
 	config := &insertFromTableFunctionConfig{
 		destinationTable: "t1",
 		schema:           schema,
+		// connector present but non-clustered (Cluster == "") must leave the INSERT target
+		// as the plain destination table — no _shard resolution, no DB I/O.
+		connector: &ClickHouseConnector{Config: &protos.ClickhouseConfig{}},
 		config: &protos.QRepConfig{
 			Env: map[string]string{
 				"PEERDB_SOURCE_SCHEMA_AS_DESTINATION_COLUMN": "false",


### PR DESCRIPTION
## Problem

On a clustered replicated ClickHouse target (`cluster` set plus `replicated=true`), PeerDB creates a `Distributed` table `<t>` in front of the local `ReplicatedMergeTree` `<t>_shard` and runs all of its data inserts through the Distributed table. On a real multi-replica cluster this loses rows silently: the Distributed front returns `written_rows=1`, nothing errors, but 0 rows land in the shard (0 parts, empty `system.distribution_queue`, no shard insert in `query_log`).

It hits every insert path: the initial snapshot, the CDC raw-table write, and normalize.

### Why

It's [ClickHouse #97557](https://github.com/ClickHouse/ClickHouse/issues/97557). An `INSERT` into a Distributed table with `insert_quorum_parallel=0` (sequential quorum) drops the committed part. PeerDB sets exactly that for replicated targets (`insert_quorum=auto`, `insert_quorum_parallel=0`, `select_sequential_consistency=1`), which #4676 added to keep normalize's read-back consistent.

There's no safe setting while the insert goes through Distributed:

- `insert_quorum_parallel=0` through Distributed drops the write ([#97557](https://github.com/ClickHouse/ClickHouse/issues/97557)).
- `insert_quorum_parallel=1` makes it land, but read-your-writes stops holding, so the #4676 normalize race comes back.

`insert_quorum` is a `ReplicatedMergeTree` level contract. `Distributed` only passes it through and gives no guarantee of its own.

### Fix

Insert straight into the local `<t>_shard` `ReplicatedMergeTree`, where `insert_quorum` actually applies, and keep the `Distributed` table for reads. Direct-to-shard with `insert_quorum_parallel=0` lands the row and keeps read-your-writes.

This routes all three insert paths to the shard when `cluster` is set:

- snapshot QRep, `buildInsertFromTableFunctionQuery` (`table_function.go`)
- snapshot / raw copy, `CopyStageToDestination` (`avro_sync.go`)
- normalize, `NormalizeQueryGenerator.BuildQuery` (`normalize_query.go`), with the target resolved by the caller in `normalize.go`

The shard name comes from the existing `getDistributedShardTable` (reads `engine_full` from `system.tables`), so a post-`RESYNC` name like `<t>_shard<timestamp>` is handled instead of hardcoding `_shard`. Metadata bookkeeping (`_peerdb_destination_table_name`, last-normalized-batch tracking) still keys on the logical destination name. Only the physical `INSERT INTO` target changes, and the Distributed table stays for reads.

## Verification (live, multi-replica cluster)

ClickHouse 26.6, 1 shard, 2 replicas, `ReplicatedReplacingMergeTree`, GCS Avro staging.

- Snapshot: seed row lands on both replicas, and the insert targets `<t>_shard` rather than the Distributed table.
- CDC: a live `UPDATE` and `INSERT` on the source both reach both replicas within one sync cycle.
- `query_log` shows every insert this run (snapshot, normalize, `_peerdb_raw`) going to a `_shard` table, none to the Distributed front.

Before the change the same mirror lost the snapshot row and every post-snapshot change on the replicated target.

## Notes

- Non-clustered targets are unchanged. The `_shard`/Distributed split only exists when `cluster` is set.
- No proto or config change.

Fixes #4746. Related: #4676, ClickHouse/ClickHouse#97557.
