### PR TITLE
remove maintenance arg and use cli command intead

### DIFF
--- a/flow/cmd/maintenance.go
+++ b/flow/cmd/maintenance.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/PeerDB-io/peerdb/flow/db"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/shared"
@@ -32,7 +31,6 @@ type MaintenanceCLIParams struct {
 	FlowGrpcAddress                   string
 	SkipIfK8sServiceMissing           string
 	FlowTlsEnabled                    bool
-	RunCatalogMigrations              bool
 	SkipOnApiVersionMatch             bool
 	SkipOnDeploymentVersionMatch      bool
 	SkipOnNoMirrors                   bool
@@ -53,16 +51,6 @@ type StartMaintenanceResult struct {
 // running the requested maintenance workflow
 func MaintenanceMain(ctx context.Context, args *MaintenanceCLIParams) error {
 	slog.InfoContext(ctx, "Starting Maintenance Mode CLI")
-
-	// If enabled, goose migration runs unconditionally on start-maintenance
-	// Off by default for now while refinery's migration hook still exist.
-	if args.Mode == "start" && args.RunCatalogMigrations {
-		slog.InfoContext(ctx, "Running goose migrations")
-		if err := db.Run(ctx); err != nil {
-			return fmt.Errorf("failed to run goose migrations: %w", err)
-		}
-	}
-
 	clientOptions := client.Options{
 		HostPort:  args.TemporalHostPort,
 		Namespace: args.TemporalNamespace,

--- a/flow/db/migrations.go
+++ b/flow/db/migrations.go
@@ -33,6 +33,8 @@ func Run(ctx context.Context) error {
 }
 
 func Apply(ctx context.Context, connStr string) error {
+	slog.InfoContext(ctx, "Starting db migrations")
+
 	db, err := sql.Open("pgx", connStr)
 	if err != nil {
 		return fmt.Errorf("failed to open catalog connection: %w", err)
@@ -64,6 +66,7 @@ func Apply(ctx context.Context, connStr string) error {
 	if err != nil {
 		return fmt.Errorf("failed to run migrations: %w", err)
 	}
+	slog.InfoContext(ctx, "Completed db migrations")
 	return nil
 }
 

--- a/flow/main.go
+++ b/flow/main.go
@@ -20,6 +20,7 @@ import (
 	_ "go.uber.org/automaxprocs"
 
 	"github.com/PeerDB-io/peerdb/flow/cmd"
+	"github.com/PeerDB-io/peerdb/flow/db"
 	"github.com/PeerDB-io/peerdb/flow/shared"
 )
 
@@ -87,13 +88,6 @@ func main() {
 		Value:   "",
 		Usage:   "Run a maintenance flow. Options are 'start' or 'end'",
 		Sources: cli.EnvVars("RUN_MAINTENANCE_FLOW"),
-	}
-
-	maintenanceRunCatalogMigrationsFlag := &cli.BoolFlag{
-		Name:    "run-catalog-migrations",
-		Value:   false,
-		Usage:   "Run catalog schema migrations as the first step of 'start' maintenance",
-		Sources: cli.EnvVars("MAINTENANCE_RUN_CATALOG_MIGRATIONS"),
 	}
 
 	maintenanceSkipOnApiVersionMatchFlag := &cli.BoolFlag{
@@ -274,12 +268,18 @@ func main() {
 				},
 			},
 			{
+				Name:  "migrate",
+				Usage: "Run catalog schema migrations to the latest version and exit",
+				Action: func(ctx context.Context, clicmd *cli.Command) error {
+					return db.Run(ctx)
+				},
+			},
+			{
 				Name: "maintenance",
 				Flags: []cli.Flag{
 					temporalHostPortFlag,
 					temporalNamespaceFlag,
 					maintenanceModeWorkflowFlag,
-					maintenanceRunCatalogMigrationsFlag,
 					maintenanceSkipOnApiVersionMatchFlag,
 					maintenanceSkipOnDeploymentVersionMatch,
 					maintenanceSkipOnNoMirrorsFlag,
@@ -296,7 +296,6 @@ func main() {
 						TemporalHostPort:                  temporalHostPort,
 						TemporalNamespace:                 clicmd.String(temporalNamespaceFlag.Name),
 						Mode:                              clicmd.String(maintenanceModeWorkflowFlag.Name),
-						RunCatalogMigrations:              clicmd.Bool(maintenanceRunCatalogMigrationsFlag.Name),
 						SkipOnApiVersionMatch:             clicmd.Bool(maintenanceSkipOnApiVersionMatchFlag.Name),
 						SkipOnDeploymentVersionMatch:      clicmd.Bool(maintenanceSkipOnDeploymentVersionMatch.Name),
 						SkipOnNoMirrors:                   clicmd.Bool(maintenanceSkipOnNoMirrorsFlag.Name),


### PR DESCRIPTION
It's better to not couple migration with maintenance for now. Introduce a cli command that can be run independently. 