### PR TITLE
MongoDB CDC: User facing log upon drop and rename collection events

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/PeerDB-io/peerdb/flow/alerting"
 	"github.com/PeerDB-io/peerdb/flow/generated/protos"
 	"github.com/PeerDB-io/peerdb/flow/internal"
 	"github.com/PeerDB-io/peerdb/flow/model"
@@ -34,6 +35,8 @@ const (
 	operationTypeUpdate  operationType = "update"
 	operationTypeReplace operationType = "replace"
 	operationTypeDelete  operationType = "delete"
+	operationTypeDrop    operationType = "drop"
+	operationTypeRename  operationType = "rename"
 )
 
 func parseOperationType(s string) (operationType, bool) {
@@ -234,6 +237,11 @@ func (c *MongoConnector) PullRecords(
 	req *model.PullRecordsRequest[model.RecordItems],
 ) error {
 	defer req.RecordStream.Close()
+
+	var alerter *alerting.Alerter
+	if catalogPool.Pool != nil {
+		alerter = alerting.NewAlerter(ctx, catalogPool, otelManager)
+	}
 
 	fullDocumentColumnName := DefaultFullDocumentColumnName
 	if req.InternalVersion < shared.InternalVersion_MongoDBFullDocumentColumnToDoc {
@@ -575,6 +583,20 @@ func (c *MongoConnector) PullRecords(
 		default:
 			c.logger.Warn(fmt.Sprintf("skipping event with unsupported operation type '%s' (db=%s coll=%s)",
 				changeEvent.OperationType, changeEvent.Ns.Db, changeEvent.Ns.Coll))
+
+			// When the skipped event is a collection-level DDL (drop or rename), generate customer facing logs.
+			if alerter != nil {
+				switch operationType(changeEvent.OperationType) {
+				case operationTypeDrop, operationTypeRename:
+					ddlErr := fmt.Errorf(
+						"%s event on %s.%s: collection DDL is not replicated, the destination table is left unchanged",
+						changeEvent.OperationType, changeEvent.Ns.Db, changeEvent.Ns.Coll)
+					alerter.LogFlowWarning(ctx, req.FlowJobName, ddlErr)
+				}
+			} else {
+				c.logger.Error("Alerter not initialized")
+			}
+
 			continue
 		}
 		otelManager.Metrics.FetchedEventSizeHistogram.Record(ctx, changeEventSize)

--- a/flow/connectors/mongo/cdc_test.go
+++ b/flow/connectors/mongo/cdc_test.go
@@ -6,9 +6,12 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -28,6 +31,8 @@ const (
 	idle iterationType = iota
 	// insert returns true on Next() with a generated insert event
 	insert
+	// rawEvent returns true on Next() with the next event queued in mockChangeStream.rawEvents
+	rawEvent
 )
 
 type mockChangeStream struct {
@@ -38,6 +43,7 @@ type mockChangeStream struct {
 	idx          int
 	iterations   []iterationType
 	emittedTimes []time.Time
+	rawEvents    []bson.Raw
 
 	t *testing.T
 }
@@ -61,6 +67,14 @@ func (cs *mockChangeStream) Next(context.Context) bool {
 	switch label {
 	case insert:
 		cs.current = newInsertChangeEvent(bson.NewObjectID(), ts)
+		cs.err = nil
+		return true
+	case rawEvent:
+		if len(cs.rawEvents) == 0 {
+			cs.t.Fatal("mockChangeStream: rawEvent label with no queued events")
+		}
+		cs.current = cs.rawEvents[0]
+		cs.rawEvents = cs.rawEvents[1:]
 		cs.err = nil
 		return true
 	case idle:
@@ -118,6 +132,32 @@ func newInsertChangeEvent(id bson.ObjectID, ts time.Time) bson.Raw {
 		{Key: "wallTime", Value: wallTime},
 	})
 	return event
+}
+
+func newDDLChangeEvent(op string, db string, coll string, ts time.Time) bson.Raw {
+	wallTime := ts.UTC().Truncate(time.Millisecond)
+	event, _ := bson.Marshal(bson.D{
+		{Key: "ns", Value: bson.D{
+			{Key: "db", Value: db},
+			{Key: "coll", Value: coll},
+		}},
+		{Key: "operationType", Value: op},
+		{Key: "clusterTime", Value: toBsonTs(ts)},
+		{Key: "wallTime", Value: wallTime},
+	})
+	return event
+}
+
+// captureSlog redirects the default slog logger for the duration of the test. That is
+// where the Alerter writes its user-facing log lines, and where internal.LoggerFromCtx
+// sends the connector's own logging.
+func captureSlog(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return &buf
 }
 
 func TestChangeStreamIdleConnectionAdvancesOffset(t *testing.T) {
@@ -196,6 +236,77 @@ func TestChangeStreamRecreationFailureReturnsError(t *testing.T) {
 	require.Equal(t, 2, streamCreations)
 	require.Len(t, mockStore.persisted, 1)
 	require.Equal(t, b64(toResumeToken(mockCS.emittedTimes[0])), mockStore.persisted[0].Text)
+}
+
+func TestChangeStreamReportsCollectionDDLToUser(t *testing.T) {
+	ctx := t.Context()
+
+	// installed before the connector logger is built, since LoggerFromCtx wraps
+	// whatever slog.Default() is at construction time
+	logs := captureSlog(t)
+
+	// the catalog pool is non-nil but never reachable. pgxpool connects lazily, so this
+	// is enough for PullRecords to build a real Alerter, while the insert into
+	// flow_errors fails immediately rather than blocking the test.
+	pool, err := pgxpool.New(ctx, "postgres://peerdb:peerdb@127.0.0.1:1/peerdb")
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	// drop and rename are collection DDL and must reach the user; dropIndexes is also
+	// unsupported but is not collection DDL, so it must stay internal
+	// the trailing insert matters: a batch with no records treats idle as a stream
+	// recreation rather than a return, so DDL-only input never terminates the pull
+	ts := time.Now()
+	mockCS := newMockChangeStream(t, rawEvent, rawEvent, rawEvent, insert, idle)
+	mockCS.rawEvents = []bson.Raw{
+		newDDLChangeEvent("drop", "db", "coll", ts),
+		newDDLChangeEvent("rename", "db", "other", ts),
+		newDDLChangeEvent("dropIndexes", "db", "coll", ts),
+	}
+	connector := &MongoConnector{
+		logger: internal.LoggerFromCtx(ctx),
+		createChangeStream: func(
+			context.Context, mongo.Pipeline, ...options.Lister[options.ChangeStreamOptions],
+		) (ChangeStream, error) {
+			return mockCS, nil
+		},
+		metadataStore: &mockMetadataStore{},
+	}
+
+	otelManager, err := otel_metrics.NewOtelManager(ctx, "test", false)
+	require.NoError(t, err)
+
+	req := &model.PullRecordsRequest[model.RecordItems]{
+		FlowJobName:  "test_mongo_ddl",
+		RecordStream: model.NewCDCStream[model.RecordItems](100),
+		// both namespaces must be mapped, otherwise the events are dropped by the
+		// destination-table guard before reaching the unsupported-operation branch
+		TableNameMapping: map[string]model.NameAndExclude{
+			"db.coll":  {Name: "db_coll"},
+			"db.other": {Name: "db_other"},
+		},
+		TableNameSchemaMapping: map[string]*protos.TableSchema{},
+		MaxBatchSize:           10000,
+		IdleTimeout:            time.Minute,
+	}
+	drainMongoCDCRecordsAsync(t, req.RecordStream)
+
+	require.NoError(t, connector.PullRecords(ctx, shared.CatalogPool{Pool: pool}, otelManager, req))
+
+	out := logs.String()
+
+	// the Alerter is always available in production, so the fallback must not be taken
+	require.NotContains(t, out, "Alerter not initialized")
+
+	// InsertFlowLog logs every row before writing it, so this covers both the severity
+	// that lands in flow_errors.error_type and the message the user will read
+	require.Contains(t, out, "[warn] drop event on db.coll: collection DDL is not replicated")
+	require.Contains(t, out, "[warn] rename event on db.other: collection DDL is not replicated")
+	require.Equal(t, 2, strings.Count(out, "inserting user-facing flow log"))
+
+	// dropIndexes did reach the same branch, so the absence of a third user-facing log
+	// above is the operation-type filter working, not a missing event
+	require.Contains(t, out, "unsupported operation type 'dropIndexes'")
 }
 
 func b64(raw bson.Raw) string {

--- a/flow/e2e/mongo_test.go
+++ b/flow/e2e/mongo_test.go
@@ -622,6 +622,85 @@ func (s MongoClickhouseSuite) Test_CDC_Excluded_Operation_Types() {
 	RequireEnvCanceled(t, env)
 }
 
+func (s MongoClickhouseSuite) Test_CDC_Collection_DDL_Reported_To_User() {
+	t := s.T()
+
+	srcDatabase := GetTestDatabase(s.Suffix())
+	dropTable := "test_ddl_dropped"
+	renameTable := "test_ddl_renamed"
+	renameTarget := "test_ddl_renamed_to"
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName: AddSuffix(s, "test_collection_ddl"),
+		TableMappings: TableMappings(s,
+			dropTable, dropTable+"_dst",
+			renameTable, renameTable+"_dst"),
+		Destination: s.Peer().Name,
+	}
+	flowConnConfig := s.generateFlowConnectionConfigsDefaultEnv(connectionGen)
+	flowConnConfig.DoInitialSnapshot = true
+
+	catalogPool, err := internal.GetCatalogConnectionPoolFromEnv(t.Context())
+	require.NoError(t, err)
+
+	adminClient := s.Source().(*MongoSource).AdminClient()
+	for _, coll := range []string{dropTable, renameTable} {
+		require.NoError(t, adminClient.Database(srcDatabase).CreateCollection(t.Context(), coll))
+	}
+
+	tc := NewTemporalClient(t)
+	env := ExecutePeerflow(t, tc, flowConnConfig)
+	SetupCDCFlowStatusQuery(t, env, flowConnConfig)
+
+	// replicate a document from each collection first, so the mirror is demonstrably
+	// streaming before any DDL is issued
+	for _, coll := range []string{dropTable, renameTable} {
+		insertRes, err := adminClient.Database(srcDatabase).Collection(coll).
+			InsertOne(t.Context(), bson.D{bson.E{Key: "key", Value: 1}}, options.InsertOne())
+		require.NoError(t, err)
+		require.True(t, insertRes.Acknowledged)
+	}
+	EnvWaitForEqualTablesWithNames(env, s, "insert before ddl", dropTable, dropTable+"_dst", "_id,doc")
+	EnvWaitForEqualTablesWithNames(env, s, "insert before ddl", renameTable, renameTable+"_dst", "_id,doc")
+
+	// drop emits a change event whose ns is the dropped collection
+	require.NoError(t, adminClient.Database(srcDatabase).Collection(dropTable).Drop(t.Context()))
+
+	// rename emits a change event whose ns is the *source* collection, so it is still
+	// inside the mirror's table mapping and reaches the connector
+	require.NoError(t, adminClient.Database("admin").RunCommand(t.Context(), bson.D{
+		bson.E{Key: "renameCollection", Value: srcDatabase + "." + renameTable},
+		bson.E{Key: "to", Value: srcDatabase + "." + renameTarget},
+	}).Err())
+
+	EnvWaitFor(t, env, 3*time.Minute, "drop reported to user", func() bool {
+		count, err := GetLogCount(t.Context(), catalogPool, flowConnConfig.FlowJobName, "warn",
+			"drop event on "+srcDatabase+"."+dropTable)
+		if err != nil {
+			t.Log("Error querying flow_errors:", err)
+			return false
+		}
+		return count > 0
+	})
+
+	EnvWaitFor(t, env, 3*time.Minute, "rename reported to user", func() bool {
+		count, err := GetLogCount(t.Context(), catalogPool, flowConnConfig.FlowJobName, "warn",
+			"rename event on "+srcDatabase+"."+renameTable)
+		if err != nil {
+			t.Log("Error querying flow_errors:", err)
+			return false
+		}
+		return count > 0
+	})
+
+	// the DDL is reported, not applied: the destination tables are left alone
+	EnvWaitForCount(env, s, "dropped collection destination untouched", dropTable+"_dst", "_id,doc", 1)
+	EnvWaitForCount(env, s, "renamed collection destination untouched", renameTable+"_dst", "_id,doc", 1)
+
+	env.Cancel(t.Context())
+	RequireEnvCanceled(t, env)
+}
+
 func (s MongoClickhouseSuite) Test_Document_With_Dots_In_Keys() {
 	t := s.T()
 


### PR DESCRIPTION
Add an user facing alert when `drop` and `rename` events are detected in MongoDB CDC.

Closes: https://linear.app/clickhouse/issue/DBI-955 