### PR TITLE
fix: bound table validation error details

### DIFF
--- a/flow/cmd/api_error.go
+++ b/flow/cmd/api_error.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/gogo/googleapis/google/rpc"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -114,10 +115,11 @@ func NewMirrorErrorInfo(metadata map[string]string) *rpc.ErrorInfo {
 	}
 }
 
-func NewSourceTableMissingErrorInfo() *rpc.ErrorInfo {
+func NewSourceTableMissingErrorInfo(tableCount int) *rpc.ErrorInfo {
 	return &rpc.ErrorInfo{
-		Reason: common.ErrorInfoReasonSourceTableMissing,
-		Domain: common.ErrorInfoDomain,
+		Reason:   common.ErrorInfoReasonSourceTableMissing,
+		Domain:   common.ErrorInfoDomain,
+		Metadata: map[string]string{common.ErrorMetadataTableCount: strconv.Itoa(tableCount)},
 	}
 }
 
@@ -143,11 +145,22 @@ func NewSourceTableMissingPreconditionFailure(tables []common.QualifiedTable) pr
 	return protoadapt.MessageV1Of(&errdetails.PreconditionFailure{Violations: violations})
 }
 
-func NewTablesNotInPublicationErrorInfo(publication string) *rpc.ErrorInfo {
+func NewSourceTableMissingErrorDetails(tables []common.QualifiedTable) []protoadapt.MessageV1 {
+	displayedTables := tables[:min(len(tables), common.MaxTablesInErrorDetails)]
+	return []protoadapt.MessageV1{
+		NewSourceTableMissingErrorInfo(len(tables)),
+		NewSourceTableMissingPreconditionFailure(displayedTables),
+	}
+}
+
+func NewTablesNotInPublicationErrorInfo(publication string, tableCount int) *rpc.ErrorInfo {
 	return &rpc.ErrorInfo{
-		Reason:   common.ErrorInfoReasonTablesNotInPublication,
-		Domain:   common.ErrorInfoDomain,
-		Metadata: map[string]string{common.ErrorMetadataPublication: publication},
+		Reason: common.ErrorInfoReasonTablesNotInPublication,
+		Domain: common.ErrorInfoDomain,
+		Metadata: map[string]string{
+			common.ErrorMetadataPublication: publication,
+			common.ErrorMetadataTableCount:  strconv.Itoa(tableCount),
+		},
 	}
 }
 
@@ -164,6 +177,17 @@ func NewTablesNotInPublicationPreconditionFailure(publication string, tables []c
 		}
 	}
 	return protoadapt.MessageV1Of(&errdetails.PreconditionFailure{Violations: violations})
+}
+
+func NewTablesNotInPublicationErrorDetails(
+	publication string,
+	tables []common.QualifiedTable,
+) []protoadapt.MessageV1 {
+	displayedTables := tables[:min(len(tables), common.MaxTablesInErrorDetails)]
+	return []protoadapt.MessageV1{
+		NewTablesNotInPublicationErrorInfo(publication, len(tables)),
+		NewTablesNotInPublicationPreconditionFailure(publication, displayedTables),
+	}
 }
 
 var ErrUnderMaintenance = errors.New("PeerDB is under maintenance. Please retry in a few minutes")

