### PR TITLE
Fix classification for missing tables

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -573,7 +573,12 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 				Source: pgErrSource,
 				Code:   temporalErr.Type(),
 			}
-		case exceptions.ApplicationErrorTypeIrrecoverableExistingSlot, exceptions.ApplicationErrorTypeIrrecoverableMissingTables:
+		case exceptions.ApplicationErrorTypeIrrecoverableMissingTables:
+			return ErrorNotifySourceTableMissing, ErrorInfo{
+				Source: pgErrSource,
+				Code:   temporalErr.Type(),
+			}
+		case exceptions.ApplicationErrorTypeIrrecoverableExistingSlot:
 			return ErrorNotifyConnectivity, ErrorInfo{
 				Source: pgErrSource,
 				Code:   temporalErr.Type(),

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -130,6 +130,22 @@ func TestUnwrappedPgErrorShouldKeepPostgresSource(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestQRepMissingWatermarkTableShouldBeSourceTableMissing(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors the QRep partition-planning chain: classifyTable finds no pg_class row for the
+	// watermark table, and the connector and activity wrappers each add context on the way out.
+	err := shared.WrapError("failed to get partitions from source",
+		fmt.Errorf("failed to get partitions: %w",
+			fmt.Errorf(`table "public"."whois_scans" not found in pg_class: %w`, shared.ErrTableDoesNotExist)))
+	errorClass, errInfo := GetErrorClass(t.Context(), err)
+	assert.Equal(t, ErrorNotifySourceTableMissing, errorClass, "Unexpected error class")
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourcePostgres,
+		Code:   "TABLE_DOES_NOT_EXIST",
+	}, errInfo, "Unexpected error info")
+}
+
 func TestOtherDNSErrorsShouldBeConnectivity(t *testing.T) {
 	t.Parallel()
 
@@ -1164,6 +1180,20 @@ func TestTemporalKnownErrorsShouldBeCorrectlyClassified(t *testing.T) {
 			errInfo: ErrorInfo{
 				Source: ErrorSourcePostgres,
 				Code:   exceptions.ApplicationErrorTypeIrrecoverableCouldNotImportSnapshot.String(),
+			},
+		},
+		exceptions.ApplicationErrorTypeIrrecoverableMissingTables: {
+			errorClass: ErrorNotifySourceTableMissing,
+			errInfo: ErrorInfo{
+				Source: ErrorSourcePostgres,
+				Code:   exceptions.ApplicationErrorTypeIrrecoverableMissingTables.String(),
+			},
+		},
+		exceptions.ApplicationErrorTypeIrrecoverableExistingSlot: {
+			errorClass: ErrorNotifyConnectivity,
+			errInfo: ErrorInfo{
+				Source: ErrorSourcePostgres,
+				Code:   exceptions.ApplicationErrorTypeIrrecoverableExistingSlot.String(),
 			},
 		},
 	} {

--- a/flow/connectors/postgres/qrep_partition.go
+++ b/flow/connectors/postgres/qrep_partition.go
@@ -324,7 +324,7 @@ func classifyTable(ctx context.Context, tx pgx.Tx, table string) (tableClassific
 		table).Scan(&classification.oid, &classification.qualifiedName, &classification.relkind, &classification.relhassubclass)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return classification, fmt.Errorf("table %s not found in pg_class", table)
+			return classification, fmt.Errorf("table %s not found in pg_class: %w", table, shared.ErrTableDoesNotExist)
 		}
 		return classification, fmt.Errorf("failed to classify table %s: %w", table, err)
 	}

--- a/flow/shared/err_types.go
+++ b/flow/shared/err_types.go
@@ -29,7 +29,10 @@ type QRepWarnings []error
 
 func WrapError(s string, err error) error {
 	if applicationError, ok := errors.AsType[*temporal.ApplicationError](err); ok {
-		return temporal.NewNonRetryableApplicationError(s, applicationError.Type(), applicationError)
+		// Keep err, not applicationError, as the cause: the ApplicationError may sit several
+		// wraps deep, and using it directly would drop every intermediate message (such as the
+		// name of the table that went missing) from the user-facing error.
+		return temporal.NewNonRetryableApplicationError(s, applicationError.Type(), err)
 	} else {
 		return fmt.Errorf("%s: %w", s, err)
 	}

--- a/flow/shared/err_types_test.go
+++ b/flow/shared/err_types_test.go
@@ -23,7 +23,7 @@ func TestWrapErrorKeepsIntermediateWraps(t *testing.T) {
 
 	message := fmt.Sprintf("%+v", err)
 	assert.Contains(t, message, `"public"."whois_scans"`, "Error message lost the table name")
-	assert.ErrorIs(t, err, ErrTableDoesNotExist, "Error no longer unwraps to the sentinel")
+	require.ErrorIs(t, err, ErrTableDoesNotExist, "Error no longer unwraps to the sentinel")
 
 	applicationErr, ok := errors.AsType[*temporal.ApplicationError](err)
 	require.True(t, ok, "Expected an ApplicationError")
@@ -39,5 +39,5 @@ func TestWrapErrorWithoutApplicationError(t *testing.T) {
 	err := WrapError("failed to sync records", cause)
 
 	assert.Equal(t, "failed to sync records: connection reset by peer", err.Error(), "Unexpected error message")
-	assert.ErrorIs(t, err, cause, "Error no longer unwraps to its cause")
+	require.ErrorIs(t, err, cause, "Error no longer unwraps to its cause")
 }

--- a/flow/shared/err_types_test.go
+++ b/flow/shared/err_types_test.go
@@ -1,0 +1,43 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/PeerDB-io/peerdb/flow/shared/exceptions"
+)
+
+func TestWrapErrorKeepsIntermediateWraps(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors the QRep partition-planning chain: the sentinel sits three wraps deep, and every
+	// layer above it carries context the user needs -- above all the name of the missing table.
+	err := WrapError("failed to get partitions from source",
+		fmt.Errorf("failed to get partitions: %w",
+			fmt.Errorf(`table "public"."whois_scans" not found in pg_class: %w`, ErrTableDoesNotExist)))
+
+	message := fmt.Sprintf("%+v", err)
+	assert.Contains(t, message, `"public"."whois_scans"`, "Error message lost the table name")
+	assert.ErrorIs(t, err, ErrTableDoesNotExist, "Error no longer unwraps to the sentinel")
+
+	applicationErr, ok := errors.AsType[*temporal.ApplicationError](err)
+	require.True(t, ok, "Expected an ApplicationError")
+	assert.Equal(t, exceptions.ApplicationErrorTypeIrrecoverableMissingTables.String(), applicationErr.Type(),
+		"Error type was not carried over from the wrapped sentinel")
+	assert.True(t, applicationErr.NonRetryable(), "Expected the wrapped error to stay non-retryable")
+}
+
+func TestWrapErrorWithoutApplicationError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("connection reset by peer")
+	err := WrapError("failed to sync records", cause)
+
+	assert.Equal(t, "failed to sync records: connection reset by peer", err.Error(), "Unexpected error message")
+	assert.ErrorIs(t, err, cause, "Error no longer unwraps to its cause")
+}


### PR DESCRIPTION
Three issues came together:
* A change in snapshotting wasn't hooked up to the shared table missing type
* Temporal error wrapping didn't keep the table name in the message
* Missing table error was classified as notify connectivity when there's already a dedicated code

Fixes: DBI-1094