### PR TITLE
fix correctness and consistency in date and datetime inference

### DIFF
--- a/flow/connectors/clickhouse/avro_sync.go
+++ b/flow/connectors/clickhouse/avro_sync.go
@@ -281,6 +281,11 @@ func (s *ClickHouseAvroSyncMethod) pushStagingDataToClickHouseForSnapshot(
 	if config.Version >= shared.InternalVersion_JsonEscapeDotsInKeys {
 		chSettings.Add(clickhouse.SettingJsonTypeEscapeDotsInKeys, "1")
 	}
+	if config.Version >= shared.InternalVersion_AlwaysUseDateTime64Inference {
+		chSettings.Add(clickhouse.SettingInputFormatTryInferDates, "0")
+		chSettings.Add(clickhouse.SettingInputFormatTryInferDatetimes, "1")
+		chSettings.Add(clickhouse.SettingInputFormatTryInferDatetimesOnlyDatetime64, "1")
+	}
 
 	// Process each chunk file individually
 	for chunkIdx, avroFile := range avroFiles {

--- a/flow/connectors/clickhouse/normalize_query.go
+++ b/flow/connectors/clickhouse/normalize_query.go
@@ -386,6 +386,11 @@ func (t *NormalizeQueryGenerator) BuildQuery(ctx context.Context) (string, error
 	if t.version >= shared.InternalVersion_JsonEscapeDotsInKeys {
 		chSettings.Add(clickhouse.SettingJsonTypeEscapeDotsInKeys, "1")
 	}
+	if t.version >= shared.InternalVersion_AlwaysUseDateTime64Inference {
+		chSettings.Add(clickhouse.SettingInputFormatTryInferDates, "0")
+		chSettings.Add(clickhouse.SettingInputFormatTryInferDatetimes, "1")
+		chSettings.Add(clickhouse.SettingInputFormatTryInferDatetimesOnlyDatetime64, "1")
+	}
 
 	insertIntoSelectQuery := fmt.Sprintf("INSERT INTO %s %s %s%s",
 		peerdb_clickhouse.QuoteIdentifier(t.TableName), colSelector.String(), selectQuery.String(), chSettings.String())

--- a/flow/connectors/clickhouse/object_sync.go
+++ b/flow/connectors/clickhouse/object_sync.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
+	chinternal "github.com/PeerDB-io/peerdb/flow/internal/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/model"
 	peerdb_clickhouse "github.com/PeerDB-io/peerdb/flow/pkg/clickhouse"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -320,6 +321,13 @@ func (c *ClickHouseConnector) insertFromURLBatch(
 		connector:                 c,
 		logger:                    c.logger,
 		fieldExpressionConverters: fieldExpressionConverters,
+	}
+
+	chSettings := chinternal.NewCHSettings(c.chVersion)
+	if config.Version >= shared.InternalVersion_AlwaysUseDateTime64Inference {
+		chSettings.Add(chinternal.SettingInputFormatTryInferDates, "0")
+		chSettings.Add(chinternal.SettingInputFormatTryInferDatetimes, "1")
+		chSettings.Add(chinternal.SettingInputFormatTryInferDatetimesOnlyDatetime64, "1")
 	}
 
 	query, err := buildInsertFromTableFunctionQuery(ctx, insertConfig, urlTableFunction, nil)

--- a/flow/e2e/mongo_test.go
+++ b/flow/e2e/mongo_test.go
@@ -1320,3 +1320,88 @@ func (s MongoClickhouseSuite) Test_Json_Types() {
 	env.Cancel(t.Context())
 	RequireEnvCanceled(t, env)
 }
+
+// Verifies that date/datetime string inference in JSON columns is order-independent. Previously,
+// the first value in an insert block determines the inferred type, so a post-1970 date infers Date
+// type and clamps subsequent pre-1970 dates as 1970-01-01; while a pre-1970 value arriving first
+// infers DateTime64 type. With InternalVersion_AlwaysUseDateTime64Inference, test ensures both
+// date-like and datetime-like strings will infer as DateTime64 regardless of row order.
+func (s MongoClickhouseSuite) Test_Json_Date_Field_Inference_Consistency() {
+	t := s.T()
+	srcDatabase := GetTestDatabase(s.Suffix())
+	srcTable1 := "test_json_date_infer_t1"
+	dstTable1 := "test_json_date_infer_t1_dst"
+	srcTable2 := "test_json_date_infer_t2"
+	dstTable2 := "test_json_date_infer_t2_dst"
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:   AddSuffix(s, "test_json_date_infer"),
+		TableMappings: TableMappings(s, srcTable1, dstTable1, srcTable2, dstTable2),
+		Destination:   s.Peer().Name,
+	}
+	flowConnConfig := s.generateFlowConnectionConfigsDefaultEnv(connectionGen)
+	flowConnConfig.DoInitialSnapshot = true
+
+	adminClient := s.Source().(*MongoSource).AdminClient()
+	collection1 := adminClient.Database(srcDatabase).Collection(srcTable1)
+	collection2 := adminClient.Database(srcDatabase).Collection(srcTable2)
+
+	post1970Date := "1981-01-01"
+	pre1970Date := "1911-01-01"
+	// DateTime64 JSON paths are scanned as time.Time by clickhouse-go and re-marshaled as RFC3339 on readback
+	expectedDocTemplate := `{"_id":%d,"date_str":"%sT00:00:00Z","datetime_str":"%sT00:00:00Z"}`
+
+	insert := func(collection *mongo.Collection, id int, date string) {
+		res, err := collection.InsertOne(t.Context(), bson.D{
+			{Key: "_id", Value: id},
+			{Key: "date_str", Value: date},
+			{Key: "datetime_str", Value: date + " 00:00:00"},
+		}, options.InsertOne())
+		require.NoError(t, err)
+		require.True(t, res.Acknowledged)
+	}
+
+	validate := func(dstTable string, id int, date string) {
+		rows, err := s.GetRows(dstTable, "_id,doc")
+		require.NoError(t, err)
+		for _, record := range rows.Records {
+			if record[0].Value().(string) == strconv.Itoa(id) {
+				require.Equal(t, fmt.Sprintf(expectedDocTemplate, id, date, date), record[1].Value().(string))
+				return
+			}
+		}
+		require.Failf(t, "row not found", "_id %d not found in %s", id, dstTable)
+	}
+
+	insert(collection1, 1, post1970Date)
+	insert(collection1, 2, pre1970Date)
+	insert(collection2, 1, pre1970Date)
+	insert(collection2, 2, post1970Date)
+
+	tc := NewTemporalClient(t)
+	env := ExecutePeerflow(t, tc, flowConnConfig)
+
+	EnvWaitForCount(env, s, "initial load t1", dstTable1, "_id,doc", 2)
+	EnvWaitForCount(env, s, "initial load t2", dstTable2, "_id,doc", 2)
+	validate(dstTable1, 1, post1970Date)
+	validate(dstTable1, 2, pre1970Date)
+	validate(dstTable2, 1, pre1970Date)
+	validate(dstTable2, 2, post1970Date)
+
+	SetupCDCFlowStatusQuery(t, env, flowConnConfig)
+
+	insert(collection1, 3, post1970Date)
+	insert(collection1, 4, pre1970Date)
+	insert(collection2, 3, pre1970Date)
+	insert(collection2, 4, post1970Date)
+
+	EnvWaitForCount(env, s, "cdc t1", dstTable1, "_id,doc", 4)
+	EnvWaitForCount(env, s, "cdc t2", dstTable2, "_id,doc", 4)
+	validate(dstTable1, 3, post1970Date)
+	validate(dstTable1, 4, pre1970Date)
+	validate(dstTable2, 3, pre1970Date)
+	validate(dstTable2, 4, post1970Date)
+
+	env.Cancel(t.Context())
+	RequireEnvCanceled(t, env)
+}

--- a/flow/internal/clickhouse/settings.go
+++ b/flow/internal/clickhouse/settings.go
@@ -14,20 +14,26 @@ import (
 // Important: if the setting causes breaking changes to existing PeerDB flows (not just ClickHouse compatibility),
 // it must also be gated by PeerDB's internal version.
 const (
-	SettingAllowNullableKey                   CHSetting = "allow_nullable_key"
-	SettingJsonTypeEscapeDotsInKeys           CHSetting = "json_type_escape_dots_in_keys"
-	SettingTypeJsonSkipDuplicatedPaths        CHSetting = "type_json_skip_duplicated_paths"
-	SettingThrowOnMaxPartitionsPerInsertBlock CHSetting = "throw_on_max_partitions_per_insert_block"
-	SettingParallelDistributedInsertSelect    CHSetting = "parallel_distributed_insert_select"
-	SettingMaxTableSizeToDrop                 CHSetting = "max_table_size_to_drop"
+	SettingAllowNullableKey                           CHSetting = "allow_nullable_key"
+	SettingInputFormatTryInferDates                   CHSetting = "input_format_try_infer_dates"
+	SettingInputFormatTryInferDatetimes               CHSetting = "input_format_try_infer_datetimes"
+	SettingInputFormatTryInferDatetimesOnlyDatetime64 CHSetting = "input_format_try_infer_datetimes_only_datetime64"
+	SettingJsonTypeEscapeDotsInKeys                   CHSetting = "json_type_escape_dots_in_keys"
+	SettingTypeJsonSkipDuplicatedPaths                CHSetting = "type_json_skip_duplicated_paths"
+	SettingThrowOnMaxPartitionsPerInsertBlock         CHSetting = "throw_on_max_partitions_per_insert_block"
+	SettingParallelDistributedInsertSelect            CHSetting = "parallel_distributed_insert_select"
+	SettingMaxTableSizeToDrop                         CHSetting = "max_table_size_to_drop"
 )
 
 // CHSettingMinVersions maps setting names to their minimum required ClickHouse versions that PeerDB supports.
 // If minimum version is not specified, we assume the setting is available to all ClickHouse versions
 var CHSettingMinVersions = map[CHSetting]chproto.Version{
-	SettingJsonTypeEscapeDotsInKeys:    {Major: 25, Minor: 8, Patch: 0},
-	SettingTypeJsonSkipDuplicatedPaths: {Major: 24, Minor: 8, Patch: 0},
-	SettingMaxTableSizeToDrop:          {Major: 23, Minor: 12, Patch: 0},
+	SettingInputFormatTryInferDates:                   {Major: 22, Minor: 8, Patch: 0},
+	SettingInputFormatTryInferDatetimes:               {Major: 22, Minor: 8, Patch: 0},
+	SettingInputFormatTryInferDatetimesOnlyDatetime64: {Major: 24, Minor: 8, Patch: 0},
+	SettingJsonTypeEscapeDotsInKeys:                   {Major: 25, Minor: 8, Patch: 0},
+	SettingTypeJsonSkipDuplicatedPaths:                {Major: 24, Minor: 8, Patch: 0},
+	SettingMaxTableSizeToDrop:                         {Major: 23, Minor: 12, Patch: 0},
 }
 
 type CHSetting string

--- a/flow/shared/constants.go
+++ b/flow/shared/constants.go
@@ -41,6 +41,10 @@ const (
 	InternalVersion_MySQLConvertBitToUInt64
 	// MySQL: convert sets to integers for older versions without binlog row metadata support
 	InternalVersion_MySQL5ConvertSetsToInts
+	// All: infer date-like and timestamp-like string fields in JSON columns as DateTime64 when
+	// inserting into ClickHouse. Otherwise inference is indeterministic depending on initial
+	// input data, and can silently corrupts out-of-range values (e,g, pre-1970 date becomes 1970-01-01).
+	InternalVersion_AlwaysUseDateTime64Inference
 
 	TotalNumberOfInternalVersions
 	InternalVersion_Latest = TotalNumberOfInternalVersions - 1


### PR DESCRIPTION
We don't support type hinting in table creation for MongoDB. The default date/datetime inference settings in ClickHouse are:
- input_format_try_infer_dates = 1
- input_format_try_infer_datetimes = 1

The problem with this is depending on the first row in a insert block, a date string will be inferred as DateTime64 if it's <1970, and Date if it's >1970. The former is fine, but the latter means if subsequent rows in the insert block contains <1970 date, they get clamped to 1970 and result in incorrect data propagation that can only be fixed with updating clickhouse user settings and resync pipe.


The fix is to disable `input_format_try_infer_dates` (unfortunately there is not a setting for date32 inference), and always have both `input_format_try_infer_datetimes` and `input_format_try_infer_datetimes_only_datetime64` enabled.  This allows both date string and datetime string to be inferred as DateTime64 going forward. 

Use internal versioning for backward compatibility (although we could probably get away with applying to existing pipes without interval versioning, as the indeterminism is on the insert-block level). 

Fixes: DBI-1086