### PR TITLE
Don't propagate schema delta for excluded columns in MySQL

### DIFF
--- a/flow/connectors/mysql/cdc.go
+++ b/flow/connectors/mysql/cdc.go
@@ -1312,6 +1312,13 @@ func (c *MySqlConnector) processAlterTableQuery(ctx context.Context, catalogPool
 		if spec.NewColumns != nil {
 			// these are added columns
 			for _, col := range spec.NewColumns {
+				columnName := col.Name.OrigColName()
+				if _, excluded := req.TableNameMapping[sourceTableName].Exclude[columnName]; excluded {
+					c.logger.Warn("added column detected but not propagating because excluded",
+						slog.String("columnName", columnName),
+						slog.String("tableName", sourceTableName))
+					continue
+				}
 				if col.Tp == nil {
 					// ignore, can be plain ALTER TABLE ... ALTER COLUMN ... DEFAULT ...
 					c.logger.Warn("ALTER TABLE with no column type detected, ignoring",

--- a/flow/e2e/clickhouse_mysql_test.go
+++ b/flow/e2e/clickhouse_mysql_test.go
@@ -1497,6 +1497,51 @@ func (s ClickHouseSuite) Test_MySQL_AlterTableAddColumnTypes() {
 	RequireEnvCanceled(s.t, env)
 }
 
+func (s ClickHouseSuite) Test_MySQL_AlterTableAddExcludedColumn() {
+	if _, ok := s.source.(*MySqlSource); !ok {
+		s.t.Skip("only applies to mysql")
+	}
+
+	srcTableName := "test_add_excluded_col"
+	srcFullName := s.attachSchemaSuffix(srcTableName)
+	dstTableName := "test_add_excluded_col_dst"
+
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT PRIMARY KEY)", srcFullName)))
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName: s.attachSuffix(srcTableName),
+		TableMappings: []*protos.TableMapping{{
+			SourceTableIdentifier:      srcFullName,
+			DestinationTableIdentifier: dstTableName,
+			Exclude:                    []string{"secret"},
+		}},
+		Destination: s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.DoInitialSnapshot = true
+
+	tc := NewTemporalClient(s.t)
+	env := ExecutePeerflow(s.t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	EnvNoError(s.t, env, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("ALTER TABLE %s ADD COLUMN secret TEXT", srcFullName)))
+	EnvNoError(s.t, env, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (id, secret) VALUES (1, 'do not replicate')", srcFullName)))
+
+	EnvWaitForCount(env, s, "waiting on cdc add excluded column", dstTableName, "id", 1)
+
+	rows, err := s.GetRows(dstTableName, "*")
+	require.NoError(s.t, err)
+	for _, field := range rows.Schema.Fields {
+		require.NotEqual(s.t, "secret", field.Name, "excluded column added during CDC reached the destination schema")
+	}
+
+	env.Cancel(s.t.Context())
+	RequireEnvCanceled(s.t, env)
+}
+
 // Test_MySQL_AlterTableAddColumnDefault covers rows that existed before an ADD COLUMN with a
 // DEFAULT.
 func (s ClickHouseSuite) Test_MySQL_AlterTableAddColumnDefault() {

--- a/flow/e2e/clickhouse_mysql_test.go
+++ b/flow/e2e/clickhouse_mysql_test.go
@@ -1498,8 +1498,18 @@ func (s ClickHouseSuite) Test_MySQL_AlterTableAddColumnTypes() {
 }
 
 func (s ClickHouseSuite) Test_MySQL_AlterTableAddExcludedColumn() {
-	if _, ok := s.source.(*MySqlSource); !ok {
+	mysource, ok := s.source.(*MySqlSource)
+	if !ok {
 		s.t.Skip("only applies to mysql")
+	}
+	minVersion := mysql_validation.MySQLMinVersionForBinlogRowMetadata
+	if mysource.Config.Flavor == protos.MySqlFlavor_MYSQL_MARIA {
+		minVersion = mysql_validation.MariaDBMinVersionForBinlogRowMetadata
+	}
+	cmp, err := mysource.CompareServerVersion(s.t.Context(), minVersion)
+	require.NoError(s.t, err)
+	if cmp < 0 {
+		s.t.Skip("column exclusion requires binlog row metadata")
 	}
 
 	srcTableName := "test_add_excluded_col"
@@ -1515,6 +1525,7 @@ func (s ClickHouseSuite) Test_MySQL_AlterTableAddExcludedColumn() {
 			SourceTableIdentifier:      srcFullName,
 			DestinationTableIdentifier: dstTableName,
 			Exclude:                    []string{"secret"},
+			ShardingKey:                "id",
 		}},
 		Destination: s.Peer().Name,
 	}
@@ -1526,11 +1537,15 @@ func (s ClickHouseSuite) Test_MySQL_AlterTableAddExcludedColumn() {
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
 	EnvNoError(s.t, env, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("INSERT INTO %s (id) VALUES (1)", srcFullName)))
+	EnvWaitForCount(env, s, "waiting for CDC to start", dstTableName, "id", 1)
+
+	EnvNoError(s.t, env, s.source.Exec(s.t.Context(),
 		fmt.Sprintf("ALTER TABLE %s ADD COLUMN secret TEXT", srcFullName)))
 	EnvNoError(s.t, env, s.source.Exec(s.t.Context(),
-		fmt.Sprintf("INSERT INTO %s (id, secret) VALUES (1, 'do not replicate')", srcFullName)))
+		fmt.Sprintf("INSERT INTO %s (id, secret) VALUES (2, 'do not replicate')", srcFullName)))
 
-	EnvWaitForCount(env, s, "waiting on cdc add excluded column", dstTableName, "id", 1)
+	EnvWaitForCount(env, s, "waiting on cdc add excluded column", dstTableName, "id", 2)
 
 	rows, err := s.GetRows(dstTableName, "*")
 	require.NoError(s.t, err)

--- a/flow/e2e/clickhouse_mysql_test.go
+++ b/flow/e2e/clickhouse_mysql_test.go
@@ -1502,13 +1502,9 @@ func (s ClickHouseSuite) Test_MySQL_AlterTableAddExcludedColumn() {
 	if !ok {
 		s.t.Skip("only applies to mysql")
 	}
-	minVersion := mysql_validation.MySQLMinVersionForBinlogRowMetadata
-	if mysource.Config.Flavor == protos.MySqlFlavor_MYSQL_MARIA {
-		minVersion = mysql_validation.MariaDBMinVersionForBinlogRowMetadata
-	}
-	cmp, err := mysource.CompareServerVersion(s.t.Context(), minVersion)
+	supportsBinlogRowMetadata, err := mysource.IsBinlogRowMetadataSupported(s.t.Context())
 	require.NoError(s.t, err)
-	if cmp < 0 {
+	if !supportsBinlogRowMetadata {
 		s.t.Skip("column exclusion requires binlog row metadata")
 	}
 
@@ -1537,15 +1533,11 @@ func (s ClickHouseSuite) Test_MySQL_AlterTableAddExcludedColumn() {
 	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
 
 	EnvNoError(s.t, env, s.source.Exec(s.t.Context(),
-		fmt.Sprintf("INSERT INTO %s (id) VALUES (1)", srcFullName)))
-	EnvWaitForCount(env, s, "waiting for CDC to start", dstTableName, "id", 1)
-
-	EnvNoError(s.t, env, s.source.Exec(s.t.Context(),
 		fmt.Sprintf("ALTER TABLE %s ADD COLUMN secret TEXT", srcFullName)))
 	EnvNoError(s.t, env, s.source.Exec(s.t.Context(),
-		fmt.Sprintf("INSERT INTO %s (id, secret) VALUES (2, 'do not replicate')", srcFullName)))
+		fmt.Sprintf("INSERT INTO %s (id, secret) VALUES (1, 'do not replicate')", srcFullName)))
 
-	EnvWaitForCount(env, s, "waiting on cdc add excluded column", dstTableName, "id", 2)
+	EnvWaitForCount(env, s, "waiting on cdc add excluded column", dstTableName, "id", 1)
 
 	rows, err := s.GetRows(dstTableName, "*")
 	require.NoError(s.t, err)


### PR DESCRIPTION
Data wasn't being propagated but a column add on the destination would still be unexpected