### PR TITLE
chore(bigquery): extract shared-stream CDC path into syncFlowSharedStream

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -354,28 +355,10 @@ func (a *FlowableActivity) SyncFlow(
 	config *protos.FlowConnectionConfigsCore,
 	options *protos.SyncFlowOptions,
 ) error {
-	var currentSyncFlowNum atomic.Int32
-	var totalRecordsSynced atomic.Int64
-	var normalizingBatchID atomic.Int64
-	var normalizeWaiting atomic.Bool
-	var syncingBatchID atomic.Int64
-	var syncState atomic.Pointer[string]
-	syncState.Store(new("setup"))
-	shutdown := common.HeartbeatRoutine(ctx, func() string {
-		// Must load Waiting after BatchID to avoid race saying we're waiting on currently processing batch
-		sBatchID := syncingBatchID.Load()
-		nBatchID := normalizingBatchID.Load()
-		var nWaiting string
-		if normalizeWaiting.Load() {
-			nWaiting = " (W)"
-		}
-		return fmt.Sprintf(
-			"currentSyncFlowNum:%d, totalRecordsSynced:%d, syncingBatchID:%d (%s), normalizingBatchID:%d%s",
-			currentSyncFlowNum.Load(), totalRecordsSynced.Load(),
-			sBatchID, *syncState.Load(), nBatchID, nWaiting,
-		)
-	})
-	defer shutdown()
+	// Heartbeats connector setup below, which must not exceed the activity's heartbeat
+	// timeout. Each sync path stops it and installs its own heartbeat once it takes over.
+	stopSetupHeartbeat := sync.OnceFunc(common.HeartbeatRoutine(ctx, func() string { return "setup" }))
+	defer stopSetupHeartbeat()
 
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
@@ -419,9 +402,49 @@ func (a *FlowableActivity) SyncFlow(
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 	}
 
+	stopSetupHeartbeat()
 	if isIsolatedTableCDCPath(config, destinationType) {
-		return a.syncFlowIsolatedTables(ctx, config, options, srcConn.(connectors.TableCDCPullConnector))
+		return a.syncFlowIsolatedTables(ctx, config, options, srcConn.(connectors.TableCDCPullConnector), &shutDown)
 	}
+
+	return a.syncFlowSharedStream(ctx, config, options, srcConn, destinationType, &shutDown)
+}
+
+// syncFlowSharedStream runs the classic shared-stream CDC path: a single pull+sync
+// loop for the whole mirror feeding a single normalize loop, with all tables sharing
+// one batch counter and one backpressure window.
+func (a *FlowableActivity) syncFlowSharedStream(
+	ctx context.Context,
+	config *protos.FlowConnectionConfigsCore,
+	options *protos.SyncFlowOptions,
+	srcConn connectors.CDCPullConnectorCore,
+	destinationType protos.DBType,
+	shutDown *atomic.Bool,
+) error {
+	logger := internal.LoggerFromCtx(ctx)
+
+	var currentSyncFlowNum atomic.Int32
+	var totalRecordsSynced atomic.Int64
+	var normalizingBatchID atomic.Int64
+	var normalizeWaiting atomic.Bool
+	var syncingBatchID atomic.Int64
+	var syncState atomic.Pointer[string]
+	syncState.Store(new("setup"))
+	shutdown := common.HeartbeatRoutine(ctx, func() string {
+		// Must load Waiting after BatchID to avoid race saying we're waiting on currently processing batch
+		sBatchID := syncingBatchID.Load()
+		nBatchID := normalizingBatchID.Load()
+		var nWaiting string
+		if normalizeWaiting.Load() {
+			nWaiting = " (W)"
+		}
+		return fmt.Sprintf(
+			"currentSyncFlowNum:%d, totalRecordsSynced:%d, syncingBatchID:%d (%s), normalizingBatchID:%d%s",
+			currentSyncFlowNum.Load(), totalRecordsSynced.Load(),
+			sBatchID, *syncState.Load(), nBatchID, nWaiting,
+		)
+	})
+	defer shutdown()
 
 	reconnectAfterBatches, err := internal.PeerDBReconnectAfterBatches(ctx, config.Env)
 	if err != nil {

--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -355,9 +355,10 @@ func (a *FlowableActivity) SyncFlow(
 	config *protos.FlowConnectionConfigsCore,
 	options *protos.SyncFlowOptions,
 ) error {
+	activityCtx := ctx
 	// Heartbeats connector setup below, which must not exceed the activity's heartbeat
-	// timeout. Each sync path stops it and installs its own heartbeat once it takes over.
-	stopSetupHeartbeat := sync.OnceFunc(common.HeartbeatRoutine(ctx, func() string { return "setup" }))
+	// timeout. Each sync path replaces it with its own heartbeat once it takes over.
+	stopSetupHeartbeat := sync.OnceFunc(common.HeartbeatRoutine(activityCtx, func() string { return "setup" }))
 	defer stopSetupHeartbeat()
 
 	ctx, cancelCtx := context.WithCancel(ctx)
@@ -396,12 +397,21 @@ func (a *FlowableActivity) SyncFlow(
 	if err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 	}
-	defer srcClose(ctx)
+	defer func() {
+		// The sync path has stopped its heartbeat by the time it returns. Keep the
+		// activity alive while closing the source, even after a worker shutdown has
+		// canceled the derived sync context.
+		stopSetupHeartbeat()
+		stopCloseHeartbeat := common.HeartbeatRoutine(activityCtx, func() string { return "closing source" })
+		defer stopCloseHeartbeat()
+		srcClose(ctx)
+	}()
 
 	if err := srcConn.SetupReplConn(ctx, config.Env); err != nil {
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 	}
 
+	stopSetupHeartbeat()
 	if isQueryCDCPath(config, destinationType) {
 		return a.syncFlowQueryCDC(ctx, config, options, srcConn.(connectors.QueryCDCPullConnector), &shutDown)
 	}

--- a/flow/activities/flowable_isolated_cdc.go
+++ b/flow/activities/flowable_isolated_cdc.go
@@ -35,10 +35,18 @@ func (a *FlowableActivity) syncFlowIsolatedTables(
 	config *protos.FlowConnectionConfigsCore,
 	options *protos.SyncFlowOptions,
 	srcConn connectors.TableCDCPullConnector,
+	shutDown *atomic.Bool,
 ) error {
 	flowName := config.FlowJobName
 	logger := internal.LoggerFromCtx(ctx)
 	pgMetadata := connmetadata.NewPostgresMetadataFromCatalog(logger, a.CatalogPool)
+
+	var totalRecordsSynced atomic.Int64
+	shutdown := common.HeartbeatRoutine(ctx, func() string {
+		return fmt.Sprintf("isolated CDC: %d tables, totalRecordsSynced:%d",
+			len(options.TableMappings), totalRecordsSynced.Load())
+	})
+	defer shutdown()
 
 	if err := srcConn.ConnectionActive(ctx); err != nil {
 		return a.Alerter.LogFlowError(ctx, flowName, fmt.Errorf("connection to source down: %w", err))
@@ -100,12 +108,6 @@ func (a *FlowableActivity) syncFlowIsolatedTables(
 		return err
 	}
 
-	var totalRecordsSynced atomic.Int64
-	shutdown := common.HeartbeatRoutine(ctx, func() string {
-		return fmt.Sprintf("isolated CDC: %d tables, totalRecordsSynced:%d", len(sourceTables), totalRecordsSynced.Load())
-	})
-	defer shutdown()
-
 	group, groupCtx := errgroup.WithContext(ctx)
 	for _, tableMapping := range options.TableMappings {
 		normRequests := concurrency.NewLastChan()
@@ -120,7 +122,24 @@ func (a *FlowableActivity) syncFlowIsolatedTables(
 				channelBufferSize, idleTimeout, normBufferSize, pullSyncSem, &totalRecordsSynced, normRequests, normResponses)
 		})
 	}
-	return group.Wait()
+
+	if err := group.Wait(); err != nil {
+		// mirrors syncFlowSharedStream: a worker shutdown cancels ctx ourselves, so the
+		// resulting context.Canceled is expected teardown rather than an activity failure
+		if shutDown.Load() {
+			logger.Info("isolated CDC SyncFlow shutdown")
+			return nil
+		}
+		// errgroup cancels groupCtx, not ctx, on a table error, so ctx being done here
+		// means an outside cancel rather than a replication failure
+		if ctx.Err() != nil {
+			logger.Info("isolated CDC SyncFlow canceled", slog.Any("error", ctx.Err()))
+			return ctx.Err()
+		}
+		logger.Error("isolated CDC SyncFlow failed", slog.Any("error", err))
+		return err
+	}
+	return nil
 }
 
 // isolatedTablePollWait mirrors bigquery/cdc.go's checkpoint.nextPollWait,

--- a/flow/activities/flowable_query_cdc.go
+++ b/flow/activities/flowable_query_cdc.go
@@ -43,7 +43,7 @@ func (a *FlowableActivity) syncFlowQueryCDC(
 
 	var totalRecordsSynced atomic.Int64
 	shutdown := common.HeartbeatRoutine(ctx, func() string {
-		return fmt.Sprintf("isolated CDC: %d tables, totalRecordsSynced:%d",
+		return fmt.Sprintf("query-based CDC: %d tables, totalRecordsSynced:%d",
 			len(options.TableMappings), totalRecordsSynced.Load())
 	})
 	defer shutdown()


### PR DESCRIPTION
Follow-up refactor on top of `bq/isolate-tables-flow`. The shared-stream path behaves the same as before. The isolated path gets two small behavior fixes.

### What changed

`SyncFlow` now does only the setup both CDC paths need: cancellable context, flow name and operation context, worker-stop handling, destination peer type, source connector plus `SetupReplConn`. It then hands off to `syncFlowIsolatedTables` or the new `syncFlowSharedStream`.

Resolves: DBI-1045