### PR TITLE
sync error should not wait for normalize to complete current normRequest

### DIFF
--- a/flow/activities/flowable.go
+++ b/flow/activities/flowable.go
@@ -460,9 +460,6 @@ func (a *FlowableActivity) syncFlowSharedStream(
 		return a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 	}
 
-	// syncDone is closed by SyncFlow to signal the normalize goroutine that no more batches
-	// are coming, whereas normDone is closed by the normalize goroutine upon exit.
-	syncDone := make(chan struct{})
 	normDone := make(chan struct{})
 	normRequests := concurrency.NewLastChan()
 	normResponses := concurrency.NewLastChan()
@@ -491,10 +488,11 @@ func (a *FlowableActivity) syncFlowSharedStream(
 	// Normalize is always 1 batch behind, allow 2 to still run in parallel with pull-sync
 	normBufferSize = max(normBufferSize, 2)
 
+	normCtx, cancelNormCtx := context.WithCancel(internal.WithOperationContext(ctx, protos.FlowOperation_FLOW_OPERATION_NORMALIZE))
+	defer cancelNormCtx()
 	go func() {
 		defer close(normDone)
-		normalizeCtx := internal.WithOperationContext(ctx, protos.FlowOperation_FLOW_OPERATION_NORMALIZE)
-		a.normalizeLoop(normalizeCtx, logger, config, syncDone, normRequests, normResponses, &normalizingBatchID, &normalizeWaiting)
+		a.normalizeLoop(normCtx, logger, config, normRequests, normResponses, &normalizingBatchID, &normalizeWaiting)
 	}()
 
 	var syncErr error
@@ -528,7 +526,7 @@ func (a *FlowableActivity) syncFlowSharedStream(
 	}
 
 	syncState.Store(new("cleanup"))
-	close(syncDone)
+	cancelNormCtx()
 	normRequests.Close()
 	normResponses.Close()
 	<-normDone

--- a/flow/activities/flowable_core.go
+++ b/flow/activities/flowable_core.go
@@ -792,7 +792,6 @@ func (a *FlowableActivity) normalizeLoop(
 	ctx context.Context,
 	logger log.Logger,
 	config *protos.FlowConnectionConfigsCore,
-	syncDone <-chan struct{},
 	normalizeRequests *concurrency.LastChan,
 	normalizeResponses *concurrency.LastChan,
 	normalizingBatchID *atomic.Int64,
@@ -815,9 +814,6 @@ func (a *FlowableActivity) normalizeLoop(
 				return
 			}
 			select {
-			case <-syncDone:
-				logger.Info("[normalize-loop] syncDone closed")
-				return
 			case <-ctx.Done():
 				logger.Info("[normalize-loop] context closed")
 				return
@@ -835,9 +831,6 @@ func (a *FlowableActivity) normalizeLoop(
 				_ = a.Alerter.LogFlowError(ctx, config.FlowJobName, err)
 				// update req to latest normalize request & retry
 				select {
-				case <-syncDone:
-					logger.Info("[normalize-loop] syncDone closed before retry")
-					return
 				case <-ctx.Done():
 					logger.Info("[normalize-loop] context closed before retry")
 					return

--- a/flow/e2e/clickhouse.go
+++ b/flow/e2e/clickhouse.go
@@ -408,6 +408,31 @@ func (s ClickHouseSuite) queryRawTable(conn clickhouse.Conn, table string, cols 
 	)
 }
 
+// CreateSlowInsertViaMV attaches a materialized view to tableName that makes every insert into it takes sleepSeconds
+func (s ClickHouseSuite) CreateSlowInsertViaMV(tableName string, sleepSeconds int) (func(), error) {
+	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	if err != nil {
+		return nil, err
+	}
+	mvName := fmt.Sprintf(`"%s_slow_insert_mv"`, tableName)
+	if err := ch.Exec(s.t.Context(), fmt.Sprintf(
+		`CREATE MATERIALIZED VIEW %s ENGINE = Null AS SELECT * FROM "%s"
+		WHERE 0 IN (SELECT number FROM numbers(%d) WHERE sleepEachRow(1) = 0 SETTINGS max_block_size = 1)`,
+		mvName, tableName, sleepSeconds)); err != nil {
+		ch.Close()
+		return nil, err
+	}
+	cleanup := func() {
+		defer ch.Close()
+		rows, err := ch.Query(s.t.Context(), fmt.Sprintf(
+			`KILL QUERY WHERE current_database = currentDatabase() AND query ILIKE 'INSERT INTO%%%s%%' SYNC`, tableName))
+		require.NoError(s.t, err)
+		rows.Close()
+		require.NoError(s.t, ch.Exec(s.t.Context(), "DROP VIEW IF EXISTS "+mvName))
+	}
+	return cleanup, nil
+}
+
 func SetupClickHouseSuite[TSource SuiteSource](
 	t *testing.T,
 	cluster bool,

--- a/flow/e2e/clickhouse_test.go
+++ b/flow/e2e/clickhouse_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	protojson "google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	connclickhouse "github.com/PeerDB-io/peerdb/flow/connectors/clickhouse"
 	connpostgres "github.com/PeerDB-io/peerdb/flow/connectors/postgres"
@@ -4072,4 +4073,62 @@ func (s ClickHouseSuite) Test_Offload_Partition_Ranges() {
 		`SELECT COUNT(*) FROM metadata_qrep_offloaded_partition_ranges WHERE parent_mirror_name = $1`,
 		flowConnConfig.FlowJobName).Scan(&remainingRanges))
 	require.Zero(s.t, remainingRanges)
+}
+
+func (s ClickHouseSuite) Test_Sync_Error_Cancels_InProgress_Normalize() {
+	if s.cluster {
+		s.t.Skip("slow materialized view helper is not cluster-aware")
+	}
+	const table = "test_sync_error_cancels_norm"
+	srcTable := s.attachSchemaSuffix(table)
+	require.NoError(s.t, s.source.Exec(s.t.Context(),
+		fmt.Sprintf(`CREATE TABLE %s (id INT PRIMARY KEY, val TEXT NOT NULL)`, srcTable)))
+
+	connectionGen := FlowConnectionGenerationConfig{
+		FlowJobName:      s.attachSuffix("sync_error_norm"),
+		TableNameMapping: map[string]string{srcTable: table},
+		Destination:      s.Peer().Name,
+	}
+	flowConnConfig := connectionGen.GenerateFlowConnectionConfigs(s)
+	flowConnConfig.MaxBatchSize = 1
+	flowConnConfig.IdleTimeoutSeconds = 1
+
+	tc := NewTemporalClient(s.t)
+	env := ExecutePeerflow(s.t, tc, flowConnConfig)
+	defer func() {
+		env.Cancel(s.t.Context())
+		RequireEnvCanceled(s.t, env)
+	}()
+	SetupCDCFlowStatusQuery(s.t, env, flowConnConfig)
+
+	cleanupSlowInsert, err := s.CreateSlowInsertViaMV(table, 600)
+	require.NoError(s.t, err)
+	defer cleanupSlowInsert()
+	EnvNoError(s.t, env, s.source.Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s VALUES (1, 'a')`, srcTable)))
+
+	ch, err := connclickhouse.Connect(s.t.Context(), nil, s.Peer().GetClickhouseConfig())
+	require.NoError(s.t, err)
+	defer ch.Close()
+	EnvWaitFor(s.t, env, time.Minute, "normalize insert to be running", func() bool {
+		var count uint64
+		err := ch.QueryRow(s.t.Context(), fmt.Sprintf(
+			`SELECT count() FROM system.processes WHERE current_database = currentDatabase() AND query ILIKE '%s'`,
+			"INSERT INTO%"+table+"%")).Scan(&count)
+		return err == nil && count > 0
+	})
+
+	// set an invalid s3 access key which will trigger a sync error
+	peer := s.Peer()
+	peer.GetClickhouseConfig().S3 = proto.CloneOf(peer.GetClickhouseConfig().S3)
+	peer.GetClickhouseConfig().S3.SecretAccessKey = proto.String("bad")
+	CreatePeer(s.t, peer)
+
+	lastErrorBefore := EnvGetWorkflowState(s.t, env).LastError
+	require.True(s.t, lastErrorBefore.IsZero())
+
+	EnvNoError(s.t, env, s.source.Exec(s.t.Context(), fmt.Sprintf(`INSERT INTO %s VALUES (2, 'b')`, srcTable)))
+
+	EnvWaitFor(s.t, env, 10*time.Second, "timed out waiting for SyncFlow to return an error", func() bool {
+		return EnvGetWorkflowState(s.t, env).LastError.After(lastErrorBefore)
+	})
 }


### PR DESCRIPTION
Previously we had two ways to terminate normalize goroutine which seems redundant:
- when syncDone channel is closed
- when context.Done channel is closed

And when we encountered a sync error, the old code closed `syncDone` channel without cancelling anything, and the normalizeLoop only checked `syncDone` after each loop iteration, meaning a heavily backlogged normalize can take a long time to complete `startNormalize`, thus appear to hang waiting for normalize goroutine to exit. 

Also, SyncDone actually wasn't adding much value because the only scenarios that sync loop exits were (1) on shutdown, which we already depend on context cancellation (2) on sync error and (3) if we hit the reconnectAfterBatches limit (which is disabled by default).  Otherwise sync loop runs indefinitely. 

With this fix, remove syncDone and just rely on context cancellation alone (this will allow clickhouse driver to detect context cancellation caused by sync error so we don't have to explicitly check for ctx.Done inside `startNormalize`)

Fixes: DBI-1119