### PR TITLE
fix(nexus): accept UUID arrays in value serializer

### DIFF
--- a/nexus/value/Cargo.toml
+++ b/nexus/value/Cargo.toml
@@ -13,6 +13,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 pgwire.workspace = true
 postgres-inet = "0.19.0"
-postgres-types = { version = "0.2.5", features = ["array-impls"] }
+postgres-types = { version = "0.2.5", features = ["array-impls", "with-uuid-1"] }
 rust_decimal.workspace = true
 uuid = { version = "1.0", features = ["serde", "v4"] }

--- a/nexus/value/src/array.rs
+++ b/nexus/value/src/array.rs
@@ -185,6 +185,7 @@ impl ToSql for ArrayValue {
                 | Type::VARCHAR_ARRAY
                 | Type::TEXT_ARRAY
                 | Type::BYTEA_ARRAY
+                | Type::UUID_ARRAY
                 | Type::DATE_ARRAY
                 | Type::TIME_ARRAY
                 | Type::TIMETZ_ARRAY
@@ -203,6 +204,22 @@ impl ToSql for ArrayValue {
         }
 
         ToSql::to_sql(self, ty, out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ArrayValue;
+    use bytes::BytesMut;
+    use postgres_types::{ToSql, Type};
+    use uuid::Uuid;
+
+    #[test]
+    fn to_sql_checked_accepts_uuid_array() {
+        let value = ArrayValue::Uuid(vec![Uuid::nil()]);
+        let mut out = BytesMut::new();
+
+        assert!(value.to_sql_checked(&Type::UUID_ARRAY, &mut out).is_ok());
     }
 }
 


### PR DESCRIPTION
## What changed

- **Accept `UUID_ARRAY`** in `ArrayValue`’s `ToSql` type whitelist.
- Enable `postgres-types` UUID support for the standalone `value` crate.
- Add a unit test through `to_sql_checked`.

## Why

`peer-postgres` already decodes PostgreSQL `uuid[]` columns into `ArrayValue::Uuid`, and the serializer already handles UUID arrays. But `to_sql_checked` rejected `Type::UUID_ARRAY` as `Invalid type`.

## Tests

- `cargo test -p value --lib`
- `rustfmt --edition 2024 --check nexus/value/src/array.rs`