### PR TITLE
clickhouse: parallelize S3 to raw table ingestion

### DIFF
--- a/flow/connectors/clickhouse/normalize.go
+++ b/flow/connectors/clickhouse/normalize.go
@@ -449,7 +449,9 @@ func (c *ClickHouseConnector) NormalizeRecords(
 
 	endBatchID := min(req.SyncBatchID, lastNormBatchID+groupBatches)
 
-	if err := c.copyAvroStagesToDestination(ctx, req.FlowJobName, lastNormBatchID, endBatchID, req.Env, req.Version); err != nil {
+	if err := c.copyAvroStagesToDestination(
+		ctx, req.FlowJobName, lastNormBatchID, endBatchID, req.Env, req.Version, req.TableMappings,
+	); err != nil {
 		return model.NormalizeResponse{}, fmt.Errorf("failed to copy avro stages to destination: %w", err)
 	}
 
@@ -696,7 +698,13 @@ func (c *ClickHouseConnector) copyAvroStageToDestination(
 }
 
 func (c *ClickHouseConnector) copyAvroStagesToDestination(
-	ctx context.Context, flowJobName string, lastNormBatchID int64, endBatchID int64, env map[string]string, version uint32,
+	ctx context.Context,
+	flowJobName string,
+	lastNormBatchID int64,
+	endBatchID int64,
+	env map[string]string,
+	version uint32,
+	tableMappings []*protos.TableMapping,
 ) error {
 	// Skip batches already copied to raw table. This can happen if a previous normalization
 	// run failed after copying to raw table but before completing normalization.
@@ -707,6 +715,44 @@ func (c *ClickHouseConnector) copyAvroStagesToDestination(
 	lastCopiedBatchID := max(lastBatchIDInRawTable, lastNormBatchID)
 	c.logger.Info("[clickhouse] pushing s3 data to raw table",
 		slog.Int64("batchID", lastCopiedBatchID), slog.Int64("endBatchID", endBatchID))
+
+	parallelism, err := internal.PeerDBClickHouseParallelRawIngestion(ctx, env)
+	if err != nil {
+		return fmt.Errorf("failed to load ClickHouse raw ingestion parallelism: %w", err)
+	}
+	parallelism = max(parallelism, 1)
+	if !allTablesUseReplacingMergeTree(tableMappings) {
+		parallelism = 1
+	}
+	parallelism = min(parallelism, int(endBatchID-lastCopiedBatchID))
+
+	if parallelism > 1 {
+		c.logger.Info("[clickhouse] copying s3 batches to raw table in parallel",
+			slog.Int64("startBatchID", lastCopiedBatchID+1),
+			slog.Int64("endBatchID", endBatchID),
+			slog.Int("parallelism", parallelism))
+
+		group, groupCtx := errgroup.WithContext(ctx)
+		group.SetLimit(parallelism)
+		for batchID := lastCopiedBatchID + 1; batchID <= endBatchID; batchID++ {
+			group.Go(func() error {
+				if err := c.copyAvroStageToDestination(groupCtx, flowJobName, batchID, env, version); err != nil {
+					return fmt.Errorf("failed to copy avro stage for batch %d to destination: %w", batchID, err)
+				}
+				return nil
+			})
+		}
+		if err := group.Wait(); err != nil {
+			return err
+		}
+
+		// The metadata value represents a contiguous high-water mark. Publish it only
+		// after every batch succeeds so an out-of-order partial failure cannot skip a gap.
+		if err := c.SetLastBatchIDInRawTable(ctx, flowJobName, endBatchID); err != nil {
+			return fmt.Errorf("failed to set last batch id in raw table: %w", err)
+		}
+		return nil
+	}
 
 	for batchID := lastCopiedBatchID + 1; batchID <= endBatchID; batchID++ {
 		if err := c.copyAvroStageToDestination(ctx, flowJobName, batchID, env, version); err != nil {
@@ -721,6 +767,24 @@ func (c *ClickHouseConnector) copyAvroStagesToDestination(
 		}
 	}
 	return nil
+}
+
+func allTablesUseReplacingMergeTree(tableMappings []*protos.TableMapping) bool {
+	if len(tableMappings) == 0 {
+		return false
+	}
+	for _, tableMapping := range tableMappings {
+		if tableMapping == nil {
+			return false
+		}
+		switch tableMapping.Engine {
+		case protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE,
+			protos.TableEngine_CH_ENGINE_REPLICATED_REPLACING_MERGE_TREE:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func getColName(overrides map[string]string, name string) string {

--- a/flow/connectors/clickhouse/normalize_test.go
+++ b/flow/connectors/clickhouse/normalize_test.go
@@ -517,3 +517,49 @@ func TestGenerateCreateTableSQLForNormalizedTable(t *testing.T) {
 		})
 	}
 }
+
+func TestAllTablesUseReplacingMergeTree(t *testing.T) {
+	tests := []struct {
+		name          string
+		tableMappings []*protos.TableMapping
+		expected      bool
+	}{
+		{
+			name: "replacing merge tree",
+			tableMappings: []*protos.TableMapping{
+				{Engine: protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE},
+			},
+			expected: true,
+		},
+		{
+			name: "replicated replacing merge tree",
+			tableMappings: []*protos.TableMapping{
+				{Engine: protos.TableEngine_CH_ENGINE_REPLICATED_REPLACING_MERGE_TREE},
+			},
+			expected: true,
+		},
+		{
+			name: "mixed engines",
+			tableMappings: []*protos.TableMapping{
+				{Engine: protos.TableEngine_CH_ENGINE_REPLACING_MERGE_TREE},
+				{Engine: protos.TableEngine_CH_ENGINE_MERGE_TREE},
+			},
+			expected: false,
+		},
+		{
+			name: "no table mappings",
+		},
+		{
+			name: "nil table mapping",
+			tableMappings: []*protos.TableMapping{
+				nil,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, allTablesUseReplacingMergeTree(tc.tableMappings))
+		})
+	}
+}

--- a/flow/internal/dynamicconf.go
+++ b/flow/internal/dynamicconf.go
@@ -353,6 +353,15 @@ var DynamicSettings = [...]*protos.DynamicSetting{
 		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
 	},
 	{
+		Name: "PEERDB_CLICKHOUSE_PARALLEL_RAW_INGESTION",
+		Description: "Number of concurrent S3-to-raw-table batch inserts. Values above 1 are only applied " +
+			"when every destination table uses a ReplacingMergeTree engine",
+		DefaultValue:     "1",
+		ValueType:        protos.DynconfValueType_INT,
+		ApplyMode:        protos.DynconfApplyMode_APPLY_MODE_IMMEDIATE,
+		TargetForSetting: protos.DynconfTarget_CLICKHOUSE,
+	},
+	{
 		Name: "PEERDB_CLICKHOUSE_ENABLE_REPLICATED_QUORUM",
 		Description: "On Replicated ClickHouse clusters, write raw/normalize inserts with quorum " +
 			"(insert_quorum=auto, insert_quorum_parallel=0) so that select_sequential_consistency reads " +
@@ -907,6 +916,10 @@ func PeerDBClickHouseParallelViewProcessing(ctx context.Context, env map[string]
 
 func PeerDBClickHouseParallelNormalize(ctx context.Context, env map[string]string) (int, error) {
 	return dynamicConfSigned[int](ctx, env, "PEERDB_CLICKHOUSE_PARALLEL_NORMALIZE")
+}
+
+func PeerDBClickHouseParallelRawIngestion(ctx context.Context, env map[string]string) (int, error) {
+	return dynamicConfSigned[int](ctx, env, "PEERDB_CLICKHOUSE_PARALLEL_RAW_INGESTION")
 }
 
 func PeerDBClickHouseEnableReplicatedQuorum(ctx context.Context, env map[string]string) (bool, error) {


### PR DESCRIPTION
## Summary

- add PEERDB_CLICKHOUSE_PARALLEL_RAW_INGESTION with a default of 1
- copy grouped Avro batches into the ClickHouse raw table concurrently when configured above 1
- only enable parallel ingestion when every destination table mapping uses ReplacingMergeTree or ReplicatedReplacingMergeTree
- advance the raw-table batch watermark only after the full contiguous batch range succeeds

## Failure semantics

A partial parallel failure does not advance latest_batch_id_in_raw_table. Successful out-of-order copies can therefore be retried, while the RMT version column prevents an older batch from replacing a newer value in the final table.

## Testing

- GOCACHE=/tmp/peerdb-go-build go test ./connectors/clickhouse -run Test\(AllTablesUseReplacingMergeTree\|GenerateCreateTableSQLForNormalizedTable\)$
- GOCACHE=/tmp/peerdb-go-build go test ./internal
- GOCACHE=/tmp/peerdb-go-build go vet ./connectors/clickhouse ./internal
- GOCACHE=/tmp/peerdb-go-build golangci-lint run ./connectors/clickhouse ./internal

The complete ClickHouse package suite was attempted but sandbox restrictions prevent its localhost catalog and httptest listeners from starting; CI should exercise those integration-dependent tests.