### PR TITLE
fix(mongo): move dynconf read for parallel workers to conn setup

### DIFF
--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -462,12 +462,8 @@ func (c *MongoConnector) PullRecords(
 			slog.Int("channelLen", req.RecordStream.ChannelLen()),
 			slog.Float64("elapsedMinutes", time.Since(pullStart).Minutes()))
 	}()
-	numParallelDecodeWorkers, err := internal.PeerDBMongoDBNumParallelDecodeThreads(ctx, req.Env)
-	if err != nil {
-		return err
-	}
 	workerPool := concurrency.PullRecordsWorkerPool[encodedMongoEvent, []model.Record[model.RecordItems], string]{
-		Concurrency: int(numParallelDecodeWorkers),
+		Concurrency: int(c.numDecodeWorkers),
 		ChunkSize:   pullRecordsItemsChunkSize,
 		WorkerFunc: func(events []encodedMongoEvent) ([]model.Record[model.RecordItems], error) {
 			return c.decodeEvent(events, req)
@@ -811,6 +807,11 @@ func (c *MongoConnector) SetupReplConn(ctx context.Context, env map[string]strin
 	if len(c.excludedOps) > 0 {
 		c.logger.Info("excluding operation types from replication", slog.Any("operationTypes", c.excludedOps))
 	}
+	numParallelDecodeWorkers, err := internal.PeerDBMongoDBNumParallelDecodeThreads(ctx, env)
+	if err != nil {
+		return err
+	}
+	c.numDecodeWorkers = int(numParallelDecodeWorkers)
 	return nil
 }
 

--- a/flow/connectors/mongo/cdc.go
+++ b/flow/connectors/mongo/cdc.go
@@ -463,7 +463,7 @@ func (c *MongoConnector) PullRecords(
 			slog.Float64("elapsedMinutes", time.Since(pullStart).Minutes()))
 	}()
 	workerPool := concurrency.PullRecordsWorkerPool[encodedMongoEvent, []model.Record[model.RecordItems], string]{
-		Concurrency: int(c.numDecodeWorkers),
+		Concurrency: c.numDecodeWorkers,
 		ChunkSize:   pullRecordsItemsChunkSize,
 		WorkerFunc: func(events []encodedMongoEvent) ([]model.Record[model.RecordItems], error) {
 			return c.decodeEvent(events, req)

--- a/flow/connectors/mongo/mongo.go
+++ b/flow/connectors/mongo/mongo.go
@@ -71,6 +71,7 @@ type MongoConnector struct {
 	totalBytesRead       atomic.Int64
 	deltaBytesRead       atomic.Int64
 	clockOffset          time.Duration
+	numDecodeWorkers     int
 }
 
 func NewMongoConnector(ctx context.Context, config *protos.MongoConfig) (*MongoConnector, error) {

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -589,7 +589,7 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		Description:      "Number of parallel threads to use when decoding full BSON documents in MongoDB change events.",
 		DefaultValue:     "1",
 		ValueType:        protos.DynconfValueType_INT,
-		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_AFTER_RESUME,
 		TargetForSetting: protos.DynconfTarget_ALL,
 	},
 }


### PR DESCRIPTION
Previously, we read the numParallelDecodeWorkers dynamic conf setting on every single PullRecords. This change speeds this up by making it a one-time read in connection setup.