### PR TITLE
Exclude unlogged tables from CDC mirror selection

### DIFF
--- a/flow/connectors/postgres/schema.go
+++ b/flow/connectors/postgres/schema.go
@@ -61,7 +61,8 @@ func (c *PostgresConnector) GetTablesInSchema(
 		t.relname,
 		(con.contype = 'p' OR t.relreplident in ('i', 'f')) AS can_mirror,
 		pg_size_pretty(pg_total_relation_size(t.oid))::text AS table_size,
-		(t.relreplident = 'f') AS is_replica_identity_full
+		(t.relreplident = 'f') AS is_replica_identity_full,
+		(t.relpersistence = 'u') AS is_unlogged
 	FROM pg_class t
 	LEFT JOIN pg_namespace n ON t.relnamespace = n.oid
 	LEFT JOIN pg_constraint con ON con.conrelid = t.oid
@@ -78,20 +79,24 @@ func (c *PostgresConnector) GetTablesInSchema(
 		var hasPkeyOrReplica pgtype.Bool
 		var tableSize pgtype.Text
 		var isReplicaIdentityFull pgtype.Bool
-		if err := rows.Scan(&table, &hasPkeyOrReplica, &tableSize, &isReplicaIdentityFull); err != nil {
+		var isUnlogged bool
+		if err := rows.Scan(&table, &hasPkeyOrReplica, &tableSize, &isReplicaIdentityFull, &isUnlogged); err != nil {
 			return nil, err
 		}
 		var sizeOfTable string
 		if tableSize.Valid {
 			sizeOfTable = tableSize.String
 		}
-		canMirror := !cdcEnabled || (hasPkeyOrReplica.Valid && hasPkeyOrReplica.Bool)
+		hasPrimaryKeyOrReplicaIdentity := hasPkeyOrReplica.Valid && hasPkeyOrReplica.Bool
+		canMirror := !cdcEnabled || (hasPrimaryKeyOrReplicaIdentity && !isUnlogged)
 
 		return &protos.TableResponse{
-			TableName:             table.String,
-			CanMirror:             canMirror,
-			TableSize:             sizeOfTable,
-			IsReplicaIdentityFull: isReplicaIdentityFull.Bool,
+			TableName:                      table.String,
+			CanMirror:                      canMirror,
+			TableSize:                      sizeOfTable,
+			IsReplicaIdentityFull:          isReplicaIdentityFull.Bool,
+			IsUnlogged:                     isUnlogged,
+			HasPrimaryKeyOrReplicaIdentity: hasPrimaryKeyOrReplicaIdentity,
 		}, nil
 	})
 	if err != nil {

--- a/flow/e2e/api_test.go
+++ b/flow/e2e/api_test.go
@@ -1189,6 +1189,42 @@ func (s APITestSuite) TestGetTablesExcludeViews() {
 	require.NotContains(s.t, tableNames, viewName, "view should not be in the list")
 }
 
+func (s APITestSuite) TestGetTablesUnloggedNotMirrorable() {
+	if _, ok := s.source.(*PostgresSource); !ok {
+		s.t.Skip("unlogged tables are a postgres concept")
+	}
+
+	tableName := "test_unlogged_table"
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf("CREATE UNLOGGED TABLE %s(id int primary key, val text)", AttachSchema(s, tableName))))
+
+	peer := s.source.GeneratePeer(s.t)
+
+	findTable := func(cdcEnabled bool) *protos.TableResponse {
+		resp, err := s.GetTablesInSchema(s.t.Context(), &protos.SchemaTablesRequest{
+			PeerName:   peer.Name,
+			SchemaName: Schema(s),
+			CdcEnabled: cdcEnabled,
+		})
+		require.NoError(s.t, err)
+		for _, table := range resp.Tables {
+			if table.TableName == tableName {
+				return table
+			}
+		}
+		require.Fail(s.t, "unlogged table should be listed")
+		return nil
+	}
+
+	cdcTable := findTable(true)
+	require.True(s.t, cdcTable.IsUnlogged, "table should be reported as unlogged")
+	require.True(s.t, cdcTable.HasPrimaryKeyOrReplicaIdentity, "table has a primary key")
+	require.False(s.t, cdcTable.CanMirror, "unlogged table cannot be mirrored via cdc")
+
+	initialLoadTable := findTable(false)
+	require.True(s.t, initialLoadTable.CanMirror, "unlogged table can be mirrored via initial load")
+}
+
 func (s APITestSuite) TestScripts() {
 	if _, ok := s.source.(*PostgresSource); !ok {
 		s.t.Skip("only run with pg so only one test against scripts runs")

--- a/protos/route.proto
+++ b/protos/route.proto
@@ -193,6 +193,8 @@ message TableResponse {
   bool can_mirror = 2;
   string table_size = 3;
   bool is_replica_identity_full = 4;
+  bool is_unlogged = 5;
+  bool has_primary_key_or_replica_identity = 6;
 }
 
 message AllTablesResponse { repeated string tables = 1; }

--- a/ui/app/dto/MirrorsDTO.ts
+++ b/ui/app/dto/MirrorsDTO.ts
@@ -24,4 +24,6 @@ export type TableMapRow = Omit<
   tableSize: string;
   editingDisabled: boolean;
   isReplicaIdentityFull: boolean;
+  isUnlogged: boolean;
+  hasPrimaryKeyOrReplicaIdentity: boolean;
 };

--- a/ui/app/mirrors/create/cdc/schemabox.tsx
+++ b/ui/app/mirrors/create/cdc/schemabox.tsx
@@ -45,6 +45,19 @@ import {
   tableBoxStyle,
   tooltipStyle,
 } from './styles';
+function cannotMirrorReason(row: TableMapRow): string {
+  const reasons: string[] = [];
+  if (!row.hasPrimaryKeyOrReplicaIdentity) {
+    reasons.push('It needs a primary key or replica identity.');
+  }
+  if (row.isUnlogged) {
+    reasons.push(
+      'It is unlogged, which CDC cannot replicate. Run ALTER TABLE ... SET LOGGED.'
+    );
+  }
+  return `This table cannot be mirrored. ${reasons.join(' ')}`;
+}
+
 interface SchemaBoxProps {
   sourcePeer: string;
   schema: string;
@@ -361,9 +374,7 @@ export default function SchemaBox({
                               ...tooltipStyle(styledTheme),
                               display: row.canMirror ? 'none' : 'block',
                             }}
-                            content={
-                              'This table must have a primary key or replica identity to be mirrored.'
-                            }
+                            content={cannotMirrorReason(row)}
                           >
                             <Label
                               as='label'

--- a/ui/app/mirrors/create/handlers.ts
+++ b/ui/app/mirrors/create/handlers.ts
@@ -459,6 +459,9 @@ export async function fetchTables(
         bigqueryCdcEventsFunction:
           BigqueryCdcEventsFunction.BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
         isReplicaIdentityFull: tableObject.isReplicaIdentityFull,
+        isUnlogged: tableObject.isUnlogged,
+        hasPrimaryKeyOrReplicaIdentity:
+          tableObject.hasPrimaryKeyOrReplicaIdentity,
       });
     }
   }


### PR DESCRIPTION
Unlogged tables aren't WAL-logged, so CDC can't replicate them. GetTablesInSchema now reports is_unlogged and marks them non-mirrorable when cdc is enabled; the UI greys them out with reason.