### PR TITLE
bq: rename mode to method in validation.go

### DIFF
--- a/flow/connectors/bigquery/source.go
+++ b/flow/connectors/bigquery/source.go
@@ -25,9 +25,9 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 	if !snapshotOnly {
 		switch cfg.GetBigqueryCdcConfig().GetReplicationMethod() {
 		case protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_QUERY:
-			sourceConfig.ReplicationMode = bqvalidate.ReplicationModeQuery
+			sourceConfig.ReplicationMode = bqvalidate.ReplicationMethodQuery
 		case protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS:
-			sourceConfig.ReplicationMode = bqvalidate.ReplicationModeEvents
+			sourceConfig.ReplicationMode = bqvalidate.ReplicationMethodEvents
 		default:
 			return fmt.Errorf("invalid replication mode: %v", cfg.GetBigqueryCdcConfig().GetReplicationMethod())
 		}
@@ -43,7 +43,7 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 			RequiresOrderingKey: tableMapping.Engine == protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE ||
 				tableMapping.Engine == protos.TableEngine_CH_ENGINE_REPLICATED_REPLACING_MERGE_TREE,
 		}
-		if sourceConfig.ReplicationMode == bqvalidate.ReplicationModeEvents {
+		if sourceConfig.ReplicationMode == bqvalidate.ReplicationMethodEvents {
 			switch tableMapping.GetBigqueryCdcEventsFunction() {
 			case protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS:
 				t.CDCEventsFunction = bqvalidate.CDCEventsFunctionAppends

--- a/flow/connectors/bigquery/source.go
+++ b/flow/connectors/bigquery/source.go
@@ -25,9 +25,9 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 	if !snapshotOnly {
 		switch cfg.GetBigqueryCdcConfig().GetReplicationMethod() {
 		case protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_QUERY:
-			sourceConfig.ReplicationMode = bqvalidate.ReplicationMethodQuery
+			sourceConfig.ReplicationMethod = bqvalidate.ReplicationMethodQuery
 		case protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS:
-			sourceConfig.ReplicationMode = bqvalidate.ReplicationMethodEvents
+			sourceConfig.ReplicationMethod = bqvalidate.ReplicationMethodEvents
 		default:
 			return fmt.Errorf("invalid replication mode: %v", cfg.GetBigqueryCdcConfig().GetReplicationMethod())
 		}
@@ -43,7 +43,7 @@ func (c *BigQueryConnector) ValidateMirrorSource(ctx context.Context, cfg *proto
 			RequiresOrderingKey: tableMapping.Engine == protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE ||
 				tableMapping.Engine == protos.TableEngine_CH_ENGINE_REPLICATED_REPLACING_MERGE_TREE,
 		}
-		if sourceConfig.ReplicationMode == bqvalidate.ReplicationMethodEvents {
+		if sourceConfig.ReplicationMethod == bqvalidate.ReplicationMethodEvents {
 			switch tableMapping.GetBigqueryCdcEventsFunction() {
 			case protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS:
 				t.CDCEventsFunction = bqvalidate.CDCEventsFunctionAppends

--- a/flow/e2e/bigquery_cdc_test.go
+++ b/flow/e2e/bigquery_cdc_test.go
@@ -144,9 +144,9 @@ func quoteBigQueryTableFQN(fqn string) string {
 }
 
 type bqCdcFlowParams struct {
-	eventsFunction  protos.BigqueryCdcEventsFunction
-	replicationMode protos.BigQueryReplicationMethod
-	watermarkColumn string
+	eventsFunction    protos.BigqueryCdcEventsFunction
+	replicationMethod protos.BigQueryReplicationMethod
+	watermarkColumn   string
 }
 
 func bqCdcFlowConnectionConfig(
@@ -171,7 +171,7 @@ func bqCdcFlowConnectionConfig(
 	flowConnConfig.SnapshotStagingPath = bigQueryTestStagingPath(s, srcTable)
 	flowConnConfig.SourceConnectorConfig = &protos.FlowConnectionConfigs_BigqueryCdcConfig{
 		BigqueryCdcConfig: &protos.BigqueryCdcConfig{
-			ReplicationMethod: params.replicationMode,
+			ReplicationMethod: params.replicationMethod,
 		},
 	}
 	flowConnConfig.IdleTimeoutSeconds = 5
@@ -195,8 +195,8 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Snapshot_To_CDC_Handoff() {
 	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "pre-snapshot-1"}, {ID: 2, Val: "pre-snapshot-2"}})
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
-		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
+		eventsFunction:    protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 
 	tc := NewTemporalClient(t)
@@ -235,8 +235,8 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Appends_Insert_Only() {
 	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "initial-1"}})
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
-		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
+		eventsFunction:    protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 
 	tc := NewTemporalClient(t)
@@ -289,9 +289,9 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Query_Mode() {
 	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "pre-snapshot-1"}})
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
-		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_QUERY,
-		watermarkColumn: "updated_at",
+		eventsFunction:    protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_QUERY,
+		watermarkColumn:   "updated_at",
 	})
 
 	tc := NewTemporalClient(t)
@@ -332,8 +332,8 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_All_Types() {
 
 	flowConnConfig := bqCdcFlowConnectionConfig(
 		s, srcTable, dstTable, bqCdcFlowParams{
-			eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-			replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
+			eventsFunction:    protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+			replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 		},
 	)
 	flowConnConfig.DoInitialSnapshot = false
@@ -435,8 +435,8 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Changes_Insert_Update_Delete(
 	})
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
-		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES,
-		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
+		eventsFunction:    protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_CHANGES,
+		replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 	flowConnConfig.Env = map[string]string{"PEERDB_BIGQUERY_CDC_SAFETY_LAG_SECONDS": "5"}
 
@@ -495,8 +495,8 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Restart_Mid_Window_Resume() {
 	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "initial-1"}})
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
-		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
-		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
+		eventsFunction:    protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 
 	tc := NewTemporalClient(t)
