### PR TITLE
support overriding env on the pipe-level in UI

### DIFF
--- a/flow/cmd/handler.go
+++ b/flow/cmd/handler.go
@@ -162,6 +162,9 @@ func (h *FlowRequestHandler) CreateCDCFlow(
 	if cfg == nil {
 		return nil, NewInvalidArgumentApiError(fmt.Errorf("connection configs cannot be nil"))
 	}
+	if err := internal.ValidateEnv(cfg.Env); err != nil {
+		return nil, NewInvalidArgumentApiError(fmt.Errorf("invalid settings override: %w", err))
+	}
 	if internalVersion, err := internal.PeerDBForceInternalVersion(ctx, cfg.Env); err != nil {
 		return nil, NewInternalApiError(err)
 	} else {
@@ -446,6 +449,12 @@ func (h *FlowRequestHandler) FlowStateChange(
 	if err != nil {
 		slog.ErrorContext(ctx, "[flow-state-change] unable to get workflow status", logs, slog.Any("error", err))
 		return nil, NewInternalApiError(err)
+	}
+
+	if cdcUpdate := req.FlowConfigUpdate.GetCdcFlowConfigUpdate(); cdcUpdate != nil {
+		if err := internal.ValidateEnv(cdcUpdate.UpdatedEnv); err != nil {
+			return nil, NewInvalidArgumentApiError(fmt.Errorf("invalid settings override: %w", err))
+		}
 	}
 
 	if req.FlowConfigUpdate != nil && req.FlowConfigUpdate.GetCdcFlowConfigUpdate() != nil &&

--- a/flow/cmd/validate_mirror.go
+++ b/flow/cmd/validate_mirror.go
@@ -38,6 +38,9 @@ func (h *FlowRequestHandler) ValidateCDCMirror(
 	ctx context.Context, req *protos.CreateCDCFlowRequest,
 ) (*protos.ValidateCDCMirrorResponse, APIError) {
 	if req.ConnectionConfigs != nil {
+		if err := internal.ValidateEnv(req.ConnectionConfigs.Env); err != nil {
+			return nil, NewInvalidArgumentApiError(fmt.Errorf("invalid settings override: %w", err))
+		}
 		if internalVersion, err := internal.PeerDBForceInternalVersion(ctx, req.ConnectionConfigs.Env); err != nil {
 			return nil, NewInternalApiError(err)
 		} else {

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -601,6 +603,32 @@ var DynamicIndex = func() map[string]int {
 	}
 	return defaults
 }()
+
+func ValidateEnv(env map[string]string) error {
+	var errs []error
+	for _, key := range slices.Sorted(maps.Keys(env)) {
+		idx, ok := DynamicIndex[key]
+		if !ok {
+			errs = append(errs, fmt.Errorf("%s is not a known setting", key))
+			continue
+		}
+		value := env[key]
+		var err error
+		switch DynamicSettings[idx].ValueType {
+		case protos.DynconfValueType_INT:
+			_, err = strconv.ParseInt(value, 10, 64)
+		case protos.DynconfValueType_UINT:
+			_, err = strconv.ParseUint(value, 10, 64)
+		case protos.DynconfValueType_BOOL:
+			_, err = strconv.ParseBool(value)
+		}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: invalid value %q for %s setting",
+				key, value, strings.ToLower(DynamicSettings[idx].ValueType.String())))
+		}
+	}
+	return errors.Join(errs...)
+}
 
 type BinaryFormat int
 

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -621,10 +621,13 @@ func ValidateEnv(env map[string]string) error {
 			_, err = strconv.ParseUint(value, 10, 64)
 		case protos.DynconfValueType_BOOL:
 			_, err = strconv.ParseBool(value)
+		case protos.DynconfValueType_STRING:
+		default:
+			err = fmt.Errorf("unsupported value type %s", DynamicSettings[idx].ValueType)
 		}
 		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: invalid value %q for %s setting",
-				key, value, strings.ToLower(DynamicSettings[idx].ValueType.String())))
+			errs = append(errs, fmt.Errorf("%s: invalid value %q for %s setting: %w",
+				key, value, strings.ToLower(DynamicSettings[idx].ValueType.String()), err))
 		}
 	}
 	return errors.Join(errs...)

