### PR TITLE
bq: rename replication mode to method

### DIFF
--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -163,7 +163,7 @@ func (c *BigQueryConnector) PullTableRecords(
 	}
 
 	var bytesProcessed int64
-	if cfg.GetBigqueryCdcConfig().ReplicationMethod == protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY {
+	if cfg.GetBigqueryCdcConfig().GetReplicationMethod() == protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_QUERY {
 		bytesProcessed, err = c.pullTableQuery(ctx, tm.QueryCdcWatermarkColumn, req.SourceTableIdentifier,
 			req.NameAndExclude, start, upper, addRecord)
 	} else if tm.BigqueryCdcEventsFunction == protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES {

--- a/flow/connectors/bigquery/cdc.go
+++ b/flow/connectors/bigquery/cdc.go
@@ -163,7 +163,7 @@ func (c *BigQueryConnector) PullTableRecords(
 	}
 
 	var bytesProcessed int64
-	if cfg.GetBigqueryCdcConfig().ReplicationMode == protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY {
+	if cfg.GetBigqueryCdcConfig().ReplicationMethod == protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY {
 		bytesProcessed, err = c.pullTableQuery(ctx, tm.QueryCdcWatermarkColumn, req.SourceTableIdentifier,
 			req.NameAndExclude, start, upper, addRecord)
 	} else if tm.BigqueryCdcEventsFunction == protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES {

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -590,7 +590,7 @@ func (c *BigQueryConnector) SetupReplication(
 	}
 
 	var checkpointByTable map[string]time.Time
-	if cfg.GetBigqueryCdcConfig().GetReplicationMode() == protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY {
+	if cfg.GetBigqueryCdcConfig().GetReplicationMethod() == protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_QUERY {
 		checkpointByTable, err = c.setupQueryModeReplication(ctx, req, cfg)
 	} else {
 		checkpointByTable, err = c.setupEventsModeReplication(ctx, req, cfg)

--- a/flow/connectors/bigquery/qrep_object_pull.go
+++ b/flow/connectors/bigquery/qrep_object_pull.go
@@ -465,7 +465,7 @@ func (c *BigQueryConnector) bigQueryExportQueryStatement(
 // buildBigQueryExportSQL builds the EXPORT DATA SQL string. With watermarkColumn
 // empty, tables are read consistently as of bound via FOR SYSTEM_TIME AS OF
 // (EVENTS mode's shared BigQuery-clock snapshot). With watermarkColumn set
-// (BIGQUERY_REPLICATION_MODE_QUERY), tables are instead filtered to
+// (BIGQUERY_REPLICATION_METHOD_QUERY), tables are instead filtered to
 // watermarkColumn <= bound, matching that table's own watermark progress.
 func buildBigQueryExportSQL(
 	dsTable datasetTable,

--- a/flow/connectors/bigquery/source.go
+++ b/flow/connectors/bigquery/source.go
@@ -23,13 +23,13 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 		SnapshotStagingPath: cfg.SnapshotStagingPath,
 	}
 	if !snapshotOnly {
-		switch cfg.GetBigqueryCdcConfig().GetReplicationMode() {
-		case protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY:
+		switch cfg.GetBigqueryCdcConfig().GetReplicationMethod() {
+		case protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_QUERY:
 			sourceConfig.ReplicationMode = bqvalidate.ReplicationModeQuery
-		case protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS:
+		case protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS:
 			sourceConfig.ReplicationMode = bqvalidate.ReplicationModeEvents
 		default:
-			return fmt.Errorf("invalid replication mode: %v", cfg.GetBigqueryCdcConfig().GetReplicationMode())
+			return fmt.Errorf("invalid replication mode: %v", cfg.GetBigqueryCdcConfig().GetReplicationMethod())
 		}
 	}
 

--- a/flow/e2e/bigquery_cdc_test.go
+++ b/flow/e2e/bigquery_cdc_test.go
@@ -272,7 +272,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Appends_Insert_Only() {
 	RequireEnvCanceled(t, env)
 }
 
-// Test_BigQuery_CDC_Query_Mode covers BIGQUERY_REPLICATION_MODE_QUERY: a plain
+// Test_BigQuery_CDC_Query_Mode covers BIGQUERY_REPLICATION_METHOD_QUERY: a plain
 // SELECT ... WHERE watermark_column > lower AND watermark_column <= upper scan,
 // rather than APPENDS()/CHANGES(). The initial snapshot is bounded by the
 // watermark column's max value at setup time instead of FOR SYSTEM_TIME AS OF.

--- a/flow/e2e/bigquery_cdc_test.go
+++ b/flow/e2e/bigquery_cdc_test.go
@@ -145,7 +145,7 @@ func quoteBigQueryTableFQN(fqn string) string {
 
 type bqCdcFlowParams struct {
 	eventsFunction  protos.BigqueryCdcEventsFunction
-	replicationMode protos.BigQueryReplicationMode
+	replicationMode protos.BigQueryReplicationMethod
 	watermarkColumn string
 }
 
@@ -171,7 +171,7 @@ func bqCdcFlowConnectionConfig(
 	flowConnConfig.SnapshotStagingPath = bigQueryTestStagingPath(s, srcTable)
 	flowConnConfig.SourceConnectorConfig = &protos.FlowConnectionConfigs_BigqueryCdcConfig{
 		BigqueryCdcConfig: &protos.BigqueryCdcConfig{
-			ReplicationMode: params.replicationMode,
+			ReplicationMethod: params.replicationMode,
 		},
 	}
 	flowConnConfig.IdleTimeoutSeconds = 5
@@ -196,7 +196,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Snapshot_To_CDC_Handoff() {
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
 		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 
 	tc := NewTemporalClient(t)
@@ -236,7 +236,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Appends_Insert_Only() {
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
 		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 
 	tc := NewTemporalClient(t)
@@ -290,7 +290,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Query_Mode() {
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
 		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY,
+		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_QUERY,
 		watermarkColumn: "updated_at",
 	})
 
@@ -333,7 +333,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_All_Types() {
 	flowConnConfig := bqCdcFlowConnectionConfig(
 		s, srcTable, dstTable, bqCdcFlowParams{
 			eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-			replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+			replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 		},
 	)
 	flowConnConfig.DoInitialSnapshot = false
@@ -436,7 +436,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Changes_Insert_Update_Delete(
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
 		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES,
-		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 	flowConnConfig.Env = map[string]string{"PEERDB_BIGQUERY_CDC_SAFETY_LAG_SECONDS": "5"}
 
@@ -496,7 +496,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Restart_Mid_Window_Resume() {
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
 		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 
 	tc := NewTemporalClient(t)
@@ -588,7 +588,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Isolated_Table_Failure_Does_N
 	appends := protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS
 	flowConnConfig := bqCdcFlowConnectionConfig(s, failedSrc, failedDst, bqCdcFlowParams{
 		eventsFunction:  appends,
-		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 	flowConnConfig.TableMappings = append(flowConnConfig.TableMappings, &protos.TableMapping{
 		SourceTableIdentifier:      fmt.Sprintf("%s.%s", source.config.DatasetId, healthySrc),
@@ -665,7 +665,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Isolated_Table_Backpressure_D
 	appends := protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS
 	flowConnConfig := bqCdcFlowConnectionConfig(s, stuckSrc, stuckDst, bqCdcFlowParams{
 		eventsFunction:  appends,
-		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 	flowConnConfig.TableMappings = append(flowConnConfig.TableMappings, &protos.TableMapping{
 		SourceTableIdentifier:      fmt.Sprintf("%s.%s", source.config.DatasetId, healthySrc),
@@ -763,7 +763,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Isolated_Table_Removal_Mid_CD
 	appends := protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS
 	flowConnConfig := bqCdcFlowConnectionConfig(s, retainedSrc, retainedDst, bqCdcFlowParams{
 		eventsFunction:  appends,
-		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 	removedMapping := &protos.TableMapping{
 		SourceTableIdentifier:      removedSourceID,
@@ -878,7 +878,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Replication_State_Handler() {
 	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "initial-1"}})
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
-		replicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
 	})
 

--- a/flow/e2e/bigquery_source_test.go
+++ b/flow/e2e/bigquery_source_test.go
@@ -170,7 +170,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_Source_CDC_Validation() {
 
 	eventsConfig := &protos.FlowConnectionConfigsCore_BigqueryCdcConfig{
 		BigqueryCdcConfig: &protos.BigqueryCdcConfig{
-			ReplicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+			ReplicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 		},
 	}
 	flowConfig := &protos.FlowConnectionConfigsCore{
@@ -244,7 +244,7 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_Source_CDC_Validation() {
 	t.Run("QUERY replication mode", func(t *testing.T) {
 		flowConfig.SourceConnectorConfig = &protos.FlowConnectionConfigsCore_BigqueryCdcConfig{
 			BigqueryCdcConfig: &protos.BigqueryCdcConfig{
-				ReplicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_QUERY,
+				ReplicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_QUERY,
 			},
 		}
 		defer func() { flowConfig.SourceConnectorConfig = eventsConfig }()

--- a/flow/proto_conversions/flow_config_converter_test.go
+++ b/flow/proto_conversions/flow_config_converter_test.go
@@ -86,7 +86,7 @@ func TestFlowConnectionConfigsOneof(t *testing.T) {
 		FlowJobName: "oneof_test",
 		SourceConnectorConfig: &protos.FlowConnectionConfigs_BigqueryCdcConfig{
 			BigqueryCdcConfig: &protos.BigqueryCdcConfig{
-				ReplicationMode: protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS,
+				ReplicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 			},
 		},
 	}
@@ -94,13 +94,13 @@ func TestFlowConnectionConfigsOneof(t *testing.T) {
 	core := FlowConnectionConfigsToCore(api)
 	coreVariant, ok := core.SourceConnectorConfig.(*protos.FlowConnectionConfigsCore_BigqueryCdcConfig)
 	require.Truef(t, ok, "expected *FlowConnectionConfigsCore_BigqueryCdcConfig, got %T", core.SourceConnectorConfig)
-	require.Equal(t, protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS, coreVariant.BigqueryCdcConfig.ReplicationMode)
+	require.Equal(t, protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS, coreVariant.BigqueryCdcConfig.ReplicationMethod)
 
 	roundTripped := &protos.FlowConnectionConfigs{}
 	copyFieldsByNumber(core.ProtoReflect(), roundTripped.ProtoReflect())
 	apiVariant, ok := roundTripped.SourceConnectorConfig.(*protos.FlowConnectionConfigs_BigqueryCdcConfig)
 	require.Truef(t, ok, "expected *FlowConnectionConfigs_BigqueryCdcConfig, got %T", roundTripped.SourceConnectorConfig)
-	require.Equal(t, protos.BigQueryReplicationMode_BIGQUERY_REPLICATION_MODE_EVENTS, apiVariant.BigqueryCdcConfig.ReplicationMode)
+	require.Equal(t, protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS, apiVariant.BigqueryCdcConfig.ReplicationMethod)
 
 	// mirrors with no connector-specific config leave the oneof unset
 	unset := FlowConnectionConfigsToCore(&protos.FlowConnectionConfigs{FlowJobName: "no_oneof_test"})

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -32,7 +32,7 @@ message ColumnSetting {
 }
 
 // BigqueryCdcEventsFunction selects which BigQuery table-valued function backs
-// EVENTS-mode CDC polling (see BigQueryReplicationMode) for one table:
+// EVENTS-mode CDC polling (see BigQueryReplicationMethod) for one table:
 // APPENDS() (insert-only) or CHANGES() (insert/update/delete).
 enum BigqueryCdcEventsFunction {
   BIGQUERY_CDC_EVENTS_FUNCTION_UNSPECIFIED = 0;
@@ -50,11 +50,11 @@ message TableMapping {
   string sharding_key = 7;
   string policy_name = 8;
   string partition_by_expr = 9;
-  // Only meaningful when the mirror's BigqueryCdcConfig.replication_mode is
-  // BIGQUERY_REPLICATION_MODE_EVENTS.
+  // Only meaningful when the mirror's BigqueryCdcConfig.replication_method is
+  // BIGQUERY_REPLICATION_METHOD_EVENTS.
   BigqueryCdcEventsFunction bigquery_cdc_events_function = 10;
   // the column to use as a cursor for query-based CDC replication
-  // required if replication_mode is BIGQUERY_REPLICATION_MODE_QUERY
+  // required if replication_method is BIGQUERY_REPLICATION_METHOD_QUERY
   string query_cdc_watermark_column = 11;
 }
 
@@ -64,16 +64,16 @@ message SetupInput {
   string peer_name = 3;
 }
 
-enum BigQueryReplicationMode {
-  BIGQUERY_REPLICATION_MODE_UNSPECIFIED = 0;
+enum BigQueryReplicationMethod {
+  BIGQUERY_REPLICATION_METHOD_UNSPECIFIED = 0;
   // table-valued function (APPENDS()/CHANGES()) based CDC polling.
-  BIGQUERY_REPLICATION_MODE_EVENTS = 1;
+  BIGQUERY_REPLICATION_METHOD_EVENTS = 1;
   // query-based CDC polling. (e.g. SELECT * FROM table WHERE watermark_column > last_watermark)
-  BIGQUERY_REPLICATION_MODE_QUERY = 2;
+  BIGQUERY_REPLICATION_METHOD_QUERY = 2;
 }
 
 message BigqueryCdcConfig {
-  BigQueryReplicationMode replication_mode = 1;
+  BigQueryReplicationMethod replication_method = 1;
 }
 
 // FlowConnectionConfigs is for external use by the API, maintaining backwards compatibility


### PR DESCRIPTION
renama bq replication mode to replication method to avoid confusion with mirror replication mode.
it's a breaking change, but should be fine to deploy since we don't have cdc BQ pipes in prod yet