@@ -587,8 +587,8 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Isolated_Table_Failure_Does_N
 
 	appends := protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS
 	flowConnConfig := bqCdcFlowConnectionConfig(s, failedSrc, failedDst, bqCdcFlowParams{
-		eventsFunction:  appends,
-		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
+		eventsFunction:    appends,
+		replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 	flowConnConfig.TableMappings = append(flowConnConfig.TableMappings, &protos.TableMapping{
 		SourceTableIdentifier:      fmt.Sprintf("%s.%s", source.config.DatasetId, healthySrc),
@@ -664,8 +664,8 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Isolated_Table_Backpressure_D
 
 	appends := protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS
 	flowConnConfig := bqCdcFlowConnectionConfig(s, stuckSrc, stuckDst, bqCdcFlowParams{
-		eventsFunction:  appends,
-		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
+		eventsFunction:    appends,
+		replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 	flowConnConfig.TableMappings = append(flowConnConfig.TableMappings, &protos.TableMapping{
 		SourceTableIdentifier:      fmt.Sprintf("%s.%s", source.config.DatasetId, healthySrc),
@@ -762,8 +762,8 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Isolated_Table_Removal_Mid_CD
 
 	appends := protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS
 	flowConnConfig := bqCdcFlowConnectionConfig(s, retainedSrc, retainedDst, bqCdcFlowParams{
-		eventsFunction:  appends,
-		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
+		eventsFunction:    appends,
+		replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
 	})
 	removedMapping := &protos.TableMapping{
 		SourceTableIdentifier:      removedSourceID,
@@ -878,8 +878,8 @@ func (s BigQueryClickhouseSuite) Test_BigQuery_CDC_Replication_State_Handler() {
 	bqInsertRows(ctx, t, source, tableFQN, []bqCdcRow{{ID: 1, Val: "initial-1"}})
 
 	flowConnConfig := bqCdcFlowConnectionConfig(s, srcTable, dstTable, bqCdcFlowParams{
-		replicationMode: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
-		eventsFunction:  protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
+		replicationMethod: protos.BigQueryReplicationMethod_BIGQUERY_REPLICATION_METHOD_EVENTS,
+		eventsFunction:    protos.BigqueryCdcEventsFunction_BIGQUERY_CDC_EVENTS_FUNCTION_APPENDS,
 	})
 
 	tc := NewTemporalClient(t)

--- a/flow/pkg/bigquery/validation.go
+++ b/flow/pkg/bigquery/validation.go
@@ -151,11 +151,11 @@ func GetTables(
 	return result, nil
 }
 
-// ReplicationMode selects how CDC events are produced for a BigQuery source mirror.
-type ReplicationMode int
+// ReplicationMethod selects how CDC events are produced for a BigQuery source mirror.
+type ReplicationMethod int
 
 const (
-	ReplicationMethodUnspecified ReplicationMode = iota
+	ReplicationMethodUnspecified ReplicationMethod = iota
 	ReplicationMethodEvents
 	ReplicationMethodQuery
 )
@@ -202,7 +202,7 @@ type SourceConfig struct {
 	// DefaultDataset is used for table identifiers with no dataset qualifier.
 	DefaultDataset  string
 	Tables          []SourceTableConfig
-	ReplicationMode ReplicationMode
+	ReplicationMode ReplicationMethod
 	// HasSnapshot enables validation of snapshot staging access and export
 	// permissions using SnapshotStagingPath.
 	HasSnapshot         bool

--- a/flow/pkg/bigquery/validation.go
+++ b/flow/pkg/bigquery/validation.go
@@ -173,7 +173,7 @@ const (
 type SourceTableConfig struct {
 	// SourceTableIdentifier is "table", "dataset.table", or "project.dataset.table".
 	SourceTableIdentifier string
-	// WatermarkColumn is required when the mirror's ReplicationMode is ReplicationModeQuery.
+	// WatermarkColumn is required when the mirror's ReplicationMethod is ReplicationMethodQuery.
 	WatermarkColumn string
 	// Include, if non-empty, restricts replication to these column names
 	// ("selected_columns"). Mutually exclusive with Exclude.
@@ -200,9 +200,9 @@ type SourceConfig struct {
 	StorageClient *storage.Client
 	ProjectID     string
 	// DefaultDataset is used for table identifiers with no dataset qualifier.
-	DefaultDataset  string
-	Tables          []SourceTableConfig
-	ReplicationMode ReplicationMethod
+	DefaultDataset    string
+	Tables            []SourceTableConfig
+	ReplicationMethod ReplicationMethod
 	// HasSnapshot enables validation of snapshot staging access and export
 	// permissions using SnapshotStagingPath.
 	HasSnapshot         bool
@@ -456,7 +456,7 @@ func validateSourceCDC(ctx context.Context, cfg SourceConfig, tablesByKey map[Da
 	for i, t := range cfg.Tables {
 		key := validateTables[i]
 
-		switch cfg.ReplicationMode {
+		switch cfg.ReplicationMethod {
 		case ReplicationMethodQuery:
 			if t.WatermarkColumn == "" {
 				return fmt.Errorf("table %q has no watermark_column configured; QUERY replication mode requires "+

--- a/flow/pkg/bigquery/validation.go
+++ b/flow/pkg/bigquery/validation.go
@@ -155,9 +155,9 @@ func GetTables(
 type ReplicationMode int
 
 const (
-	ReplicationModeUnspecified ReplicationMode = iota
-	ReplicationModeEvents
-	ReplicationModeQuery
+	ReplicationMethodUnspecified ReplicationMode = iota
+	ReplicationMethodEvents
+	ReplicationMethodQuery
 )
 
 // CDCEventsFunction selects which BigQuery CDC function backs a table's events.
@@ -457,7 +457,7 @@ func validateSourceCDC(ctx context.Context, cfg SourceConfig, tablesByKey map[Da
 		key := validateTables[i]
 
 		switch cfg.ReplicationMode {
-		case ReplicationModeQuery:
+		case ReplicationMethodQuery:
 			if t.WatermarkColumn == "" {
 				return fmt.Errorf("table %q has no watermark_column configured; QUERY replication mode requires "+
 					"one TIMESTAMP column per table to incrementally scan", key)
@@ -475,7 +475,7 @@ func validateSourceCDC(ctx context.Context, cfg SourceConfig, tablesByKey map[Da
 				return fmt.Errorf("watermark column %q on table %q must be TIMESTAMP, got %s",
 					t.WatermarkColumn, key, column.Type)
 			}
-		case ReplicationModeEvents:
+		case ReplicationMethodEvents:
 			switch t.CDCEventsFunction {
 			case CDCEventsFunctionChanges:
 				if !tablesByKey[key].HasPrimaryKey() && !t.HasOrderingKey {


### PR DESCRIPTION
rename remaining bq replication mode to method occurances