### PR TITLE
classify mongo connector KeyNotFound error

### DIFF
--- a/flow/alerting/classifier.go
+++ b/flow/alerting/classifier.go
@@ -1004,6 +1004,8 @@ func GetErrorClass(ctx context.Context, err error) (ErrorClass, ErrorInfo) {
 			return ErrorIgnoreConnTemporary, mongoErrorInfo
 		case 202: // NetworkInterfaceExceededTimeLimit
 			return ErrorNotifyConnectivity, mongoErrorInfo
+		case 211: // KeyNotFound
+			return ErrorRetryRecoverable, mongoErrorInfo
 		case 136, // CappedPositionLost
 			286: // ChangeStreamHistoryLost
 			return ErrorNotifyChangeStreamHistoryLost, mongoErrorInfo

--- a/flow/alerting/classifier_test.go
+++ b/flow/alerting/classifier_test.go
@@ -1280,6 +1280,19 @@ func TestMongoPoolErrorShouldBeRecoverable(t *testing.T) {
 	}, errInfo, "Unexpected error info")
 }
 
+func TestMongoKeyNotFoundShouldBeRecoverable(t *testing.T) {
+	err := mongo.CommandError{
+		Code:    211,
+		Message: "(KeyNotFound) No keys found for HMAC that is valid for time",
+	}
+	errorClass, errInfo := GetErrorClass(t.Context(), fmt.Errorf("failed to create change stream: %w", err))
+	assert.Equal(t, ErrorRetryRecoverable, errorClass)
+	assert.Equal(t, ErrorInfo{
+		Source: ErrorSourceMongoDB,
+		Code:   "211",
+	}, errInfo)
+}
+
 func TestMongoCursorErrors(t *testing.T) {
 	err := mongo.CommandError{
 		Code:    6,


### PR DESCRIPTION
Fixes: DBI-1108

Observed error message:

> failed to create change stream: connection() error occurred during connection handshake: auth error: unable to authenticate using mechanism "SCRAM-SHA-256": (KeyNotFound) No keys found for HMAC that is valid for time: { ts: Timestamp(xxxxxxxxxx, xxx) } with id: xxxxxxxxxx

Happens right after "(ShutdownInProgress) The server is in quiesce mode and will shut down" error. Transient and automatically recovers