--- a/flow/cmd/api_error_test.go
+++ b/flow/cmd/api_error_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/protoadapt"
+
+	"github.com/PeerDB-io/peerdb/flow/pkg/common"
+)
+
+func TestTableErrorDetailsLimitViolationsAndIncludeTotalCount(t *testing.T) {
+	tables := make([]common.QualifiedTable, common.MaxTablesInErrorDetails+2)
+	for i := range tables {
+		tables[i] = common.QualifiedTable{Namespace: "public", Table: fmt.Sprintf("table_%02d", i)}
+	}
+
+	for _, details := range [][]protoadapt.MessageV1{
+		NewSourceTableMissingErrorDetails(tables),
+		NewTablesNotInPublicationErrorDetails("publication", tables),
+	} {
+		require.Len(t, details, 2)
+		st, err := status.New(codes.FailedPrecondition, "table validation failed").WithDetails(details...)
+		require.NoError(t, err)
+		decodedDetails := st.Details()
+
+		info, ok := decodedDetails[0].(*errdetails.ErrorInfo)
+		require.True(t, ok)
+		require.Equal(t, strconv.Itoa(len(tables)), info.Metadata[common.ErrorMetadataTableCount])
+
+		failure, ok := decodedDetails[1].(*errdetails.PreconditionFailure)
+		require.True(t, ok)
+		require.Len(t, failure.Violations, common.MaxTablesInErrorDetails)
+		require.Equal(t, "public.table_00", failure.Violations[0].Subject)
+		require.Equal(t, "public.table_19", failure.Violations[common.MaxTablesInErrorDetails-1].Subject)
+	}
+}

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -123,14 +123,12 @@ func (h *FlowRequestHandler) validateCDCMirrorImpl(
 		if missing, ok := errors.AsType[*common.SourceTablesMissingError](err); ok {
 			return nil, NewFailedPreconditionApiError(
 				missing,
-				NewSourceTableMissingErrorInfo(),
-				NewSourceTableMissingPreconditionFailure(missing.Tables))
+				NewSourceTableMissingErrorDetails(missing.Tables)...)
 		}
 		if notInPub, ok := errors.AsType[*common.TablesNotInPublicationError](err); ok {
 			return nil, NewFailedPreconditionApiError(
 				notInPub,
-				NewTablesNotInPublicationErrorInfo(notInPub.Publication),
-				NewTablesNotInPublicationPreconditionFailure(notInPub.Publication, notInPub.Tables))
+				NewTablesNotInPublicationErrorDetails(notInPub.Publication, notInPub.Tables)...)
 		}
 		if replicaIdErr, ok := errors.AsType[*common.ReplicaIdentifierInUseError](err); ok {
 			// Beyond other PeerDB mirrors, a replica id must not be already

--- a/flow/pkg/common/errors.go
+++ b/flow/pkg/common/errors.go
@@ -8,6 +8,10 @@ import (
 // gRPC ErrorInfo constants
 const (
 	ErrorInfoDomain = "peerdb.io"
+	// MaxTablesInErrorDetails bounds table lists carried in gRPC status metadata.
+	// Rich gRPC errors are transported in response headers/trailers, which have
+	// substantially smaller limits than response bodies.
+	MaxTablesInErrorDetails = 20
 
 	ErrorInfoReasonMirror                 = "MIRROR"
 	ErrorInfoReasonSourceTableMissing     = "SOURCE_TABLE_MISSING"
@@ -16,6 +20,7 @@ const (
 
 	ErrorMetadataOffendingField = "offendingField"
 	ErrorMetadataPublication    = "publication"
+	ErrorMetadataTableCount     = "tableCount"
 )
 
 type SourceTablesMissingError struct {
@@ -27,11 +32,7 @@ func NewSourceTablesMissingError(tables []QualifiedTable) *SourceTablesMissingEr
 }
 
 func (e *SourceTablesMissingError) Error() string {
-	parts := make([]string, len(e.Tables))
-	for i, t := range e.Tables {
-		parts[i] = fmt.Sprintf("%s.%s", t.Namespace, t.Table)
-	}
-	return "source tables do not exist: " + strings.Join(parts, ", ")
+	return "source tables do not exist: " + formatTablesForError(e.Tables)
 }
 
 type TablesNotInPublicationError struct {
@@ -44,11 +45,19 @@ func NewTablesNotInPublicationError(publication string, tables []QualifiedTable)
 }
 
 func (e *TablesNotInPublicationError) Error() string {
-	parts := make([]string, len(e.Tables))
-	for i, t := range e.Tables {
+	return fmt.Sprintf("tables not in publication %q: %s", e.Publication, formatTablesForError(e.Tables))
+}
+
+func formatTablesForError(tables []QualifiedTable) string {
+	limit := min(len(tables), MaxTablesInErrorDetails)
+	parts := make([]string, limit)
+	for i, t := range tables[:limit] {
 		parts[i] = fmt.Sprintf("%s.%s", t.Namespace, t.Table)
 	}
-	return fmt.Sprintf("tables not in publication %q: %s", e.Publication, strings.Join(parts, ", "))
+	if omitted := len(tables) - limit; omitted > 0 {
+		parts = append(parts, fmt.Sprintf("and %d more", omitted))
+	}
+	return strings.Join(parts, ", ")
 }
 
 type ReplicaIdentifierInUseError struct {

--- a/flow/pkg/common/errors_test.go
+++ b/flow/pkg/common/errors_test.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableErrorsLimitDisplayedTables(t *testing.T) {
+	tables := make([]QualifiedTable, MaxTablesInErrorDetails+2)
+	for i := range tables {
+		tables[i] = QualifiedTable{Namespace: "public", Table: fmt.Sprintf("table_%02d", i)}
+	}
+
+	for _, err := range []error{
+		NewSourceTablesMissingError(tables),
+		NewTablesNotInPublicationError("publication", tables),
+	} {
+		message := err.Error()
+		require.Contains(t, message, "public.table_19")
+		require.NotContains(t, message, "public.table_20")
+		require.Contains(t, message, "and 2 more")
+		require.Equal(t, MaxTablesInErrorDetails, strings.Count(message, "public.table_"))
+	}
+}


### PR DESCRIPTION
Large table-validation failures can exceed proxy gRPC header limits because both the status message and rich details contain every table. This causes nginx to return a 502 and hides the FailedPrecondition status from callers.

This change:
- caps table names in the error string and rich status details at 20
- includes the total affected table count in ErrorInfo metadata
- preserves individual violations for the displayed tables
- adds coverage for both bounded error strings and rich details

Contributes to DBI-1084