--- a/flow/shared/telemetry/activity_logging.go
+++ b/flow/shared/telemetry/activity_logging.go
@@ -77,6 +77,10 @@ func LogActivityStartFlowConfigUpdate(ctx context.Context, flowName string, upda
 	var changes []string
 
 	// Only logging fields that don't need old values to compare to
+	if len(update.RemovedEnv) > 0 {
+		changes = append(changes, fmt.Sprintf("env removed: %v", update.RemovedEnv))
+	}
+
 	if len(update.AdditionalTables) > 0 {
 		addedTables := make([]string, 0, len(update.AdditionalTables))
 		for _, t := range update.AdditionalTables {
@@ -141,6 +145,11 @@ func LogActivityUpdateFlowConfig(ctx context.Context, flowName string, oldValues
 			if oldValue := oldValues.Env[key]; oldValue != newValue {
 				changes = append(changes, fmt.Sprintf("env %s: %s->%s", key, oldValue, newValue))
 			}
+		}
+	}
+	for _, key := range update.RemovedEnv {
+		if oldValue, ok := oldValues.Env[key]; ok {
+			changes = append(changes, fmt.Sprintf("env %s: %s->(removed)", key, oldValue))
 		}
 	}
 

--- a/flow/workflows/cdc_flow.go
+++ b/flow/workflows/cdc_flow.go
@@ -120,11 +120,16 @@ func processCDCFlowConfigUpdate(
 		SnapshotMaxParallelWorkers:    state.SnapshotMaxParallelWorkers,
 		SnapshotNumTablesInParallel:   state.SnapshotNumTablesInParallel,
 	}
-	if len(flowConfigUpdate.UpdatedEnv) > 0 {
-		oldValues.Env = make(map[string]string, len(flowConfigUpdate.UpdatedEnv))
+	if len(flowConfigUpdate.UpdatedEnv) > 0 || len(flowConfigUpdate.RemovedEnv) > 0 {
+		oldValues.Env = make(map[string]string, len(flowConfigUpdate.UpdatedEnv)+len(flowConfigUpdate.RemovedEnv))
 		if cfg.Env != nil {
 			for key := range flowConfigUpdate.UpdatedEnv {
 				oldValues.Env[key] = cfg.Env[key]
+			}
+			for _, key := range flowConfigUpdate.RemovedEnv {
+				if value, ok := cfg.Env[key]; ok {
+					oldValues.Env[key] = value
+				}
 			}
 		}
 	}
@@ -135,12 +140,7 @@ func processCDCFlowConfigUpdate(
 	if flowConfigUpdate.IdleTimeout > 0 {
 		state.SyncFlowOptions.IdleTimeoutSeconds = flowConfigUpdate.IdleTimeout
 	}
-	if flowConfigUpdate.UpdatedEnv != nil {
-		if cfg.Env == nil {
-			cfg.Env = make(map[string]string, len(flowConfigUpdate.UpdatedEnv))
-		}
-		maps.Copy(cfg.Env, flowConfigUpdate.UpdatedEnv)
-	}
+	cfg.Env = applyEnvUpdate(cfg.Env, flowConfigUpdate.UpdatedEnv, flowConfigUpdate.RemovedEnv)
 	if flowConfigUpdate.SnapshotNumRowsPerPartition > 0 {
 		state.SnapshotNumRowsPerPartition = flowConfigUpdate.SnapshotNumRowsPerPartition
 	}
@@ -185,6 +185,19 @@ func processCDCFlowConfigUpdate(
 	telemetry.LogActivityUpdateFlowConfig(context.Background(), cfg.FlowJobName, oldValues, flowConfigUpdate)
 	syncStateToConfigProtoInCatalog(ctx, cfg, state)
 	return nextRunNone, nil
+}
+
+func applyEnvUpdate(env map[string]string, updatedEnv map[string]string, removedEnv []string) map[string]string {
+	if len(updatedEnv) > 0 {
+		if env == nil {
+			env = make(map[string]string, len(updatedEnv))
+		}
+		maps.Copy(env, updatedEnv)
+	}
+	for _, key := range removedEnv {
+		delete(env, key)
+	}
+	return env
 }
 
 func processTerminate(
@@ -519,6 +532,7 @@ func addCdcPropertiesSignalListener(
 			slog.Any("AdditionalTables", cdcConfigUpdate.AdditionalTables),
 			slog.Any("RemovedTables", cdcConfigUpdate.RemovedTables),
 			slog.Any("UpdatedEnv", cdcConfigUpdate.UpdatedEnv),
+			slog.Any("RemovedEnv", cdcConfigUpdate.RemovedEnv),
 			slog.Uint64("SnapshotNumRowsPerPartition", uint64(cdcConfigUpdate.SnapshotNumRowsPerPartition)),
 			slog.Uint64("SnapshotNumPartitionsOverride", uint64(cdcConfigUpdate.SnapshotNumPartitionsOverride)),
 			slog.Uint64("SnapshotMaxParallelWorkers", uint64(cdcConfigUpdate.SnapshotMaxParallelWorkers)),

--- a/flow/workflows/cdc_flow_env_test.go
+++ b/flow/workflows/cdc_flow_env_test.go
@@ -1,0 +1,53 @@
+package peerflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyEnvUpdate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merge into nil env", func(t *testing.T) {
+		t.Parallel()
+		got := applyEnvUpdate(nil, map[string]string{"A": "1"}, nil)
+		require.Equal(t, map[string]string{"A": "1"}, got)
+	})
+
+	t.Run("merge keeps untouched keys", func(t *testing.T) {
+		t.Parallel()
+		got := applyEnvUpdate(map[string]string{"A": "1", "B": "2"}, map[string]string{"B": "3", "C": "4"}, nil)
+		require.Equal(t, map[string]string{"A": "1", "B": "3", "C": "4"}, got)
+	})
+
+	t.Run("empty update is a no-op", func(t *testing.T) {
+		t.Parallel()
+		got := applyEnvUpdate(map[string]string{"A": "1"}, map[string]string{}, nil)
+		require.Equal(t, map[string]string{"A": "1"}, got)
+	})
+
+	t.Run("remove deletes keys and ignores unknown ones", func(t *testing.T) {
+		t.Parallel()
+		got := applyEnvUpdate(map[string]string{"A": "1", "B": "2"}, nil, []string{"A", "missing"})
+		require.Equal(t, map[string]string{"B": "2"}, got)
+	})
+
+	t.Run("update and remove together", func(t *testing.T) {
+		t.Parallel()
+		got := applyEnvUpdate(map[string]string{"K1": "V1", "K2": "V2"}, map[string]string{"K1": "k1b"}, []string{"K2"})
+		require.Equal(t, map[string]string{"K1": "k1b"}, got)
+	})
+
+	t.Run("remove wins over update for same key", func(t *testing.T) {
+		t.Parallel()
+		got := applyEnvUpdate(map[string]string{"A": "1"}, map[string]string{"A": "2"}, []string{"A"})
+		require.Empty(t, got)
+	})
+
+	t.Run("remove on nil env is a no-op", func(t *testing.T) {
+		t.Parallel()
+		got := applyEnvUpdate(nil, nil, []string{"A"})
+		require.Nil(t, got)
+	})
+}

--- a/protos/flow.proto
+++ b/protos/flow.proto
@@ -587,6 +587,8 @@ message CDCFlowConfigUpdate {
   uint32 snapshot_max_parallel_workers = 8;
   uint32 snapshot_num_tables_in_parallel = 9;
   bool skip_initial_snapshot_for_table_additions = 11;
+  // removes keys from the env map, applied after updated_env
+  repeated string removed_env = 12;
 }
 
 message QRepFlowConfigUpdate {

--- a/ui/app/mirrors/[mirrorId]/edit/EditMirror.tsx
+++ b/ui/app/mirrors/[mirrorId]/edit/EditMirror.tsx
@@ -48,6 +48,40 @@ const defaultSnapshotMaxParallelWorkers =
 const defaultSnapshotNumTablesInParallel =
   blankCDCSetting.snapshotNumTablesInParallel;
 
+function envStringFromState(res: MirrorStatusResponse): string {
+  const env = res.cdcStatus?.config?.env ?? {};
+  return Object.keys(env).length > 0 ? JSON.stringify(env, null, 2) : '';
+}
+
+// Parses the settings override textarea into the updated_env map.
+// Returns an error message on invalid input.
+export function parseEnvString(
+  envString: string
+): { env: Record<string, string> } | { error: string } {
+  if (envString.trim() === '') {
+    return { env: {} };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(envString);
+  } catch (err: any) {
+    return { error: `Settings override is not valid JSON: ${err.message}` };
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { error: 'Settings override must be a JSON object' };
+  }
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value !== 'string') {
+      return {
+        error: `Settings override value for "${key}" must be a string`,
+      };
+    }
+    env[key] = value;
+  }
+  return { env };
+}
+
 function configFromState(res: MirrorStatusResponse): CDCFlowConfigUpdate {
   return {
     batchSize: res.cdcStatus?.config?.maxBatchSize || defaultBatchSize,
@@ -56,6 +90,7 @@ function configFromState(res: MirrorStatusResponse): CDCFlowConfigUpdate {
     additionalTables: [],
     removedTables: [],
     updatedEnv: {},
+    removedEnv: [],
     snapshotNumRowsPerPartition:
       res.cdcStatus?.config?.snapshotNumRowsPerPartition ||
       defaultSnapshotNumRowsPerPartition,
@@ -82,6 +117,9 @@ export default function EditMirror({
   const [loading, startSubmit] = useTransition();
   const [config, setConfig] = useState<CDCFlowConfigUpdate>(() =>
     configFromState(mirrorState)
+  );
+  const [envString, setEnvString] = useState<string>(() =>
+    envStringFromState(mirrorState)
   );
   const { push } = useRouter();
 
@@ -115,6 +153,15 @@ export default function EditMirror({
         return;
       }
     }
+    const envResult = parseEnvString(envString);
+    if ('error' in envResult) {
+      notifyErr(envResult.error);
+      return;
+    }
+    const currentEnv = mirrorState.cdcStatus?.config?.env ?? {};
+    const removedEnv = Object.keys(currentEnv).filter(
+      (key) => !(key in envResult.env)
+    );
     const existingTableCount =
       mirrorState.cdcStatus?.config?.tableMappings.length ?? 0;
     if (
@@ -131,7 +178,13 @@ export default function EditMirror({
         flowJobName: mirrorId,
         requestedFlowState: FlowStatus.STATUS_RUNNING,
         flowConfigUpdate: {
-          cdcFlowConfigUpdate: { ...config, additionalTables, removedTables },
+          cdcFlowConfigUpdate: {
+            ...config,
+            additionalTables,
+            removedTables,
+            updatedEnv: envResult.env,
+            removedEnv,
+          },
         },
         dropMirrorStats: false,
         skipDestinationDrop: false,
@@ -144,7 +197,8 @@ export default function EditMirror({
       if (res.ok) {
         push(`/mirrors/${mirrorId}`);
       } else {
-        notifyErr(`Something went wrong: ${res.statusText}`);
+        const body = await res.json().catch(() => null);
+        notifyErr(body?.message || `Something went wrong: ${res.statusText}`);
       }
     });
   };
@@ -261,6 +315,22 @@ export default function EditMirror({
                 Number.isNaN(config.snapshotNumTablesInParallel)
                   ? ''
                   : config.snapshotNumTablesInParallel
+              }
+            />
+          </div>
+        }
+      />
+
+      <RowWithTextField
+        key={6}
+        label={<Label>{'Settings override'} </Label>}
+        action={
+          <div style={fieldStyle}>
+            <TextField
+              variant='text-area'
+              value={envString}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                setEnvString(e.target.value)
               }
             />
           </div>


### PR DESCRIPTION
Previously we already support settings override during pipe creation in the PeerDB UI:
<img width="1874" height="886" alt="Screenshot 2026-09-10 at 17 50 06@2x" src="https://github.com/user-attachments/assets/f7d700af-218e-4798-9ac5-b9d8afae9b34" />

This PR:
- adds the same option to the pipe editing UI (so we do not have to rely on API alone for this modification)
- because `updated_env` does not support env removal, add a separate `removed_env` field and let the typescript code perform a diff to determine the `removed_env` (otherwise, removing an env from `Settings Override` is a no-op)
- add validation for env override to ensure the key/value are legitimate.

edit mirror UI:
<img width="2298" height="746" alt="Screenshot 2026-09-10 at 17 47 01@2x" src="https://github.com/user-attachments/assets/06031dd0-c41e-4d1f-bc23-93127f65a885" />

validate env key must exist:
<img width="2294" height="1826" alt="Screenshot 2026-09-10 at 17 46 01@2x" src="https://github.com/user-attachments/assets/76068cab-6d0a-4c13-88df-dbe4f21d2f17" />

validate env value must container valid type:
<img width="2280" height="1792" alt="Screenshot 2026-09-10 at 17 44 40@2x" src="https://github.com/user-attachments/assets/cc76fc88-8b85-48df-8b1c-a33975f35423" />

valiate invalid json:
<img width="2294" height="1834" alt="Screenshot 2026-09-10 at 17 46 32@2x" src="https://github.com/user-attachments/assets/816e9287-1899-49bb-b954-d397e273e477" />

Fixes: DBI-1118